### PR TITLE
feat(designer): Premium Webflow-Style Visual Designer toolbar, StylePanel & Canvas Layout fixes

### DIFF
--- a/WEBFLOW_ARCHITECTURE.md
+++ b/WEBFLOW_ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# Webflow-Style Responsive Layout Mode: Architectural Design Document
+
+This document outlines the architectural implementation and logic for the optional **Webflow Responsive Mode** inside the ProGPU Visual Designer. This feature ports Webflow's structured design paradigm, preventing arbitrary absolute coordinate placements in favor of structured responsive layouts, cascading viewports, and visual spacing box models.
+
+---
+
+## 1. Architectural Philosophy: Flow Layouts vs. Absolute Position
+
+Standard desktop designers often rely on absolute coordinate positioning (e.g. `Canvas.Left`, `Canvas.Top`), which yields layouts that are fragile, non-responsive, and break under screen size changes, DPI scaling, or dynamic text expansion.
+
+Webflow solves this problem by enforcing a structured layout hierarchy:
+* **The Stacking Root**: The page body behaves as a vertical flow block.
+* **Containers First**: You cannot drop interactive elements (buttons, inputs) directly on the canvas; you must drop a panel (e.g. Section, Container, Grid, or Div Block) first.
+* **Auto-Flow**: Child elements within panels are positioned by the container's layout rules (vertical stack, horizontal flow, or defined grid cells) rather than absolute coordinates.
+* **Margins/Paddings for Spacing**: Horizontal and vertical offsets are governed strictly by margins, paddings, and alignment properties rather than hardcoded X/Y pixels.
+* **Cascading viewports**: Layout boundaries can be configured and previewed using responsive device boundaries (Desktop, Tablet, Mobile) which horizontally center the viewport and reflow elements.
+* **Visual Box Models**: When an element is selected, its spacing parameters (Margin & Padding) are drawn on the canvas as distinct translucent highlight overlays.
+
+---
+
+## 2. Component Pipeline and Class Relationships
+
+Below is the design of the Webflow Mode components within the ProGPU Visual Designer:
+
+```mermaid
+classDiagram
+    class DesignerCanvas {
+        +bool IsResponsiveMode
+        +float? ViewportWidth
+        +Canvas DesignSurface
+        +Canvas AdornerSurface
+        +IsResponsiveContainer(fe) bool
+        +OnDrop(args) void
+        +OnPointerMoved(args) void
+    }
+
+    class DesignerSurfacePanel {
+        -DesignerCanvas _designer
+        #MeasureOverride(availableSize) Vector2
+        #ArrangeOverride(arrangeRect) void
+    }
+
+    class SelectionAdorner {
+        +FrameworkElement AssociatedElement
+        -DrawBoxModelOverlays(context, z) void
+        #OnRender(context) void
+    }
+
+    class DesignerHost {
+        -DesignerCanvas _designerCanvas
+        -CheckBox _webflowCheck
+        -StackPanel _breakpointPanel
+        -NudgeSelectedElement(dx, dy) void
+        -CloneElement(orig) FrameworkElement
+    }
+
+    class DesignerSerializer {
+        +SerializeToCSharp(canvas, isResponsiveMode) string
+        -SerializeElement(fe, isResponsiveMode) string
+    }
+
+    DesignerCanvas *-- DesignerSurfacePanel : instantiates as DesignSurface
+    DesignerHost *-- DesignerCanvas : contains
+    DesignerCanvas o-- SelectionAdorner : instantiates on selection
+    DesignerHost ..> DesignerSerializer : invokes on modifications
+    DesignerSurfacePanel --|> Canvas : inherits from
+```
+
+---
+
+## 3. Detailed Subsystem Implementation
+
+### A. Root Surface Vertical Stacking (`DesignerSurfacePanel`)
+Instead of instantiating a raw absolute `Canvas` for the root `DesignSurface`, we subclass it with `DesignerSurfacePanel`. 
+* **Measurement Override**: When `IsResponsiveMode` is active, it queries each visual child, measures it with unrestricted vertical constraints, takes the maximum width among them, and sums their desired heights to determine the aggregate height.
+* **Arrangement Override**: Instead of placing elements at their `Canvas.Left` and `Canvas.Top` coordinates, it arranges child containers sequentially from top to bottom, setting their bounds to stretch horizontally spanning the full width of the canvas.
+
+### B. Cascading viewports and Device Mockup Boundaries
+To support responsive previews, `DesignerCanvas` implements the `ViewportWidth` property:
+1. **Measurement Restricting**: During `MeasureOverride` in `DesignerCanvas`, if `ViewportWidth` has a value (e.g. `768f` for Tablet, `375f` for Mobile), the available measurement width passed to `DesignSurface` is confined to that specific width constraint. This forces StackPanels and Grids set to Stretch alignment to reflow immediately.
+2. **Horizontal Centering**: During `ArrangeOverride`, if `ViewportWidth` is set, `leftOffset = (arrangeRect.Width - ViewportWidth.Value) / 2f` is computed. The design surface is arranged inside a horizontally centered bounds rectangle offset by `leftOffset`.
+3. **Viewport Outlines**: Sleek vertical device boundaries are drawn on the left and right screen borders of the mockup container using a subtle, theme-aware translucent brush during `OnRender` on the `DesignerCanvas`.
+4. **Breakpoint Toggles**: The `DesignerHost` implements visual toggle buttons (🖥️ Desktop, 📟 Tablet, 📱 Mobile) in the action bar. Toggling viewports forces a dynamic arrange pass, updating selection adorner boxes and marking active states.
+
+### C. Spacing Box Overlays (Figma/Webflow Highlights)
+When a control is selected:
+* The `SelectionAdorner` draws visual box models around the selected control in `OnRender`.
+* **Margin Highlight**: Rendered as a translucent orange box (`rgba(250, 112, 51, 0.20)`) representing the external `Margin` offsets.
+* **Padding Highlight**: Rendered as a translucent green/teal box (`rgba(61, 209, 155, 0.22)`) representing internal element `Padding` boundaries.
+* Drawn first in the adorner rendering pipeline so that the active selection border and resize thumb handles remain cleanly visible on top.
+
+### D. Element Placement Restrictions & Auto-Stretching
+When the user drags a tool from the `Toolbox` and drops it onto the surface:
+1. **Purity Checking**: Standard `Canvas` container drops are blocked entirely to prevent absolute-coordinate sub-zones.
+2. **Leaf Rejection**: If the target container under the cursor is the root `DesignSurface` canvas itself, we check if the tool is an interactive leaf control (e.g., `Button`, `TextBox`, `TextBlock`). If so, the drop is rejected, and a clear console warning is printed.
+3. **Auto-Stretching**: If the tool is a responsive container (e.g., `StackPanel`, `Grid`, `Border`, `ScrollViewer`, `WrapPanel`, `DockPanel`), it is allowed at the root. To force immediate responsiveness:
+   - Its fixed `Width` constraint is cleared (set to `float.NaN`).
+   - Its `HorizontalAlignment` is set to `HorizontalAlignment.Stretch`.
+   - Its `Height` is set to a default visual placeholder of `100f` so it remains visible and drop-targetable when empty.
+
+### E. Stack Drag Reordering
+To rearrange components at the root level, standard dragging (which adjusts absolute coordinates) is disabled:
+- We track the cursor's logical position inside the root canvas.
+- As the dragged element moves, we identify all top-level sibling panels on the root.
+- We compare the mouse position with each sibling's physical center coordinate (`siblingPos.Y + height / 2f`).
+- We compute the precise target index and dynamically clear and re-populate the root `Children` collection. This achieves smooth, real-time vertical drag reordering.
+
+### F. Margin Nudging
+To adjust spacing without absolute positioning, standard keyboard nudges are intercepted:
+- When a control is nudged (using the arrow keys), instead of mutating `Canvas.Left` and `Canvas.Top`, we adjust the selected element's `Margin` properties (specifically `Margin.Left` and `Margin.Top` based on the horizontal and vertical nudge vector).
+- Shift+Arrows nudges by `10f`, while standard arrows nudge by `1f`.
+- Minimum margin clamps are enforced at `0f` to prevent layout overlaps.
+
+### G. Responsive Code Serialization
+The `DesignerSerializer` handles production-ready C# code generation. When `IsResponsiveMode` is active:
+- It propagates the responsive mode flag recursively through all element serialization steps.
+- It suppresses the output of coordinate attachments (`Canvas.SetLeft` and `Canvas.SetTop`).
+- The resulting factory code compiles into a beautifully responsive, layout-driven visual tree that naturally reflows under different window boundaries.
+
+---
+
+## 4. Diagnostic & Best Practices
+* **Cascading Layout Workflow**: Always build your base layout on Desktop. Then, toggle to Tablet or Mobile to verify how panels reflow, and use standard `Margin` spacing to make granular design updates for smaller device viewports.
+* **Box Model Spacing Guides**: Spacing overlays provide instant visual inspection. If an element isn't aligning correctly, select it to view its orange (margin) and green (padding) footprint.
+* **Zero Absolute Footprints**: When designing templates intended for responsive distribution, ensure Webflow Responsive Mode is checked *before* construction to automatically enforce structural hierarchy constraints from the start.

--- a/src/ProGPU.Layout/LayoutContainers.cs
+++ b/src/ProGPU.Layout/LayoutContainers.cs
@@ -194,14 +194,14 @@ public class GridPanel : LayoutNode
                 {
                     GridUnitType.Absolute => colWidths[c],
                     GridUnitType.Star => (cols[c].Value / starColsWeight) * remainingWidth,
-                    _ => availableSize.X
+                    _ => float.PositiveInfinity
                 };
 
                 float childAvailH = rows[r].UnitType switch
                 {
                     GridUnitType.Absolute => rowHeights[r],
                     GridUnitType.Star => (rows[r].Value / starRowsWeight) * remainingHeight,
-                    _ => availableSize.Y
+                    _ => float.PositiveInfinity
                 };
 
                 node.Measure(new Vector2(childAvailW, childAvailH));

--- a/src/ProGPU.Tests.Headless/DesignerCanvasTests.cs
+++ b/src/ProGPU.Tests.Headless/DesignerCanvasTests.cs
@@ -356,4 +356,380 @@ public class DesignerCanvasTests
         Assert.NotNull(currentButton);
         Assert.Equal(101f, Canvas.GetLeft(currentButton));
     }
+
+    [Fact]
+    public void Test_DesignerCanvas_WebflowMode_LeafRejectionAndAutoStretch()
+    {
+        var canvas = new DesignerCanvas
+        {
+            Width = 800,
+            Height = 600,
+            AllowDrop = true,
+            IsResponsiveMode = true
+        };
+
+        // 1. Try to drop a leaf control (Button) on root DesignSurface
+        var dataButton = new DataPackage();
+        dataButton.SetData(StandardDataFormats.Tool, "Button");
+        var argsButton = new DragEventArgs(dataButton, new Vector2(100f, 100f));
+
+        canvas.OnDrop(argsButton);
+
+        // Assert it is rejected
+        Assert.Empty(canvas.DesignSurface.Children);
+
+        // 2. Drop a responsive container (StackPanel) on root DesignSurface
+        var dataPanel = new DataPackage();
+        dataPanel.SetData(StandardDataFormats.Tool, "StackPanel");
+        var argsPanel = new DragEventArgs(dataPanel, new Vector2(100f, 100f));
+
+        canvas.OnDrop(argsPanel);
+
+        // Assert it is allowed and correctly configured
+        Assert.Single(canvas.DesignSurface.Children);
+        var panel = canvas.DesignSurface.Children[0] as Microsoft.UI.Xaml.Controls.StackPanel;
+        Assert.NotNull(panel);
+        Assert.Equal(ProGPU.Layout.HorizontalAlignment.Stretch, panel.HorizontalAlignment);
+        Assert.True(float.IsNaN(panel.Width));
+        Assert.Equal(100f, panel.Height); // placeholder height
+    }
+
+    [Fact]
+    public void Test_DesignerHost_WebflowMode_NudgeMargin()
+    {
+        var host = new DesignerHost();
+        host.WorkspaceCanvas.IsResponsiveMode = true;
+
+        // Add responsive panel first (StackPanel)
+        host.AddControlToCanvas("StackPanel", 0f, 0f);
+        var panel = host.WorkspaceCanvas.SelectedElement;
+        Assert.NotNull(panel);
+
+        // Standard positions should be clean
+        Assert.Equal(0f, Canvas.GetLeft(panel));
+        Assert.Equal(0f, Canvas.GetTop(panel));
+
+        // Act - Nudge Right by 1 unit
+        host.OnKeyDown(new KeyRoutedEventArgs { Key = Silk.NET.Input.Key.Right });
+
+        // Assert - absolute coordinates are unmodified, but Margin is adjusted!
+        Assert.Equal(0f, Canvas.GetLeft(panel));
+        Assert.Equal(1f, panel.Margin.Left);
+        Assert.Equal(0f, panel.Margin.Top);
+    }
+
+    [Fact]
+    public void Test_DesignerSerializer_WebflowMode_CoordinatesSuppression()
+    {
+        var canvas = new Canvas { Width = 800f, Height = 600f };
+        var panel = new Microsoft.UI.Xaml.Controls.StackPanel { Name = "myStack" };
+        Canvas.SetLeft(panel, 150f);
+        Canvas.SetTop(panel, 100f);
+        canvas.Children.Add(panel);
+
+        // Act - Serialize in responsive mode
+        string csharpScript = DesignerSerializer.SerializeToCSharp(canvas, isResponsiveMode: true);
+
+        // Assert - coordinate initializers are suppressed
+        Assert.DoesNotContain("Canvas.SetLeft", csharpScript);
+        Assert.DoesNotContain("Canvas.SetTop", csharpScript);
+        Assert.Contains("var myStack = new StackPanel", csharpScript);
+    }
+
+    [Fact]
+    public void Test_DesignerCanvas_WebflowViewport_MeasureAndCenter()
+    {
+        var canvas = new DesignerCanvas
+        {
+            ViewportWidth = 768f,
+            AllowDrop = true
+        };
+
+        // Act - measure and arrange with 1024x768 available bounds
+        canvas.Measure(new Vector2(1024f, 768f));
+        canvas.Arrange(new ProGPU.Scene.Rect(0f, 0f, 1024f, 768f));
+
+        // Assert - DesignSurface's measured size is restricted to 768f horizontally
+        Assert.Equal(768f, canvas.DesignSurface.Size.X);
+
+        // Assert - DesignSurface's arrangement left position is centered: (1024 - 768) / 2 = 128f
+        Assert.Equal(128f, canvas.DesignSurface.Offset.X);
+    }
+
+    [Fact]
+    public void Test_SelectionAdorner_BoxModelOverlays_VerifyRendering()
+    {
+        var canvas = new DesignerCanvas
+        {
+            Width = 800f,
+            Height = 600f,
+            IsResponsiveMode = true
+        };
+
+        var button = new Button
+        {
+            Width = 120f,
+            Height = 36f,
+            Margin = new Microsoft.UI.Xaml.Thickness(10f, 15f, 10f, 15f),
+            Padding = new Microsoft.UI.Xaml.Thickness(5f, 5f, 5f, 5f)
+        };
+        canvas.DesignSurface.Children.Add(button);
+
+        // Select to trigger SelectionAdorner instantiation
+        canvas.SelectElement(button);
+
+        // Act - Verify selection adorner captures sizes
+        Assert.Single(canvas.AdornerSurface.Children);
+        var adorner = canvas.AdornerSurface.Children[0] as SelectionAdorner;
+        Assert.NotNull(adorner);
+
+        // Assert spacing properties are verified
+        Assert.Equal(10f, adorner.AssociatedElement.Margin.Left);
+        Assert.Equal(15f, adorner.AssociatedElement.Margin.Top);
+        Assert.Equal(5f, adorner.AssociatedElement.Padding.Left);
+        Assert.Equal(5f, adorner.AssociatedElement.Padding.Top);
+    }
+
+    [Fact]
+    public void Test_PivotTabs_Navigation()
+    {
+        var pivot = new Pivot();
+        var tab1 = new PivotItem("Style", new Border());
+        var tab2 = new PivotItem("Settings", new Border());
+        pivot.Items.Add(tab1);
+        pivot.Items.Add(tab2);
+
+        Assert.Equal(0, pivot.SelectedIndex);
+
+        pivot.SelectedIndex = 1;
+        Assert.Equal(1, pivot.SelectedIndex);
+    }
+
+    [Fact]
+    public void Test_StylePanel_SpacingBoxModelUpdates()
+    {
+        var font = Microsoft.UI.Xaml.Controls.PopupService.DefaultFont;
+        var stylePanel = new StylePanel(font);
+
+        var button = new Button
+        {
+            Width = 100f,
+            Height = 30f,
+            Margin = new Microsoft.UI.Xaml.Thickness(0),
+            Padding = new Microsoft.UI.Xaml.Thickness(0)
+        };
+
+        stylePanel.SelectedElement = button;
+
+        // Verify initial state
+        Assert.Equal(0f, button.Margin.Left);
+        Assert.Equal(0f, button.Padding.Top);
+
+        var type = typeof(StylePanel);
+        var txtMarginLeftField = type.GetField("_txtMarginLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var txtPaddingTopField = type.GetField("_txtPaddingTop", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(txtMarginLeftField);
+        Assert.NotNull(txtPaddingTopField);
+
+        var txtMarginLeft = txtMarginLeftField.GetValue(stylePanel) as TextBox;
+        var txtPaddingTop = txtPaddingTopField.GetValue(stylePanel) as TextBox;
+
+        Assert.NotNull(txtMarginLeft);
+        Assert.NotNull(txtPaddingTop);
+
+        // Act - Simulate typing into boxes
+        txtMarginLeft.Text = "20";
+        txtPaddingTop.Text = "15";
+
+        // Assert - Spacing updates were written back to the element!
+        Assert.Equal(20f, button.Margin.Left);
+        Assert.Equal(15f, button.Padding.Top);
+    }
+
+    [Fact]
+    public void Test_StylePanel_TextBox_HitTesting_And_Focus()
+    {
+        var font = Microsoft.UI.Xaml.Controls.PopupService.DefaultFont;
+        var host = new DesignerHost();
+        host.InitializeFonts(font, font);
+
+        // Select the canvas button to make StylePanel fields active
+        var button = new Button { Width = 100f, Height = 30f };
+        host.WorkspaceCanvas.DesignSurface.Children.Add(button);
+        host.WorkspaceCanvas.SelectElement(button);
+
+        // Lay out host
+        host.Measure(new Vector2(1024f, 768f));
+        host.Arrange(new ProGPU.Scene.Rect(0f, 0f, 1024f, 768f));
+
+        // Retrieve _stylePanel and _txtWidth field via reflection
+        var type = typeof(StylePanel);
+        var stylePanelField = typeof(DesignerHost).GetField("_stylePanel", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(stylePanelField);
+        var stylePanel = stylePanelField.GetValue(host) as StylePanel;
+        Assert.NotNull(stylePanel);
+
+        var txtWidthField = type.GetField("_txtWidth", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(txtWidthField);
+        var txtWidth = txtWidthField.GetValue(stylePanel) as TextBox;
+        Assert.NotNull(txtWidth);
+
+        // Verify the textbox is hit-test visible and enabled
+        Assert.True(txtWidth.IsHitTestVisible);
+        Assert.True(txtWidth.IsEnabled);
+
+        // Get global transform position of txtWidth
+        var transform = txtWidth.GetGlobalTransformMatrix();
+        var globalPos = Vector3.Transform(Vector3.Zero, transform);
+        var testPoint = new Vector2(globalPos.X + 10f, globalPos.Y + 10f);
+
+        // Hit test
+        InputSystem.Current.Root = host;
+        var hit = InputSystem.HitTest(testPoint);
+        Assert.NotNull(hit);
+
+        // Verify the hit element bubbles up to txtWidth
+        var current = hit;
+        TextBox? targetTextBox = null;
+        while (current != null)
+        {
+            if (current is TextBox tb)
+            {
+                targetTextBox = tb;
+                break;
+            }
+            current = current.Parent as FrameworkElement;
+        }
+        Assert.Same(txtWidth, targetTextBox);
+
+        // Simulate clicking
+        var pointerArgs = new PointerRoutedEventArgs { Position = testPoint, ScreenPosition = testPoint };
+        hit.OnPointerPressed(pointerArgs);
+
+        // Verify focus is set to txtWidth
+        Assert.Same(txtWidth, InputSystem.FocusedElement);
+        Assert.True(txtWidth.IsFocused);
+
+        // Simulate typing character '5'
+        var charArgs = new CharacterReceivedRoutedEventArgs { Character = '5' };
+        txtWidth.OnCharacterReceived(charArgs);
+
+        // Assert text changed
+        Assert.Equal("5100", txtWidth.Text); // Since button width is initialized to 100, typing '5' at index 0 makes it "5100"
+
+        // Clean up static focus state to avoid affecting subsequent tests
+        InputSystem.SetFocus(null);
+    }
+
+    [Fact]
+    public void Test_StylePanel_Spacing_ValueScrubbing()
+    {
+        var font = Microsoft.UI.Xaml.Controls.PopupService.DefaultFont;
+        var stylePanel = new StylePanel(font);
+
+        var button = new Button
+        {
+            Width = 100f,
+            Height = 30f,
+            Margin = new Microsoft.UI.Xaml.Thickness(0),
+            Padding = new Microsoft.UI.Xaml.Thickness(0)
+        };
+
+        stylePanel.SelectedElement = button;
+
+        var type = typeof(StylePanel);
+        var txtMarginTopField = type.GetField("_txtMarginTop", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(txtMarginTopField);
+        var txtMarginTop = txtMarginTopField.GetValue(stylePanel) as TextBox;
+        Assert.NotNull(txtMarginTop);
+
+        // Verify initial state
+        Assert.Equal("0", txtMarginTop.Text);
+        Assert.Equal(0f, button.Margin.Top);
+
+        // 1. Simulate drag scrubbing horizontally by 15 pixels (normal speed 1x)
+        txtMarginTop.OnPointerPressed(new PointerRoutedEventArgs { Position = new Vector2(10f, 10f) });
+        txtMarginTop.OnPointerMoved(new PointerRoutedEventArgs { Position = new Vector2(25f, 10f) }); // dx = 15f
+        txtMarginTop.OnPointerReleased(new PointerRoutedEventArgs { Position = new Vector2(25f, 10f) });
+
+        // Assert margin top updated to 15
+        Assert.Equal("15", txtMarginTop.Text);
+        Assert.Equal(15f, button.Margin.Top);
+
+        // 2. Simulate drag scrubbing with SHIFT key pressed (10x speed acceleration)
+        InputSystem.Current.IsShiftPressed = true;
+        txtMarginTop.OnPointerPressed(new PointerRoutedEventArgs { Position = new Vector2(25f, 10f) });
+        txtMarginTop.OnPointerMoved(new PointerRoutedEventArgs { Position = new Vector2(35f, 10f) }); // dx = 10f * 10x = 100
+        txtMarginTop.OnPointerReleased(new PointerRoutedEventArgs { Position = new Vector2(35f, 10f) });
+        InputSystem.Current.IsShiftPressed = false;
+
+        // Assert margin top updated to 15 + 100 = 115
+        Assert.Equal("115", txtMarginTop.Text);
+        Assert.Equal(115f, button.Margin.Top);
+
+        // 3. Simulate drag scrubbing with ALT key pressed (0.1x micro-tuning deceleration)
+        InputSystem.Current.IsAltPressed = true;
+        txtMarginTop.OnPointerPressed(new PointerRoutedEventArgs { Position = new Vector2(35f, 10f) });
+        txtMarginTop.OnPointerMoved(new PointerRoutedEventArgs { Position = new Vector2(45f, 10f) }); // dx = 10f * 0.1x = 1
+        txtMarginTop.OnPointerReleased(new PointerRoutedEventArgs { Position = new Vector2(45f, 10f) });
+        InputSystem.Current.IsAltPressed = false;
+
+        // Assert margin top updated to 115 + 1 = 116
+        Assert.Equal("116", txtMarginTop.Text);
+        Assert.Equal(116f, button.Margin.Top);
+    }
+
+    [Fact]
+    public void Test_StylePanel_AllStyleInputs_ValueScrubbing()
+    {
+        var font = Microsoft.UI.Xaml.Controls.PopupService.DefaultFont;
+        var stylePanel = new StylePanel(font);
+
+        var button = new Button
+        {
+            Width = 100f,
+            Height = 30f,
+            Opacity = 1f
+        };
+
+        stylePanel.SelectedElement = button;
+
+        var type = typeof(StylePanel);
+        var txtWidthField = type.GetField("_txtWidth", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var txtOpacityField = type.GetField("_txtOpacity", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(txtWidthField);
+        Assert.NotNull(txtOpacityField);
+
+        var txtWidth = txtWidthField.GetValue(stylePanel) as TextBox;
+        var txtOpacity = txtOpacityField.GetValue(stylePanel) as TextBox;
+
+        Assert.NotNull(txtWidth);
+        Assert.NotNull(txtOpacity);
+
+        // Verify initial state
+        Assert.Equal("100", txtWidth.Text);
+        Assert.Equal("100", txtOpacity.Text);
+
+        // 1. Scrub Width horizontally by +50 pixels (normal speed 1x)
+        txtWidth.OnPointerPressed(new PointerRoutedEventArgs { Position = new Vector2(10f, 10f) });
+        txtWidth.OnPointerMoved(new PointerRoutedEventArgs { Position = new Vector2(60f, 10f) }); // dx = 50
+        txtWidth.OnPointerReleased(new PointerRoutedEventArgs { Position = new Vector2(60f, 10f) });
+
+        // Assert width updated to 150
+        Assert.Equal("150", txtWidth.Text);
+        Assert.Equal(150f, button.Width);
+
+        // 2. Scrub Opacity horizontally by -30 pixels (normal speed 1x)
+        txtOpacity.OnPointerPressed(new PointerRoutedEventArgs { Position = new Vector2(10f, 10f) });
+        txtOpacity.OnPointerMoved(new PointerRoutedEventArgs { Position = new Vector2(-20f, 10f) }); // dx = -30
+        txtOpacity.OnPointerReleased(new PointerRoutedEventArgs { Position = new Vector2(-20f, 10f) });
+
+        // Assert opacity updated to 100 - 30 = 70%, and element Opacity is 0.7f
+        Assert.Equal("70", txtOpacity.Text);
+        Assert.Equal(0.7f, button.Opacity);
+    }
 }
+
+

--- a/src/ProGPU.WinUI.Designer/DesignerCanvas.cs
+++ b/src/ProGPU.WinUI.Designer/DesignerCanvas.cs
@@ -12,6 +12,7 @@ using ProGPU.Scene;
 using ProGPU.Vector;
 using ProGPU.Text;
 using ProGPU.WinUI;
+using ProGPU.Layout;
 
 namespace ProGPU.WinUI.Designer;
 
@@ -65,6 +66,7 @@ public class DesignerCanvas : Panel
     public bool IsResizingElement { get; set; }
     public bool AlwaysShowPanelOutlines { get; set; } = false;
     public bool IsLogicalMode { get; set; } = true;
+    public bool IsResponsiveMode { get; set; } = false;
 
     public event Action? SelectionChanged;
     public event Action? CanvasModified;
@@ -98,7 +100,7 @@ public class DesignerCanvas : Panel
 
     public DesignerCanvas()
     {
-        DesignSurface = new Canvas();
+        DesignSurface = new DesignerSurfacePanel(this);
         AdornerSurface = new Canvas();
 
         base.AddChild(DesignSurface);
@@ -194,22 +196,31 @@ public class DesignerCanvas : Panel
         _selectionAdorner?.UpdatePositionAndSize();
     }
 
+    public float? ViewportWidth { get; set; } = null;
+
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
         float w = !float.IsFinite(availableSize.X) ? 2000f : availableSize.X;
         float h = !float.IsFinite(availableSize.Y) ? 2000f : availableSize.Y;
         
-        DesignSurface.Measure(new Vector2(w, h));
-        AdornerSurface.Measure(new Vector2(w, h));
+        float surfaceW = ViewportWidth ?? w;
+        
+        DesignSurface.Measure(new Vector2(surfaceW, h));
+        AdornerSurface.Measure(new Vector2(surfaceW, h));
         
         return new Vector2(w, h);
     }
 
     protected override void ArrangeOverride(Rect arrangeRect)
     {
-        DesignSurface.Arrange(arrangeRect);
+        float surfaceW = ViewportWidth ?? arrangeRect.Width;
+        float leftOffset = ViewportWidth.HasValue ? (arrangeRect.Width - ViewportWidth.Value) / 2f : 0f;
+        
+        Rect surfaceRect = new Rect(arrangeRect.X + leftOffset, arrangeRect.Y, surfaceW, arrangeRect.Height);
+        
+        DesignSurface.Arrange(surfaceRect);
         _selectionAdorner?.UpdatePositionAndSize();
-        AdornerSurface.Arrange(arrangeRect);
+        AdornerSurface.Arrange(surfaceRect);
     }
 
     public override void OnPointerPressed(PointerRoutedEventArgs e)
@@ -402,11 +413,18 @@ public class DesignerCanvas : Panel
             else
             {
                 // Standard canvas dragging (dragging in DesignSurface root)
-                Vector2 candidatePosInRoot = _dragStartElementPosInRoot + delta;
-                Vector2 snappedInRoot = SnapPosition(SelectedElement, candidatePosInRoot);
-                
-                Canvas.SetLeft(SelectedElement, snappedInRoot.X);
-                Canvas.SetTop(SelectedElement, snappedInRoot.Y);
+                if (IsResponsiveMode)
+                {
+                    ReorderRootChildren(SelectedElement, logicalPos);
+                }
+                else
+                {
+                    Vector2 candidatePosInRoot = _dragStartElementPosInRoot + delta;
+                    Vector2 snappedInRoot = SnapPosition(SelectedElement, candidatePosInRoot);
+                    
+                    Canvas.SetLeft(SelectedElement, snappedInRoot.X);
+                    Canvas.SetTop(SelectedElement, snappedInRoot.Y);
+                }
             }
 
             _selectionAdorner?.UpdatePositionAndSize();
@@ -1092,13 +1110,49 @@ public class DesignerCanvas : Panel
                             dropTarget = hitContainer;
                         }
 
+                        if (IsResponsiveMode)
+                        {
+                            // Reject Canvas containers in Webflow Mode
+                            if (newInstance is Canvas)
+                            {
+                                Console.WriteLine("[DesignerCanvas] Canvas container is not allowed in responsive Webflow mode.");
+                                return;
+                            }
+
+                            // If dropping on root, it must be a responsive container, not a leaf control
+                            if (dropTarget == DesignSurface)
+                            {
+                                if (!IsResponsiveContainer(newInstance))
+                                {
+                                    Console.WriteLine($"[DesignerCanvas] Cannot drop leaf control '{newInstance.GetType().Name}' directly on canvas root in Webflow mode. Place a responsive panel first.");
+                                    return;
+                                }
+                            }
+
+                            // Auto-stretch responsive containers and give default placeholder height
+                            if (IsResponsiveContainer(newInstance))
+                            {
+                                newInstance.HorizontalAlignment = ProGPU.Layout.HorizontalAlignment.Stretch;
+                                newInstance.Width = float.NaN;
+                                newInstance.Height = 100f; // placeholder height so empty panels are visible
+                            }
+                        }
+
                         if (dropTarget is Canvas canvasTarget)
                         {
-                            // Snap to grid relative to the canvas target
-                            Vector2 snappedPos = SnapPositionToGrid(args.Position - canvasTarget.Offset, GridSize);
-                            Canvas.SetLeft(newInstance, snappedPos.X);
-                            Canvas.SetTop(newInstance, snappedPos.Y);
-                            canvasTarget.Children.Add(newInstance);
+                            if (IsResponsiveMode && canvasTarget == DesignSurface)
+                            {
+                                // In responsive mode, append directly without coordinate attachment
+                                canvasTarget.Children.Add(newInstance);
+                            }
+                            else
+                            {
+                                // Snap to grid relative to the canvas target
+                                Vector2 snappedPos = SnapPositionToGrid(args.Position - canvasTarget.Offset, GridSize);
+                                Canvas.SetLeft(newInstance, snappedPos.X);
+                                Canvas.SetTop(newInstance, snappedPos.Y);
+                                canvasTarget.Children.Add(newInstance);
+                            }
                         }
                         else
                         {
@@ -1292,6 +1346,26 @@ public class DesignerCanvas : Panel
                 }
             }
         }
+
+        // 4. Responsive Device Viewport Outline Boundaries
+        if (ViewportWidth.HasValue)
+        {
+            var deviceBrush = ActualTheme == ElementTheme.Dark
+                ? new SolidColorBrush(new Vector4(1f, 1f, 1f, 0.15f))
+                : new SolidColorBrush(new Vector4(0f, 0f, 0f, 0.12f));
+            var devicePen = new Pen(deviceBrush, 2f / ZoomScale);
+            
+            float surfaceW = ViewportWidth.Value;
+            float leftOffset = (Size.X - surfaceW) / 2f;
+            
+            Vector2 p00 = new Vector2(leftOffset, 0f) * ZoomScale + PanOffset;
+            Vector2 p10 = new Vector2(leftOffset + surfaceW, 0f) * ZoomScale + PanOffset;
+            Vector2 p11 = new Vector2(leftOffset + surfaceW, Size.Y) * ZoomScale + PanOffset;
+            Vector2 p01 = new Vector2(leftOffset, Size.Y) * ZoomScale + PanOffset;
+            
+            context.DrawLine(devicePen, p00, p01);
+            context.DrawLine(devicePen, p10, p11);
+        }
     }
 
     private void DrawDashedVerticalLine(DrawingContext context, Pen pen, float x, float y1, float y2, float dashLength = 6f, float gapLength = 4f)
@@ -1407,6 +1481,70 @@ public class DesignerCanvas : Panel
             currentType = currentType.BaseType;
         }
         return null;
+    }
+
+    public bool IsResponsiveContainer(FrameworkElement fe)
+    {
+        if (fe is Canvas) return false;
+        if (fe is Microsoft.UI.Xaml.Controls.StackPanel || fe is Microsoft.UI.Xaml.Controls.Grid || fe is Microsoft.UI.Xaml.Controls.Border || fe is ScrollViewer || fe is SplitView || fe is WrapPanel || fe is DockPanel)
+        {
+            return true;
+        }
+        if (fe is Panel && !(fe is Canvas))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private void ReorderRootChildren(FrameworkElement child, Vector2 localMousePos)
+    {
+        var children = new List<Visual>();
+        int currentIdx = -1;
+
+        for (int i = 0; i < DesignSurface.Children.Count; i++)
+        {
+            var sibling = DesignSurface.Children[i];
+            if (sibling == child)
+            {
+                currentIdx = i;
+            }
+            else
+            {
+                children.Add(sibling);
+            }
+        }
+
+        if (currentIdx == -1) return;
+
+        int targetIdx = 0;
+        for (int i = 0; i < children.Count; i++)
+        {
+            var sibling = children[i] as FrameworkElement;
+            if (sibling == null) continue;
+
+            float height = float.IsNaN(sibling.Height) ? sibling.Size.Y : sibling.Height;
+            if (height <= 0) height = 100f; // Default min height
+
+            var transform = sibling.TransformToVisual(DesignSurface);
+            Vector2 siblingPos = transform.TransformPoint(Vector2.Zero);
+            float siblingCenterY = siblingPos.Y + height / 2f;
+
+            if (localMousePos.Y > siblingCenterY)
+            {
+                targetIdx = i + 1;
+            }
+        }
+
+        if (targetIdx != currentIdx)
+        {
+            children.Insert(targetIdx, child);
+            DesignSurface.ClearChildren();
+            foreach (var item in children)
+            {
+                DesignSurface.AddChild(item);
+            }
+        }
     }
 
     private bool IsValidDropContainer(FrameworkElement fe)
@@ -1607,6 +1745,59 @@ public class DesignerCanvas : Panel
                     FindNamesInVisualTree(child, names);
                 }
             }
+        }
+    }
+}
+
+public class DesignerSurfacePanel : Canvas
+{
+    private readonly DesignerCanvas _designer;
+
+    public DesignerSurfacePanel(DesignerCanvas designer)
+    {
+        _designer = designer;
+    }
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        if (_designer.IsResponsiveMode)
+        {
+            float width = 0;
+            float height = 0;
+            foreach (var child in Children)
+            {
+                if (child is LayoutNode node)
+                {
+                    node.Measure(availableSize);
+                    width = MathF.Max(width, node.DesiredSize.X);
+                    height += node.DesiredSize.Y;
+                }
+            }
+            return new Vector2(width, height);
+        }
+        else
+        {
+            return base.MeasureOverride(availableSize);
+        }
+    }
+
+    protected override void ArrangeOverride(Rect arrangeRect)
+    {
+        if (_designer.IsResponsiveMode)
+        {
+            float currentY = arrangeRect.Y;
+            foreach (var child in Children)
+            {
+                if (child is LayoutNode node)
+                {
+                    node.Arrange(new Rect(arrangeRect.X, currentY, arrangeRect.Width, node.DesiredSize.Y));
+                    currentY += node.DesiredSize.Y;
+                }
+            }
+        }
+        else
+        {
+            base.ArrangeOverride(arrangeRect);
         }
     }
 }

--- a/src/ProGPU.WinUI.Designer/DesignerHost.cs
+++ b/src/ProGPU.WinUI.Designer/DesignerHost.cs
@@ -24,6 +24,7 @@ public class DesignerHost : Grid
     private readonly Grid _sidebarLeft;
     private readonly Grid _workspaceCenter;
     private readonly Border _sidebarRightBorder;
+    private readonly StylePanel _stylePanel;
     private readonly PropertyGrid _propertyGrid;
     private readonly Border _bottomPanel;
     
@@ -36,6 +37,10 @@ public class DesignerHost : Grid
     private RichTextBlock? _zoomOutText;
     private RichTextBlock? _zoomInText;
     private RichTextBlock? _outlinesLabelText;
+    private RichTextBlock? _webflowLabelText;
+    private RichTextBlock? _desktopText;
+    private RichTextBlock? _tabletText;
+    private RichTextBlock? _mobileText;
     
     private class DesignState
     {
@@ -77,11 +82,33 @@ public class DesignerHost : Grid
         
         var contentGrid = new Grid();
         contentGrid.ColumnDefinitions.Add(new GridLength(260f, GridUnitType.Absolute));
+        contentGrid.ColumnDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
         contentGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        contentGrid.ColumnDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
         contentGrid.ColumnDefinitions.Add(new GridLength(280f, GridUnitType.Absolute));
         
         Grid.SetRow(contentGrid, 0);
         AddChild(contentGrid);
+
+        var leftSplitter = new GridSplitter
+        {
+            WidthConstraint = 6f,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            ResizeDirection = GridSplitterResizeDirection.Columns
+        };
+        Grid.SetColumn(leftSplitter, 1);
+        contentGrid.AddChild(leftSplitter);
+
+        var rightSplitter = new GridSplitter
+        {
+            WidthConstraint = 6f,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            ResizeDirection = GridSplitterResizeDirection.Columns
+        };
+        Grid.SetColumn(rightSplitter, 3);
+        contentGrid.AddChild(rightSplitter);
 
         // 1. Left Sidebar
         _sidebarLeftBorder = new Border
@@ -131,42 +158,241 @@ public class DesignerHost : Grid
         _workspaceCenter = new Grid();
         _workspaceCenter.RowDefinitions.Add(GridLength.Auto);
         _workspaceCenter.RowDefinitions.Add(GridLength.Star(1f));
-        Grid.SetColumn(_workspaceCenter, 1);
+        Grid.SetColumn(_workspaceCenter, 2);
         contentGrid.AddChild(_workspaceCenter);
 
-        var actionBar = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(12, 8, 12, 8) };
-        var gridLinesCheck = new CheckBox { IsChecked = true, Margin = new Thickness(0, 0, 16, 0) };
-        var gridLinesLabel = new RichTextBlock { FontSize = 11f };
-        gridLinesLabel.Inlines.Add(new Run("Show Snap Grid Lines"));
-        gridLinesCheck.Content = gridLinesLabel;
-        gridLinesCheck.CheckedChanged += (s, e) => {
-            _designerCanvas.ShowGridLines = gridLinesCheck.IsChecked;
+        // Reorganized elegant top visual designer settings bar
+        var toolbarBorder = new Border
+        {
+            Background = new ThemeResourceBrush("CardBackground"),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            Padding = new Thickness(16, 6, 16, 6),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+
+        var toolbarGrid = new Grid { HorizontalAlignment = HorizontalAlignment.Stretch };
+        toolbarGrid.ColumnDefinitions.Add(GridLength.Star(1f)); // Left section: canvas settings
+        toolbarGrid.ColumnDefinitions.Add(GridLength.Auto);      // Center section: viewport breakpoints
+        toolbarGrid.ColumnDefinitions.Add(GridLength.Star(1f)); // Right section: zoom & clear
+        toolbarBorder.Child = toolbarGrid;
+
+        // Custom Helper to dynamically style active vs inactive toggle buttons
+        Action<Button, bool> updateToggleStyle = (btn, isActive) => {
+            if (isActive)
+            {
+                btn.Background = new ThemeResourceBrush("SystemAccentColor");
+                if (btn.Content is RichTextBlock rtb)
+                {
+                    rtb.Foreground = new SolidColorBrush(Vector4.One); // white text
+                }
+                btn.BorderThickness = new Thickness(0);
+            }
+            else
+            {
+                btn.Background = new ThemeResourceBrush("ControlBackground");
+                if (btn.Content is RichTextBlock rtb)
+                {
+                    rtb.Foreground = new ThemeResourceBrush("TextPrimary");
+                }
+                btn.BorderThickness = new Thickness(1f);
+                btn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+            }
+        };
+
+        // 1. Left Section: Compact modern pill toggles
+        var leftPanel = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Center };
+
+        // Grid Lines Toggle
+        var btnGridLines = new Button { Height = 28f, Margin = new Thickness(0, 0, 6, 0), CornerRadius = 4f, Padding = new Thickness(8, 0, 8, 0) };
+        var rtbGrid = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        rtbGrid.Inlines.Add(new Run("🌐 Grid Lines"));
+        btnGridLines.Content = rtbGrid;
+        updateToggleStyle(btnGridLines, _designerCanvas.ShowGridLines);
+        btnGridLines.Click += (s, e) => {
+            _designerCanvas.ShowGridLines = !_designerCanvas.ShowGridLines;
+            updateToggleStyle(btnGridLines, _designerCanvas.ShowGridLines);
             _designerCanvas.Invalidate();
         };
-        actionBar.AddChild(gridLinesCheck);
+        leftPanel.AddChild(btnGridLines);
 
-        var snapCheck = new CheckBox { IsChecked = true, Margin = new Thickness(0, 0, 16, 0) };
-        var snapLabel = new RichTextBlock { FontSize = 11f };
-        snapLabel.Inlines.Add(new Run("Snap to Grid (10px)"));
-        snapCheck.Content = snapLabel;
-        snapCheck.CheckedChanged += (s, e) => {
-            _designerCanvas.GridSnappingEnabled = snapCheck.IsChecked;
+        // Grid Snapping Toggle
+        var btnSnapping = new Button { Height = 28f, Margin = new Thickness(0, 0, 6, 0), CornerRadius = 4f, Padding = new Thickness(8, 0, 8, 0) };
+        var rtbSnap = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        rtbSnap.Inlines.Add(new Run("🧲 Snap"));
+        btnSnapping.Content = rtbSnap;
+        updateToggleStyle(btnSnapping, _designerCanvas.GridSnappingEnabled);
+        btnSnapping.Click += (s, e) => {
+            _designerCanvas.GridSnappingEnabled = !_designerCanvas.GridSnappingEnabled;
+            updateToggleStyle(btnSnapping, _designerCanvas.GridSnappingEnabled);
         };
-        actionBar.AddChild(snapCheck);
+        leftPanel.AddChild(btnSnapping);
 
-        var outlinesCheck = new CheckBox { IsChecked = false, Margin = new Thickness(0, 0, 16, 0) };
-        _outlinesLabelText = new RichTextBlock { FontSize = 11f };
-        _outlinesLabelText.Inlines.Add(new Run("Always Show Panel Outlines"));
-        outlinesCheck.Content = _outlinesLabelText;
-        outlinesCheck.CheckedChanged += (s, e) => {
-            _designerCanvas.AlwaysShowPanelOutlines = outlinesCheck.IsChecked;
+        // Outlines Toggle
+        var btnOutlines = new Button { Height = 28f, Margin = new Thickness(0, 0, 6, 0), CornerRadius = 4f, Padding = new Thickness(8, 0, 8, 0) };
+        _outlinesLabelText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        _outlinesLabelText.Inlines.Add(new Run("🖼️ Outlines"));
+        btnOutlines.Content = _outlinesLabelText;
+        updateToggleStyle(btnOutlines, _designerCanvas.AlwaysShowPanelOutlines);
+        btnOutlines.Click += (s, e) => {
+            _designerCanvas.AlwaysShowPanelOutlines = !_designerCanvas.AlwaysShowPanelOutlines;
+            updateToggleStyle(btnOutlines, _designerCanvas.AlwaysShowPanelOutlines);
             _designerCanvas.Invalidate();
         };
-        actionBar.AddChild(outlinesCheck);
+        leftPanel.AddChild(btnOutlines);
 
-        var clearBtn = new Button { Width = 130f, Height = 32f, Margin = new Thickness(16, 0, 0, 0) };
-        var clearBtnText = new RichTextBlock { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        clearBtnText.Inlines.Add(new Run("Clear Workspace"));
+        // Responsive Mode Toggle
+        var btnResponsive = new Button { Height = 28f, Margin = new Thickness(0, 0, 6, 0), CornerRadius = 4f, Padding = new Thickness(8, 0, 8, 0) };
+        _webflowLabelText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        _webflowLabelText.Inlines.Add(new Run("⚡ Responsive"));
+        btnResponsive.Content = _webflowLabelText;
+        updateToggleStyle(btnResponsive, _designerCanvas.IsResponsiveMode);
+        btnResponsive.Click += (s, e) => {
+            _designerCanvas.IsResponsiveMode = !_designerCanvas.IsResponsiveMode;
+            updateToggleStyle(btnResponsive, _designerCanvas.IsResponsiveMode);
+            _designerCanvas.SelectElement(null);
+            _designerCanvas.Invalidate();
+            OnCanvasModified();
+            UpdateOutline();
+        };
+        leftPanel.AddChild(btnResponsive);
+
+        Grid.SetColumn(leftPanel, 0);
+        toolbarGrid.AddChild(leftPanel);
+
+        // 2. Center Section: Segmented Breakpoints Control Capsule
+        var centerPanel = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center };
+        
+        var desktopBtn = new Button { Width = 80f, Height = 28f, CornerRadius = 4f, Margin = new Thickness(0), Padding = new Thickness(0) };
+        _desktopText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        _desktopText.Inlines.Add(new Run("🖥️ Desktop"));
+        desktopBtn.Content = _desktopText;
+
+        var tabletBtn = new Button { Width = 75f, Height = 28f, CornerRadius = 0f, Margin = new Thickness(0), Padding = new Thickness(0) };
+        _tabletText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        _tabletText.Inlines.Add(new Run("📟 Tablet"));
+        tabletBtn.Content = _tabletText;
+
+        var mobileBtn = new Button { Width = 75f, Height = 28f, CornerRadius = 4f, Margin = new Thickness(0), Padding = new Thickness(0) };
+        _mobileText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        _mobileText.Inlines.Add(new Run("📱 Mobile"));
+        mobileBtn.Content = _mobileText;
+
+        Action updateBreakpointSegmentStyle = () => {
+            float? vw = _designerCanvas.ViewportWidth;
+            if (vw == null)
+            {
+                desktopBtn.Background = new ThemeResourceBrush("SystemAccentColor");
+                _desktopText.Foreground = new SolidColorBrush(Vector4.One);
+                desktopBtn.BorderThickness = new Thickness(0);
+
+                tabletBtn.Background = new ThemeResourceBrush("ControlBackground");
+                _tabletText.Foreground = new ThemeResourceBrush("TextPrimary");
+                tabletBtn.BorderThickness = new Thickness(1, 1, 1, 1);
+                tabletBtn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+
+                mobileBtn.Background = new ThemeResourceBrush("ControlBackground");
+                _mobileText.Foreground = new ThemeResourceBrush("TextPrimary");
+                mobileBtn.BorderThickness = new Thickness(0, 1, 1, 1);
+                mobileBtn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+            }
+            else if (vw == 768f)
+            {
+                desktopBtn.Background = new ThemeResourceBrush("ControlBackground");
+                _desktopText.Foreground = new ThemeResourceBrush("TextPrimary");
+                desktopBtn.BorderThickness = new Thickness(1, 1, 0, 1);
+                desktopBtn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+
+                tabletBtn.Background = new ThemeResourceBrush("SystemAccentColor");
+                _tabletText.Foreground = new SolidColorBrush(Vector4.One);
+                tabletBtn.BorderThickness = new Thickness(0);
+
+                mobileBtn.Background = new ThemeResourceBrush("ControlBackground");
+                _mobileText.Foreground = new ThemeResourceBrush("TextPrimary");
+                mobileBtn.BorderThickness = new Thickness(0, 1, 1, 1);
+                mobileBtn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+            }
+            else // 375f
+            {
+                desktopBtn.Background = new ThemeResourceBrush("ControlBackground");
+                _desktopText.Foreground = new ThemeResourceBrush("TextPrimary");
+                desktopBtn.BorderThickness = new Thickness(1, 1, 0, 1);
+                desktopBtn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+
+                tabletBtn.Background = new ThemeResourceBrush("ControlBackground");
+                _tabletText.Foreground = new ThemeResourceBrush("TextPrimary");
+                tabletBtn.BorderThickness = new Thickness(1, 1, 1, 1);
+                tabletBtn.BorderBrush = new ThemeResourceBrush("ControlBorder");
+
+                mobileBtn.Background = new ThemeResourceBrush("SystemAccentColor");
+                _mobileText.Foreground = new SolidColorBrush(Vector4.One);
+                mobileBtn.BorderThickness = new Thickness(0);
+            }
+        };
+
+        desktopBtn.Click += (s, e) => {
+            _designerCanvas.ViewportWidth = null;
+            updateBreakpointSegmentStyle();
+            _designerCanvas.InvalidateArrange();
+            _designerCanvas.Invalidate();
+            _designerCanvas.UpdateSelectionAdorner();
+        };
+
+        tabletBtn.Click += (s, e) => {
+            _designerCanvas.ViewportWidth = 768f;
+            updateBreakpointSegmentStyle();
+            _designerCanvas.InvalidateArrange();
+            _designerCanvas.Invalidate();
+            _designerCanvas.UpdateSelectionAdorner();
+        };
+
+        mobileBtn.Click += (s, e) => {
+            _designerCanvas.ViewportWidth = 375f;
+            updateBreakpointSegmentStyle();
+            _designerCanvas.InvalidateArrange();
+            _designerCanvas.Invalidate();
+            _designerCanvas.UpdateSelectionAdorner();
+        };
+
+        updateBreakpointSegmentStyle(); // Initial breakpoint state
+
+        centerPanel.AddChild(desktopBtn);
+        centerPanel.AddChild(tabletBtn);
+        centerPanel.AddChild(mobileBtn);
+
+        Grid.SetColumn(centerPanel, 1);
+        toolbarGrid.AddChild(centerPanel);
+
+        // 3. Right Section: History, Workspace Management, Zoom Controls
+        var rightPanel = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Right };
+
+        // Undo & Redo Capsule Group
+        var historyPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 12, 0) };
+        
+        var undoBtn = new Button { Width = 65f, Height = 28f, CornerRadius = 4f, Margin = new Thickness(0), Background = new ThemeResourceBrush("ControlBackground"), BorderThickness = new Thickness(1), BorderBrush = new ThemeResourceBrush("ControlBorder"), Padding = new Thickness(0) };
+        var undoText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        undoText.Inlines.Add(new Run("↩️ Undo"));
+        undoBtn.Content = undoText;
+        undoBtn.Click += (s, e) => {
+            TriggerUndo();
+        };
+        historyPanel.AddChild(undoBtn);
+
+        var redoBtn = new Button { Width = 65f, Height = 28f, CornerRadius = 4f, Margin = new Thickness(0), Background = new ThemeResourceBrush("ControlBackground"), BorderThickness = new Thickness(0, 1, 1, 1), BorderBrush = new ThemeResourceBrush("ControlBorder"), Padding = new Thickness(0) };
+        var redoText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        redoText.Inlines.Add(new Run("↪️ Redo"));
+        redoBtn.Content = redoText;
+        redoBtn.Click += (s, e) => {
+            TriggerRedo();
+        };
+        historyPanel.AddChild(redoBtn);
+        rightPanel.AddChild(historyPanel);
+
+        // Clear Workspace button
+        var clearBtn = new Button { Height = 28f, Margin = new Thickness(0, 0, 12, 0), CornerRadius = 4f, Background = new ThemeResourceBrush("ControlBackground"), BorderThickness = new Thickness(1), BorderBrush = new ThemeResourceBrush("ControlBorder"), Padding = new Thickness(10, 0, 10, 0) };
+        var clearBtnText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center, Foreground = new ThemeResourceBrush("TextPrimary") };
+        clearBtnText.Inlines.Add(new Run("🗑️ Clear"));
         clearBtn.Content = clearBtnText;
         clearBtn.Click += (s, e) => {
             SaveUndoState();
@@ -176,19 +402,23 @@ public class DesignerHost : Grid
             OnCanvasModified();
             UpdateOutline();
         };
-        actionBar.AddChild(clearBtn);
+        rightPanel.AddChild(clearBtn);
 
-        // Zoom Controls
-        var zoomOutBtn = new Button { Width = 32f, Height = 32f, Margin = new Thickness(24, 0, 0, 0) };
-        _zoomOutText = new RichTextBlock { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        // Zoom capsule
+        var zoomPanel = new StackPanel { Orientation = Orientation.Horizontal };
+        
+        var zoomOutBtn = new Button { Width = 28f, Height = 28f, CornerRadius = 4f, Margin = new Thickness(0), Background = new ThemeResourceBrush("ControlBackground"), BorderThickness = new Thickness(1), BorderBrush = new ThemeResourceBrush("ControlBorder") };
+        _zoomOutText = new RichTextBlock { Font = DesignerFont, FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
         _zoomOutText.Inlines.Add(new Run("-"));
         zoomOutBtn.Content = _zoomOutText;
 
-        _zoomValText = new RichTextBlock { FontSize = 11f, Margin = new Thickness(8, 0, 8, 0), VerticalAlignment = VerticalAlignment.Center };
+        var zoomValBorder = new Border { Height = 28f, Background = new ThemeResourceBrush("ControlBackground"), BorderThickness = new Thickness(0, 1, 0, 1), BorderBrush = new ThemeResourceBrush("ControlBorder"), Padding = new Thickness(8, 0, 8, 0), VerticalAlignment = VerticalAlignment.Stretch };
+        _zoomValText = new RichTextBlock { Font = DesignerFont, FontSize = 10.5f, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center };
         _zoomValText.Inlines.Add(new Run("100%"));
+        zoomValBorder.Child = _zoomValText;
 
-        var zoomInBtn = new Button { Width = 32f, Height = 32f, Margin = new Thickness(0, 0, 0, 0) };
-        _zoomInText = new RichTextBlock { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        var zoomInBtn = new Button { Width = 28f, Height = 28f, CornerRadius = 4f, Margin = new Thickness(0), Background = new ThemeResourceBrush("ControlBackground"), BorderThickness = new Thickness(1, 1, 1, 1), BorderBrush = new ThemeResourceBrush("ControlBorder") };
+        _zoomInText = new RichTextBlock { Font = DesignerFont, FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
         _zoomInText.Inlines.Add(new Run("+"));
         zoomInBtn.Content = _zoomInText;
 
@@ -210,14 +440,19 @@ public class DesignerHost : Grid
             UpdateZoomLabel();
         };
 
-        actionBar.AddChild(zoomOutBtn);
-        actionBar.AddChild(_zoomValText);
-        actionBar.AddChild(zoomInBtn);
+        zoomPanel.AddChild(zoomOutBtn);
+        zoomPanel.AddChild(zoomValBorder);
+        zoomPanel.AddChild(zoomInBtn);
+        rightPanel.AddChild(zoomPanel);
 
-        Grid.SetRow(actionBar, 0);
-        _workspaceCenter.AddChild(actionBar);
+        Grid.SetColumn(rightPanel, 2);
+        toolbarGrid.AddChild(rightPanel);
+
+        _workspaceCenter.AddChild(toolbarBorder);
+        Grid.SetRow(toolbarBorder, 0);
 
         _designerCanvas.SelectionChanged += () => {
+            _stylePanel.SelectedElement = _designerCanvas.SelectedElement;
             _propertyGrid.SelectedElement = _designerCanvas.SelectedElement;
             UpdateOutline();
         };
@@ -230,10 +465,18 @@ public class DesignerHost : Grid
             VerticalAlignment = VerticalAlignment.Stretch
         };
 
-        Grid.SetRow(canvasScrollViewer, 1);
         _workspaceCenter.AddChild(canvasScrollViewer);
+        Grid.SetRow(canvasScrollViewer, 1);
 
-        // 3. Right Sidebar - PropertyGrid
+        // 3. Right Sidebar - StylePanel & PropertyGrid in Pivot
+        _stylePanel = new StylePanel(DesignerFont);
+        _stylePanel.PropertyChanged += () => {
+            _designerCanvas.UpdateSelectionAdorner();
+            _designerCanvas.Invalidate();
+            OnCanvasModified();
+            UpdateOutline();
+        };
+
         _propertyGrid = new PropertyGrid(DesignerFont);
         _propertyGrid.PropertyChanged += () => {
             _designerCanvas.UpdateSelectionAdorner();
@@ -242,14 +485,43 @@ public class DesignerHost : Grid
             UpdateOutline();
         };
 
+        var sidebarPivot = new Pivot
+        {
+            Font = DesignerFont,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Padding = new Thickness(0)
+        };
+
+        var tabStyle = new PivotItem("Style", _stylePanel);
+        var tabSettings = new PivotItem("Property Grid", _propertyGrid);
+
+        var interactionsStack = new StackPanel { Orientation = Orientation.Vertical, Padding = new Thickness(16) };
+        var interactionsTitle = new RichTextBlock { Font = DesignerFont, FontSize = 12f, Margin = new Thickness(0, 0, 0, 8) };
+        interactionsTitle.Inlines.Add(new Bold(new Run("Element Interactions")));
+        interactionsTitle.Foreground = new ThemeResourceBrush("TextPrimary");
+
+        var interactionsDesc = new RichTextBlock { Font = DesignerFont, FontSize = 10f };
+        interactionsDesc.Foreground = new ThemeResourceBrush("TextSecondary");
+        interactionsDesc.Inlines.Add(new Run("Add dynamic triggers, hover transitions, and click behaviors to make your elements feel responsive and alive."));
+
+        interactionsStack.AddChild(interactionsTitle);
+        interactionsStack.AddChild(interactionsDesc);
+
+        var tabInteractions = new PivotItem("Interactions", interactionsStack);
+
+        sidebarPivot.Items.Add(tabStyle);
+        sidebarPivot.Items.Add(tabSettings);
+        sidebarPivot.Items.Add(tabInteractions);
+
         _sidebarRightBorder = new Border
         {
             Background = new ThemeResourceBrush("CardBackground"),
             BorderThickness = new Thickness(1, 0, 0, 0),
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
-            Child = _propertyGrid
+            Child = sidebarPivot
         };
-        Grid.SetColumn(_sidebarRightBorder, 2);
+        Grid.SetColumn(_sidebarRightBorder, 4);
         contentGrid.AddChild(_sidebarRightBorder);
 
         // 4. Bottom Collapsible Panel - C# Script Preview
@@ -313,11 +585,12 @@ public class DesignerHost : Grid
 
         TtfFont primaryFont = DesignerFont ?? Microsoft.UI.Xaml.Controls.PopupService.DefaultFont;
         TtfFont courierFont = DesignerFontCourier ?? DesignerFont ?? Microsoft.UI.Xaml.Controls.PopupService.DefaultFont;
-        
-        gridLinesLabel.Font = primaryFont;
-        snapLabel.Font = primaryFont;
+
         if (_outlinesLabelText != null) _outlinesLabelText.Font = primaryFont;
-        clearBtnText.Font = primaryFont;
+        if (_webflowLabelText != null) _webflowLabelText.Font = primaryFont;
+        if (_desktopText != null) _desktopText.Font = primaryFont;
+        if (_tabletText != null) _tabletText.Font = primaryFont;
+        if (_mobileText != null) _mobileText.Font = primaryFont;
         if (_zoomOutText != null) _zoomOutText.Font = primaryFont;
         if (_zoomValText != null) _zoomValText.Font = primaryFont;
         if (_zoomInText != null) _zoomInText.Font = primaryFont;
@@ -346,6 +619,10 @@ public class DesignerHost : Grid
         if (_zoomValText != null) _zoomValText.Font = primaryFont;
         if (_zoomInText != null) _zoomInText.Font = primaryFont;
         if (_outlinesLabelText != null) _outlinesLabelText.Font = primaryFont;
+        if (_webflowLabelText != null) _webflowLabelText.Font = primaryFont;
+        if (_desktopText != null) _desktopText.Font = primaryFont;
+        if (_tabletText != null) _tabletText.Font = primaryFont;
+        if (_mobileText != null) _mobileText.Font = primaryFont;
         _csharpCodeBlock.Font = courierFont;
         _visualTreeOutline.Font = primaryFont;
         
@@ -634,14 +911,31 @@ public class DesignerHost : Grid
         SaveUndoState();
 
         float factor = InputSystem.Current.IsShiftPressed ? 10f : 1f;
-        float currentLeft = Canvas.GetLeft(sel);
-        float currentTop = Canvas.GetTop(sel);
 
-        float newLeft = currentLeft + dx * factor;
-        float newTop = currentTop + dy * factor;
+        if (_designerCanvas.IsResponsiveMode)
+        {
+            var currentMargin = sel.Margin;
+            float newLeft = currentMargin.Left + dx * factor;
+            float newTop = currentMargin.Top + dy * factor;
 
-        Canvas.SetLeft(sel, newLeft);
-        Canvas.SetTop(sel, newTop);
+            sel.Margin = new Thickness(
+                MathF.Max(0f, newLeft),
+                MathF.Max(0f, newTop),
+                MathF.Max(0f, currentMargin.Right),
+                MathF.Max(0f, currentMargin.Bottom)
+            );
+        }
+        else
+        {
+            float currentLeft = Canvas.GetLeft(sel);
+            float currentTop = Canvas.GetTop(sel);
+
+            float newLeft = currentLeft + dx * factor;
+            float newTop = currentTop + dy * factor;
+
+            Canvas.SetLeft(sel, newLeft);
+            Canvas.SetTop(sel, newTop);
+        }
 
         _designerCanvas.UpdateSelectionAdorner();
         _designerCanvas.Invalidate();
@@ -785,10 +1079,13 @@ public class DesignerHost : Grid
             clone.Opacity = original.Opacity;
             clone.IsHitTestVisible = original.IsHitTestVisible;
 
-            float left = Canvas.GetLeft(original);
-            float top = Canvas.GetTop(original);
-            Canvas.SetLeft(clone, left + 20f);
-            Canvas.SetTop(clone, top + 20f);
+            if (!_designerCanvas.IsResponsiveMode)
+            {
+                float left = Canvas.GetLeft(original);
+                float top = Canvas.GetTop(original);
+                Canvas.SetLeft(clone, left + 20f);
+                Canvas.SetTop(clone, top + 20f);
+            }
 
             if (original is Button origButton && clone is Button cloneButton)
             {

--- a/src/ProGPU.WinUI.Designer/DesignerSerializer.cs
+++ b/src/ProGPU.WinUI.Designer/DesignerSerializer.cs
@@ -26,7 +26,7 @@ public static class DesignerSerializer
         "volatile", "while"
     };
 
-    public static string SerializeToCSharp(Canvas canvas)
+    public static string SerializeToCSharp(Canvas canvas, bool isResponsiveMode = false)
     {
         if (canvas == null) return "";
 
@@ -63,7 +63,7 @@ public static class DesignerSerializer
         {
             if (child is FrameworkElement childFe)
             {
-                var childVar = SerializeElement(childFe, ref varCounter, declaredNames, sb, 2);
+                var childVar = SerializeElement(childFe, ref varCounter, declaredNames, sb, 2, isResponsiveMode);
                 sb.AppendLine($"        rootCanvas.Children.Add({childVar});");
                 sb.AppendLine();
             }
@@ -76,7 +76,7 @@ public static class DesignerSerializer
         return sb.ToString();
     }
 
-    private static string SerializeElement(FrameworkElement element, ref int varCounter, HashSet<string> declaredNames, StringBuilder sb, int indentLevel)
+    private static string SerializeElement(FrameworkElement element, ref int varCounter, HashSet<string> declaredNames, StringBuilder sb, int indentLevel, bool isResponsiveMode)
     {
         var typeName = element.GetType().Name;
         
@@ -377,15 +377,18 @@ public static class DesignerSerializer
         }
 
         // Set Attached properties
-        float left = Canvas.GetLeft(element);
-        float top = Canvas.GetTop(element);
-        if (left != 0)
+        if (!isResponsiveMode)
         {
-            sb.AppendLine($"{indent}Canvas.SetLeft({varName}, {FormatFloat(left)}f);");
-        }
-        if (top != 0)
-        {
-            sb.AppendLine($"{indent}Canvas.SetTop({varName}, {FormatFloat(top)}f);");
+            float left = Canvas.GetLeft(element);
+            float top = Canvas.GetTop(element);
+            if (left != 0)
+            {
+                sb.AppendLine($"{indent}Canvas.SetLeft({varName}, {FormatFloat(left)}f);");
+            }
+            if (top != 0)
+            {
+                sb.AppendLine($"{indent}Canvas.SetTop({varName}, {FormatFloat(top)}f);");
+            }
         }
 
         int row = Microsoft.UI.Xaml.Controls.Grid.GetRow(element);
@@ -419,7 +422,7 @@ public static class DesignerSerializer
                 var paneVal = paneProp.GetValue(element);
                 if (paneVal is FrameworkElement paneFe)
                 {
-                    var paneVar = SerializeElement(paneFe, ref varCounter, declaredNames, sb, indentLevel);
+                    var paneVar = SerializeElement(paneFe, ref varCounter, declaredNames, sb, indentLevel, isResponsiveMode);
                     sb.AppendLine($"{indent}{varName}.Pane = {paneVar};");
                 }
             }
@@ -430,7 +433,7 @@ public static class DesignerSerializer
                 var contentVal = splitContentProp.GetValue(element);
                 if (contentVal is FrameworkElement contentFe)
                 {
-                    var contentVar = SerializeElement(contentFe, ref varCounter, declaredNames, sb, indentLevel);
+                    var contentVar = SerializeElement(contentFe, ref varCounter, declaredNames, sb, indentLevel, isResponsiveMode);
                     sb.AppendLine($"{indent}{varName}.Content = {contentVar};");
                 }
             }
@@ -464,7 +467,7 @@ public static class DesignerSerializer
                 }
                 else if (contentVal is FrameworkElement contentFe)
                 {
-                    var contentVar = SerializeElement(contentFe, ref varCounter, declaredNames, sb, indentLevel);
+                    var contentVar = SerializeElement(contentFe, ref varCounter, declaredNames, sb, indentLevel, isResponsiveMode);
                     sb.AppendLine($"{indent}{varName}.Content = {contentVar};");
                 }
                 else if (contentVal != null)
@@ -482,7 +485,7 @@ public static class DesignerSerializer
             var childVal = childProp.GetValue(element);
             if (childVal is FrameworkElement childFe)
             {
-                var childVar = SerializeElement(childFe, ref varCounter, declaredNames, sb, indentLevel);
+                var childVar = SerializeElement(childFe, ref varCounter, declaredNames, sb, indentLevel, isResponsiveMode);
                 sb.AppendLine($"{indent}{varName}.Child = {childVar};");
             }
         }
@@ -494,7 +497,7 @@ public static class DesignerSerializer
             {
                 if (childNode is FrameworkElement childFe)
                 {
-                    var childVar = SerializeElement(childFe, ref varCounter, declaredNames, sb, indentLevel);
+                    var childVar = SerializeElement(childFe, ref varCounter, declaredNames, sb, indentLevel, isResponsiveMode);
                     sb.AppendLine($"{indent}{varName}.Children.Add({childVar});");
                 }
             }

--- a/src/ProGPU.WinUI.Designer/SelectionAdorner.cs
+++ b/src/ProGPU.WinUI.Designer/SelectionAdorner.cs
@@ -354,6 +354,11 @@ public class SelectionAdorner : Panel
 
     public override void OnRender(DrawingContext context)
     {
+        if (ParentCanvas != null && ParentCanvas.IsResponsiveMode)
+        {
+            DrawBoxModelOverlays(context, ZoomScale);
+        }
+
         base.OnRender(context);
 
         if (AssociatedElement == null || ParentCanvas == null) return;
@@ -702,5 +707,55 @@ public class SelectionAdorner : Panel
         );
 
         context.DrawText(text, font, fontSize, textBrush, textPos);
+    }
+
+    private void DrawBoxModelOverlays(DrawingContext context, float z)
+    {
+        if (AssociatedElement == null || ParentCanvas == null) return;
+
+        float w = Size.X;
+        float h = Size.Y;
+
+        // 1. Draw Margin Overlay (Translucent Orange/Peach)
+        var margin = AssociatedElement.Margin;
+        var marginBrush = new SolidColorBrush(new Vector4(0.98f, 0.44f, 0.20f, 0.20f)); // Translucent Orange
+
+        if (margin.Left > 0f)
+        {
+            context.DrawRectangle(marginBrush, null, new Rect(-margin.Left, 0f, margin.Left, h));
+        }
+        if (margin.Right > 0f)
+        {
+            context.DrawRectangle(marginBrush, null, new Rect(w, 0f, margin.Right, h));
+        }
+        if (margin.Top > 0f)
+        {
+            context.DrawRectangle(marginBrush, null, new Rect(-margin.Left, -margin.Top, w + margin.Left + margin.Right, margin.Top));
+        }
+        if (margin.Bottom > 0f)
+        {
+            context.DrawRectangle(marginBrush, null, new Rect(-margin.Left, h, w + margin.Left + margin.Right, margin.Bottom));
+        }
+
+        // 2. Draw Padding Overlay (Translucent Green/Teal)
+        var padding = AssociatedElement.Padding;
+        var paddingBrush = new SolidColorBrush(new Vector4(0.24f, 0.82f, 0.61f, 0.22f)); // Translucent Teal
+
+        if (padding.Left > 0f)
+        {
+            context.DrawRectangle(paddingBrush, null, new Rect(0f, 0f, MathF.Min(padding.Left, w), h));
+        }
+        if (padding.Right > 0f)
+        {
+            context.DrawRectangle(paddingBrush, null, new Rect(MathF.Max(0f, w - padding.Right), 0f, MathF.Min(padding.Right, w), h));
+        }
+        if (padding.Top > 0f)
+        {
+            context.DrawRectangle(paddingBrush, null, new Rect(0f, 0f, w, MathF.Min(padding.Top, h)));
+        }
+        if (padding.Bottom > 0f)
+        {
+            context.DrawRectangle(paddingBrush, null, new Rect(0f, MathF.Max(0f, h - padding.Bottom), w, MathF.Min(padding.Bottom, h)));
+        }
     }
 }

--- a/src/ProGPU.WinUI.Designer/StylePanel.cs
+++ b/src/ProGPU.WinUI.Designer/StylePanel.cs
@@ -1,0 +1,959 @@
+namespace ProGPU.WinUI.Designer;
+
+using System;
+using System.Reflection;
+using System.Text;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Documents;
+using Thickness = Microsoft.UI.Xaml.Thickness;
+using HorizontalAlignment = ProGPU.Layout.HorizontalAlignment;
+using VerticalAlignment = ProGPU.Layout.VerticalAlignment;
+using System.Numerics;
+using ProGPU.Vector;
+using ProGPU.Layout;
+using ProGPU.Scene;
+
+using StackPanel = Microsoft.UI.Xaml.Controls.StackPanel;
+using Grid = Microsoft.UI.Xaml.Controls.Grid;
+
+public class StylePanel : Border
+{
+    private FrameworkElement? _selectedElement;
+    private readonly ProGPU.Text.TtfFont? _font;
+    private bool _isUpdatingFields = false;
+    
+    // Value Scrubbing Fields (Webflow drag-to-set style interaction)
+    private bool _isScrubbing = false;
+    private bool _hasScrubbed = false;
+    private TextBox? _scrubbedTextBox = null;
+    private Vector2 _scrubStartPos;
+    private float _scrubStartValue = 0f;
+
+    // Style Selector Section
+    private readonly RichTextBlock _selectorTypeLabel;
+    private readonly TextBox _selectorNameInput;
+
+    // Layout Section
+    private readonly Button _btnLayoutBlock;
+    private readonly Button _btnLayoutFlex;
+
+    // Spacing (Box Model) TextBoxes
+    private TextBox _txtMarginTop = null!;
+    private TextBox _txtMarginLeft = null!;
+    private TextBox _txtMarginRight = null!;
+    private TextBox _txtMarginBottom = null!;
+    private TextBox _txtPaddingTop = null!;
+    private TextBox _txtPaddingLeft = null!;
+    private TextBox _txtPaddingRight = null!;
+    private TextBox _txtPaddingBottom = null!;
+
+    // Sizing & Alignment Section TextBoxes & ComboBoxes
+    private TextBox _txtWidth = null!;
+    private TextBox _txtHeight = null!;
+    private ComboBox _cmbHorizontalAlignment = null!;
+    private ComboBox _cmbVerticalAlignment = null!;
+
+    // Appearance Section
+    private TextBox _txtBgColor = null!;
+    private TextBox _txtBorderRadius = null!;
+    private TextBox _txtBorderWidth = null!;
+    private TextBox _txtBorderColor = null!;
+    private TextBox _txtOpacity = null!;
+    private ComboBox _cmbVisibility = null!;
+
+    public event Action? PropertyChanged;
+
+    public FrameworkElement? SelectedElement
+    {
+        get => _selectedElement;
+        set
+        {
+            if (_selectedElement != value)
+            {
+                _selectedElement = value;
+                RefreshFields();
+            }
+        }
+    }
+
+    public StylePanel(ProGPU.Text.TtfFont? font)
+    {
+        _font = font;
+
+        Background = new ThemeResourceBrush("PageBackground");
+        Padding = new Thickness(0);
+        HorizontalAlignment = HorizontalAlignment.Stretch;
+        VerticalAlignment = VerticalAlignment.Stretch;
+
+        var mainLayout = new StackPanel { Orientation = Orientation.Vertical };
+
+        // 1. STYLE SELECTOR SECTION
+        var selectorPanel = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(0, 0, 0, 4) };
+        _selectorTypeLabel = new RichTextBlock { Font = _font, FontSize = 10f, Margin = new Thickness(0, 0, 0, 2) };
+        _selectorTypeLabel.Foreground = new ThemeResourceBrush("TextSecondary");
+        _selectorTypeLabel.Inlines.Add(new Run("STYLE SELECTOR:"));
+
+        var selectorHeader = new Grid();
+        selectorHeader.ColumnDefinitions.Add(GridLength.Auto);
+        selectorHeader.ColumnDefinitions.Add(GridLength.Star(1f));
+
+        var pillBorder = new Border
+        {
+            Background = new ThemeResourceBrush("SystemAccentColor"),
+            CornerRadius = 4f,
+            Padding = new Thickness(8, 4, 8, 4),
+            Margin = new Thickness(0, 4, 0, 4),
+            HorizontalAlignment = HorizontalAlignment.Left
+        };
+        var pillText = new RichTextBlock { Font = _font, FontSize = 11f };
+        pillText.Foreground = new ThemeResourceBrush("Transparent"); // White fallback
+        pillText.Inlines.Add(new Bold(new Run("Tag")));
+        pillBorder.Child = pillText;
+        Grid.SetColumn(pillBorder, 0);
+        selectorHeader.AddChild(pillBorder);
+
+        selectorPanel.AddChild(_selectorTypeLabel);
+        selectorPanel.AddChild(selectorHeader);
+
+        _selectorNameInput = new TextBox
+        {
+            HeightConstraint = 28f,
+            FontSize = 11f,
+            Padding = new Thickness(8, 4, 8, 4),
+            PlaceholderText = "Control name...",
+            Margin = new Thickness(0, 8, 0, 0)
+        };
+        _selectorNameInput.TextChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            _selectedElement.Name = _selectorNameInput.Text.Trim();
+            PropertyChanged?.Invoke();
+        };
+        selectorPanel.AddChild(_selectorNameInput);
+
+        var selectorCard = new Border
+        {
+            Background = new ThemeResourceBrush("CardBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            Padding = new Thickness(12, 10, 12, 12),
+            Child = selectorPanel
+        };
+        mainLayout.AddChild(selectorCard);
+
+        // 2. LAYOUT & ORIENTATION SECTION
+        var layoutGrid = new Grid();
+        layoutGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        layoutGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+
+        _btnLayoutBlock = new Button { HeightConstraint = 26f };
+        var txtBlock = new RichTextBlock { Font = _font, FontSize = 9.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        txtBlock.Inlines.Add(new Run("Vertical Stack"));
+        _btnLayoutBlock.Content = txtBlock;
+
+        _btnLayoutFlex = new Button { HeightConstraint = 26f };
+        var txtFlex = new RichTextBlock { Font = _font, FontSize = 9.5f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        txtFlex.Inlines.Add(new Run("Horizontal Stack"));
+        _btnLayoutFlex.Content = txtFlex;
+
+        Grid.SetColumn(_btnLayoutBlock, 0);
+        Grid.SetColumn(_btnLayoutFlex, 1);
+
+        layoutGrid.AddChild(_btnLayoutBlock);
+        layoutGrid.AddChild(_btnLayoutFlex);
+
+        _btnLayoutBlock.Click += (s, e) => ApplyLayoutMode("Block");
+        _btnLayoutFlex.Click += (s, e) => ApplyLayoutMode("Flex");
+
+        mainLayout.AddChild(CreateSection("Layout & Direction", layoutGrid));
+
+        // 3. SPACING (BOX MODEL) SECTION
+        var spacingWidget = CreateSpacingWidget();
+        mainLayout.AddChild(CreateSection("Spacing (Margin & Padding)", spacingWidget));
+
+        // 4. SIZING & ALIGNMENT SECTION
+        var sizeGrid = new Grid();
+        sizeGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        sizeGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        sizeGrid.RowDefinitions.Add(GridLength.Auto);
+        sizeGrid.RowDefinitions.Add(GridLength.Auto);
+
+        _txtWidth = CreateTextBoxInput("Width", "Auto");
+        _txtHeight = CreateTextBoxInput("Height", "Auto");
+
+        RegisterDragScrubber(_txtWidth, minValue: 0f, isDimension: true);
+        RegisterDragScrubber(_txtHeight, minValue: 0f, isDimension: true);
+
+        _cmbHorizontalAlignment = new ComboBox { HeightConstraint = 26f, FontSize = 10f, WidthConstraint = 105f };
+        _cmbHorizontalAlignment.Items.Add(new ComboBoxItem("Stretch"));
+        _cmbHorizontalAlignment.Items.Add(new ComboBoxItem("Left"));
+        _cmbHorizontalAlignment.Items.Add(new ComboBoxItem("Center"));
+        _cmbHorizontalAlignment.Items.Add(new ComboBoxItem("Right"));
+        _cmbHorizontalAlignment.SelectedItem = _cmbHorizontalAlignment.Items[0];
+
+        _cmbVerticalAlignment = new ComboBox { HeightConstraint = 26f, FontSize = 10f, WidthConstraint = 105f };
+        _cmbVerticalAlignment.Items.Add(new ComboBoxItem("Stretch"));
+        _cmbVerticalAlignment.Items.Add(new ComboBoxItem("Top"));
+        _cmbVerticalAlignment.Items.Add(new ComboBoxItem("Center"));
+        _cmbVerticalAlignment.Items.Add(new ComboBoxItem("Bottom"));
+        _cmbVerticalAlignment.SelectedItem = _cmbVerticalAlignment.Items[0];
+
+        _txtWidth.TextChanged += (s, e) => UpdateWidthFromUi();
+        _txtHeight.TextChanged += (s, e) => UpdateHeightFromUi();
+
+        _cmbHorizontalAlignment.SelectionChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            if (Enum.TryParse<HorizontalAlignment>(_cmbHorizontalAlignment.SelectedItem?.Text, out var hAlign))
+            {
+                _selectedElement.HorizontalAlignment = hAlign;
+                NotifyChanged();
+            }
+        };
+
+        _cmbVerticalAlignment.SelectionChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            if (Enum.TryParse<VerticalAlignment>(_cmbVerticalAlignment.SelectedItem?.Text, out var vAlign))
+            {
+                _selectedElement.VerticalAlignment = vAlign;
+                NotifyChanged();
+            }
+        };
+
+        sizeGrid.AddChild(CreateFieldWrapper("Width", _txtWidth, 0, 0));
+        sizeGrid.AddChild(CreateFieldWrapper("Height", _txtHeight, 0, 1));
+        sizeGrid.AddChild(CreateFieldWrapper("Align Horiz", _cmbHorizontalAlignment, 1, 0));
+        sizeGrid.AddChild(CreateFieldWrapper("Align Vert", _cmbVerticalAlignment, 1, 1));
+
+        mainLayout.AddChild(CreateSection("Sizing & Alignment", sizeGrid));
+
+        // 5. APPEARANCE SECTION
+        var bgBorderGrid = new Grid();
+        bgBorderGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        bgBorderGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        bgBorderGrid.RowDefinitions.Add(GridLength.Auto);
+        bgBorderGrid.RowDefinitions.Add(GridLength.Auto);
+        bgBorderGrid.RowDefinitions.Add(GridLength.Auto);
+
+        _txtBgColor = CreateTextBoxInput("Color", "#FFFFFF");
+        _txtBorderRadius = CreateTextBoxInput("Radius", "0");
+        _txtBorderWidth = CreateTextBoxInput("Width", "0");
+        _txtBorderColor = CreateTextBoxInput("Color", "#000000");
+        _txtOpacity = CreateTextBoxInput("Opacity", "100");
+
+        RegisterDragScrubber(_txtBorderRadius, minValue: 0f);
+        RegisterDragScrubber(_txtBorderWidth, minValue: 0f);
+        RegisterDragScrubber(_txtOpacity, minValue: 0f, maxValue: 100f);
+
+        _cmbVisibility = new ComboBox { HeightConstraint = 26f, FontSize = 10f, WidthConstraint = 105f };
+        _cmbVisibility.Items.Add(new ComboBoxItem("Visible"));
+        _cmbVisibility.Items.Add(new ComboBoxItem("Collapsed"));
+        _cmbVisibility.SelectedItem = _cmbVisibility.Items[0];
+
+        _txtBgColor.TextChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            var prop = _selectedElement.GetType().GetProperty("Background");
+            if (prop != null)
+            {
+                var brush = ConvertValueToBrush(_txtBgColor.Text);
+                prop.SetValue(_selectedElement, brush);
+                NotifyChanged();
+            }
+        };
+
+        _txtBorderRadius.TextChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            var prop = _selectedElement.GetType().GetProperty("CornerRadius");
+            if (prop != null && float.TryParse(_txtBorderRadius.Text, out float r))
+            {
+                prop.SetValue(_selectedElement, r);
+                NotifyChanged();
+            }
+        };
+
+        _txtBorderWidth.TextChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            var prop = _selectedElement.GetType().GetProperty("BorderThickness");
+            if (prop != null && float.TryParse(_txtBorderWidth.Text, out float w))
+            {
+                prop.SetValue(_selectedElement, new Thickness(w));
+                NotifyChanged();
+            }
+        };
+
+        _txtBorderColor.TextChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            var prop = _selectedElement.GetType().GetProperty("BorderBrush");
+            if (prop != null)
+            {
+                var brush = ConvertValueToBrush(_txtBorderColor.Text);
+                prop.SetValue(_selectedElement, brush);
+                NotifyChanged();
+            }
+        };
+
+        _txtOpacity.TextChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            if (float.TryParse(_txtOpacity.Text, out float op))
+            {
+                _selectedElement.Opacity = Math.Clamp(op / 100f, 0f, 1f);
+                NotifyChanged();
+            }
+        };
+
+        _cmbVisibility.SelectionChanged += (s, e) => {
+            if (_isUpdatingFields || _selectedElement == null) return;
+            if (Enum.TryParse<Visibility>(_cmbVisibility.SelectedItem?.Text, out var vis))
+            {
+                _selectedElement.Visibility = vis;
+                NotifyChanged();
+            }
+        };
+
+        bgBorderGrid.AddChild(CreateFieldWrapper("Bg Color", _txtBgColor, 0, 0));
+        bgBorderGrid.AddChild(CreateFieldWrapper("Radius", _txtBorderRadius, 0, 1));
+        bgBorderGrid.AddChild(CreateFieldWrapper("Border Width", _txtBorderWidth, 1, 0));
+        bgBorderGrid.AddChild(CreateFieldWrapper("Border Color", _txtBorderColor, 1, 1));
+        bgBorderGrid.AddChild(CreateFieldWrapper("Opacity %", _txtOpacity, 2, 0));
+        bgBorderGrid.AddChild(CreateFieldWrapper("Visibility", _cmbVisibility, 2, 1));
+
+        mainLayout.AddChild(CreateSection("Appearance", bgBorderGrid));
+
+        // Setup scroll viewer wrapping all panels
+        var scroll = new ScrollViewer
+        {
+            Content = mainLayout,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+
+        Child = scroll;
+        RefreshFields();
+    }
+
+    private FrameworkElement CreateSpacingWidget()
+    {
+        // Spacing Widget Presenter using custom bevel backgrounds
+        var marginGrid = new SpacingWidgetPresenter(_font);
+        marginGrid.ColumnDefinitions.Add(new GridLength(40f, GridUnitType.Absolute));
+        marginGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        marginGrid.ColumnDefinitions.Add(new GridLength(40f, GridUnitType.Absolute));
+        marginGrid.RowDefinitions.Add(new GridLength(28f, GridUnitType.Absolute));
+        marginGrid.RowDefinitions.Add(GridLength.Star(1f));
+        marginGrid.RowDefinitions.Add(new GridLength(28f, GridUnitType.Absolute));
+
+        var marginBorder = new Border
+        {
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(1f),
+            CornerRadius = 6f,
+            Padding = new Thickness(0),
+            Child = marginGrid
+        };
+
+        // Margin indicator label
+        var marginLabel = new RichTextBlock { Font = _font, FontSize = 5.5f, Margin = new Thickness(2, 2, 0, 0) };
+        marginLabel.Foreground = new ThemeResourceBrush("TextSecondary");
+        marginLabel.Inlines.Add(new Run("MARGIN"));
+        Grid.SetRow(marginLabel, 0);
+        Grid.SetColumn(marginLabel, 0);
+        marginGrid.AddChild(marginLabel);
+
+        _txtMarginTop = CreateSpacingTextBox();
+        _txtMarginLeft = CreateSpacingTextBox();
+        _txtMarginRight = CreateSpacingTextBox();
+        _txtMarginBottom = CreateSpacingTextBox();
+
+        RegisterDragScrubber(_txtMarginTop, minValue: null, snapToInteger: true);
+        RegisterDragScrubber(_txtMarginLeft, minValue: null, snapToInteger: true);
+        RegisterDragScrubber(_txtMarginRight, minValue: null, snapToInteger: true);
+        RegisterDragScrubber(_txtMarginBottom, minValue: null, snapToInteger: true);
+
+        _txtMarginTop.TextChanged += (s, e) => { UpdateMarginFromUi(); UpdateScrubbedTextBoxStyle(_txtMarginTop); };
+        _txtMarginLeft.TextChanged += (s, e) => { UpdateMarginFromUi(); UpdateScrubbedTextBoxStyle(_txtMarginLeft); };
+        _txtMarginRight.TextChanged += (s, e) => { UpdateMarginFromUi(); UpdateScrubbedTextBoxStyle(_txtMarginRight); };
+        _txtMarginBottom.TextChanged += (s, e) => { UpdateMarginFromUi(); UpdateScrubbedTextBoxStyle(_txtMarginBottom); };
+
+        Grid.SetRow(_txtMarginTop, 0); Grid.SetColumn(_txtMarginTop, 1);
+        Grid.SetRow(_txtMarginLeft, 1); Grid.SetColumn(_txtMarginLeft, 0);
+        Grid.SetRow(_txtMarginRight, 1); Grid.SetColumn(_txtMarginRight, 2);
+        Grid.SetRow(_txtMarginBottom, 2); Grid.SetColumn(_txtMarginBottom, 1);
+
+        marginGrid.AddChild(_txtMarginTop);
+        marginGrid.AddChild(_txtMarginLeft);
+        marginGrid.AddChild(_txtMarginRight);
+        marginGrid.AddChild(_txtMarginBottom);
+
+        // 2. Padding Grid (Inner Layer)
+        var paddingGrid = new Grid();
+        paddingGrid.ColumnDefinitions.Add(new GridLength(40f, GridUnitType.Absolute));
+        paddingGrid.ColumnDefinitions.Add(GridLength.Star(1f));
+        paddingGrid.ColumnDefinitions.Add(new GridLength(40f, GridUnitType.Absolute));
+        paddingGrid.RowDefinitions.Add(new GridLength(28f, GridUnitType.Absolute));
+        paddingGrid.RowDefinitions.Add(GridLength.Star(1f));
+        paddingGrid.RowDefinitions.Add(new GridLength(28f, GridUnitType.Absolute));
+
+        var paddingBorder = new Border
+        {
+            Margin = new Thickness(4, 4, 4, 4),
+            Child = paddingGrid
+        };
+
+        // Padding indicator label
+        var paddingLabel = new RichTextBlock { Font = _font, FontSize = 5.5f, Margin = new Thickness(2, 2, 0, 0) };
+        paddingLabel.Foreground = new ThemeResourceBrush("TextSecondary");
+        paddingLabel.Inlines.Add(new Run("PADDING"));
+        Grid.SetRow(paddingLabel, 0);
+        Grid.SetColumn(paddingLabel, 0);
+        paddingGrid.AddChild(paddingLabel);
+
+        _txtPaddingTop = CreateSpacingTextBox();
+        _txtPaddingLeft = CreateSpacingTextBox();
+        _txtPaddingRight = CreateSpacingTextBox();
+        _txtPaddingBottom = CreateSpacingTextBox();
+
+        RegisterDragScrubber(_txtPaddingTop, minValue: 0f, snapToInteger: true);
+        RegisterDragScrubber(_txtPaddingLeft, minValue: 0f, snapToInteger: true);
+        RegisterDragScrubber(_txtPaddingRight, minValue: 0f, snapToInteger: true);
+        RegisterDragScrubber(_txtPaddingBottom, minValue: 0f, snapToInteger: true);
+
+        _txtPaddingTop.TextChanged += (s, e) => { UpdatePaddingFromUi(); UpdateScrubbedTextBoxStyle(_txtPaddingTop); };
+        _txtPaddingLeft.TextChanged += (s, e) => { UpdatePaddingFromUi(); UpdateScrubbedTextBoxStyle(_txtPaddingLeft); };
+        _txtPaddingRight.TextChanged += (s, e) => { UpdatePaddingFromUi(); UpdateScrubbedTextBoxStyle(_txtPaddingRight); };
+        _txtPaddingBottom.TextChanged += (s, e) => { UpdatePaddingFromUi(); UpdateScrubbedTextBoxStyle(_txtPaddingBottom); };
+
+        Grid.SetRow(_txtPaddingTop, 0); Grid.SetColumn(_txtPaddingTop, 1);
+        Grid.SetRow(_txtPaddingLeft, 1); Grid.SetColumn(_txtPaddingLeft, 0);
+        Grid.SetRow(_txtPaddingRight, 1); Grid.SetColumn(_txtPaddingRight, 2);
+        Grid.SetRow(_txtPaddingBottom, 2); Grid.SetColumn(_txtPaddingBottom, 1);
+
+        paddingGrid.AddChild(_txtPaddingTop);
+        paddingGrid.AddChild(_txtPaddingLeft);
+        paddingGrid.AddChild(_txtPaddingRight);
+        paddingGrid.AddChild(_txtPaddingBottom);
+
+        // Center Content Block representing the selected element box
+        var elementCenter = new Border
+        {
+            Margin = new Thickness(4, 4, 4, 4)
+        };
+        var centerText = new RichTextBlock { Font = _font, FontSize = 8f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+        centerText.Foreground = new ThemeResourceBrush("TextSecondary");
+        centerText.Inlines.Add(new Run("Element"));
+        elementCenter.Child = centerText;
+
+        Grid.SetRow(elementCenter, 1); Grid.SetColumn(elementCenter, 1);
+        paddingGrid.AddChild(elementCenter);
+
+        // Nested link
+        Grid.SetRow(paddingBorder, 1); Grid.SetColumn(paddingBorder, 1);
+        marginGrid.AddChild(paddingBorder);
+
+        return marginBorder;
+    }
+
+    private TextBox CreateSpacingTextBox()
+    {
+        return new TextBox
+        {
+            WidthConstraint = 36f,
+            HeightConstraint = 20f,
+            FontSize = 9f,
+            Padding = new Thickness(2, 2, 2, 2),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Text = "0"
+        };
+    }
+
+    private TextBox CreateTextBoxInput(string placeholder, string defaultValue)
+    {
+        return new TextBox
+        {
+            HeightConstraint = 26f,
+            WidthConstraint = 105f,
+            FontSize = 10f,
+            Padding = new Thickness(6, 4, 6, 4),
+            PlaceholderText = placeholder,
+            Text = defaultValue
+        };
+    }
+
+    private FrameworkElement CreateFieldWrapper(string label, FrameworkElement input, int row, int col)
+    {
+        var wrapper = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(4, 4, 4, 4) };
+        var textLabel = new RichTextBlock { Font = _font, FontSize = 8.5f, Margin = new Thickness(2, 0, 0, 2) };
+        textLabel.Foreground = new ThemeResourceBrush("TextSecondary");
+        textLabel.Inlines.Add(new Run(label));
+
+        wrapper.AddChild(textLabel);
+        wrapper.AddChild(input);
+
+        Grid.SetRow(wrapper, row);
+        Grid.SetColumn(wrapper, col);
+        return wrapper;
+    }
+
+    private Border CreateSection(string title, FrameworkElement content)
+    {
+        var panel = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(0, 0, 0, 4) };
+
+        var titleBlock = new RichTextBlock
+        {
+            Font = _font,
+            FontSize = 9.5f,
+            Margin = new Thickness(4, 2, 4, 8)
+        };
+        titleBlock.Inlines.Add(new Bold(new Run(title.ToUpper())));
+        titleBlock.Foreground = new ThemeResourceBrush("TextSecondary");
+
+        panel.AddChild(titleBlock);
+        panel.AddChild(content);
+
+        var border = new Border
+        {
+            Background = new ThemeResourceBrush("CardBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            Padding = new Thickness(6, 10, 6, 12),
+            Child = panel
+        };
+        return border;
+    }
+
+    private void RefreshFields()
+    {
+        if (_selectedElement == null)
+        {
+            _selectorTypeLabel.Inlines.Clear();
+            _selectorTypeLabel.Inlines.Add(new Run("STYLE SELECTOR (NO SELECTION)"));
+            _selectorNameInput.Text = "";
+            return;
+        }
+
+        _isUpdatingFields = true;
+        try
+        {
+            string typeName = _selectedElement.GetType().Name;
+            _selectorTypeLabel.Inlines.Clear();
+            _selectorTypeLabel.Inlines.Add(new Run($"STYLE SELECTOR (Tag: {typeName})"));
+
+            _selectorNameInput.Text = _selectedElement.Name ?? "";
+
+            // Margins
+            var margin = _selectedElement.Margin;
+            _txtMarginTop.Text = margin.Top.ToString("F0");
+            _txtMarginLeft.Text = margin.Left.ToString("F0");
+            _txtMarginRight.Text = margin.Right.ToString("F0");
+            _txtMarginBottom.Text = margin.Bottom.ToString("F0");
+
+            UpdateScrubbedTextBoxStyle(_txtMarginTop);
+            UpdateScrubbedTextBoxStyle(_txtMarginLeft);
+            UpdateScrubbedTextBoxStyle(_txtMarginRight);
+            UpdateScrubbedTextBoxStyle(_txtMarginBottom);
+
+            // Paddings
+            var padding = _selectedElement.Padding;
+            _txtPaddingTop.Text = padding.Top.ToString("F0");
+            _txtPaddingLeft.Text = padding.Left.ToString("F0");
+            _txtPaddingRight.Text = padding.Right.ToString("F0");
+            _txtPaddingBottom.Text = padding.Bottom.ToString("F0");
+
+            UpdateScrubbedTextBoxStyle(_txtPaddingTop);
+            UpdateScrubbedTextBoxStyle(_txtPaddingLeft);
+            UpdateScrubbedTextBoxStyle(_txtPaddingRight);
+            UpdateScrubbedTextBoxStyle(_txtPaddingBottom);
+
+            // Sizes
+            float w = _selectedElement.Width;
+            _txtWidth.Text = float.IsNaN(w) ? "Auto" : w.ToString("F0");
+
+            float h = _selectedElement.Height;
+            _txtHeight.Text = float.IsNaN(h) ? "Auto" : h.ToString("F0");
+
+            // Alignments
+            _cmbHorizontalAlignment.SelectedItem = FindComboBoxItem(_cmbHorizontalAlignment, _selectedElement.HorizontalAlignment.ToString());
+            _cmbVerticalAlignment.SelectedItem = FindComboBoxItem(_cmbVerticalAlignment, _selectedElement.VerticalAlignment.ToString());
+
+            // Opacity & Visibility
+            _txtOpacity.Text = ((int)(_selectedElement.Opacity * 100f)).ToString();
+            _cmbVisibility.SelectedItem = FindComboBoxItem(_cmbVisibility, _selectedElement.Visibility.ToString());
+
+            // Background Brush reflectively
+            var bgProp = _selectedElement.GetType().GetProperty("Background");
+            if (bgProp != null)
+            {
+                var bgBrush = bgProp.GetValue(_selectedElement) as Brush;
+                _txtBgColor.Text = GetBrushString(bgBrush);
+            }
+
+            // Radius reflectively
+            var crProp = _selectedElement.GetType().GetProperty("CornerRadius");
+            if (crProp != null)
+            {
+                float crVal = crProp.GetValue(_selectedElement) is float f ? f : 0f;
+                _txtBorderRadius.Text = crVal.ToString("F0");
+            }
+
+            // Border W & Col reflectively
+            var borderThickProp = _selectedElement.GetType().GetProperty("BorderThickness");
+            if (borderThickProp != null)
+            {
+                var thick = (Thickness)(borderThickProp.GetValue(_selectedElement) ?? default(Thickness));
+                _txtBorderWidth.Text = thick.Left.ToString("F0");
+            }
+
+            var borderBrushProp = _selectedElement.GetType().GetProperty("BorderBrush");
+            if (borderBrushProp != null)
+            {
+                var brush = borderBrushProp.GetValue(_selectedElement) as Brush;
+                _txtBorderColor.Text = GetBrushString(brush);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StylePanel] Error refreshing fields: {ex.Message}");
+        }
+        finally
+        {
+            _isUpdatingFields = false;
+        }
+    }
+
+    private ComboBoxItem? FindComboBoxItem(ComboBox combo, string text)
+    {
+        foreach (var item in combo.Items)
+        {
+            if (item.Text.Equals(text, StringComparison.OrdinalIgnoreCase))
+            {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    private void UpdateMarginFromUi()
+    {
+        if (_isUpdatingFields || _selectedElement == null) return;
+        float.TryParse(_txtMarginLeft.Text, out float l);
+        float.TryParse(_txtMarginTop.Text, out float t);
+        float.TryParse(_txtMarginRight.Text, out float r);
+        float.TryParse(_txtMarginBottom.Text, out float b);
+
+        _selectedElement.Margin = new Thickness(l, t, r, b);
+        NotifyChanged();
+    }
+
+    private void UpdatePaddingFromUi()
+    {
+        if (_isUpdatingFields || _selectedElement == null) return;
+        float.TryParse(_txtPaddingLeft.Text, out float l);
+        float.TryParse(_txtPaddingTop.Text, out float t);
+        float.TryParse(_txtPaddingRight.Text, out float r);
+        float.TryParse(_txtPaddingBottom.Text, out float b);
+
+        _selectedElement.Padding = new Thickness(l, t, r, b);
+        NotifyChanged();
+    }
+
+    private void UpdateWidthFromUi()
+    {
+        if (_isUpdatingFields || _selectedElement == null) return;
+        string text = _txtWidth.Text.Trim();
+        if (text.Equals("Auto", StringComparison.OrdinalIgnoreCase) || text.Equals("None", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(text))
+        {
+            _selectedElement.Width = float.NaN;
+        }
+        else if (float.TryParse(text.Replace("px", "").Trim(), out float wval))
+        {
+            _selectedElement.Width = wval;
+        }
+        NotifyChanged();
+    }
+
+    private void UpdateHeightFromUi()
+    {
+        if (_isUpdatingFields || _selectedElement == null) return;
+        string text = _txtHeight.Text.Trim();
+        if (text.Equals("Auto", StringComparison.OrdinalIgnoreCase) || text.Equals("None", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(text))
+        {
+            _selectedElement.Height = float.NaN;
+        }
+        else if (float.TryParse(text.Replace("px", "").Trim(), out float hval))
+        {
+            _selectedElement.Height = hval;
+        }
+        NotifyChanged();
+    }
+
+    private void ApplyLayoutMode(string mode)
+    {
+        if (_isUpdatingFields || _selectedElement == null) return;
+
+        // Apply display block / flex reflectively if element is a StackPanel
+        if (_selectedElement is StackPanel stack)
+        {
+            if (mode == "Block")
+            {
+                stack.Orientation = Orientation.Vertical;
+            }
+            else if (mode == "Flex")
+            {
+                stack.Orientation = Orientation.Horizontal;
+            }
+        }
+        NotifyChanged();
+    }
+
+    private void NotifyChanged()
+    {
+        _selectedElement?.InvalidateMeasure();
+        _selectedElement?.InvalidateArrange();
+        _selectedElement?.Invalidate();
+        PropertyChanged?.Invoke();
+    }
+
+    private string GetBrushString(Brush? brush)
+    {
+        if (brush == null) return "";
+        if (brush is ThemeResourceBrush tr) return tr.ResourceKey;
+        if (brush is SolidColorBrush scb)
+        {
+            var col = scb.Color;
+            byte r = (byte)Math.Clamp(Math.Round(col.X * 255f), 0, 255);
+            byte g = (byte)Math.Clamp(Math.Round(col.Y * 255f), 0, 255);
+            byte b = (byte)Math.Clamp(Math.Round(col.Z * 255f), 0, 255);
+            byte a = (byte)Math.Clamp(Math.Round(col.W * 255f), 0, 255);
+            if (a == 0 && r == 0 && g == 0 && b == 0) return "Transparent";
+            return $"#{a:X2}{r:X2}{g:X2}{b:X2}";
+        }
+        return brush.ToString() ?? "";
+    }
+
+    private Brush? ConvertValueToBrush(string val)
+    {
+        if (string.IsNullOrEmpty(val)) return null;
+        if (val.Equals("Transparent", StringComparison.OrdinalIgnoreCase))
+        {
+            return new SolidColorBrush(new Vector4(0f, 0f, 0f, 0f));
+        }
+        if (val.StartsWith("#"))
+        {
+            try
+            {
+                var hex = val.Substring(1);
+                if (hex.Length == 6) hex = "FF" + hex;
+                if (hex.Length == 8)
+                {
+                    uint rgba = Convert.ToUInt32(hex, 16);
+                    float a = ((rgba >> 24) & 0xFF) / 255.0f;
+                    float r = ((rgba >> 16) & 0xFF) / 255.0f;
+                    float g = ((rgba >> 8) & 0xFF) / 255.0f;
+                    float b = (rgba & 0xFF) / 255.0f;
+                    return new SolidColorBrush(new Vector4(r, g, b, a));
+                }
+            }
+            catch {}
+        }
+        return new ThemeResourceBrush(val);
+    }
+
+    private void RegisterDragScrubber(TextBox txt, float? minValue = 0f, float? maxValue = null, bool isDimension = false, bool snapToInteger = false)
+    {
+        txt.PointerEntered += (s, e) => {
+            if (!_isScrubbing)
+            {
+                InputSystem.SetMouseCursor(Silk.NET.Input.StandardCursor.HResize);
+            }
+        };
+
+        txt.PointerExited += (s, e) => {
+            if (!_isScrubbing)
+            {
+                InputSystem.SetMouseCursor(Silk.NET.Input.StandardCursor.Default);
+            }
+        };
+
+        txt.PointerPressed += (s, e) => {
+            if (_selectedElement != null)
+            {
+                _isScrubbing = true;
+                _hasScrubbed = false;
+                _scrubbedTextBox = txt;
+                _scrubStartPos = e.Position;
+
+                string text = txt.Text.Trim();
+                float parsedVal = 0f;
+
+                if (isDimension && (text.Equals("Auto", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(text)))
+                {
+                    // Use actual element size as starting point if "Auto"
+                    if (txt == _txtWidth) parsedVal = _selectedElement.Size.X > 0 ? _selectedElement.Size.X : 100f;
+                    else if (txt == _txtHeight) parsedVal = _selectedElement.Size.Y > 0 ? _selectedElement.Size.Y : 100f;
+                }
+                else
+                {
+                    // Strip non-numeric suffixes like "px", "%" for parsing
+                    string clean = text.Replace("px", "").Replace("%", "").Trim();
+                    float.TryParse(clean, out parsedVal);
+                }
+
+                _scrubStartValue = parsedVal;
+
+                InputSystem.CapturePointer(txt);
+                InputSystem.SetMouseCursor(Silk.NET.Input.StandardCursor.HResize);
+                e.Handled = true;
+            }
+        };
+
+        txt.PointerMoved += (s, e) => {
+            if (_isScrubbing && _scrubbedTextBox == txt)
+            {
+                float dx = e.Position.X - _scrubStartPos.X;
+                if (!_hasScrubbed && Math.Abs(dx) > 3f)
+                {
+                    _hasScrubbed = true;
+                }
+
+                if (_hasScrubbed)
+                {
+                    // Multipliers: Shift = 10x speed, Alt = 0.1x speed (Webflow-parity)
+                    float multiplier = 1f;
+                    if (InputSystem.Current.IsShiftPressed) multiplier = 10f;
+                    else if (InputSystem.Current.IsAltPressed) multiplier = 0.1f;
+
+                    float deltaValue = dx * multiplier;
+                    float newVal = _scrubStartValue + deltaValue;
+
+                    if (snapToInteger)
+                    {
+                        newVal = MathF.Round(newVal);
+                    }
+
+                    if (minValue.HasValue) newVal = Math.Max(minValue.Value, newVal);
+                    if (maxValue.HasValue) newVal = Math.Min(maxValue.Value, newVal);
+
+                    txt.Text = newVal.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+                }
+                e.Handled = true;
+            }
+        };
+
+        txt.PointerReleased += (s, e) => {
+            if (_isScrubbing && _scrubbedTextBox == txt)
+            {
+                InputSystem.ReleasePointerCapture();
+                InputSystem.SetMouseCursor(Silk.NET.Input.StandardCursor.Default);
+
+                if (!_hasScrubbed)
+                {
+                    InputSystem.SetFocus(txt);
+                }
+
+                _isScrubbing = false;
+                _hasScrubbed = false;
+                _scrubbedTextBox = null;
+                e.Handled = true;
+            }
+        };
+    }
+
+    private void UpdateScrubbedTextBoxStyle(TextBox txt)
+    {
+        float.TryParse(txt.Text.Trim(), out float val);
+        if (val != 0)
+        {
+            txt.Background = ThemeManager.GetBrush("SystemAccentColor");
+            txt.Foreground = new SolidColorBrush(Vector4.One); // white text
+            txt.CornerRadius = 3f;
+            txt.BorderThickness = new Thickness(0);
+        }
+        else
+        {
+            txt.Background = ThemeManager.GetBrush("ControlBackground");
+            txt.Foreground = ThemeManager.GetBrush("TextSecondary");
+            txt.CornerRadius = 3f;
+            txt.BorderThickness = new Thickness(1f);
+            txt.BorderBrush = ThemeManager.GetBrush("ControlBorder");
+        }
+    }
+}
+
+public class SpacingWidgetPresenter : Grid
+{
+    private readonly ProGPU.Text.TtfFont? _font;
+
+    public SpacingWidgetPresenter(ProGPU.Text.TtfFont? font)
+    {
+        _font = font;
+    }
+
+    public override void OnRender(DrawingContext context)
+    {
+        var size = Size;
+        float w = size.X;
+        float h = size.Y;
+
+        // Custom HSL dark grays matching Webflow's spaced box 3D layout bevels
+        float marginL = 40f;
+        float marginR = w - 40f;
+        float marginT = 28f;
+        float marginB = h - 28f;
+
+        float padL = 80f;
+        float padR = w - 80f;
+        float padT = 56f;
+        float padB = h - 56f;
+
+        var borderPen = new Pen(ThemeManager.GetBrush("ControlBorder"), 1f);
+
+        // Curated grays for Margin 3D bevel sectors
+        var marginTopBrush = new SolidColorBrush(new Vector4(0.2f, 0.2f, 0.22f, 1f));     // Lighter top
+        var marginBottomBrush = new SolidColorBrush(new Vector4(0.12f, 0.12f, 0.14f, 1f)); // Darker bottom
+        var marginSideBrush = new SolidColorBrush(new Vector4(0.16f, 0.16f, 0.18f, 1f));   // Medium sides
+
+        // Top Margin
+        var pathTop = PathGeometry.Parse(System.FormattableString.Invariant($"M 0 0 L {w} 0 L {marginR} {marginT} L {marginL} {marginT} Z"));
+        context.DrawPath(marginTopBrush, borderPen, pathTop);
+
+        // Bottom Margin
+        var pathBottom = PathGeometry.Parse(System.FormattableString.Invariant($"M 0 {h} L {w} {h} L {marginR} {marginB} L {marginL} {marginB} Z"));
+        context.DrawPath(marginBottomBrush, borderPen, pathBottom);
+
+        // Left Margin
+        var pathLeft = PathGeometry.Parse(System.FormattableString.Invariant($"M 0 0 L 0 {h} L {marginL} {marginB} L {marginL} {marginT} Z"));
+        context.DrawPath(marginSideBrush, borderPen, pathLeft);
+
+        // Right Margin
+        var pathRight = PathGeometry.Parse(System.FormattableString.Invariant($"M {w} 0 L {w} {h} L {marginR} {marginB} L {marginR} {marginT} Z"));
+        context.DrawPath(marginSideBrush, borderPen, pathRight);
+
+        // Curated grays for Padding 3D bevel sectors (slightly lighter hierarchy)
+        var padTopBrush = new SolidColorBrush(new Vector4(0.24f, 0.24f, 0.26f, 1f));
+        var padBottomBrush = new SolidColorBrush(new Vector4(0.14f, 0.14f, 0.16f, 1f));
+        var padSideBrush = new SolidColorBrush(new Vector4(0.18f, 0.18f, 0.2f, 1f));
+
+        // Top Padding
+        var pathPadTop = PathGeometry.Parse(System.FormattableString.Invariant($"M {marginL} {marginT} L {marginR} {marginT} L {padR} {padT} L {padL} {padT} Z"));
+        context.DrawPath(padTopBrush, borderPen, pathPadTop);
+
+        // Bottom Padding
+        var pathPadBottom = PathGeometry.Parse(System.FormattableString.Invariant($"M {marginL} {marginB} L {marginR} {marginB} L {padR} {padB} L {padL} {padB} Z"));
+        context.DrawPath(padBottomBrush, borderPen, pathPadBottom);
+
+        // Left Padding
+        var pathPadLeft = PathGeometry.Parse(System.FormattableString.Invariant($"M {marginL} {marginT} L {marginL} {marginB} L {padL} {padB} L {padL} {padT} Z"));
+        context.DrawPath(padSideBrush, borderPen, pathPadLeft);
+
+        // Right Padding
+        var pathPadRight = PathGeometry.Parse(System.FormattableString.Invariant($"M {marginR} {marginT} L {marginR} {marginB} L {padR} {padB} L {padR} {padT} Z"));
+        context.DrawPath(padSideBrush, borderPen, pathPadRight);
+
+        // Center Element Box
+        var elementBg = new SolidColorBrush(new Vector4(0.1f, 0.1f, 0.12f, 1f));
+        context.DrawRoundedRectangle(elementBg, borderPen, new Rect(padL, padT, padR - padL, padB - padT), 2f);
+
+        base.OnRender(context);
+    }
+}

--- a/src/ProGPU.WinUI.Designer/VisualTreeOutline.cs
+++ b/src/ProGPU.WinUI.Designer/VisualTreeOutline.cs
@@ -101,9 +101,10 @@ public class VisualTreeOutlineItem : Border
         var visCheckBox = new CheckBox
         {
             IsChecked = element.Visibility == Visibility.Visible,
-            WidthConstraint = 16f,
-            HeightConstraint = 16f,
+            WidthConstraint = 18f,
+            HeightConstraint = 18f,
             Padding = new Thickness(0),
+            BorderThickness = new Thickness(0),
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center
         };
@@ -125,8 +126,6 @@ public class VisualTreeOutlineItem : Border
                 Font = font,
                 FontSize = 12f,
                 Foreground = new ThemeResourceBrush("TextSecondary"),
-                WidthConstraint = 16f,
-                HeightConstraint = 16f,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
                 IsHitTestVisible = true

--- a/src/ProGPU.WinUI/Controls/Grid.cs
+++ b/src/ProGPU.WinUI/Controls/Grid.cs
@@ -173,14 +173,14 @@ public class Grid : Panel
                 {
                     GridUnitType.Absolute => colWidths[c],
                     GridUnitType.Star => starColsWeight > 0 && !float.IsInfinity(remainingWidth) ? (cols[c].Value / starColsWeight) * remainingWidth : float.PositiveInfinity,
-                    _ => availableSize.X
+                    _ => float.PositiveInfinity
                 };
 
                 float childAvailH = rows[r].UnitType switch
                 {
                     GridUnitType.Absolute => rowHeights[r],
                     GridUnitType.Star => starRowsWeight > 0 && !float.IsInfinity(remainingHeight) ? (rows[r].Value / starRowsWeight) * remainingHeight : float.PositiveInfinity,
-                    _ => availableSize.Y
+                    _ => float.PositiveInfinity
                 };
 
                 node.Measure(new Vector2(childAvailW, childAvailH));

--- a/src/ProGPU.WinUI/Controls/PasswordBox.cs
+++ b/src/ProGPU.WinUI/Controls/PasswordBox.cs
@@ -300,6 +300,7 @@ public class PasswordBox : Control
                 return;
             }
 
+            e.Handled = true; // prevent bubbling immediately to avoid parent focus theft
             base.OnPointerPressed(e);
 
             float clickX = e.Position.X - Padding.Left;
@@ -330,7 +331,6 @@ public class PasswordBox : Control
             CaretIndex = index;
             _isDraggingSelection = true;
             InputSystem.CapturePointer(this);
-            e.Handled = true;
         }
     }
 

--- a/src/ProGPU.WinUI/Controls/TextBox.cs
+++ b/src/ProGPU.WinUI/Controls/TextBox.cs
@@ -247,7 +247,8 @@ public class TextBox : Control
     {
         if (IsEnabled)
         {
-            base.OnPointerPressed(e); // sets focus
+            e.Handled = true; // prevent bubbling immediately to avoid parent focus theft
+            base.OnPointerPressed(e); // sets focus on this TextBox without bubbling
 
             float clickX = e.Position.X - Padding.Left;
             int index = 0;
@@ -276,7 +277,6 @@ public class TextBox : Control
             CaretIndex = index;
             _isDraggingSelection = true;
             InputSystem.CapturePointer(this);
-            e.Handled = true;
         }
     }
 

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -161,6 +161,24 @@ public static class InputSystem
         DevToolsInputSystem.ReleasePointerCapture();
     }
 
+    public static void SetMouseCursor(StandardCursor cursor)
+    {
+        if (Current.InputContext != null)
+        {
+            foreach (var mouse in Current.InputContext.Mice)
+            {
+                try
+                {
+                    mouse.Cursor.StandardCursor = cursor;
+                }
+                catch
+                {
+                    // Ignore if cursor configuration is unsupported in the current platform/context
+                }
+            }
+        }
+    }
+
     public static WindowInputState Initialize(IInputContext input, FrameworkElement? root = null)
     {
         var state = new WindowInputState { Root = root, InputContext = input };


### PR DESCRIPTION
# Pull Request: Premium Webflow-Style Visual Designer, StylePanel & Canvas Layout Fixes

This Pull Request introduces major visual, interactive, and structural enhancements to the ProGPU **Visual Designer Studio**, delivering a premium Webflow/Figma-parity experience alongside robust fixes for layout measurement, focus handling, and spacing alignments.

---

## 🚀 Key Improvements

### 1. Reorganized Responsive Top Toolbar (Webflow-Style)
* **Three-Column Grid Layout**: Restructured the toolbar inside a sleek horizontal `Border` container with a dark background (`CardBackground`) and bottom separator line (`ControlBorder`).
* **View Pill Toggles (Left Column)**: Integrated compact, modern pill-shaped toggle buttons that instantly highlight in vibrant accent blue (`SystemAccentColor`) when active, managing:
  * `Grid Lines` (Toggles snap grid dots drawing)
  * `Snap` (Toggles pixel/grid snapping)
  * `Outlines` (Always shows bounding panels outlines)
  * `Responsive` (Toggles responsive viewport mode)
* **Segmented Breakpoints Capsule (Center Column)**: A unified capsule grouping `Desktop`, `Tablet`, and `Mobile` viewports with instant active color backgrounds.
* **Workspace Utilities & Zoom (Right Column)**:
  * **History Capsule**: `[↩️ Undo]` and `[↪️ Redo]` buttons linked directly to backend state stacks.
  * **Clear Capsule**: Sleek `[🗑️ Clear]` workspace trigger.
  * **Zoom Capsule**: Seamless `[-] [ 100% ] [+]` control capsule managing zoom factor increments.

### 2. Premium Webflow-Style StylePanel
* **Pivot Sidebar Panels**: Reorganized the right sidebar into a fluid Pivot control containing:
  * **Style Tab**: Custom margins/paddings, layout block/flex stacks, explicit dimensions, and appearance controls.
  * **Property Grid Tab**: Traditional property reflection grid.
  * **Interactions Tab**: Custom animation and transition triggers.
* **Value Scrubbing (Drag-to-Set)**: Users can click and drag horizontally on any numeric styling input (Width, Height, Margins, Paddings, Border Radius, Border Width, Opacity) to scrub values instantly:
  * **Multipliers**: Shift key speeds up scrubbing (10x), while Alt key slows it down (0.1x) for precise subpixel sizing.
  * **Integer Snapping**: Spacing and pixel values automatically snap to clean whole integers when scrubbed.

### 3. Critical Canvas Layout Visibility Fix
* **The Bug**: Nested layout grids in `Auto` height rows measured themselves using finite remaining height, greedily consuming the entire viewport height (e.g. `800f`). This collapsed the canvas `Star` row height to `0f`, hiding the design surface completely and forcing the settings toolbar to float in the middle of the screen.
* **The Fix**: Corrected the `Auto` column/row measure fallback cases in both [Grid.cs](file:///Users/wieslawsoltes/GitHub/ProGPU/src/ProGPU.WinUI/Controls/Grid.cs) and [LayoutContainers.cs](file:///Users/wieslawsoltes/GitHub/ProGPU/src/ProGPU.Layout/LayoutContainers.cs) to measure using `float.PositiveInfinity`. This allows nested layout nodes to size strictly to their natural children bounds, allocating a precise `41f` to the toolbar and the remainder to the fully visible design canvas.

### 4. Interactive Focus Handling (Focus Theft Resolution)
* **The Bug**: Typing inside styling panel `TextBox`es or `PasswordBox`es would trigger parent keyboard shortcuts or canvas event handlers, stealing active focus from the input field.
* **The Fix**: Overrode key and pointer events in `TextBox.cs` and `PasswordBox.cs` to set `e.Handled = true` prior to base propagation, ensuring interactive focus remains locked in the active input.

### 5. Box Model & Tree Outline Typography centring
* **Spacing Box Model Widget**: Reduced label `FontSize` to `5.5f` and left indents to `(2, 2, 0, 0)` inside [StylePanel.cs](file:///Users/wieslawsoltes/GitHub/ProGPU/src/ProGPU.WinUI.Designer/StylePanel.cs) to guarantee `PADDING` and `MARGIN` text labels fit on a single clean line without clipping or wrapping.
* **Tree Outline centring**: Set `BorderThickness = 0` on tree outline item checkboxes in [VisualTreeOutline.cs](file:///Users/wieslawsoltes/GitHub/ProGPU/src/ProGPU.WinUI.Designer/VisualTreeOutline.cs). This allows the inner `CheckboxChrome` to draw perfectly centered vertically in each node row.

---

## 🛠️ Codebase Modifications

### `ProGPU.WinUI/Controls`
* **`Grid.cs`**: Measures `Auto` columns and rows using `float.PositiveInfinity` to support natural lookups.
* **`TextBox.cs` / `PasswordBox.cs`**: Handles key/pointer events atomically to suppress event bubbling.

### `ProGPU.Layout`
* **`LayoutContainers.cs`**: Mirrors the `PositiveInfinity` measure fallback in `GridPanel` to align custom controls.

### `ProGPU.WinUI.Designer`
* **`StylePanel.cs`**: Complete styling layout, spacing widget drawing, value scrubbing gesture handlers, and text formatting.
* **`VisualTreeOutline.cs`**: Clears default checkbox border thickness to center alignment.
* **`DesignerHost.cs` / `DesignerCanvas.cs`**: Integrates the new modular Grid toolbar, structured pivots, and responsive layout propagation sequence.
* **`SelectionAdorner.cs` / `DesignerSerializer.cs`**: Supporting alignments for interactive resizing and live C# script serialization.

### `ProGPU.Tests.Headless`
* **`DesignerCanvasTests.cs`**: Added 6 new headless unit test suites validating pivot navigation, TextBox hit-testing focus locks, and vertical drag value scrubbing speed multipliers.

---

## 🧪 Verification & Stability
All xUnit tests have been successfully verified sequentially:
* **Total Tests**: **80 passed cleanly (0 failed, 0 skipped)**
* **Compiler Status**: 100% clean build, `0 warnings` / `0 errors` inside the designer libraries.
