### PR TITLE
feat: WPF-Compliant 3D Object Model, Advanced Split Viewports, Viewport Compass & Fluent Color Picker

### DIFF
--- a/src/ProGPU.Backend/GpuTexture.cs
+++ b/src/ProGPU.Backend/GpuTexture.cs
@@ -21,10 +21,11 @@ public unsafe class GpuTexture : IDisposable
     public uint Height { get; private set; }
     public TextureFormat Format { get; private set; }
     public TextureUsage Usage { get; private set; }
+    public uint SampleCount { get; private set; } = 1;
 
     private bool _isDisposed;
 
-    public GpuTexture(WgpuContext context, uint width, uint height, TextureFormat format, TextureUsage usage, string label = "GpuTexture")
+    public GpuTexture(WgpuContext context, uint width, uint height, TextureFormat format, TextureUsage usage, string label = "GpuTexture", uint sampleCount = 1)
     {
         Id = (ulong)Interlocked.Increment(ref s_idCounter);
         _context = context;
@@ -33,6 +34,7 @@ public unsafe class GpuTexture : IDisposable
         Format = format;
         Usage = usage;
         _label = label;
+        SampleCount = sampleCount;
 
         Allocate();
     }
@@ -50,7 +52,7 @@ public unsafe class GpuTexture : IDisposable
             Size = new Extent3D { Width = Width, Height = Height, DepthOrArrayLayers = 1 },
             Format = Format,
             MipLevelCount = 1,
-            SampleCount = 1,
+            SampleCount = SampleCount,
             ViewFormatCount = 0,
             ViewFormats = null
         };

--- a/src/ProGPU.Backend/RenderPipelineCache.cs
+++ b/src/ProGPU.Backend/RenderPipelineCache.cs
@@ -73,7 +73,9 @@ public unsafe class RenderPipelineCache : IDisposable
         StencilOperation stencilFail = StencilOperation.Keep,
         StencilOperation stencilDepthFail = StencilOperation.Keep,
         StencilOperation stencilPass = StencilOperation.Keep,
-        uint sampleCount = 1)
+        uint sampleCount = 1,
+        bool depthWriteEnabled = false,
+        CompareFunction depthCompare = CompareFunction.Always)
     {
         if (_isDisposed) throw new ObjectDisposedException(nameof(RenderPipelineCache));
         if (_renderPipelines.TryGetValue(key, out var cachedPipeline)) return (RenderPipeline*)cachedPipeline;
@@ -142,8 +144,8 @@ public unsafe class RenderPipelineCache : IDisposable
             var depthStencilState = new DepthStencilState
             {
                 Format = depthFormat,
-                DepthWriteEnabled = false,
-                DepthCompare = CompareFunction.Always,
+                DepthWriteEnabled = depthWriteEnabled,
+                DepthCompare = depthCompare,
                 StencilFront = new StencilFaceState
                 {
                     Compare = stencilCompare,

--- a/src/ProGPU.Backend/RenderPipelineCache.cs
+++ b/src/ProGPU.Backend/RenderPipelineCache.cs
@@ -75,7 +75,8 @@ public unsafe class RenderPipelineCache : IDisposable
         StencilOperation stencilPass = StencilOperation.Keep,
         uint sampleCount = 1,
         bool depthWriteEnabled = false,
-        CompareFunction depthCompare = CompareFunction.Always)
+        CompareFunction depthCompare = CompareFunction.Always,
+        CullMode cullMode = CullMode.None)
     {
         if (_isDisposed) throw new ObjectDisposedException(nameof(RenderPipelineCache));
         if (_renderPipelines.TryGetValue(key, out var cachedPipeline)) return (RenderPipeline*)cachedPipeline;
@@ -177,7 +178,7 @@ public unsafe class RenderPipelineCache : IDisposable
                     Topology = topology,
                     StripIndexFormat = IndexFormat.Undefined,
                     FrontFace = FrontFace.Ccw,
-                    CullMode = CullMode.None
+                    CullMode = cullMode
                 },
                 DepthStencil = enableDepthStencil ? &depthStencilState : null,
                 Multisample = new MultisampleState

--- a/src/ProGPU.Samples/Helpers/ObjModels.cs
+++ b/src/ProGPU.Samples/Helpers/ObjModels.cs
@@ -142,21 +142,28 @@ namespace ProGPU.Samples
 
         public static void EnsureSamplesExist(string targetDirectory)
         {
-            if (!Directory.Exists(targetDirectory))
+            try
             {
-                Directory.CreateDirectory(targetDirectory);
-            }
+                if (!Directory.Exists(targetDirectory))
+                {
+                    Directory.CreateDirectory(targetDirectory);
+                }
 
-            string spacecraftPath = Path.Combine(targetDirectory, "spacecraft.obj");
-            if (!File.Exists(spacecraftPath))
-            {
-                File.WriteAllText(spacecraftPath, GenerateSpacecraftObj());
-            }
+                string spacecraftPath = Path.Combine(targetDirectory, "spacecraft.obj");
+                if (!File.Exists(spacecraftPath))
+                {
+                    File.WriteAllText(spacecraftPath, GenerateSpacecraftObj());
+                }
 
-            string jewelPath = Path.Combine(targetDirectory, "jewel.obj");
-            if (!File.Exists(jewelPath))
+                string jewelPath = Path.Combine(targetDirectory, "jewel.obj");
+                if (!File.Exists(jewelPath))
+                {
+                    File.WriteAllText(jewelPath, GenerateFacetedJewelObj());
+                }
+            }
+            catch (Exception ex)
             {
-                File.WriteAllText(jewelPath, GenerateFacetedJewelObj());
+                System.Diagnostics.Debug.WriteLine($"Failed to write sample models in read-only directory: {ex.Message}");
             }
         }
     }

--- a/src/ProGPU.Samples/Helpers/ObjModels.cs
+++ b/src/ProGPU.Samples/Helpers/ObjModels.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace ProGPU.Samples
+{
+    public static class ObjModels
+    {
+        public static string GenerateSpacecraftObj()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("# Procedural Spacecraft OBJ model");
+
+            // Vertices
+            sb.AppendLine("v 0.0 0.0 3.0"); // 1: Nose tip
+            sb.AppendLine("v 0.0 0.4 1.5");  // 2
+            sb.AppendLine("v -0.4 -0.2 1.5"); // 3
+            sb.AppendLine("v 0.4 -0.2 1.5");  // 4
+
+            sb.AppendLine("v 0.0 0.5 0.0");  // 5
+            sb.AppendLine("v -0.5 -0.3 0.0"); // 6
+            sb.AppendLine("v 0.5 -0.3 0.0");  // 7
+
+            sb.AppendLine("v 0.0 0.4 -2.0");  // 8
+            sb.AppendLine("v -0.4 -0.2 -2.0"); // 9
+            sb.AppendLine("v 0.4 -0.2 -2.0");  // 10
+            sb.AppendLine("v 0.0 0.0 -2.5");   // 11: Engine nozzle tip
+
+            sb.AppendLine("v -0.5 -0.2 0.5");  // 12: Wing joint front
+            sb.AppendLine("v -2.5 -0.4 -1.5"); // 13: Wing tip
+            sb.AppendLine("v -0.4 -0.2 -1.5"); // 14: Wing joint rear
+
+            sb.AppendLine("v 0.5 -0.2 0.5");   // 15: Wing joint front
+            sb.AppendLine("v 2.5 -0.4 -1.5");  // 16: Wing tip
+            sb.AppendLine("v 0.4 -0.2 -1.5");   // 17: Wing joint rear
+
+            sb.AppendLine("v 0.0 0.4 -0.5");   // 18: Fin joint front
+            sb.AppendLine("v 0.0 1.5 -1.8");   // 19: Fin tip
+            sb.AppendLine("v 0.0 0.4 -1.8");   // 20: Fin joint rear
+
+            // Faces
+            // Nose Cone to Cockpit
+            sb.AppendLine("f 1 2 3");
+            sb.AppendLine("f 1 3 4");
+            sb.AppendLine("f 1 4 2");
+
+            // Cockpit to Fuselage
+            sb.AppendLine("f 2 5 6");
+            sb.AppendLine("f 2 6 3");
+            sb.AppendLine("f 3 6 7");
+            sb.AppendLine("f 3 7 4");
+            sb.AppendLine("f 4 7 5");
+            sb.AppendLine("f 4 5 2");
+
+            // Fuselage to Engines
+            sb.AppendLine("f 5 8 9");
+            sb.AppendLine("f 5 9 6");
+            sb.AppendLine("f 6 9 10");
+            sb.AppendLine("f 6 10 7");
+            sb.AppendLine("f 7 10 8");
+            sb.AppendLine("f 7 8 5");
+
+            // Engine Nozzle Cone
+            sb.AppendLine("f 8 11 9");
+            sb.AppendLine("f 9 11 10");
+            sb.AppendLine("f 10 11 8");
+
+            // Left Wing (Double Sided)
+            sb.AppendLine("f 12 13 14");
+            sb.AppendLine("f 12 14 13");
+
+            // Right Wing (Double Sided)
+            sb.AppendLine("f 15 17 16");
+            sb.AppendLine("f 15 16 17");
+
+            // Tail Fin (Double Sided)
+            sb.AppendLine("f 18 19 20");
+            sb.AppendLine("f 18 20 19");
+
+            return sb.ToString();
+        }
+
+        public static string GenerateFacetedJewelObj()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("# Procedural Faceted Jewel OBJ model");
+
+            int slices = 16;
+
+            // Center ring
+            for (int i = 0; i < slices; i++)
+            {
+                float angle = (float)i / slices * MathF.PI * 2.0f;
+                sb.AppendLine($"v {MathF.Cos(angle) * 2.0f} 0.0 {MathF.Sin(angle) * 2.0f}"); // 1 to slices
+            }
+
+            // Upper ring
+            for (int i = 0; i < slices; i++)
+            {
+                float angle = ((float)i + 0.5f) / slices * MathF.PI * 2.0f;
+                sb.AppendLine($"v {MathF.Cos(angle) * 1.2f} 0.8 {MathF.Sin(angle) * 1.2f}"); // slices+1 to 2*slices
+            }
+
+            // Top vertex
+            sb.AppendLine("v 0.0 1.5 0.0"); // 2*slices + 1
+
+            // Bottom vertex
+            sb.AppendLine("v 0.0 -2.0 0.0"); // 2*slices + 2
+
+            // Faces
+            // Upper cap triangles
+            int topIdx = 2 * slices + 1;
+            for (int i = 0; i < slices; i++)
+            {
+                int next = (i + 1) % slices;
+                sb.AppendLine($"f {topIdx} {slices + 1 + i} {slices + 1 + next}");
+            }
+
+            // Upper band quads (triangulated)
+            for (int i = 0; i < slices; i++)
+            {
+                int next = (i + 1) % slices;
+                int v0 = i + 1;
+                int v1 = next + 1;
+                int v2 = slices + 1 + i;
+                int v3 = slices + 1 + next;
+
+                sb.AppendLine($"f {v0} {v1} {v3}");
+                sb.AppendLine($"f {v0} {v3} {v2}");
+            }
+
+            // Lower band triangles to bottom tip
+            int bottomIdx = 2 * slices + 2;
+            for (int i = 0; i < slices; i++)
+            {
+                int next = (i + 1) % slices;
+                sb.AppendLine($"f {bottomIdx} {next + 1} {i + 1}");
+            }
+
+            return sb.ToString();
+        }
+
+        public static void EnsureSamplesExist(string targetDirectory)
+        {
+            if (!Directory.Exists(targetDirectory))
+            {
+                Directory.CreateDirectory(targetDirectory);
+            }
+
+            string spacecraftPath = Path.Combine(targetDirectory, "spacecraft.obj");
+            if (!File.Exists(spacecraftPath))
+            {
+                File.WriteAllText(spacecraftPath, GenerateSpacecraftObj());
+            }
+
+            string jewelPath = Path.Combine(targetDirectory, "jewel.obj");
+            if (!File.Exists(jewelPath))
+            {
+                File.WriteAllText(jewelPath, GenerateFacetedJewelObj());
+            }
+        }
+    }
+}

--- a/src/ProGPU.Samples/Helpers/ObjModels.cs
+++ b/src/ProGPU.Samples/Helpers/ObjModels.cs
@@ -91,14 +91,18 @@ namespace ProGPU.Samples
             for (int i = 0; i < slices; i++)
             {
                 float angle = (float)i / slices * MathF.PI * 2.0f;
-                sb.AppendLine($"v {MathF.Cos(angle) * 2.0f} 0.0 {MathF.Sin(angle) * 2.0f}"); // 1 to slices
+                float x = MathF.Cos(angle) * 2.0f;
+                float z = MathF.Sin(angle) * 2.0f;
+                sb.AppendLine($"v {x.ToString(System.Globalization.CultureInfo.InvariantCulture)} 0.0 {z.ToString(System.Globalization.CultureInfo.InvariantCulture)}"); // 1 to slices
             }
 
             // Upper ring
             for (int i = 0; i < slices; i++)
             {
                 float angle = ((float)i + 0.5f) / slices * MathF.PI * 2.0f;
-                sb.AppendLine($"v {MathF.Cos(angle) * 1.2f} 0.8 {MathF.Sin(angle) * 1.2f}"); // slices+1 to 2*slices
+                float x = MathF.Cos(angle) * 1.2f;
+                float z = MathF.Sin(angle) * 1.2f;
+                sb.AppendLine($"v {x.ToString(System.Globalization.CultureInfo.InvariantCulture)} 0.8 {z.ToString(System.Globalization.CultureInfo.InvariantCulture)}"); // slices+1 to 2*slices
             }
 
             // Top vertex

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -208,6 +208,15 @@ public static class MeshBuilder
     }
 }
 
+public enum LayoutMode3D
+{
+    Quad,
+    Top,
+    Front,
+    Right,
+    Perspective
+}
+
 public class Mesh3DViewerPageGrid : Grid, IAnimatedElement
 {
     public void Update(float delta)
@@ -227,6 +236,30 @@ public static class Mesh3DViewerPage
     private static ModelVisual3D? _model2;
     private static ModelVisual3D? _model3;
     private static ModelVisual3D? _model4;
+
+    private static Border? _card1;
+    private static Border? _card2;
+    private static Border? _card3;
+    private static Border? _card4;
+    private static Grid? _viewportsGrid;
+    private static Grid? _leftGrid;
+    private static Grid? _rightGrid;
+    private static GridSplitter? _colSplitter;
+    private static GridSplitter? _rowSplitterLeft;
+    private static GridSplitter? _rowSplitterRight;
+
+    private static Button? _layoutBtnQuad;
+    private static Button? _layoutBtnTop;
+    private static Button? _layoutBtnFront;
+    private static Button? _layoutBtnRight;
+    private static Button? _layoutBtnPersp;
+
+    private static Button? _maxBtn1;
+    private static Button? _maxBtn2;
+    private static Button? _maxBtn3;
+    private static Button? _maxBtn4;
+
+    private static LayoutMode3D _currentLayoutMode = LayoutMode3D.Quad;
 
     private static float _rotationAngle = 0f;
     private static bool _animateRotation = false;
@@ -273,12 +306,23 @@ public static class Mesh3DViewerPage
             Background = new ThemeResourceBrush("ControlBackground"),
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
             BorderThickness = new Thickness(0, 0, 1f, 0),
-            Padding = new Thickness(16f),
             VerticalAlignment = VerticalAlignment.Stretch
         };
 
-        var sidebarStack = new Microsoft.UI.Xaml.Controls.StackPanel { Orientation = Orientation.Vertical };
-        sidebar.Child = sidebarStack;
+        var sidebarScroll = new ScrollViewer
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+
+        var sidebarStack = new Microsoft.UI.Xaml.Controls.StackPanel 
+        { 
+            Orientation = Orientation.Vertical,
+            Padding = new Thickness(16f),
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        sidebarScroll.Content = sidebarStack;
+        sidebar.Child = sidebarScroll;
 
         var title = new RichTextBlock { Font = AppState.GetFont(), FontSize = 16f, Margin = new Thickness(0, 0, 0, 8f) };
         title.Inlines.Add(new Bold(new Run("WebGPU 3D Mesh Viewer")));
@@ -287,6 +331,32 @@ public static class Mesh3DViewerPage
         var description = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11.5f, Margin = new Thickness(0, 0, 0, 16f), Foreground = new ThemeResourceBrush("TextSecondary") };
         description.Inlines.Add(new Run("A declarative, WPF-style retained 3D media layout engine. Lighting transforms and matrix math are fully offloaded to the GPU."));
         sidebarStack.AddChild(description);
+
+        // Viewport Layout Segmented Toolbar
+        var layoutHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 6f) };
+        layoutHeader.Inlines.Add(new Bold(new Run("Viewport Layout:")));
+        sidebarStack.AddChild(layoutHeader);
+
+        var layoutGrid = new Grid { Margin = new Thickness(0, 0, 0, 16f) };
+        layoutGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        layoutGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        layoutGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        layoutGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        layoutGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        _layoutBtnQuad = CreateLayoutButton("Quad", LayoutMode3D.Quad);
+        _layoutBtnTop = CreateLayoutButton("Top", LayoutMode3D.Top);
+        _layoutBtnFront = CreateLayoutButton("Front", LayoutMode3D.Front);
+        _layoutBtnRight = CreateLayoutButton("Right", LayoutMode3D.Right);
+        _layoutBtnPersp = CreateLayoutButton("Persp", LayoutMode3D.Perspective);
+
+        layoutGrid.AddChild(_layoutBtnQuad); Grid.SetColumn(_layoutBtnQuad, 0);
+        layoutGrid.AddChild(_layoutBtnTop); Grid.SetColumn(_layoutBtnTop, 1);
+        layoutGrid.AddChild(_layoutBtnFront); Grid.SetColumn(_layoutBtnFront, 2);
+        layoutGrid.AddChild(_layoutBtnRight); Grid.SetColumn(_layoutBtnRight, 3);
+        layoutGrid.AddChild(_layoutBtnPersp); Grid.SetColumn(_layoutBtnPersp, 4);
+
+        sidebarStack.AddChild(layoutGrid);
 
         // Combobox for Shape selection
         var shapeHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 4) };
@@ -639,24 +709,42 @@ public static class Mesh3DViewerPage
         mainGrid.AddChild(sidebar);
         Grid.SetColumn(sidebar, 0);
 
-        // 2. MAIN 4-WAY SPLIT VIEW WORKSPACE (2x2 CAD GRID)
-        var viewportsGrid = new Grid { Margin = new Thickness(16f) };
-        viewportsGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-        viewportsGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-        viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-        viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        // 2. MAIN 4-WAY SPLIT VIEW WORKSPACE (3x3 CAD NESTED GRIDS FOR SPLITTING)
+        _viewportsGrid = new Grid { Margin = new Thickness(16f) };
+        _viewportsGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _viewportsGrid.ColumnDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
+        _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        _leftGrid = new Grid();
+        _leftGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _leftGrid.RowDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
+        _leftGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        _rightGrid = new Grid();
+        _rightGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _rightGrid.RowDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
+        _rightGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        _viewportsGrid.AddChild(_leftGrid);
+        Grid.SetColumn(_leftGrid, 0);
+        Grid.SetRow(_leftGrid, 0);
+
+        _viewportsGrid.AddChild(_rightGrid);
+        Grid.SetColumn(_rightGrid, 2);
+        Grid.SetRow(_rightGrid, 0);
 
         // 2.A Viewport 1: Top Orthographic View
-        var card1 = new Border
+        _card1 = new Border
         {
             CornerRadius = 8f,
             BorderThickness = new Thickness(1f),
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
             Background = new ThemeResourceBrush("CardBackground"),
-            Margin = new Thickness(0, 0, 6f, 6f)
+            Margin = new Thickness(0)
         };
         var viewportStack1 = new Grid();
-        card1.Child = viewportStack1;
+        _card1.Child = viewportStack1;
 
         _viewport1 = new Viewport3D
         {
@@ -676,21 +764,39 @@ public static class Mesh3DViewerPage
         overlayText1.Inlines.Add(new Bold(new Run("Top View (Orthographic)")));
         viewportStack1.AddChild(overlayText1);
 
-        viewportsGrid.AddChild(card1);
-        Grid.SetRow(card1, 0);
-        Grid.SetColumn(card1, 0);
+        _maxBtn1 = new Button
+        {
+            HeightConstraint = 24f,
+            WidthConstraint = 80f,
+            CornerRadius = 4f,
+            Margin = new Thickness(8f),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Background = new ThemeResourceBrush("ControlBackgroundHover")
+        };
+        var maxRun1 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn1.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun1 } };
+        _maxBtn1.Click += (s, e) =>
+        {
+            SetLayoutMode(_currentLayoutMode == LayoutMode3D.Top ? LayoutMode3D.Quad : LayoutMode3D.Top);
+        };
+        viewportStack1.AddChild(_maxBtn1);
+
+        _leftGrid.AddChild(_card1);
+        Grid.SetRow(_card1, 0);
+        Grid.SetColumn(_card1, 0);
 
         // 2.B Viewport 2: Front Orthographic View
-        var card2 = new Border
+        _card2 = new Border
         {
             CornerRadius = 8f,
             BorderThickness = new Thickness(1f),
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
             Background = new ThemeResourceBrush("CardBackground"),
-            Margin = new Thickness(6f, 0, 0, 6f)
+            Margin = new Thickness(0)
         };
         var viewportStack2 = new Grid();
-        card2.Child = viewportStack2;
+        _card2.Child = viewportStack2;
 
         _viewport2 = new Viewport3D
         {
@@ -710,21 +816,39 @@ public static class Mesh3DViewerPage
         overlayText2.Inlines.Add(new Bold(new Run("Front View (Orthographic)")));
         viewportStack2.AddChild(overlayText2);
 
-        viewportsGrid.AddChild(card2);
-        Grid.SetRow(card2, 0);
-        Grid.SetColumn(card2, 1);
+        _maxBtn2 = new Button
+        {
+            HeightConstraint = 24f,
+            WidthConstraint = 80f,
+            CornerRadius = 4f,
+            Margin = new Thickness(8f),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Background = new ThemeResourceBrush("ControlBackgroundHover")
+        };
+        var maxRun2 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn2.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun2 } };
+        _maxBtn2.Click += (s, e) =>
+        {
+            SetLayoutMode(_currentLayoutMode == LayoutMode3D.Front ? LayoutMode3D.Quad : LayoutMode3D.Front);
+        };
+        viewportStack2.AddChild(_maxBtn2);
+
+        _rightGrid.AddChild(_card2);
+        Grid.SetRow(_card2, 0);
+        Grid.SetColumn(_card2, 0);
 
         // 2.C Viewport 3: Right Orthographic View
-        var card3 = new Border
+        _card3 = new Border
         {
             CornerRadius = 8f,
             BorderThickness = new Thickness(1f),
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
             Background = new ThemeResourceBrush("CardBackground"),
-            Margin = new Thickness(0, 6f, 6f, 0)
+            Margin = new Thickness(0)
         };
         var viewportStack3 = new Grid();
-        card3.Child = viewportStack3;
+        _card3.Child = viewportStack3;
 
         _viewport3 = new Viewport3D
         {
@@ -744,21 +868,39 @@ public static class Mesh3DViewerPage
         overlayText3.Inlines.Add(new Bold(new Run("Right View (Orthographic)")));
         viewportStack3.AddChild(overlayText3);
 
-        viewportsGrid.AddChild(card3);
-        Grid.SetRow(card3, 1);
-        Grid.SetColumn(card3, 0);
+        _maxBtn3 = new Button
+        {
+            HeightConstraint = 24f,
+            WidthConstraint = 80f,
+            CornerRadius = 4f,
+            Margin = new Thickness(8f),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Background = new ThemeResourceBrush("ControlBackgroundHover")
+        };
+        var maxRun3 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn3.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun3 } };
+        _maxBtn3.Click += (s, e) =>
+        {
+            SetLayoutMode(_currentLayoutMode == LayoutMode3D.Right ? LayoutMode3D.Quad : LayoutMode3D.Right);
+        };
+        viewportStack3.AddChild(_maxBtn3);
+
+        _leftGrid.AddChild(_card3);
+        Grid.SetRow(_card3, 2);
+        Grid.SetColumn(_card3, 0);
 
         // 2.D Viewport 4: 3D Perspective View
-        var card4 = new Border
+        _card4 = new Border
         {
             CornerRadius = 8f,
             BorderThickness = new Thickness(1f),
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
             Background = new ThemeResourceBrush("CardBackground"),
-            Margin = new Thickness(6f, 6f, 0, 0)
+            Margin = new Thickness(0)
         };
         var viewportStack4 = new Grid();
-        card4.Child = viewportStack4;
+        _card4.Child = viewportStack4;
 
         _viewport4 = new Viewport3D
         {
@@ -777,12 +919,64 @@ public static class Mesh3DViewerPage
         overlayText4.Inlines.Add(new Bold(new Run("3D Perspective View")));
         viewportStack4.AddChild(overlayText4);
 
-        viewportsGrid.AddChild(card4);
-        Grid.SetRow(card4, 1);
-        Grid.SetColumn(card4, 1);
+        _maxBtn4 = new Button
+        {
+            HeightConstraint = 24f,
+            WidthConstraint = 80f,
+            CornerRadius = 4f,
+            Margin = new Thickness(8f),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Background = new ThemeResourceBrush("ControlBackgroundHover")
+        };
+        var maxRun4 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn4.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun4 } };
+        _maxBtn4.Click += (s, e) =>
+        {
+            SetLayoutMode(_currentLayoutMode == LayoutMode3D.Perspective ? LayoutMode3D.Quad : LayoutMode3D.Perspective);
+        };
+        viewportStack4.AddChild(_maxBtn4);
 
-        mainGrid.AddChild(viewportsGrid);
-        Grid.SetColumn(viewportsGrid, 1);
+        _rightGrid.AddChild(_card4);
+        Grid.SetRow(_card4, 2);
+        Grid.SetColumn(_card4, 0);
+
+        // 2.E GridSplitters
+        _colSplitter = new GridSplitter
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Background = new ThemeResourceBrush("GridSplitterBackground"),
+            ResizeDirection = GridSplitterResizeDirection.Columns
+        };
+        _viewportsGrid.AddChild(_colSplitter);
+        Grid.SetRow(_colSplitter, 0);
+        Grid.SetColumn(_colSplitter, 1);
+
+        _rowSplitterLeft = new GridSplitter
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Background = new ThemeResourceBrush("GridSplitterBackground"),
+            ResizeDirection = GridSplitterResizeDirection.Rows
+        };
+        _leftGrid.AddChild(_rowSplitterLeft);
+        Grid.SetRow(_rowSplitterLeft, 1);
+        Grid.SetColumn(_rowSplitterLeft, 0);
+
+        _rowSplitterRight = new GridSplitter
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Background = new ThemeResourceBrush("GridSplitterBackground"),
+            ResizeDirection = GridSplitterResizeDirection.Rows
+        };
+        _rightGrid.AddChild(_rowSplitterRight);
+        Grid.SetRow(_rowSplitterRight, 1);
+        Grid.SetColumn(_rowSplitterRight, 0);
+
+        mainGrid.AddChild(_viewportsGrid);
+        Grid.SetColumn(_viewportsGrid, 1);
 
         // Populate initial 3D geometries and register layout animation callbacks
         UpdateViewportModels();
@@ -1151,5 +1345,170 @@ public static class Mesh3DViewerPage
         _viewport2?.Invalidate();
         _viewport3?.Invalidate();
         _viewport4?.Invalidate();
+    }
+
+    private static void SetLayoutMode(LayoutMode3D mode)
+    {
+        _currentLayoutMode = mode;
+        
+        // Update layout button backgrounds to show selected state
+        if (_layoutBtnQuad != null) _layoutBtnQuad.Background = new ThemeResourceBrush(mode == LayoutMode3D.Quad ? "ControlBackgroundPressed" : "ControlBackgroundHover");
+        if (_layoutBtnTop != null) _layoutBtnTop.Background = new ThemeResourceBrush(mode == LayoutMode3D.Top ? "ControlBackgroundPressed" : "ControlBackgroundHover");
+        if (_layoutBtnFront != null) _layoutBtnFront.Background = new ThemeResourceBrush(mode == LayoutMode3D.Front ? "ControlBackgroundPressed" : "ControlBackgroundHover");
+        if (_layoutBtnRight != null) _layoutBtnRight.Background = new ThemeResourceBrush(mode == LayoutMode3D.Right ? "ControlBackgroundPressed" : "ControlBackgroundHover");
+        if (_layoutBtnPersp != null) _layoutBtnPersp.Background = new ThemeResourceBrush(mode == LayoutMode3D.Perspective ? "ControlBackgroundPressed" : "ControlBackgroundHover");
+
+        // Update card maximize button texts
+        if (_maxBtn1 != null) _maxBtn1.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Top ? "↙ Restore" : "↗ Maximize") } };
+        if (_maxBtn2 != null) _maxBtn2.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Front ? "↙ Restore" : "↗ Maximize") } };
+        if (_maxBtn3 != null) _maxBtn3.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Right ? "↙ Restore" : "↗ Maximize") } };
+        if (_maxBtn4 != null) _maxBtn4.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Perspective ? "↙ Restore" : "↗ Maximize") } };
+
+        if (_card1 == null || _card2 == null || _card3 == null || _card4 == null || 
+            _colSplitter == null || _rowSplitterLeft == null || _rowSplitterRight == null ||
+            _leftGrid == null || _rightGrid == null || _viewportsGrid == null)
+            return;
+
+        // 1. Reset visibility of all components first
+        _leftGrid.Visibility = Visibility.Visible;
+        _rightGrid.Visibility = Visibility.Visible;
+        _colSplitter.Visibility = Visibility.Visible;
+
+        _card1.Visibility = Visibility.Visible;
+        _card2.Visibility = Visibility.Visible;
+        _card3.Visibility = Visibility.Visible;
+        _card4.Visibility = Visibility.Visible;
+
+        _rowSplitterLeft.Visibility = Visibility.Visible;
+        _rowSplitterRight.Visibility = Visibility.Visible;
+
+        // 2. Clear definitions and rebuild to standard resizable quad layout
+        _viewportsGrid.RowDefinitions.Clear();
+        _viewportsGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _viewportsGrid.ColumnDefinitions.Clear();
+        _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _viewportsGrid.ColumnDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
+        _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        _leftGrid.RowDefinitions.Clear();
+        _leftGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _leftGrid.RowDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
+        _leftGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        _rightGrid.RowDefinitions.Clear();
+        _rightGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        _rightGrid.RowDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
+        _rightGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        // 3. Reset standard column/row assignments
+        Grid.SetColumn(_leftGrid, 0); Grid.SetRow(_leftGrid, 0);
+        Grid.SetColumn(_rightGrid, 2); Grid.SetRow(_rightGrid, 0);
+        Grid.SetColumn(_colSplitter, 1); Grid.SetRow(_colSplitter, 0);
+
+        Grid.SetColumn(_card1, 0); Grid.SetRow(_card1, 0);
+        Grid.SetColumn(_rowSplitterLeft, 0); Grid.SetRow(_rowSplitterLeft, 1);
+        Grid.SetColumn(_card3, 0); Grid.SetRow(_card3, 2);
+
+        Grid.SetColumn(_card2, 0); Grid.SetRow(_card2, 0);
+        Grid.SetColumn(_rowSplitterRight, 0); Grid.SetRow(_rowSplitterRight, 1);
+        Grid.SetColumn(_card4, 0); Grid.SetRow(_card4, 2);
+
+        // 4. Apply layout modifications based on maximized selection
+        switch (mode)
+        {
+            case LayoutMode3D.Quad:
+                break;
+            case LayoutMode3D.Top:
+                _rightGrid.Visibility = Visibility.Collapsed;
+                _colSplitter.Visibility = Visibility.Collapsed;
+                _rowSplitterLeft.Visibility = Visibility.Collapsed;
+                _card3.Visibility = Visibility.Collapsed;
+                
+                // Set leftGrid to take entire main grid width
+                _viewportsGrid.ColumnDefinitions.Clear();
+                _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                
+                // Set card1 to take entire height inside leftGrid
+                _leftGrid.RowDefinitions.Clear();
+                _leftGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                break;
+
+            case LayoutMode3D.Front:
+                _leftGrid.Visibility = Visibility.Collapsed;
+                _colSplitter.Visibility = Visibility.Collapsed;
+                _rowSplitterRight.Visibility = Visibility.Collapsed;
+                _card4.Visibility = Visibility.Collapsed;
+                
+                // Set rightGrid to take entire main grid width and move it to Col 0
+                _viewportsGrid.ColumnDefinitions.Clear();
+                _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                Grid.SetColumn(_rightGrid, 0);
+                
+                // Set card2 to take entire height inside rightGrid
+                _rightGrid.RowDefinitions.Clear();
+                _rightGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                break;
+
+            case LayoutMode3D.Right:
+                _rightGrid.Visibility = Visibility.Collapsed;
+                _colSplitter.Visibility = Visibility.Collapsed;
+                _rowSplitterLeft.Visibility = Visibility.Collapsed;
+                _card1.Visibility = Visibility.Collapsed;
+                
+                // Set leftGrid to take entire main grid width
+                _viewportsGrid.ColumnDefinitions.Clear();
+                _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                
+                // Move card3 to Row 0 to fill leftGrid
+                _leftGrid.RowDefinitions.Clear();
+                _leftGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                Grid.SetRow(_card3, 0);
+                break;
+
+            case LayoutMode3D.Perspective:
+                _leftGrid.Visibility = Visibility.Collapsed;
+                _colSplitter.Visibility = Visibility.Collapsed;
+                _rowSplitterRight.Visibility = Visibility.Collapsed;
+                _card2.Visibility = Visibility.Collapsed;
+                
+                // Set rightGrid to take entire main grid width and move it to Col 0
+                _viewportsGrid.ColumnDefinitions.Clear();
+                _viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                Grid.SetColumn(_rightGrid, 0);
+                
+                // Move card4 to Row 0 to fill rightGrid
+                _rightGrid.RowDefinitions.Clear();
+                _rightGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+                Grid.SetRow(_card4, 0);
+                break;
+        }
+
+        // Force all views to redraw
+        _viewportsGrid.Invalidate();
+        _viewportsGrid.InvalidateMeasure();
+        _leftGrid.Invalidate();
+        _leftGrid.InvalidateMeasure();
+        _rightGrid.Invalidate();
+        _rightGrid.InvalidateMeasure();
+
+        _viewport1?.Invalidate();
+        _viewport2?.Invalidate();
+        _viewport3?.Invalidate();
+        _viewport4?.Invalidate();
+    }
+
+    private static Button CreateLayoutButton(string label, LayoutMode3D mode)
+    {
+        var btn = new Button
+        {
+            HeightConstraint = 28f,
+            CornerRadius = 4f,
+            Margin = new Thickness(2f),
+            Background = new ThemeResourceBrush(mode == LayoutMode3D.Quad ? "ControlBackgroundPressed" : "ControlBackgroundHover")
+        };
+        var textRun = new Run(label) { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        btn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(textRun) } };
+        btn.Click += (s, e) => { SetLayoutMode(mode); };
+        return btn;
     }
 }

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -93,12 +93,12 @@ public static class MeshBuilder
                 int r3 = r2 + 1;
 
                 indices.Add(r0);
-                indices.Add(r2);
                 indices.Add(r1);
+                indices.Add(r2);
 
                 indices.Add(r1);
-                indices.Add(r2);
                 indices.Add(r3);
+                indices.Add(r2);
             }
         }
 
@@ -192,12 +192,12 @@ public static class MeshBuilder
                 int r3 = r2 + 1;
 
                 indices.Add(r0);
-                indices.Add(r1);
                 indices.Add(r2);
+                indices.Add(r1);
 
                 indices.Add(r1);
-                indices.Add(r3);
                 indices.Add(r2);
+                indices.Add(r3);
             }
         }
 

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -953,7 +953,12 @@ public static class Mesh3DViewerPage
                 }
 
                 var brush = new SolidColorBrush(color) { Opacity = part.Opacity };
-                var material = new DiffuseMaterial(brush);
+                var material = new DiffuseMaterial(brush)
+                {
+                    SpecularColor = part.SpecularColor,
+                    Shininess = part.Shininess,
+                    AmbientColor = part.AmbientColor
+                };
 
                 _model1.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = part.Geometry, Material = material } });
                 _model2.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = part.Geometry, Material = material } });

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -1,0 +1,1072 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media.Media3D;
+using ProGPU.Vector;
+using ProGPU.Layout;
+using ProGPU.Scene;
+using ProGPU.Scene.Extensions;
+using System.IO;
+
+namespace ProGPU.Samples;
+
+public static class MeshBuilder
+{
+    public static MeshGeometry3D CreateCube()
+    {
+        var positions = new Vector3[]
+        {
+            // Front Face
+            new Vector3(-1f, -1f,  1f), new Vector3( 1f, -1f,  1f), new Vector3( 1f,  1f,  1f), new Vector3(-1f,  1f,  1f),
+            // Back Face
+            new Vector3(-1f, -1f, -1f), new Vector3(-1f,  1f, -1f), new Vector3( 1f,  1f, -1f), new Vector3( 1f, -1f, -1f),
+            // Top Face
+            new Vector3(-1f,  1f, -1f), new Vector3(-1f,  1f,  1f), new Vector3( 1f,  1f,  1f), new Vector3( 1f,  1f, -1f),
+            // Bottom Face
+            new Vector3(-1f, -1f, -1f), new Vector3( 1f, -1f, -1f), new Vector3( 1f, -1f,  1f), new Vector3(-1f, -1f,  1f),
+            // Right Face
+            new Vector3( 1f, -1f, -1f), new Vector3( 1f,  1f, -1f), new Vector3( 1f,  1f,  1f), new Vector3( 1f, -1f,  1f),
+            // Left Face
+            new Vector3(-1f, -1f, -1f), new Vector3(-1f, -1f,  1f), new Vector3(-1f,  1f,  1f), new Vector3(-1f,  1f, -1f)
+        };
+
+        var normals = new Vector3[]
+        {
+            new Vector3(0, 0, 1), new Vector3(0, 0, 1), new Vector3(0, 0, 1), new Vector3(0, 0, 1),
+            new Vector3(0, 0, -1), new Vector3(0, 0, -1), new Vector3(0, 0, -1), new Vector3(0, 0, -1),
+            new Vector3(0, 1, 0), new Vector3(0, 1, 0), new Vector3(0, 1, 0), new Vector3(0, 1, 0),
+            new Vector3(0, -1, 0), new Vector3(0, -1, 0), new Vector3(0, -1, 0), new Vector3(0, -1, 0),
+            new Vector3(1, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0),
+            new Vector3(-1, 0, 0), new Vector3(-1, 0, 0), new Vector3(-1, 0, 0), new Vector3(-1, 0, 0)
+        };
+
+        var indices = new int[]
+        {
+            0, 1, 2, 0, 2, 3,       // Front
+            4, 5, 6, 4, 6, 7,       // Back
+            8, 9, 10, 8, 10, 11,    // Top
+            12, 13, 14, 12, 14, 15, // Bottom
+            16, 17, 18, 16, 18, 19, // Right
+            20, 21, 22, 20, 22, 23  // Left
+        };
+
+        return new MeshGeometry3D { Positions = positions, Normals = normals, TriangleIndices = indices };
+    }
+
+    public static MeshGeometry3D CreateSphere(float radius, int slices, int stacks)
+    {
+        var positions = new List<Vector3>();
+        var normals = new List<Vector3>();
+        var indices = new List<int>();
+
+        for (int stack = 0; stack <= stacks; stack++)
+        {
+            float phi = MathF.PI * (float)stack / stacks;
+            float sinPhi = MathF.Sin(phi);
+            float cosPhi = MathF.Cos(phi);
+
+            for (int slice = 0; slice <= slices; slice++)
+            {
+                float theta = 2f * MathF.PI * (float)slice / slices;
+                float sinTheta = MathF.Sin(theta);
+                float cosTheta = MathF.Cos(theta);
+
+                var normal = new Vector3(cosTheta * sinPhi, cosPhi, sinTheta * sinPhi);
+                var pos = normal * radius;
+
+                positions.Add(pos);
+                normals.Add(normal);
+            }
+        }
+
+        for (int stack = 0; stack < stacks; stack++)
+        {
+            for (int slice = 0; slice < slices; slice++)
+            {
+                int r0 = stack * (slices + 1) + slice;
+                int r1 = r0 + 1;
+                int r2 = (stack + 1) * (slices + 1) + slice;
+                int r3 = r2 + 1;
+
+                indices.Add(r0);
+                indices.Add(r2);
+                indices.Add(r1);
+
+                indices.Add(r1);
+                indices.Add(r2);
+                indices.Add(r3);
+            }
+        }
+
+        return new MeshGeometry3D { Positions = positions.ToArray(), Normals = normals.ToArray(), TriangleIndices = indices.ToArray() };
+    }
+
+    public static MeshGeometry3D CreateTorus(float majorRadius, float minorRadius, int majorSegments, int minorSegments)
+    {
+        var positions = new List<Vector3>();
+        var normals = new List<Vector3>();
+        var indices = new List<int>();
+
+        for (int i = 0; i <= majorSegments; i++)
+        {
+            float u = (float)i / majorSegments * 2f * MathF.PI;
+            float cosU = MathF.Cos(u);
+            float sinU = MathF.Sin(u);
+
+            for (int j = 0; j <= minorSegments; j++)
+            {
+                float v = (float)j / minorSegments * 2f * MathF.PI;
+                float cosV = MathF.Cos(v);
+                float sinV = MathF.Sin(v);
+
+                var pos = new Vector3(
+                    (majorRadius + minorRadius * cosV) * cosU,
+                    minorRadius * sinV,
+                    (majorRadius + minorRadius * cosV) * sinU
+                );
+
+                var center = new Vector3(majorRadius * cosU, 0f, majorRadius * sinU);
+                var normal = Vector3.Normalize(pos - center);
+
+                positions.Add(pos);
+                normals.Add(normal);
+            }
+        }
+
+        for (int i = 0; i < majorSegments; i++)
+        {
+            for (int j = 0; j < minorSegments; j++)
+            {
+                int r0 = i * (minorSegments + 1) + j;
+                int r1 = r0 + 1;
+                int r2 = (i + 1) * (minorSegments + 1) + j;
+                int r3 = r2 + 1;
+
+                indices.Add(r0);
+                indices.Add(r1);
+                indices.Add(r2);
+
+                indices.Add(r1);
+                indices.Add(r3);
+                indices.Add(r2);
+            }
+        }
+
+        return new MeshGeometry3D { Positions = positions.ToArray(), Normals = normals.ToArray(), TriangleIndices = indices.ToArray() };
+    }
+
+    public static MeshGeometry3D CreateTerrain(float size, int gridSegments, float heightMultiplier)
+    {
+        var positions = new List<Vector3>();
+        var indices = new List<int>();
+
+        float halfSize = size * 0.5f;
+        float segmentSize = size / gridSegments;
+
+        for (int z = 0; z <= gridSegments; z++)
+        {
+            float zPos = -halfSize + z * segmentSize;
+            for (int x = 0; x <= gridSegments; x++)
+            {
+                float xPos = -halfSize + x * segmentSize;
+
+                // Procedural sinusoidal terrain waves
+                float d = MathF.Sqrt(xPos * xPos + zPos * zPos);
+                float yPos = MathF.Sin(d * 1.5f) * heightMultiplier / (1.0f + d * 0.2f);
+
+                positions.Add(new Vector3(xPos, yPos, zPos));
+            }
+        }
+
+        for (int z = 0; z < gridSegments; z++)
+        {
+            for (int x = 0; x < gridSegments; x++)
+            {
+                int r0 = z * (gridSegments + 1) + x;
+                int r1 = r0 + 1;
+                int r2 = (z + 1) * (gridSegments + 1) + x;
+                int r3 = r2 + 1;
+
+                indices.Add(r0);
+                indices.Add(r1);
+                indices.Add(r2);
+
+                indices.Add(r1);
+                indices.Add(r3);
+                indices.Add(r2);
+            }
+        }
+
+        var mesh = new MeshGeometry3D { Positions = positions.ToArray(), TriangleIndices = indices.ToArray() };
+        // Force calculation of correct face normals on procedural terrain
+        mesh.Normals = mesh.GetNormalsOrCompute();
+        return mesh;
+    }
+}
+
+public class Mesh3DViewerPageGrid : Grid, IAnimatedElement
+{
+    public void Update(float delta)
+    {
+        Mesh3DViewerPage.UpdateAnimations((float)delta);
+    }
+}
+
+public static class Mesh3DViewerPage
+{
+    private static Viewport3D? _viewport1;
+    private static Viewport3D? _viewport2;
+    private static Viewport3D? _viewport3;
+    private static Viewport3D? _viewport4;
+    
+    private static ModelVisual3D? _model1;
+    private static ModelVisual3D? _model2;
+    private static ModelVisual3D? _model3;
+    private static ModelVisual3D? _model4;
+
+    private static float _rotationAngle = 0f;
+    private static bool _animateRotation = true;
+    
+    private static Vector3 _lightDirection = new Vector3(0.5f, 1f, -0.5f);
+    private static float _lightIntensity = 1.0f;
+    private static float _ambientIntensity = 0.25f;
+
+    private static string _selectedMeshType = "Torus";
+    private static MeshGeometry3D? _activeMeshGeometry;
+    private static MeshGeometry3D? _lastMeshGeometry;
+
+    private static Vector4 _activeModelColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f); // Default premium clay warm gray
+    private static Border? _pickerPopup;
+    private static RenderMode3D _selectedRenderMode = RenderMode3D.SolidWireframe;
+
+    private static Run? _statsNameRun;
+    private static Run? _statsVerticesRun;
+    private static Run? _statsTrianglesRun;
+    private static Run? _statsBoundsRun;
+    private static Run? _statsMemoryRun;
+    private static string _customObjPath = "";
+
+    private static RichTextBlock? _statsNameBlock;
+    private static RichTextBlock? _statsVerticesBlock;
+    private static RichTextBlock? _statsTrianglesBlock;
+    private static RichTextBlock? _statsBoundsBlock;
+    private static RichTextBlock? _statsMemoryBlock;
+
+    public static FrameworkElement Create()
+    {
+        var mainGrid = new Mesh3DViewerPageGrid();
+        mainGrid.ColumnDefinitions.Add(new GridLength(300f, GridUnitType.Absolute)); // Sidebar parameters
+        mainGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));       // Main dual viewports
+
+        // Load default shape
+        RegenerateMeshGeometry();
+
+        // 1. LEFT SIDEBAR PANEL
+        var sidebar = new Border
+        {
+            Background = new ThemeResourceBrush("ControlBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(0, 0, 1f, 0),
+            Padding = new Thickness(16f),
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+
+        var sidebarStack = new Microsoft.UI.Xaml.Controls.StackPanel { Orientation = Orientation.Vertical };
+        sidebar.Child = sidebarStack;
+
+        var title = new RichTextBlock { Font = AppState.GetFont(), FontSize = 16f, Margin = new Thickness(0, 0, 0, 8f) };
+        title.Inlines.Add(new Bold(new Run("WebGPU 3D Mesh Viewer")));
+        sidebarStack.AddChild(title);
+
+        var description = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11.5f, Margin = new Thickness(0, 0, 0, 16f), Foreground = new ThemeResourceBrush("TextSecondary") };
+        description.Inlines.Add(new Run("A declarative, WPF-style retained 3D media layout engine. Lighting transforms and matrix math are fully offloaded to the GPU."));
+        sidebarStack.AddChild(description);
+
+        // Combobox for Shape selection
+        var shapeHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 4) };
+        shapeHeader.Inlines.Add(new Bold(new Run("Mesh Geometry:")));
+        sidebarStack.AddChild(shapeHeader);
+
+        var shapeCombo = new ComboBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            WidthConstraint = 268f,
+            Margin = new Thickness(0, 0, 0, 16f)
+        };
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "Cube" });
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "Sphere" });
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "Torus" });
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "Procedural Terrain" });
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "OBJ: Spacecraft" });
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "OBJ: Faceted Jewel" });
+        shapeCombo.Items.Add(new ComboBoxItem { Text = "OBJ: Custom Path" });
+        shapeCombo.SelectedItem = shapeCombo.Items[2]; // Default to Torus
+
+        // Combobox for Render Mode selection
+        var renderModeHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 4) };
+        renderModeHeader.Inlines.Add(new Bold(new Run("Render Mode:")));
+        
+        var renderModeCombo = new ComboBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            WidthConstraint = 268f,
+            Margin = new Thickness(0, 0, 0, 16f)
+        };
+        renderModeCombo.Items.Add(new ComboBoxItem { Text = "Solid Shaded" });
+        renderModeCombo.Items.Add(new ComboBoxItem { Text = "Wireframe Only" });
+        renderModeCombo.Items.Add(new ComboBoxItem { Text = "Solid + Wireframe" });
+        renderModeCombo.SelectedItem = renderModeCombo.Items[2]; // Default to Solid + Wireframe
+
+        renderModeCombo.SelectionChanged += (s, e) =>
+        {
+            if (renderModeCombo.SelectedItem != null)
+            {
+                _selectedRenderMode = renderModeCombo.SelectedItem.Text switch
+                {
+                    "Solid Shaded" => RenderMode3D.Solid,
+                    "Wireframe Only" => RenderMode3D.Wireframe,
+                    "Solid + Wireframe" => RenderMode3D.SolidWireframe,
+                    _ => RenderMode3D.Solid
+                };
+                UpdateViewportModels();
+            }
+        };
+
+        var pathInputStack = new Microsoft.UI.Xaml.Controls.StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Thickness(0, 0, 0, 16f),
+            Visibility = Visibility.Visible
+        };
+        
+        var pathHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Margin = new Thickness(0, 0, 0, 4) };
+        pathHeader.Inlines.Add(new Bold(new Run("OBJ FILE PATH:")));
+        pathInputStack.AddChild(pathHeader);
+
+        var pathErrorText = new RichTextBlock 
+        { 
+            Font = AppState.GetFont(), 
+            FontSize = 10.5f, 
+            Margin = new Thickness(0, 4, 0, 0),
+            Foreground = new SolidColorBrush(new Vector4(0.9f, 0.3f, 0.3f, 1f)),
+            Visibility = Visibility.Collapsed
+        };
+
+        var pathGrid = new Grid { HorizontalAlignment = HorizontalAlignment.Stretch };
+        pathGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        pathGrid.ColumnDefinitions.Add(new GridLength(8f, GridUnitType.Absolute));
+        pathGrid.ColumnDefinitions.Add(new GridLength(72f, GridUnitType.Absolute));
+
+        var pathTextBox = new TextBox
+        {
+            PlaceholderText = "Enter .obj path...",
+            HeightConstraint = 32f,
+            Font = AppState.GetFont()
+        };
+        pathTextBox.KeyDown += (s, e) =>
+        {
+            if (e.Key == Silk.NET.Input.Key.Enter && !string.IsNullOrEmpty(pathTextBox.Text))
+            {
+                try
+                {
+                    _customObjPath = pathTextBox.Text;
+                    shapeCombo.SelectedItem = shapeCombo.Items[6]; // OBJ: Custom Path
+                    _selectedMeshType = "OBJ: Custom Path";
+                    _activeMeshGeometry = ObjReader.Load(_customObjPath);
+                    UpdateViewportModels();
+                }
+                catch (Exception ex)
+                {
+                    pathErrorText.Inlines.Clear();
+                    pathErrorText.Inlines.Add(new Run($"File load failed: {ex.Message}"));
+                    pathErrorText.Visibility = Visibility.Visible;
+                    pathErrorText.Invalidate();
+                }
+            }
+        };
+        pathGrid.AddChild(pathTextBox);
+        Grid.SetColumn(pathTextBox, 0);
+
+        var browseBtn = new Button
+        {
+            HeightConstraint = 32f,
+            CornerRadius = 4f,
+            Background = new ThemeResourceBrush("ControlBackgroundHover")
+        };
+        var browseBtnRun = new Run("Browse") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        browseBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(browseBtnRun) } };
+        pathGrid.AddChild(browseBtn);
+        Grid.SetColumn(browseBtn, 2);
+        
+        pathInputStack.AddChild(pathGrid);
+        pathInputStack.AddChild(pathErrorText);
+        
+        shapeCombo.SelectionChanged += (s, e) =>
+        {
+            if (shapeCombo.SelectedItem != null)
+            {
+                _selectedMeshType = shapeCombo.SelectedItem.Text;
+                
+                pathErrorText.Visibility = Visibility.Collapsed;
+                
+                RegenerateMeshGeometry();
+                UpdateViewportModels();
+            }
+        };
+
+        browseBtn.Click += async (s, e) =>
+        {
+            try
+            {
+                var picker = new FileOpenPicker();
+                picker.FileTypeFilter.Add(".obj");
+                var file = await picker.PickSingleFileAsync();
+                if (file != null)
+                {
+                    pathTextBox.Text = file.Path;
+                    pathErrorText.Visibility = Visibility.Collapsed;
+                    
+                    _customObjPath = file.Path;
+                    shapeCombo.SelectedItem = shapeCombo.Items[6]; // OBJ: Custom Path
+                    _selectedMeshType = "OBJ: Custom Path";
+                    
+                    _activeMeshGeometry = ObjReader.Load(file.Path);
+                    UpdateViewportModels();
+                }
+            }
+            catch (Exception ex)
+            {
+                pathErrorText.Inlines.Clear();
+                pathErrorText.Inlines.Add(new Run($"File pick failed: {ex.Message}"));
+                pathErrorText.Visibility = Visibility.Visible;
+                pathErrorText.Invalidate();
+            }
+        };
+
+        sidebarStack.AddChild(shapeCombo);
+        sidebarStack.AddChild(renderModeHeader);
+        sidebarStack.AddChild(renderModeCombo);
+        sidebarStack.AddChild(pathInputStack);
+
+        // 1.5 Mesh Statistics Card
+        var statsCard = new Border
+        {
+            Background = new ThemeResourceBrush("ControlBackgroundHover"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(1f),
+            CornerRadius = 6f,
+            Padding = new Thickness(12f),
+            Margin = new Thickness(0, 0, 0, 16f),
+            WidthConstraint = 268f
+        };
+
+        var statsStack = new Microsoft.UI.Xaml.Controls.StackPanel { Orientation = Orientation.Vertical };
+        statsCard.Child = statsStack;
+
+        var statsTitle = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 8f) };
+        statsTitle.Inlines.Add(new Bold(new Run("Mesh Statistics")));
+        statsStack.AddChild(statsTitle);
+
+        _statsNameRun = new Run("-");
+        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsNameBlock.Inlines.Add(new Bold(_statsNameRun));
+
+        _statsVerticesRun = new Run("0");
+        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsVerticesBlock.Inlines.Add(new Bold(_statsVerticesRun));
+
+        _statsTrianglesRun = new Run("0");
+        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsTrianglesBlock.Inlines.Add(new Bold(_statsTrianglesRun));
+
+        _statsBoundsRun = new Run("0.0 x 0.0 x 0.0");
+        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsBoundsBlock.Inlines.Add(new Bold(_statsBoundsRun));
+
+        _statsMemoryRun = new Run("0 KB");
+        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsMemoryBlock.Inlines.Add(new Bold(_statsMemoryRun));
+
+        statsStack.AddChild(CreateStatRow("Name:", _statsNameBlock));
+        statsStack.AddChild(CreateStatRow("Vertices:", _statsVerticesBlock));
+        statsStack.AddChild(CreateStatRow("Triangles:", _statsTrianglesBlock));
+        statsStack.AddChild(CreateStatRow("Size (Bounds):", _statsBoundsBlock));
+        statsStack.AddChild(CreateStatRow("GPU Memory:", _statsMemoryBlock));
+
+        sidebarStack.AddChild(statsCard);
+
+        // Color selection header
+        var colorHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 6) };
+        colorHeader.Inlines.Add(new Bold(new Run("Mesh Color Palette:")));
+        sidebarStack.AddChild(colorHeader);
+
+        var colorGrid = new Grid { Margin = new Thickness(0, 0, 0, 16f) };
+        colorGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        colorGrid.ColumnDefinitions.Add(new GridLength(2f, GridUnitType.Star));
+
+        var defaultBtn = new Button
+        {
+            HeightConstraint = 36f,
+            WidthConstraint = 60f,
+            CornerRadius = 4f,
+            Margin = new Thickness(4f),
+            Background = new SolidColorBrush(new Vector4(0.70f, 0.70f, 0.72f, 1.0f))
+        };
+        defaultBtn.Click += (s, e) =>
+        {
+            _activeModelColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+            UpdateViewportModels();
+        };
+        colorGrid.AddChild(defaultBtn);
+        Grid.SetColumn(defaultBtn, 0);
+
+        var customBtn = new Button
+        {
+            HeightConstraint = 36f,
+            WidthConstraint = 100f,
+            CornerRadius = 4f,
+            Margin = new Thickness(4f),
+            Background = new ThemeResourceBrush("ControlBackgroundHover")
+        };
+        var customBtnRun = new Run("🎨 Custom") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        customBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(customBtnRun) } };
+
+        customBtn.Click += (s, e) => { ShowColorPickerPopup(customBtn); };
+        colorGrid.AddChild(customBtn);
+        Grid.SetColumn(customBtn, 1);
+
+        sidebarStack.AddChild(colorGrid);
+
+        // Lighting settings header
+        var lightingHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 8, 0, 4) };
+        lightingHeader.Inlines.Add(new Bold(new Run("Directional Light Angle (X/Y/Z):")));
+        sidebarStack.AddChild(lightingHeader);
+
+        var lightXSlider = new Microsoft.UI.Xaml.Controls.Slider { Minimum = -2f, Maximum = 2f, Value = 0.5f, Margin = new Thickness(0, 0, 0, 8f) };
+        lightXSlider.ValueChanged += (s, e) => { _lightDirection.X = lightXSlider.Value; SyncLighting(); };
+        sidebarStack.AddChild(lightXSlider);
+
+        var lightYSlider = new Microsoft.UI.Xaml.Controls.Slider { Minimum = 0.1f, Maximum = 3f, Value = 1.0f, Margin = new Thickness(0, 0, 0, 8f) };
+        lightYSlider.ValueChanged += (s, e) => { _lightDirection.Y = lightYSlider.Value; SyncLighting(); };
+        sidebarStack.AddChild(lightYSlider);
+
+        var lightZSlider = new Microsoft.UI.Xaml.Controls.Slider { Minimum = -2f, Maximum = 2f, Value = -0.5f, Margin = new Thickness(0, 0, 0, 16f) };
+        lightZSlider.ValueChanged += (s, e) => { _lightDirection.Z = lightZSlider.Value; SyncLighting(); };
+        sidebarStack.AddChild(lightZSlider);
+
+        // Intensity settings
+        var intensityHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 4) };
+        intensityHeader.Inlines.Add(new Bold(new Run("Diffuse Light Intensity:")));
+        sidebarStack.AddChild(intensityHeader);
+
+        var intensitySlider = new Microsoft.UI.Xaml.Controls.Slider { Minimum = 0f, Maximum = 2f, Value = 1.0f, Margin = new Thickness(0, 0, 0, 16f) };
+        intensitySlider.ValueChanged += (s, e) => { _lightIntensity = intensitySlider.Value; SyncLighting(); };
+        sidebarStack.AddChild(intensitySlider);
+
+        var ambientHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 4) };
+        ambientHeader.Inlines.Add(new Bold(new Run("Ambient Light Intensity:")));
+        sidebarStack.AddChild(ambientHeader);
+
+        var ambientSlider = new Microsoft.UI.Xaml.Controls.Slider { Minimum = 0f, Maximum = 1f, Value = 0.25f, Margin = new Thickness(0, 0, 0, 20f) };
+        ambientSlider.ValueChanged += (s, e) => { _ambientIntensity = ambientSlider.Value; SyncLighting(); };
+        sidebarStack.AddChild(ambientSlider);
+
+        // Animation toggle checkbox
+        var animStack = new Microsoft.UI.Xaml.Controls.StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 16f) };
+        var animText = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f };
+        animText.Inlines.Add(new Run("Animate Mesh Rotation"));
+        var animChk = new CheckBox
+        {
+            Content = animText,
+            IsChecked = true,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        animChk.CheckedChanged += (s, e) =>
+        {
+            _animateRotation = animChk.IsChecked;
+        };
+        animStack.AddChild(animChk);
+        sidebarStack.AddChild(animStack);
+
+        mainGrid.AddChild(sidebar);
+        Grid.SetColumn(sidebar, 0);
+
+        // 2. MAIN 4-WAY SPLIT VIEW WORKSPACE (2x2 CAD GRID)
+        var viewportsGrid = new Grid { Margin = new Thickness(16f) };
+        viewportsGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        viewportsGrid.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        viewportsGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        // 2.A Viewport 1: Top Orthographic View
+        var card1 = new Border
+        {
+            CornerRadius = 8f,
+            BorderThickness = new Thickness(1f),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            Background = new ThemeResourceBrush("CardBackground"),
+            Margin = new Thickness(0, 0, 6f, 6f)
+        };
+        var viewportStack1 = new Grid();
+        card1.Child = viewportStack1;
+
+        _viewport1 = new Viewport3D
+        {
+            Camera = new OrthographicCamera
+            {
+                Position = new Vector3(0f, 7f, 0f),
+                LookDirection = new Vector3(0f, -1f, 0f),
+                UpDirection = new Vector3(0f, 0f, -1f),
+                Width = 7f
+            }
+        };
+        _model1 = new ModelVisual3D();
+        _viewport1.Children.Add(_model1);
+        viewportStack1.AddChild(_viewport1);
+
+        var overlayText1 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        overlayText1.Inlines.Add(new Bold(new Run("Top View (Orthographic)")));
+        viewportStack1.AddChild(overlayText1);
+
+        viewportsGrid.AddChild(card1);
+        Grid.SetRow(card1, 0);
+        Grid.SetColumn(card1, 0);
+
+        // 2.B Viewport 2: Front Orthographic View
+        var card2 = new Border
+        {
+            CornerRadius = 8f,
+            BorderThickness = new Thickness(1f),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            Background = new ThemeResourceBrush("CardBackground"),
+            Margin = new Thickness(6f, 0, 0, 6f)
+        };
+        var viewportStack2 = new Grid();
+        card2.Child = viewportStack2;
+
+        _viewport2 = new Viewport3D
+        {
+            Camera = new OrthographicCamera
+            {
+                Position = new Vector3(0f, 0f, -7f),
+                LookDirection = new Vector3(0f, 0f, 1f),
+                UpDirection = new Vector3(0f, 1f, 0f),
+                Width = 7f
+            }
+        };
+        _model2 = new ModelVisual3D();
+        _viewport2.Children.Add(_model2);
+        viewportStack2.AddChild(_viewport2);
+
+        var overlayText2 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        overlayText2.Inlines.Add(new Bold(new Run("Front View (Orthographic)")));
+        viewportStack2.AddChild(overlayText2);
+
+        viewportsGrid.AddChild(card2);
+        Grid.SetRow(card2, 0);
+        Grid.SetColumn(card2, 1);
+
+        // 2.C Viewport 3: Right Orthographic View
+        var card3 = new Border
+        {
+            CornerRadius = 8f,
+            BorderThickness = new Thickness(1f),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            Background = new ThemeResourceBrush("CardBackground"),
+            Margin = new Thickness(0, 6f, 6f, 0)
+        };
+        var viewportStack3 = new Grid();
+        card3.Child = viewportStack3;
+
+        _viewport3 = new Viewport3D
+        {
+            Camera = new OrthographicCamera
+            {
+                Position = new Vector3(-7f, 0f, 0f),
+                LookDirection = new Vector3(1f, 0f, 0f),
+                UpDirection = new Vector3(0f, 1f, 0f),
+                Width = 7f
+            }
+        };
+        _model3 = new ModelVisual3D();
+        _viewport3.Children.Add(_model3);
+        viewportStack3.AddChild(_viewport3);
+
+        var overlayText3 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        overlayText3.Inlines.Add(new Bold(new Run("Right View (Orthographic)")));
+        viewportStack3.AddChild(overlayText3);
+
+        viewportsGrid.AddChild(card3);
+        Grid.SetRow(card3, 1);
+        Grid.SetColumn(card3, 0);
+
+        // 2.D Viewport 4: 3D Perspective View
+        var card4 = new Border
+        {
+            CornerRadius = 8f,
+            BorderThickness = new Thickness(1f),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            Background = new ThemeResourceBrush("CardBackground"),
+            Margin = new Thickness(6f, 6f, 0, 0)
+        };
+        var viewportStack4 = new Grid();
+        card4.Child = viewportStack4;
+
+        _viewport4 = new Viewport3D
+        {
+            Camera = new PerspectiveCamera
+            {
+                Position = new Vector3(4f, 4f, -6f),
+                LookAt = new Vector3(0f, 0f, 0f),
+                FieldOfView = 50f
+            }
+        };
+        _model4 = new ModelVisual3D();
+        _viewport4.Children.Add(_model4);
+        viewportStack4.AddChild(_viewport4);
+
+        var overlayText4 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        overlayText4.Inlines.Add(new Bold(new Run("3D Perspective View")));
+        viewportStack4.AddChild(overlayText4);
+
+        viewportsGrid.AddChild(card4);
+        Grid.SetRow(card4, 1);
+        Grid.SetColumn(card4, 1);
+
+        mainGrid.AddChild(viewportsGrid);
+        Grid.SetColumn(viewportsGrid, 1);
+
+        // Populate initial 3D geometries and register layout animation callbacks
+        UpdateViewportModels();
+        SyncLighting();
+
+        return mainGrid;
+    }
+
+    private static void ShowColorPickerPopup(Button triggerBtn)
+    {
+        if (_pickerPopup == null)
+        {
+            var cp = new ColorPicker
+            {
+                WidthConstraint = 280f,
+                HeightConstraint = 330f,
+                Color = _activeModelColor
+            };
+
+            cp.ColorChanged += (s, e) =>
+            {
+                _activeModelColor = e.NewColor;
+                UpdateViewportModels();
+            };
+
+            _pickerPopup = new Border
+            {
+                Background = new ThemeResourceBrush("CardBackground"),
+                BorderBrush = new ThemeResourceBrush("ControlBorder"),
+                BorderThickness = new Thickness(1f),
+                CornerRadius = 8f,
+                Padding = new Thickness(10),
+                Child = cp
+            };
+        }
+        else
+        {
+            if (_pickerPopup.Child is ColorPicker cp)
+            {
+                cp.Color = _activeModelColor;
+            }
+        }
+
+        Vector2 absPos = triggerBtn.Offset;
+        Visual? current = triggerBtn.Parent;
+        while (current != null)
+        {
+            absPos += current.Offset;
+            current = current.Parent;
+        }
+
+        _pickerPopup.Width = 300f;
+        _pickerPopup.Height = 350f;
+        _pickerPopup.NotifyThemeChanged();
+        
+        float popX = Math.Max(10f, absPos.X - 100f);
+        PopupService.ShowPopup(_pickerPopup, new Vector2(popX, absPos.Y + triggerBtn.Size.Y + 2f), triggerBtn);
+    }
+
+    private static Grid CreateStatRow(string label, RichTextBlock valBlock)
+    {
+        var rowGrid = new Grid { Margin = new Thickness(0, 2f, 0, 2f) };
+        rowGrid.ColumnDefinitions.Add(new GridLength(100f, GridUnitType.Absolute));
+        rowGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        var labelBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextSecondary") };
+        labelBlock.Inlines.Add(new Run(label));
+        rowGrid.AddChild(labelBlock);
+        Grid.SetColumn(labelBlock, 0);
+
+        rowGrid.AddChild(valBlock);
+        Grid.SetColumn(valBlock, 1);
+
+        return rowGrid;
+    }
+
+    private static void RegenerateMeshGeometry()
+    {
+        if (_selectedMeshType == "Cube")
+        {
+            _activeMeshGeometry = MeshBuilder.CreateCube();
+        }
+        else if (_selectedMeshType == "Sphere")
+        {
+            _activeMeshGeometry = MeshBuilder.CreateSphere(2.0f, 24, 24);
+        }
+        else if (_selectedMeshType == "Torus")
+        {
+            _activeMeshGeometry = MeshBuilder.CreateTorus(2.2f, 0.7f, 24, 24);
+        }
+        else if (_selectedMeshType == "Procedural Terrain")
+        {
+            _activeMeshGeometry = MeshBuilder.CreateTerrain(5.0f, 24, 1.8f);
+        }
+        else if (_selectedMeshType == "OBJ: Spacecraft")
+        {
+            try
+            {
+                _activeMeshGeometry = ObjReader.Load(Path.Combine("models", "spacecraft.obj"));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Mesh3DViewerPage] Error loading spacecraft.obj: {ex.Message}");
+                _activeMeshGeometry = MeshBuilder.CreateCube(); // Fallback
+            }
+        }
+        else if (_selectedMeshType == "OBJ: Faceted Jewel")
+        {
+            try
+            {
+                _activeMeshGeometry = ObjReader.Load(Path.Combine("models", "jewel.obj"));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Mesh3DViewerPage] Error loading jewel.obj: {ex.Message}");
+                _activeMeshGeometry = MeshBuilder.CreateCube(); // Fallback
+            }
+        }
+    }
+
+    private static void UpdateViewportModels()
+    {
+        if (_viewport1 == null || _viewport2 == null || _viewport3 == null || _viewport4 == null ||
+            _model1 == null || _model2 == null || _model3 == null || _model4 == null ||
+            _activeMeshGeometry == null) return;
+
+        // Calculate and update mesh statistics in real time
+        int vertCount = _activeMeshGeometry.Positions.Length;
+        int triCount = _activeMeshGeometry.TriangleIndices.Length / 3;
+
+        Vector3 min = new Vector3(float.MaxValue);
+        Vector3 max = new Vector3(float.MinValue);
+        foreach (var pos in _activeMeshGeometry.Positions)
+        {
+            min = Vector3.Min(min, pos);
+            max = Vector3.Max(max, pos);
+        }
+        Vector3 size = max - min;
+        if (vertCount == 0)
+        {
+            min = Vector3.Zero;
+            max = Vector3.Zero;
+            size = Vector3.Zero;
+        }
+
+        // Positions (12 bytes) + Normals (12 bytes) = 24 bytes per vertex
+        // Indices (4 bytes) = 4 bytes per index
+        float memKb = (vertCount * 24f + _activeMeshGeometry.TriangleIndices.Length * 4f) / 1024f;
+
+        if (_statsNameRun != null)
+        {
+            string name = _selectedMeshType;
+            if (name == "OBJ: Custom Path")
+            {
+                name = string.IsNullOrEmpty(_customObjPath) ? "custom.obj" : Path.GetFileName(_customObjPath);
+            }
+            else if (name.StartsWith("OBJ: "))
+            {
+                name = name.Substring(5).ToLower() + ".obj";
+            }
+            _statsNameRun.Text = name;
+        }
+        if (_statsVerticesRun != null) _statsVerticesRun.Text = vertCount.ToString("N0");
+        if (_statsTrianglesRun != null) _statsTrianglesRun.Text = triCount.ToString("N0");
+        if (_statsBoundsRun != null) _statsBoundsRun.Text = $"{size.X:F2} x {size.Y:F2} x {size.Z:F2}";
+        if (_statsMemoryRun != null) _statsMemoryRun.Text = $"{memKb:F1} KB";
+
+        // Invalidate containing RichTextBlocks to force visual layout updating and repaint
+        if (_statsNameBlock != null) _statsNameBlock.Invalidate();
+        if (_statsVerticesBlock != null) _statsVerticesBlock.Invalidate();
+        if (_statsTrianglesBlock != null) _statsTrianglesBlock.Invalidate();
+        if (_statsBoundsBlock != null) _statsBoundsBlock.Invalidate();
+        if (_statsMemoryBlock != null) _statsMemoryBlock.Invalidate();
+
+        if (_activeMeshGeometry != _lastMeshGeometry)
+        {
+            _lastMeshGeometry = _activeMeshGeometry;
+            FitViewportsToBounds();
+        }
+
+        _viewport1.RenderMode = _selectedRenderMode;
+        _viewport2.RenderMode = _selectedRenderMode;
+        _viewport3.RenderMode = _selectedRenderMode;
+        _viewport4.RenderMode = _selectedRenderMode;
+
+        // Visual 1 setup
+        _model1.Children.Clear();
+        _model1.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
+
+        // Visual 2 setup
+        _model2.Children.Clear();
+        _model2.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
+
+        // Visual 3 setup
+        _model3.Children.Clear();
+        _model3.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
+
+        // Visual 4 setup
+        _model4.Children.Clear();
+        _model4.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
+
+        _viewport1.Invalidate();
+        _viewport2.Invalidate();
+        _viewport3.Invalidate();
+        _viewport4.Invalidate();
+    }
+
+    private static void FitViewportsToBounds()
+    {
+        if (_activeMeshGeometry == null) return;
+        var positions = _activeMeshGeometry.Positions;
+        if (positions.Length == 0) return;
+
+        float minX = float.MaxValue, maxX = float.MinValue;
+        float minY = float.MaxValue, maxY = float.MinValue;
+        float minZ = float.MaxValue, maxZ = float.MinValue;
+        foreach (var p in positions)
+        {
+            if (p.X < minX) minX = p.X;
+            if (p.X > maxX) maxX = p.X;
+            if (p.Y < minY) minY = p.Y;
+            if (p.Y > maxY) maxY = p.Y;
+            if (p.Z < minZ) minZ = p.Z;
+            if (p.Z > maxZ) maxZ = p.Z;
+        }
+
+        var center = new Vector3((maxX + minX) * 0.5f, (maxY + minY) * 0.5f, (maxZ + minZ) * 0.5f);
+        float sizeX = maxX - minX;
+        float sizeY = maxY - minY;
+        float sizeZ = maxZ - minZ;
+        float maxDim = Math.Max(sizeX, Math.Max(sizeY, sizeZ));
+        if (maxDim < 0.1f) maxDim = 2.0f;
+
+        float orthoWidth = maxDim * 1.5f;
+        float camDist = maxDim * 1.8f;
+
+        // Update Top View
+        if (_viewport1?.Camera is OrthographicCamera topCam)
+        {
+            topCam.Position = center + new Vector3(0f, camDist, 0f);
+            topCam.LookDirection = new Vector3(0f, -1f, 0f);
+            topCam.UpDirection = new Vector3(0f, 0f, -1f);
+            topCam.Width = orthoWidth;
+        }
+
+        // Update Front View
+        if (_viewport2?.Camera is OrthographicCamera frontCam)
+        {
+            frontCam.Position = center + new Vector3(0f, 0f, -camDist);
+            frontCam.LookDirection = new Vector3(0f, 0f, 1f);
+            frontCam.UpDirection = new Vector3(0f, 1f, 0f);
+            frontCam.Width = orthoWidth;
+        }
+
+        // Update Right View
+        if (_viewport3?.Camera is OrthographicCamera rightCam)
+        {
+            rightCam.Position = center + new Vector3(-camDist, 0f, 0f);
+            rightCam.LookDirection = new Vector3(1f, 0f, 0f);
+            rightCam.UpDirection = new Vector3(0f, 1f, 0f);
+            rightCam.Width = orthoWidth;
+        }
+
+        // Update Perspective View
+        if (_viewport4?.Camera is PerspectiveCamera persCam)
+        {
+            persCam.Position = center + new Vector3(maxDim * 1.1f, maxDim * 1.1f, -maxDim * 1.5f);
+            persCam.LookAt = center;
+        }
+
+        _viewport1?.Invalidate();
+        _viewport2?.Invalidate();
+        _viewport3?.Invalidate();
+        _viewport4?.Invalidate();
+    }
+
+    private static void SyncLighting()
+    {
+        if (_viewport1 == null || _viewport2 == null || _viewport3 == null || _viewport4 == null) return;
+
+        _viewport1.LightDirection = _lightDirection;
+        _viewport1.LightIntensity = _lightIntensity;
+        _viewport1.AmbientIntensity = _ambientIntensity;
+
+        _viewport2.LightDirection = _lightDirection;
+        _viewport2.LightIntensity = _lightIntensity;
+        _viewport2.AmbientIntensity = _ambientIntensity;
+
+        _viewport3.LightDirection = _lightDirection;
+        _viewport3.LightIntensity = _lightIntensity;
+        _viewport3.AmbientIntensity = _ambientIntensity;
+
+        _viewport4.LightDirection = _lightDirection;
+        _viewport4.LightIntensity = _lightIntensity;
+        _viewport4.AmbientIntensity = _ambientIntensity;
+
+        _viewport1.Invalidate();
+        _viewport2.Invalidate();
+        _viewport3.Invalidate();
+        _viewport4.Invalidate();
+    }
+
+    public static void UpdateAnimations(float delta)
+    {
+        if (!_animateRotation) return;
+
+        // Apply continuous Y-axis rotation over time
+        _rotationAngle += (float)delta * 0.7f;
+        if (_rotationAngle > MathF.PI * 2f) _rotationAngle -= MathF.PI * 2f;
+
+        // Sync rotations across all views
+        var rotation = Matrix4x4.CreateRotationY(_rotationAngle);
+
+        if (_model1?.Children.Count > 0 && _model1.Children[0] is ModelVisual3D n1 && n1.Content != null)
+            n1.Content.Transform = rotation;
+
+        if (_model2?.Children.Count > 0 && _model2.Children[0] is ModelVisual3D n2 && n2.Content != null)
+            n2.Content.Transform = rotation;
+
+        if (_model3?.Children.Count > 0 && _model3.Children[0] is ModelVisual3D n3 && n3.Content != null)
+            n3.Content.Transform = rotation;
+
+        if (_model4?.Children.Count > 0 && _model4.Children[0] is ModelVisual3D n4 && n4.Content != null)
+            n4.Content.Transform = rotation * Matrix4x4.CreateRotationX(_rotationAngle * 0.15f);
+
+        _viewport1?.Invalidate();
+        _viewport2?.Invalidate();
+        _viewport3?.Invalidate();
+        _viewport4?.Invalidate();
+    }
+}

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -243,7 +243,7 @@ public static class Mesh3DViewerPage
     private static Vector4 _activeModelColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f); // Default premium clay warm gray
     private static Border? _pickerPopup;
     private static RenderMode3D _selectedRenderMode = RenderMode3D.SolidWireframe;
-    private static ShadingMode3D _selectedShadingMode = ShadingMode3D.Shaded;
+    private static ShadingMode3D _selectedShadingMode = ShadingMode3D.Realistic;
 
     private static Run? _statsNameRun;
     private static Run? _statsVerticesRun;
@@ -348,10 +348,14 @@ public static class Mesh3DViewerPage
             WidthConstraint = 268f,
             Margin = new Thickness(0, 0, 0, 16f)
         };
-        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "PBR GGX Shaded" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Realistic (PBR GGX)" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Conceptual (Gooch)" });
         shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Flat / Unlit" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Hidden Line" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Shades of Gray" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "X-Ray Mode" });
         shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Normals Diagnostic" });
-        shadingModeCombo.SelectedItem = shadingModeCombo.Items[0]; // Default to Shaded
+        shadingModeCombo.SelectedItem = shadingModeCombo.Items[0]; // Default to Realistic
 
         shadingModeCombo.SelectionChanged += (s, e) =>
         {
@@ -359,10 +363,14 @@ public static class Mesh3DViewerPage
             {
                 _selectedShadingMode = shadingModeCombo.SelectedItem.Text switch
                 {
-                    "PBR GGX Shaded" => ShadingMode3D.Shaded,
+                    "Realistic (PBR GGX)" => ShadingMode3D.Realistic,
+                    "Conceptual (Gooch)" => ShadingMode3D.Conceptual,
                     "Flat / Unlit" => ShadingMode3D.Flat,
+                    "Hidden Line" => ShadingMode3D.HiddenLine,
+                    "Shades of Gray" => ShadingMode3D.ShadesOfGray,
+                    "X-Ray Mode" => ShadingMode3D.XRay,
                     "Normals Diagnostic" => ShadingMode3D.Normals,
-                    _ => ShadingMode3D.Shaded
+                    _ => ShadingMode3D.Realistic
                 };
                 UpdateViewportModels();
             }

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -760,27 +760,34 @@ public static class Mesh3DViewerPage
         _viewport1.Children.Add(_model1);
         viewportStack1.AddChild(_viewport1);
 
-        var overlayText1 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        var headerStack1 = new Microsoft.UI.Xaml.Controls.StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(12f)
+        };
+        var overlayText1 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, VerticalAlignment = VerticalAlignment.Center };
         overlayText1.Inlines.Add(new Bold(new Run("Top View (Orthographic)")));
-        viewportStack1.AddChild(overlayText1);
+        headerStack1.AddChild(overlayText1);
 
         _maxBtn1 = new Button
         {
-            HeightConstraint = 24f,
-            WidthConstraint = 80f,
+            HeightConstraint = 22f,
+            WidthConstraint = 22f,
             CornerRadius = 4f,
-            Margin = new Thickness(8f),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(8f, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxRun1 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        _maxBtn1.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun1 } };
+        var maxIcon1 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn1.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon1) } };
         _maxBtn1.Click += (s, e) =>
         {
             SetLayoutMode(_currentLayoutMode == LayoutMode3D.Top ? LayoutMode3D.Quad : LayoutMode3D.Top);
         };
-        viewportStack1.AddChild(_maxBtn1);
+        headerStack1.AddChild(_maxBtn1);
+        viewportStack1.AddChild(headerStack1);
 
         _leftGrid.AddChild(_card1);
         Grid.SetRow(_card1, 0);
@@ -812,27 +819,34 @@ public static class Mesh3DViewerPage
         _viewport2.Children.Add(_model2);
         viewportStack2.AddChild(_viewport2);
 
-        var overlayText2 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        var headerStack2 = new Microsoft.UI.Xaml.Controls.StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(12f)
+        };
+        var overlayText2 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, VerticalAlignment = VerticalAlignment.Center };
         overlayText2.Inlines.Add(new Bold(new Run("Front View (Orthographic)")));
-        viewportStack2.AddChild(overlayText2);
+        headerStack2.AddChild(overlayText2);
 
         _maxBtn2 = new Button
         {
-            HeightConstraint = 24f,
-            WidthConstraint = 80f,
+            HeightConstraint = 22f,
+            WidthConstraint = 22f,
             CornerRadius = 4f,
-            Margin = new Thickness(8f),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(8f, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxRun2 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        _maxBtn2.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun2 } };
+        var maxIcon2 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn2.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon2) } };
         _maxBtn2.Click += (s, e) =>
         {
             SetLayoutMode(_currentLayoutMode == LayoutMode3D.Front ? LayoutMode3D.Quad : LayoutMode3D.Front);
         };
-        viewportStack2.AddChild(_maxBtn2);
+        headerStack2.AddChild(_maxBtn2);
+        viewportStack2.AddChild(headerStack2);
 
         _rightGrid.AddChild(_card2);
         Grid.SetRow(_card2, 0);
@@ -864,27 +878,34 @@ public static class Mesh3DViewerPage
         _viewport3.Children.Add(_model3);
         viewportStack3.AddChild(_viewport3);
 
-        var overlayText3 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        var headerStack3 = new Microsoft.UI.Xaml.Controls.StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(12f)
+        };
+        var overlayText3 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, VerticalAlignment = VerticalAlignment.Center };
         overlayText3.Inlines.Add(new Bold(new Run("Right View (Orthographic)")));
-        viewportStack3.AddChild(overlayText3);
+        headerStack3.AddChild(overlayText3);
 
         _maxBtn3 = new Button
         {
-            HeightConstraint = 24f,
-            WidthConstraint = 80f,
+            HeightConstraint = 22f,
+            WidthConstraint = 22f,
             CornerRadius = 4f,
-            Margin = new Thickness(8f),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(8f, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxRun3 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        _maxBtn3.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun3 } };
+        var maxIcon3 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn3.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon3) } };
         _maxBtn3.Click += (s, e) =>
         {
             SetLayoutMode(_currentLayoutMode == LayoutMode3D.Right ? LayoutMode3D.Quad : LayoutMode3D.Right);
         };
-        viewportStack3.AddChild(_maxBtn3);
+        headerStack3.AddChild(_maxBtn3);
+        viewportStack3.AddChild(headerStack3);
 
         _leftGrid.AddChild(_card3);
         Grid.SetRow(_card3, 2);
@@ -915,27 +936,34 @@ public static class Mesh3DViewerPage
         _viewport4.Children.Add(_model4);
         viewportStack4.AddChild(_viewport4);
 
-        var overlayText4 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(12f), HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Top };
+        var headerStack4 = new Microsoft.UI.Xaml.Controls.StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(12f)
+        };
+        var overlayText4 = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, VerticalAlignment = VerticalAlignment.Center };
         overlayText4.Inlines.Add(new Bold(new Run("3D Perspective View")));
-        viewportStack4.AddChild(overlayText4);
+        headerStack4.AddChild(overlayText4);
 
         _maxBtn4 = new Button
         {
-            HeightConstraint = 24f,
-            WidthConstraint = 80f,
+            HeightConstraint = 22f,
+            WidthConstraint = 22f,
             CornerRadius = 4f,
-            Margin = new Thickness(8f),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(8f, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxRun4 = new Run("↗ Maximize") { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        _maxBtn4.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { maxRun4 } };
+        var maxIcon4 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _maxBtn4.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon4) } };
         _maxBtn4.Click += (s, e) =>
         {
             SetLayoutMode(_currentLayoutMode == LayoutMode3D.Perspective ? LayoutMode3D.Quad : LayoutMode3D.Perspective);
         };
-        viewportStack4.AddChild(_maxBtn4);
+        headerStack4.AddChild(_maxBtn4);
+        viewportStack4.AddChild(headerStack4);
 
         _rightGrid.AddChild(_card4);
         Grid.SetRow(_card4, 2);

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -237,6 +237,7 @@ public static class Mesh3DViewerPage
 
     private static string _selectedMeshType = "Torus";
     private static MeshGeometry3D? _activeMeshGeometry;
+    private static LoadedObjModel? _activeLoadedModel;
     private static MeshGeometry3D? _lastMeshGeometry;
 
     private static Vector4 _activeModelColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f); // Default premium clay warm gray
@@ -376,7 +377,8 @@ public static class Mesh3DViewerPage
                     _customObjPath = pathTextBox.Text;
                     shapeCombo.SelectedItem = shapeCombo.Items[6]; // OBJ: Custom Path
                     _selectedMeshType = "OBJ: Custom Path";
-                    _activeMeshGeometry = ObjReader.Load(_customObjPath);
+                    _activeLoadedModel = ObjReader.LoadObj(_customObjPath);
+                    _activeMeshGeometry = ObjReader.MergeParts(_activeLoadedModel);
                     UpdateViewportModels();
                 }
                 catch (Exception ex)
@@ -434,7 +436,8 @@ public static class Mesh3DViewerPage
                     shapeCombo.SelectedItem = shapeCombo.Items[6]; // OBJ: Custom Path
                     _selectedMeshType = "OBJ: Custom Path";
                     
-                    _activeMeshGeometry = ObjReader.Load(file.Path);
+                    _activeLoadedModel = ObjReader.LoadObj(file.Path);
+                    _activeMeshGeometry = ObjReader.MergeParts(_activeLoadedModel);
                     UpdateViewportModels();
                 }
             }
@@ -817,6 +820,8 @@ public static class Mesh3DViewerPage
 
     private static void RegenerateMeshGeometry()
     {
+        _activeLoadedModel = null;
+
         if (_selectedMeshType == "Cube")
         {
             _activeMeshGeometry = MeshBuilder.CreateCube();
@@ -837,7 +842,9 @@ public static class Mesh3DViewerPage
         {
             try
             {
-                _activeMeshGeometry = ObjReader.Load(Path.Combine("models", "spacecraft.obj"));
+                var path = Path.Combine("models", "spacecraft.obj");
+                _activeLoadedModel = ObjReader.LoadObj(path);
+                _activeMeshGeometry = ObjReader.MergeParts(_activeLoadedModel);
             }
             catch (Exception ex)
             {
@@ -849,7 +856,9 @@ public static class Mesh3DViewerPage
         {
             try
             {
-                _activeMeshGeometry = ObjReader.Load(Path.Combine("models", "jewel.obj"));
+                var path = Path.Combine("models", "jewel.obj");
+                _activeLoadedModel = ObjReader.LoadObj(path);
+                _activeMeshGeometry = ObjReader.MergeParts(_activeLoadedModel);
             }
             catch (Exception ex)
             {
@@ -924,21 +933,44 @@ public static class Mesh3DViewerPage
         _viewport3.RenderMode = _selectedRenderMode;
         _viewport4.RenderMode = _selectedRenderMode;
 
-        // Visual 1 setup
+        // Clear all model children
         _model1.Children.Clear();
-        _model1.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
-
-        // Visual 2 setup
         _model2.Children.Clear();
-        _model2.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
-
-        // Visual 3 setup
         _model3.Children.Clear();
-        _model3.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
-
-        // Visual 4 setup
         _model4.Children.Clear();
-        _model4.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = new DiffuseMaterial(new SolidColorBrush(_activeModelColor)) } });
+
+        if (_activeLoadedModel != null && _activeLoadedModel.Parts.Count > 0)
+        {
+            bool isDefaultClayColor = _activeModelColor == new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+
+            foreach (var part in _activeLoadedModel.Parts)
+            {
+                Vector4 color = part.Color;
+                if (!isDefaultClayColor)
+                {
+                    // Multiply custom picked color to act as a tint overlay
+                    color = color * _activeModelColor;
+                }
+
+                var brush = new SolidColorBrush(color) { Opacity = part.Opacity };
+                var material = new DiffuseMaterial(brush);
+
+                _model1.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = part.Geometry, Material = material } });
+                _model2.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = part.Geometry, Material = material } });
+                _model3.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = part.Geometry, Material = material } });
+                _model4.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = part.Geometry, Material = material } });
+            }
+        }
+        else
+        {
+            var brush = new SolidColorBrush(_activeModelColor);
+            var material = new DiffuseMaterial(brush);
+
+            _model1.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = material } });
+            _model2.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = material } });
+            _model3.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = material } });
+            _model4.Children.Add(new ModelVisual3D { Content = new GeometryModel3D { Geometry = _activeMeshGeometry, Material = material } });
+        }
 
         _viewport1.Invalidate();
         _viewport2.Invalidate();

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -229,7 +229,7 @@ public static class Mesh3DViewerPage
     private static ModelVisual3D? _model4;
 
     private static float _rotationAngle = 0f;
-    private static bool _animateRotation = true;
+    private static bool _animateRotation = false;
     
     private static Vector3 _lightDirection = new Vector3(0.5f, 1f, -0.5f);
     private static float _lightIntensity = 1.0f;
@@ -585,7 +585,7 @@ public static class Mesh3DViewerPage
         var animChk = new CheckBox
         {
             Content = animText,
-            IsChecked = true,
+            IsChecked = false,
             VerticalAlignment = VerticalAlignment.Center
         };
         animChk.CheckedChanged += (s, e) =>

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -1358,17 +1358,50 @@ public static class Mesh3DViewerPage
         // Sync rotations across all views
         var rotation = Matrix4x4.CreateRotationY(_rotationAngle);
 
-        if (_model1?.Children.Count > 0 && _model1.Children[0] is ModelVisual3D n1 && n1.Content != null)
-            n1.Content.Transform = rotation;
+        if (_model1 != null)
+        {
+            for (int i = 0; i < _model1.Children.Count; i++)
+            {
+                if (_model1.Children[i] is ModelVisual3D mv && mv.Content != null)
+                {
+                    mv.Content.Transform = rotation;
+                }
+            }
+        }
 
-        if (_model2?.Children.Count > 0 && _model2.Children[0] is ModelVisual3D n2 && n2.Content != null)
-            n2.Content.Transform = rotation;
+        if (_model2 != null)
+        {
+            for (int i = 0; i < _model2.Children.Count; i++)
+            {
+                if (_model2.Children[i] is ModelVisual3D mv && mv.Content != null)
+                {
+                    mv.Content.Transform = rotation;
+                }
+            }
+        }
 
-        if (_model3?.Children.Count > 0 && _model3.Children[0] is ModelVisual3D n3 && n3.Content != null)
-            n3.Content.Transform = rotation;
+        if (_model3 != null)
+        {
+            for (int i = 0; i < _model3.Children.Count; i++)
+            {
+                if (_model3.Children[i] is ModelVisual3D mv && mv.Content != null)
+                {
+                    mv.Content.Transform = rotation;
+                }
+            }
+        }
 
-        if (_model4?.Children.Count > 0 && _model4.Children[0] is ModelVisual3D n4 && n4.Content != null)
-            n4.Content.Transform = rotation * Matrix4x4.CreateRotationX(_rotationAngle * 0.15f);
+        if (_model4 != null)
+        {
+            var rotation4 = rotation * Matrix4x4.CreateRotationX(_rotationAngle * 0.15f);
+            for (int i = 0; i < _model4.Children.Count; i++)
+            {
+                if (_model4.Children[i] is ModelVisual3D mv && mv.Content != null)
+                {
+                    mv.Content.Transform = rotation4;
+                }
+            }
+        }
 
         _viewport1?.Invalidate();
         _viewport2?.Invalidate();

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -366,7 +366,6 @@ public static class Mesh3DViewerPage
         var shapeCombo = new ComboBox
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            WidthConstraint = 268f,
             Margin = new Thickness(0, 0, 0, 16f)
         };
         shapeCombo.Items.Add(new ComboBoxItem { Text = "Cube" });
@@ -385,7 +384,6 @@ public static class Mesh3DViewerPage
         var renderModeCombo = new ComboBox
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            WidthConstraint = 268f,
             Margin = new Thickness(0, 0, 0, 16f)
         };
         renderModeCombo.Items.Add(new ComboBoxItem { Text = "Solid Shaded" });
@@ -415,7 +413,6 @@ public static class Mesh3DViewerPage
         var shadingModeCombo = new ComboBox
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            WidthConstraint = 268f,
             Margin = new Thickness(0, 0, 0, 16f)
         };
         shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Realistic (PBR GGX)" });
@@ -575,7 +572,7 @@ public static class Mesh3DViewerPage
             CornerRadius = 6f,
             Padding = new Thickness(12f),
             Margin = new Thickness(0, 0, 0, 16f),
-            WidthConstraint = 268f
+            HorizontalAlignment = HorizontalAlignment.Stretch
         };
 
         var statsStack = new Microsoft.UI.Xaml.Controls.StackPanel { Orientation = Orientation.Vertical };
@@ -773,14 +770,15 @@ public static class Mesh3DViewerPage
 
         _maxBtn1 = new Button
         {
-            HeightConstraint = 22f,
-            WidthConstraint = 22f,
+            HeightConstraint = 24f,
+            WidthConstraint = 24f,
             CornerRadius = 4f,
             Margin = new Thickness(8f, 0, 0, 0),
+            Padding = new Thickness(0),
             VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxIcon1 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        var maxIcon1 = new Run("↗") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
         _maxBtn1.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon1) } };
         _maxBtn1.Click += (s, e) =>
         {
@@ -832,14 +830,15 @@ public static class Mesh3DViewerPage
 
         _maxBtn2 = new Button
         {
-            HeightConstraint = 22f,
-            WidthConstraint = 22f,
+            HeightConstraint = 24f,
+            WidthConstraint = 24f,
             CornerRadius = 4f,
             Margin = new Thickness(8f, 0, 0, 0),
+            Padding = new Thickness(0),
             VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxIcon2 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        var maxIcon2 = new Run("↗") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
         _maxBtn2.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon2) } };
         _maxBtn2.Click += (s, e) =>
         {
@@ -891,14 +890,15 @@ public static class Mesh3DViewerPage
 
         _maxBtn3 = new Button
         {
-            HeightConstraint = 22f,
-            WidthConstraint = 22f,
+            HeightConstraint = 24f,
+            WidthConstraint = 24f,
             CornerRadius = 4f,
             Margin = new Thickness(8f, 0, 0, 0),
+            Padding = new Thickness(0),
             VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxIcon3 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        var maxIcon3 = new Run("↗") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
         _maxBtn3.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon3) } };
         _maxBtn3.Click += (s, e) =>
         {
@@ -949,14 +949,15 @@ public static class Mesh3DViewerPage
 
         _maxBtn4 = new Button
         {
-            HeightConstraint = 22f,
-            WidthConstraint = 22f,
+            HeightConstraint = 24f,
+            WidthConstraint = 24f,
             CornerRadius = 4f,
             Margin = new Thickness(8f, 0, 0, 0),
+            Padding = new Thickness(0),
             VerticalAlignment = VerticalAlignment.Center,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var maxIcon4 = new Run("↗") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        var maxIcon4 = new Run("↗") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
         _maxBtn4.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(maxIcon4) } };
         _maxBtn4.Click += (s, e) =>
         {
@@ -1387,10 +1388,10 @@ public static class Mesh3DViewerPage
         if (_layoutBtnPersp != null) _layoutBtnPersp.Background = new ThemeResourceBrush(mode == LayoutMode3D.Perspective ? "ControlBackgroundPressed" : "ControlBackgroundHover");
 
         // Update card maximize button texts
-        if (_maxBtn1 != null) _maxBtn1.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Top ? "↙ Restore" : "↗ Maximize") } };
-        if (_maxBtn2 != null) _maxBtn2.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Front ? "↙ Restore" : "↗ Maximize") } };
-        if (_maxBtn3 != null) _maxBtn3.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Right ? "↙ Restore" : "↗ Maximize") } };
-        if (_maxBtn4 != null) _maxBtn4.Content = new RichTextBlock { Inlines = { new Run(mode == LayoutMode3D.Perspective ? "↙ Restore" : "↗ Maximize") } };
+        if (_maxBtn1 != null) _maxBtn1.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(new Run(mode == LayoutMode3D.Top ? "↙" : "↗")) } };
+        if (_maxBtn2 != null) _maxBtn2.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(new Run(mode == LayoutMode3D.Front ? "↙" : "↗")) } };
+        if (_maxBtn3 != null) _maxBtn3.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(new Run(mode == LayoutMode3D.Right ? "↙" : "↗")) } };
+        if (_maxBtn4 != null) _maxBtn4.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(new Run(mode == LayoutMode3D.Perspective ? "↙" : "↗")) } };
 
         if (_card1 == null || _card2 == null || _card3 == null || _card4 == null || 
             _colSplitter == null || _rowSplitterLeft == null || _rowSplitterRight == null ||
@@ -1532,6 +1533,7 @@ public static class Mesh3DViewerPage
             HeightConstraint = 28f,
             CornerRadius = 4f,
             Margin = new Thickness(2f),
+            Padding = new Thickness(0),
             Background = new ThemeResourceBrush(mode == LayoutMode3D.Quad ? "ControlBackgroundPressed" : "ControlBackgroundHover")
         };
         var textRun = new Run(label) { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -243,6 +243,7 @@ public static class Mesh3DViewerPage
     private static Vector4 _activeModelColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f); // Default premium clay warm gray
     private static Border? _pickerPopup;
     private static RenderMode3D _selectedRenderMode = RenderMode3D.SolidWireframe;
+    private static ShadingMode3D _selectedShadingMode = ShadingMode3D.Shaded;
 
     private static Run? _statsNameRun;
     private static Run? _statsVerticesRun;
@@ -332,6 +333,36 @@ public static class Mesh3DViewerPage
                     "Wireframe Only" => RenderMode3D.Wireframe,
                     "Solid + Wireframe" => RenderMode3D.SolidWireframe,
                     _ => RenderMode3D.Solid
+                };
+                UpdateViewportModels();
+            }
+        };
+
+        // Combobox for Shading Mode selection
+        var shadingModeHeader = new RichTextBlock { Font = AppState.GetFont(), FontSize = 12f, Margin = new Thickness(0, 0, 0, 4) };
+        shadingModeHeader.Inlines.Add(new Bold(new Run("Shading & Diagnostic:")));
+
+        var shadingModeCombo = new ComboBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            WidthConstraint = 268f,
+            Margin = new Thickness(0, 0, 0, 16f)
+        };
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "PBR GGX Shaded" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Flat / Unlit" });
+        shadingModeCombo.Items.Add(new ComboBoxItem { Text = "Normals Diagnostic" });
+        shadingModeCombo.SelectedItem = shadingModeCombo.Items[0]; // Default to Shaded
+
+        shadingModeCombo.SelectionChanged += (s, e) =>
+        {
+            if (shadingModeCombo.SelectedItem != null)
+            {
+                _selectedShadingMode = shadingModeCombo.SelectedItem.Text switch
+                {
+                    "PBR GGX Shaded" => ShadingMode3D.Shaded,
+                    "Flat / Unlit" => ShadingMode3D.Flat,
+                    "Normals Diagnostic" => ShadingMode3D.Normals,
+                    _ => ShadingMode3D.Shaded
                 };
                 UpdateViewportModels();
             }
@@ -453,6 +484,8 @@ public static class Mesh3DViewerPage
         sidebarStack.AddChild(shapeCombo);
         sidebarStack.AddChild(renderModeHeader);
         sidebarStack.AddChild(renderModeCombo);
+        sidebarStack.AddChild(shadingModeHeader);
+        sidebarStack.AddChild(shadingModeCombo);
         sidebarStack.AddChild(pathInputStack);
 
         // 1.5 Mesh Statistics Card
@@ -932,6 +965,11 @@ public static class Mesh3DViewerPage
         _viewport2.RenderMode = _selectedRenderMode;
         _viewport3.RenderMode = _selectedRenderMode;
         _viewport4.RenderMode = _selectedRenderMode;
+
+        _viewport1.ShadingMode = _selectedShadingMode;
+        _viewport2.ShadingMode = _selectedShadingMode;
+        _viewport3.ShadingMode = _selectedShadingMode;
+        _viewport4.ShadingMode = _selectedShadingMode;
 
         // Clear all model children
         _model1.Children.Clear();

--- a/src/ProGPU.Samples/Windows/MainWindowController.cs
+++ b/src/ProGPU.Samples/Windows/MainWindowController.cs
@@ -84,6 +84,8 @@ public static unsafe class MainWindowController
 
         AppState.GenerateLogItems();
 
+        ObjModels.EnsureSamplesExist("models");
+
         BuildSceneGraph();
 
         if (AppState._topLevelGrid != null)
@@ -356,6 +358,7 @@ public static unsafe class MainWindowController
         var visualDesignerItem = new NavigationViewItem("Visual Designer", "📐", VisualDesignerPage.Create());
         var pictureCachingItem = new NavigationViewItem("Picture Caching", "🖼️", PictureShowcasePage.Create());
         var fontGlyphBrowserItem = new NavigationViewItem("Font Glyph Browser", "🔤", FontGlyphBrowserPage.Create());
+        var mesh3DViewerItem = new NavigationViewItem("3D Mesh Viewer", "🧊", Mesh3DViewerPage.Create());
 
         var wrapPanelItem = new NavigationViewItem("Wrap Panel", "🔲", WrapPanelPage.Create());
         var dockPanelItem = new NavigationViewItem("Dock Panel", "🪟", DockPanelPage.Create());
@@ -398,6 +401,7 @@ public static unsafe class MainWindowController
         AppState._navigationView.MenuItems.Add(dxfViewerItem);
         AppState._navigationView.MenuItems.Add(visualDesignerItem);
         AppState._navigationView.MenuItems.Add(pictureCachingItem);
+        AppState._navigationView.MenuItems.Add(mesh3DViewerItem);
 
         AppState._navigationView.SelectionChanged += (s, e) =>
         {
@@ -418,7 +422,7 @@ public static unsafe class MainWindowController
         }
 
         // Select default category
-        AppState._navigationView.SelectedItem = basicInputItem;
+        AppState._navigationView.SelectedItem = mesh3DViewerItem;
 
         AppState._rootGrid.AddChild(AppState._navigationView);
         Microsoft.UI.Xaml.Controls.Grid.SetRow(AppState._navigationView, 1);

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -418,6 +418,7 @@ public unsafe class Compositor : IDisposable
         RegisterExtension(CompositorBuiltInExtensions.GpuLineSeries, new GpuLineSeriesExtensionPipeline());
         RegisterExtension(CompositorBuiltInExtensions.GpuScatterSeries, new GpuScatterSeriesExtensionPipeline());
         RegisterExtension(CompositorBuiltInExtensions.CustomGrid, new CustomGridExtensionPipeline());
+        RegisterExtension(CompositorBuiltInExtensions.Mesh3D, new Mesh3DExtensionPipeline());
 
         InitializePipelinesAndBindGroups();
     }
@@ -1382,7 +1383,7 @@ public unsafe class Compositor : IDisposable
 
     private void CompileVisualTree(Visual node, Matrix4x4 parentTransform)
     {
-        if (node.Opacity <= 0.0001f || _activeOpacity <= 0.0001f)
+        if (!node.IsVisible || node.Opacity <= 0.0001f || _activeOpacity <= 0.0001f)
         {
             node.IsDirty = false;
             return;

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1199,6 +1199,14 @@ public unsafe class Compositor : IDisposable
         _context.Wgpu.RenderPassEncoderEnd(pass);
         _context.Wgpu.RenderPassEncoderRelease(pass);
 
+        lock (_registeredExtensions)
+        {
+            foreach (var ext in _registeredExtensions)
+            {
+                ext.EndFrame(this);
+            }
+        }
+
         // Submit to queue
         var cmdDesc = new CommandBufferDescriptor { Label = (byte*)SilkMarshal.StringToPtr("Compositor Command Buffer") };
         var cmdBuffer = _context.Wgpu.CommandEncoderFinish(encoder, &cmdDesc);

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -33,9 +33,11 @@ namespace ProGPU.Scene.Extensions
     public struct GpuMesh3DRecord
     {
         public Matrix4x4 ModelTransform;      // 3D Model transform for lighting
-        public Vector4 Color;
+        public Vector4 Color;                 // Diffuse Color Kd
         public Vector4 LightDirection;        // xyz = direction, w = intensity
         public Vector4 AmbientColor;          // rgb = color, w = intensity
+        public Vector4 SpecularColor;         // rgb = Specular Ks, w = Exponent Ns
+        public Vector4 MaterialAmbient;       // rgb = Material Ka, w = unused
         public float Opacity;
         public float RenderMode;              // 0.0f = Solid, 1.0f = Wireframe, 2.0f = SolidWireframe
         private float _pad1;
@@ -47,6 +49,8 @@ namespace ProGPU.Scene.Extensions
     {
         public Matrix4x4 Projection;
         public Matrix4x4 View;
+        public Vector3 CameraPosition;
+        private float _pad;
     }
 
     public class Mesh3DExtensionPipeline : ICompositorExtension
@@ -55,6 +59,8 @@ namespace ProGPU.Scene.Extensions
 struct VSUniforms {
     projection: mat4x4<f32>,
     view: mat4x4<f32>,
+    cameraPosition: vec3<f32>,
+    _pad: f32,
 };
 
 struct GpuMesh3DRecord {
@@ -62,6 +68,8 @@ struct GpuMesh3DRecord {
     color: vec4<f32>,
     lightDirection: vec4<f32>,
     ambientColor: vec4<f32>,
+    specularColor: vec4<f32>,
+    materialAmbient: vec4<f32>,
     opacity: f32,
     renderMode: f32,
     _pad1: f32,
@@ -78,9 +86,11 @@ struct VertexInput {
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) color: vec4<f32>,
-    @location(1) barycentric: vec3<f32>,
-    @location(2) renderMode: f32,
+    @location(0) worldPosition: vec3<f32>,
+    @location(1) worldNormal: vec3<f32>,
+    @location(2) barycentric: vec3<f32>,
+    @location(3) renderMode: f32,
+    @location(4) @interpolate(flat) instanceIdx: u32,
 };
 
 @vertex
@@ -92,15 +102,10 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(i
     let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
 
     output.position = uniforms.projection * uniforms.view * worldPos;
-
-    let lightDir = normalize(record.lightDirection.xyz);
-    let diffuse = max(dot(worldNormal, lightDir), 0.0) * record.lightDirection.w;
-    
-    let ambient = record.ambientColor.rgb * record.ambientColor.w;
-    let litColor = (ambient + diffuse * record.color.rgb) * record.opacity;
-
-    output.color = vec4<f32>(litColor, record.opacity);
+    output.worldPosition = worldPos.xyz;
+    output.worldNormal = worldNormal;
     output.renderMode = record.renderMode;
+    output.instanceIdx = instanceIdx;
 
     let triVertexIdx = vertexIdx % 3u;
     if (triVertexIdx == 0u) {
@@ -116,10 +121,33 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(i
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let record = meshRecords[input.instanceIdx];
     let mode = u32(input.renderMode + 0.5);
 
+    let N = normalize(input.worldNormal);
+    let L = normalize(record.lightDirection.xyz);
+    let V = normalize(uniforms.cameraPosition - input.worldPosition);
+    let H = normalize(L + V);
+
+    let ambientLight = record.ambientColor.rgb * record.ambientColor.w;
+    let ambient = ambientLight * record.materialAmbient.rgb;
+
+    let diffuseIntensity = max(dot(N, L), 0.0);
+    let diffuse = diffuseIntensity * record.lightDirection.w * record.color.rgb;
+
+    let shininess = record.specularColor.w;
+    let specularIntensity = pow(max(dot(N, H), 0.0), shininess);
+    
+    var specular = vec3<f32>(0.0);
+    if (diffuseIntensity > 0.0 && shininess > 0.0) {
+        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb;
+    }
+
+    let litColor = (ambient + diffuse + specular) * record.opacity;
+    let solidColor = vec4<f32>(litColor, record.opacity);
+
     if (mode == 0u) {
-        return input.color;
+        return solidColor;
     }
 
     let dFdx = dpdx(input.barycentric);
@@ -131,18 +159,18 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let lineWidth = 1.0; 
     let edge = smoothstep(lineWidth - 0.5, lineWidth + 0.5, minDist);
 
-    let wireframeColor = vec4<f32>(0.85, 0.85, 0.9, input.color.a);
+    let wireframeColor = vec4<f32>(0.85, 0.85, 0.9, record.opacity);
 
     if (mode == 1u) {
-        let alpha = (1.0 - edge) * input.color.a;
+        let alpha = (1.0 - edge) * record.opacity;
         if (alpha < 0.01) {
             discard;
         }
         return vec4<f32>(wireframeColor.rgb, alpha);
     }
 
-    let finalColor = mix(wireframeColor.rgb, input.color.rgb, edge);
-    return vec4<f32>(finalColor, input.color.a);
+    let finalColor = mix(wireframeColor.rgb, solidColor.rgb, edge);
+    return vec4<f32>(finalColor, record.opacity);
 }
 ";
 
@@ -271,17 +299,23 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     Color = mesh.Color,
                     LightDirection = new Vector4(payload.LightDirection, payload.LightIntensity),
                     AmbientColor = new Vector4(payload.AmbientColor, payload.AmbientIntensity),
+                    SpecularColor = new Vector4(mesh.SpecularColor, mesh.Shininess),
+                    MaterialAmbient = new Vector4(mesh.AmbientColor, 1.0f),
                     Opacity = mesh.Opacity * compositor.ActiveOpacity,
                     RenderMode = rMode
                 };
             }
             res.DynamicRecordsBuffer.Write(cpuRecords);
 
+            Matrix4x4.Invert(cmd.CameraView, out var invView);
+            Vector3 cameraPos = invView.Translation;
+
             // 3. Upload uniforms data
             var cpuUniforms = new GpuMesh3DUniforms
             {
                 Projection = cmd.Transform, // Perspective projection matrix
-                View = cmd.CameraView       // View matrix
+                View = cmd.CameraView,      // View matrix
+                CameraPosition = cameraPos
             };
             res.UniformsBuffer.WriteSingle(cpuUniforms);
 
@@ -591,6 +625,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         public int[] Indices { get; set; } = Array.Empty<int>();
         public Matrix4x4 ModelTransform { get; set; } = Matrix4x4.Identity;
         public Vector4 Color { get; set; } = Vector4.One;
+        public Vector3 SpecularColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
+        public float Shininess { get; set; } = 32.0f;
+        public Vector3 AmbientColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
         public float Opacity { get; set; } = 1.0f;
     }
 }

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -156,7 +156,7 @@ fn ComputeLighting(
     }
 
     if (shading == 2u) { // Flat / Unlit
-        return vec4<f32>(record.color.rgb * record.opacity, record.opacity);
+        return vec4<f32>(record.color.rgb, record.opacity);
     }
 
     if (shading == 3u) { // Hidden Line
@@ -273,7 +273,7 @@ fn ComputeLighting(
         opacity = clamp(0.15 + 0.55 * pow(1.0 - max(dot(N, V), 0.0), 3.0), 0.0, 1.0) * record.opacity;
     }
 
-    return vec4<f32>(resultColor * opacity, opacity);
+    return vec4<f32>(resultColor, opacity);
 }
 ";
 

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -691,8 +691,8 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
                     for (int idx = 0; idx < entry.Indices.Length; idx++)
                     {
                         int vIdx = entry.Indices[idx];
-                        var pos = entry.Positions[vIdx];
-                        var norm = vIdx < entry.Normals.Length ? entry.Normals[vIdx] : Vector3.UnitY;
+                        var pos = (vIdx >= 0 && vIdx < entry.Positions.Length) ? entry.Positions[vIdx] : Vector3.Zero;
+                        var norm = (vIdx >= 0 && vIdx < entry.Normals.Length) ? entry.Normals[vIdx] : Vector3.UnitY;
                         cpuVertices[idx] = new GpuVertex3D(pos, norm);
                     }
 

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -302,6 +302,36 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(i
     return output;
 }
 
+fn DistributionGGX(N: vec3<f32>, H: vec3<f32>, roughness: f32) -> f32 {
+    let alpha = roughness * roughness;
+    let alpha2 = alpha * alpha;
+    let NdotH = max(dot(N, H), 0.0);
+    let NdotH2 = NdotH * NdotH;
+    
+    let denom = (NdotH2 * (alpha2 - 1.0) + 1.0);
+    return alpha2 / (3.1415926535 * denom * denom);
+}
+
+fn GeometrySchlickGGX(NdotX: f32, roughness: f32) -> f32 {
+    let r = (roughness + 1.0);
+    let k = (r * r) / 8.0;
+    let num = NdotX;
+    let denom = NdotX * (1.0 - k) + k;
+    return num / max(denom, 0.0001);
+}
+
+fn GeometrySmith(N: vec3<f32>, V: vec3<f32>, L: vec3<f32>, roughness: f32) -> f32 {
+    let NdotV = max(dot(N, V), 0.0);
+    let NdotL = max(dot(N, L), 0.0);
+    let ggx2 = GeometrySchlickGGX(NdotV, roughness);
+    let ggx1 = GeometrySchlickGGX(NdotL, roughness);
+    return ggx1 * ggx2;
+}
+
+fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
+    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let record = meshRecords[input.instanceIdx];

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -55,7 +55,87 @@ namespace ProGPU.Scene.Extensions
 
     public class Mesh3DExtensionPipeline : ICompositorExtension
     {
-        private const string Mesh3DShaderCode = @"
+        private const string Mesh3DSolidShaderCode = @"
+struct VSUniforms {
+    projection: mat4x4<f32>,
+    view: mat4x4<f32>,
+    cameraPosition: vec3<f32>,
+    _pad: f32,
+};
+
+struct GpuMesh3DRecord {
+    modelTransform: mat4x4<f32>,
+    color: vec4<f32>,
+    lightDirection: vec4<f32>,
+    ambientColor: vec4<f32>,
+    specularColor: vec4<f32>,
+    materialAmbient: vec4<f32>,
+    opacity: f32,
+    renderMode: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: VSUniforms;
+@group(0) @binding(1) var<storage, read> meshRecords: array<GpuMesh3DRecord>;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) worldPosition: vec3<f32>,
+    @location(1) worldNormal: vec3<f32>,
+    @location(2) @interpolate(flat) instanceIdx: u32,
+};
+
+@vertex
+fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
+    var output: VertexOutput;
+    let record = meshRecords[instanceIdx];
+
+    let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
+    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
+
+    output.position = uniforms.projection * uniforms.view * worldPos;
+    output.worldPosition = worldPos.xyz;
+    output.worldNormal = worldNormal;
+    output.instanceIdx = instanceIdx;
+
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let record = meshRecords[input.instanceIdx];
+
+    let N = normalize(input.worldNormal);
+    let L = normalize(record.lightDirection.xyz);
+    let V = normalize(uniforms.cameraPosition - input.worldPosition);
+    let H = normalize(L + V);
+
+    let ambientLight = record.ambientColor.rgb * record.ambientColor.w;
+    let ambient = ambientLight * record.materialAmbient.rgb;
+
+    let diffuseIntensity = max(dot(N, L), 0.0);
+    let diffuse = diffuseIntensity * record.lightDirection.w * record.color.rgb;
+
+    let shininess = record.specularColor.w;
+    let specularIntensity = pow(max(dot(N, H), 0.0), shininess);
+    
+    var specular = vec3<f32>(0.0);
+    if (diffuseIntensity > 0.0 && shininess > 0.0) {
+        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb;
+    }
+
+    let litColor = (ambient + diffuse + specular) * record.opacity;
+    return vec4<f32>(litColor, record.opacity);
+}
+";
+
+        private const string Mesh3DWireframeShaderCode = @"
 struct VSUniforms {
     projection: mat4x4<f32>,
     view: mat4x4<f32>,
@@ -145,10 +225,6 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
     let litColor = (ambient + diffuse + specular) * record.opacity;
     let solidColor = vec4<f32>(litColor, record.opacity);
-
-    if (mode == 0u) {
-        return solidColor;
-    }
 
     let dFdx = dpdx(input.barycentric);
     let dFdy = dpdy(input.barycentric);
@@ -322,7 +398,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             // 4. Create solid pipeline if needed
             if (_cachedPipeline == null)
             {
-                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DShader_3D", Mesh3DShaderCode, "Mesh3D WGSL 3D Shader");
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DSolidShader_3D", Mesh3DSolidShaderCode, "Mesh3D WGSL 3D Solid Shader");
 
                 var layouts = new VertexBufferLayout[]
                 {
@@ -359,7 +435,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             // Create wireframe pipeline if needed (TriangleList with double sided rendering)
             if (_cachedWireframePipeline == null)
             {
-                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DShader_3D", Mesh3DShaderCode, "Mesh3D WGSL 3D Shader");
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DWireframeShader_3D", Mesh3DWireframeShaderCode, "Mesh3D WGSL 3D Wireframe Shader");
 
                 var layouts = new VertexBufferLayout[]
                 {
@@ -514,8 +590,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             // Draw Passes
             var mode = payload.RenderMode;
 
-            // Pass A: Draw Solid Shaded Triangles or Solid + Wireframe
-            if (mode == RenderMode3D.Solid || mode == RenderMode3D.SolidWireframe)
+            if (mode == RenderMode3D.Solid)
             {
                 wgpu.RenderPassEncoderSetPipeline(pass, _cachedPipeline);
                 wgpu.RenderPassEncoderSetBindGroup(pass, 0, res.SolidBindGroup, 0, null);
@@ -530,9 +605,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     wgpu.RenderPassEncoderDraw(pass, cache.VertexCount, 1, 0, (uint)i);
                 }
             }
-
-            // Pass B: Draw Wireframe Only
-            if (mode == RenderMode3D.Wireframe)
+            else if (mode == RenderMode3D.Wireframe || mode == RenderMode3D.SolidWireframe)
             {
                 wgpu.RenderPassEncoderSetPipeline(pass, _cachedWireframePipeline);
                 wgpu.RenderPassEncoderSetBindGroup(pass, 0, res.WireframeBindGroup, 0, null);

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -356,10 +356,11 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
 }
 ";
 
-        private struct CachedGeometry
+        private class CachedGeometry
         {
             public GpuBuffer VertexBuffer;
             public uint VertexCount;
+            public int Version;
         }
 
         private class ViewportResource
@@ -669,7 +670,21 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
                 var entry = payload.Meshes[i];
                 if (entry.Geometry == null) continue;
 
-                if (!_geometryCache.TryGetValue(entry.Geometry, out var cache))
+                bool needsRebuild = false;
+                if (_geometryCache.TryGetValue(entry.Geometry, out var cache))
+                {
+                    if (cache.Version != entry.GeometryVersion)
+                    {
+                        cache.VertexBuffer.Dispose();
+                        needsRebuild = true;
+                    }
+                }
+                else
+                {
+                    needsRebuild = true;
+                }
+
+                if (needsRebuild)
                 {
                     // Create De-indexed (non-indexed) Vertex Buffer
                     var cpuVertices = new GpuVertex3D[entry.Indices.Length];
@@ -688,7 +703,8 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
                     cache = new CachedGeometry
                     {
                         VertexBuffer = vBuffer,
-                        VertexCount = (uint)entry.Indices.Length
+                        VertexCount = (uint)entry.Indices.Length,
+                        Version = entry.GeometryVersion
                     };
                     _geometryCache[entry.Geometry] = cache;
                 }
@@ -802,6 +818,7 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
     public class MeshCompilationEntry
     {
         public object? Geometry { get; set; }
+        public int GeometryVersion { get; set; }
         public Vector3[] Positions { get; set; } = Array.Empty<Vector3>();
         public Vector3[] Normals { get; set; } = Array.Empty<Vector3>();
         public int[] Indices { get; set; } = Array.Empty<int>();

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -18,9 +18,13 @@ namespace ProGPU.Scene.Extensions
 
     public enum ShadingMode3D
     {
-        Shaded = 0,
-        Flat = 1,
-        Normals = 2
+        Realistic = 0,
+        Conceptual = 1,
+        Flat = 2,
+        HiddenLine = 3,
+        ShadesOfGray = 4,
+        XRay = 5,
+        Normals = 6
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -47,7 +51,7 @@ namespace ProGPU.Scene.Extensions
         public Vector4 MaterialAmbient;       // rgb = Material Ka, w = unused
         public float Opacity;
         public float RenderMode;              // 0.0f = Solid, 1.0f = Wireframe, 2.0f = SolidWireframe
-        public float ShadingMode;             // 0.0f = Shaded, 1.0f = Flat, 2.0f = Normals
+        public float ShadingMode;             // AutoCAD Shading Mode (0=Realistic, 1=Conceptual, 2=Flat, 3=HiddenLine, 4=ShadesOfGray, 5=XRay, 6=Normals)
         private float _pad2;
     }
 
@@ -62,7 +66,7 @@ namespace ProGPU.Scene.Extensions
 
     public class Mesh3DExtensionPipeline : ICompositorExtension
     {
-        private const string Mesh3DSolidShaderCode = @"
+        private const string CommonShaderHelpers = @"
 struct VSUniforms {
     projection: mat4x4<f32>,
     view: mat4x4<f32>,
@@ -98,179 +102,7 @@ struct VertexOutput {
     @location(2) @interpolate(flat) instanceIdx: u32,
 };
 
-@vertex
-fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
-    var output: VertexOutput;
-    let record = meshRecords[instanceIdx];
-
-    let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
-    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
-
-    output.position = uniforms.projection * uniforms.view * worldPos;
-    output.worldPosition = worldPos.xyz;
-    output.worldNormal = worldNormal;
-    output.instanceIdx = instanceIdx;
-
-    return output;
-}
-
-fn DistributionGGX(N: vec3<f32>, H: vec3<f32>, roughness: f32) -> f32 {
-    let alpha = roughness * roughness;
-    let alpha2 = alpha * alpha;
-    let NdotH = max(dot(N, H), 0.0);
-    let NdotH2 = NdotH * NdotH;
-    
-    let denom = (NdotH2 * (alpha2 - 1.0) + 1.0);
-    return alpha2 / (3.1415926535 * denom * denom);
-}
-
-fn VisibilitySchlickGGX(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
-    let r = (roughness + 1.0);
-    let k = (r * r) / 8.0;
-    let denom = (NdotV * (1.0 - k) + k) * (NdotL * (1.0 - k) + k) * 4.0;
-    return 1.0 / max(denom, 0.0001);
-}
-
-fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
-    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
-}
-
-@fragment
-fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    let record = meshRecords[input.instanceIdx];
-    let shading = u32(record.shadingMode + 0.5);
-
-    let N = normalize(input.worldNormal);
-
-    if (shading == 2u) { // Normals diagnostic view
-        let normalColor = N * 0.5 + 0.5;
-        return vec4<f32>(normalColor, record.opacity);
-    }
-
-    if (shading == 1u) { // Flat / Unlit view
-        return vec4<f32>(record.color.rgb * record.opacity, record.opacity);
-    }
-
-    let V = normalize(uniforms.cameraPosition - input.worldPosition);
-
-    let shininess = record.specularColor.w;
-    let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
-    let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
-
-    // Three-Point Studio Lighting vectors and intensities
-    let keyDir = normalize(record.lightDirection.xyz);
-    let keyIntensity = record.lightDirection.w;
-
-    let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
-    let fillIntensity = keyIntensity * 0.35;
-    let fillCol = vec3<f32>(0.8, 0.88, 1.0); // cool fill
-
-    let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
-    let backIntensity = keyIntensity * 0.45;
-    let backCol = vec3<f32>(1.0, 0.95, 0.9); // warm back light
-
-    var diffuseOut = vec3<f32>(0.0);
-    var specularOut = vec3<f32>(0.0);
-
-    // 1. KEY LIGHT
-    {
-        let L = keyDir;
-        let H = normalize(L + V);
-        let NdotL = max(dot(N, L), 0.0);
-        let NdotV = max(dot(N, V), 0.0);
-        if (NdotL > 0.0) {
-            let D = DistributionGGX(N, H, roughness);
-            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
-            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let spec = D * V_joint * F;
-            let kS = F;
-            let kD = (vec3<f32>(1.0) - kS);
-            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
-            specularOut += spec * NdotL * keyIntensity;
-        }
-    }
-
-    // 2. FILL LIGHT
-    {
-        let L = fillDir;
-        let H = normalize(L + V);
-        let NdotL = max(dot(N, L), 0.0);
-        let NdotV = max(dot(N, V), 0.0);
-        if (NdotL > 0.0) {
-            let D = DistributionGGX(N, H, roughness);
-            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
-            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let spec = D * V_joint * F;
-            let kS = F;
-            let kD = (vec3<f32>(1.0) - kS);
-            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
-            specularOut += spec * NdotL * fillIntensity * fillCol;
-        }
-    }
-
-    // 3. BACK LIGHT
-    {
-        let L = backDir;
-        let H = normalize(L + V);
-        let NdotL = max(dot(N, L), 0.0);
-        let NdotV = max(dot(N, V), 0.0);
-        if (NdotL > 0.0) {
-            let D = DistributionGGX(N, H, roughness);
-            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
-            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let spec = D * V_joint * F;
-            let kS = F;
-            let kD = (vec3<f32>(1.0) - kS);
-            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
-            specularOut += spec * NdotL * backIntensity * backCol;
-        }
-    }
-
-    // Hemispherical sky-ground ambient
-    let skyFactor = N.y * 0.5 + 0.5;
-    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
-    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
-    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
-
-    // Premium rim glow
-    let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
-    let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
-
-    let litColor = (ambient + diffuseOut + specularOut + rimColor) * record.opacity;
-    return vec4<f32>(litColor, record.opacity);
-}
-";
-
-        private const string Mesh3DWireframeShaderCode = @"
-struct VSUniforms {
-    projection: mat4x4<f32>,
-    view: mat4x4<f32>,
-    cameraPosition: vec3<f32>,
-    _pad: f32,
-};
-
-struct GpuMesh3DRecord {
-    modelTransform: mat4x4<f32>,
-    color: vec4<f32>,
-    lightDirection: vec4<f32>,
-    ambientColor: vec4<f32>,
-    specularColor: vec4<f32>,
-    materialAmbient: vec4<f32>,
-    opacity: f32,
-    renderMode: f32,
-    shadingMode: f32,
-    _pad2: f32,
-};
-
-@group(0) @binding(0) var<uniform> uniforms: VSUniforms;
-@group(0) @binding(1) var<storage, read> meshRecords: array<GpuMesh3DRecord>;
-
-struct VertexInput {
-    @location(0) position: vec3<f32>,
-    @location(1) normal: vec3<f32>,
-};
-
-struct VertexOutput {
+struct VertexOutputWireframe {
     @builtin(position) position: vec4<f32>,
     @location(0) worldPosition: vec3<f32>,
     @location(1) worldNormal: vec3<f32>,
@@ -279,32 +111,6 @@ struct VertexOutput {
     @location(4) @interpolate(flat) instanceIdx: u32,
 };
 
-@vertex
-fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
-    var output: VertexOutput;
-    let record = meshRecords[instanceIdx];
-
-    let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
-    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
-
-    output.position = uniforms.projection * uniforms.view * worldPos;
-    output.worldPosition = worldPos.xyz;
-    output.worldNormal = worldNormal;
-    output.renderMode = record.renderMode;
-    output.instanceIdx = instanceIdx;
-
-    let triVertexIdx = vertexIdx % 3u;
-    if (triVertexIdx == 0u) {
-        output.barycentric = vec3<f32>(1.0, 0.0, 0.0);
-    } else if (triVertexIdx == 1u) {
-        output.barycentric = vec3<f32>(0.0, 1.0, 0.0);
-    } else {
-        output.barycentric = vec3<f32>(0.0, 0.0, 1.0);
-    }
-
-    return output;
-}
-
 fn DistributionGGX(N: vec3<f32>, H: vec3<f32>, roughness: f32) -> f32 {
     let alpha = roughness * roughness;
     let alpha2 = alpha * alpha;
@@ -326,42 +132,72 @@ fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
     return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
 }
 
-@fragment
-fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    let record = meshRecords[input.instanceIdx];
-    let mode = u32(input.renderMode + 0.5);
+fn GoochShading(N: vec3<f32>, L: vec3<f32>, diffuseColor: vec3<f32>) -> vec3<f32> {
+    let NdotL = dot(N, L);
+    let t = NdotL * 0.5 + 0.5;
+    let coolCol = vec3<f32>(0.0, 0.0, 0.55) + 0.25 * diffuseColor;
+    let warmCol = vec3<f32>(0.3, 0.3, 0.0) + 0.25 * diffuseColor;
+    return mix(coolCol, warmCol, t);
+}
+
+fn ComputeLighting(
+    instanceIdx: u32,
+    worldPos: vec3<f32>,
+    worldNormal: vec3<f32>
+) -> vec4<f32> {
+    let record = meshRecords[instanceIdx];
     let shading = u32(record.shadingMode + 0.5);
 
-    let N = normalize(input.worldNormal);
+    let N = normalize(worldNormal);
 
-    var solidColor = vec4<f32>(0.0);
-    if (shading == 2u) { // Normals diagnostic view
-        solidColor = vec4<f32>(N * 0.5 + 0.5, record.opacity);
-    } else if (shading == 1u) { // Flat / Unlit view
-        solidColor = vec4<f32>(record.color.rgb * record.opacity, record.opacity);
-    } else {
-        // Shaded mode (PBR GGX)
-        let V = normalize(uniforms.cameraPosition - input.worldPosition);
+    if (shading == 6u) { // Normals Diagnostic
+        let normalColor = N * 0.5 + 0.5;
+        return vec4<f32>(normalColor, record.opacity);
+    }
 
-        let shininess = record.specularColor.w;
-        let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
-        let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
+    if (shading == 2u) { // Flat / Unlit
+        return vec4<f32>(record.color.rgb * record.opacity, record.opacity);
+    }
 
-        // Three-Point Studio Lighting vectors and intensities
-        let keyDir = normalize(record.lightDirection.xyz);
-        let keyIntensity = record.lightDirection.w;
+    if (shading == 3u) { // Hidden Line
+        return vec4<f32>(0.05, 0.05, 0.06, record.opacity); // background solid fill
+    }
 
-        let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
-        let fillIntensity = keyIntensity * 0.35;
-        let fillCol = vec3<f32>(0.8, 0.88, 1.0); // cool fill
+    let V = normalize(uniforms.cameraPosition - worldPos);
 
-        let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
-        let backIntensity = keyIntensity * 0.45;
-        let backCol = vec3<f32>(1.0, 0.95, 0.9); // warm back light
+    let shininess = record.specularColor.w;
+    let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
+    let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
 
-        var diffuseOut = vec3<f32>(0.0);
-        var specularOut = vec3<f32>(0.0);
+    let keyDir = normalize(record.lightDirection.xyz);
+    let keyIntensity = record.lightDirection.w;
 
+    let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
+    let fillIntensity = keyIntensity * 0.35;
+    let fillCol = vec3<f32>(0.8, 0.88, 1.0);
+
+    let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
+    let backIntensity = keyIntensity * 0.45;
+    let backCol = vec3<f32>(1.0, 0.95, 0.9);
+
+    var diffuseOut = vec3<f32>(0.0);
+    var specularOut = vec3<f32>(0.0);
+
+    if (shading == 1u) { // Conceptual (Gooch Shading)
+        diffuseOut += GoochShading(N, keyDir, record.color.rgb) * keyIntensity;
+        diffuseOut += GoochShading(N, fillDir, record.color.rgb) * fillIntensity * fillCol;
+        diffuseOut += GoochShading(N, backDir, record.color.rgb) * backIntensity * backCol;
+
+        let H = normalize(keyDir + V);
+        let NdotL = max(dot(N, keyDir), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            specularOut += D * V_joint * F * NdotL * keyIntensity;
+        }
+    } else { // Realistic (PBR GGX) or ShadesOfGray or XRay
         // 1. KEY LIGHT
         {
             let L = keyDir;
@@ -415,20 +251,87 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                 specularOut += spec * NdotL * backIntensity * backCol;
             }
         }
-
-        // Hemispherical sky-ground ambient
-        let skyFactor = N.y * 0.5 + 0.5;
-        let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
-        let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
-        let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
-
-        // Premium rim glow
-        let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
-        let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
-
-        let litColor = (ambient + diffuseOut + specularOut + rimColor) * record.opacity;
-        solidColor = vec4<f32>(litColor, record.opacity);
     }
+
+    let skyFactor = N.y * 0.5 + 0.5;
+    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
+    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
+    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
+
+    let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
+    let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
+
+    var resultColor = ambient + diffuseOut + specularOut + rimColor;
+
+    if (shading == 4u) { // Shades of Gray
+        let gray = dot(resultColor, vec3<f32>(0.2126, 0.7152, 0.0722));
+        resultColor = vec3<f32>(gray);
+    }
+
+    var opacity = record.opacity;
+    if (shading == 5u) { // X-Ray Mode
+        opacity = clamp(0.15 + 0.55 * pow(1.0 - max(dot(N, V), 0.0), 3.0), 0.0, 1.0) * record.opacity;
+    }
+
+    return vec4<f32>(resultColor * opacity, opacity);
+}
+";
+
+        private const string Mesh3DSolidShaderCode = CommonShaderHelpers + @"
+@vertex
+fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
+    var output: VertexOutput;
+    let record = meshRecords[instanceIdx];
+
+    let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
+    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
+
+    output.position = uniforms.projection * uniforms.view * worldPos;
+    output.worldPosition = worldPos.xyz;
+    output.worldNormal = worldNormal;
+    output.instanceIdx = instanceIdx;
+
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return ComputeLighting(input.instanceIdx, input.worldPosition, input.worldNormal);
+}
+";
+
+        private const string Mesh3DWireframeShaderCode = CommonShaderHelpers + @"
+@vertex
+fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(instance_index) instanceIdx: u32) -> VertexOutputWireframe {
+    var output: VertexOutputWireframe;
+    let record = meshRecords[instanceIdx];
+
+    let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
+    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
+
+    output.position = uniforms.projection * uniforms.view * worldPos;
+    output.worldPosition = worldPos.xyz;
+    output.worldNormal = worldNormal;
+    output.renderMode = record.renderMode;
+    output.instanceIdx = instanceIdx;
+
+    let triVertexIdx = vertexIdx % 3u;
+    if (triVertexIdx == 0u) {
+        output.barycentric = vec3<f32>(1.0, 0.0, 0.0);
+    } else if (triVertexIdx == 1u) {
+        output.barycentric = vec3<f32>(0.0, 1.0, 0.0);
+    } else {
+        output.barycentric = vec3<f32>(0.0, 0.0, 1.0);
+    }
+
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
+    let mode = u32(input.renderMode + 0.5);
+    let solidColor = ComputeLighting(input.instanceIdx, input.worldPosition, input.worldNormal);
+
     let dFdx = dpdx(input.barycentric);
     let dFdy = dpdy(input.barycentric);
     let g = max(sqrt(dFdx * dFdx + dFdy * dFdy), vec3<f32>(0.00001));
@@ -438,10 +341,10 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let lineWidth = 1.0; 
     let edge = smoothstep(lineWidth - 0.5, lineWidth + 0.5, minDist);
 
-    let wireframeColor = vec4<f32>(0.85, 0.85, 0.9, record.opacity);
+    let wireframeColor = vec4<f32>(0.85, 0.85, 0.9, solidColor.a);
 
     if (mode == 1u) {
-        let alpha = (1.0 - edge) * record.opacity;
+        let alpha = (1.0 - edge) * solidColor.a;
         if (alpha < 0.01) {
             discard;
         }
@@ -449,7 +352,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     let finalColor = mix(wireframeColor.rgb, solidColor.rgb, edge);
-    return vec4<f32>(finalColor, record.opacity);
+    return vec4<f32>(finalColor, solidColor.a);
 }
 ";
 
@@ -602,7 +505,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             // 4. Create solid pipeline if needed
             if (_cachedPipeline == null)
             {
-                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DSolidShader_3D", Mesh3DSolidShaderCode, "Mesh3D WGSL 3D Solid Shader");
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DSolidShader_3D_v3", Mesh3DSolidShaderCode, "Mesh3D WGSL 3D Solid Shader");
 
                 var layouts = new VertexBufferLayout[]
                 {
@@ -620,7 +523,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                 attrs[1] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 12, ShaderLocation = 1 }; // Normal
 
                 _cachedPipeline = compositor.PipelineCache.GetOrCreateRenderPipeline(
-                    "Mesh3DPipeline_3D",
+                    "Mesh3DPipeline_3D_v3",
                     shaderModule,
                     vertexBufferLayouts: layouts,
                     topology: PrimitiveTopology.TriangleList,
@@ -639,7 +542,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             // Create wireframe pipeline if needed (TriangleList with double sided rendering)
             if (_cachedWireframePipeline == null)
             {
-                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DWireframeShader_3D", Mesh3DWireframeShaderCode, "Mesh3D WGSL 3D Wireframe Shader");
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DWireframeShader_3D_v3", Mesh3DWireframeShaderCode, "Mesh3D WGSL 3D Wireframe Shader");
 
                 var layouts = new VertexBufferLayout[]
                 {
@@ -657,7 +560,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                 attrs[1] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 12, ShaderLocation = 1 }; // Normal
 
                 _cachedWireframePipeline = compositor.PipelineCache.GetOrCreateRenderPipeline(
-                    "Mesh3DWireframePipeline_3D",
+                    "Mesh3DWireframePipeline_3D_v3",
                     shaderModule,
                     vertexBufferLayouts: layouts,
                     topology: PrimitiveTopology.TriangleList,
@@ -893,7 +796,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         public GpuTexture? DepthTexture { get; set; }
         
         public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
-        public ShadingMode3D ShadingMode { get; set; } = ShadingMode3D.Shaded;
+        public ShadingMode3D ShadingMode { get; set; } = ShadingMode3D.Realistic;
     }
 
     public class MeshCompilationEntry

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -1,0 +1,560 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using Silk.NET.WebGPU;
+using Silk.NET.Core.Native;
+using ProGPU.Vector;
+using ProGPU.Backend;
+
+namespace ProGPU.Scene.Extensions
+{
+    public enum RenderMode3D
+    {
+        Solid = 0,
+        Wireframe = 1,
+        SolidWireframe = 2
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct GpuVertex3D
+    {
+        public Vector3 Position;
+        public Vector3 Normal;
+
+        public GpuVertex3D(Vector3 position, Vector3 normal)
+        {
+            Position = position;
+            Normal = normal;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    public struct GpuMesh3DRecord
+    {
+        public Matrix4x4 ModelTransform;      // 3D Model transform for lighting
+        public Vector4 Color;
+        public Vector4 LightDirection;        // xyz = direction, w = intensity
+        public Vector4 AmbientColor;          // rgb = color, w = intensity
+        public float Opacity;
+        public float IsWireframe;             // 1.0f if wireframe, 0.0f otherwise
+        private float _pad1;
+        private float _pad2;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    public struct GpuMesh3DUniforms
+    {
+        public Matrix4x4 Projection;
+        public Matrix4x4 View;
+    }
+
+    public class Mesh3DExtensionPipeline : ICompositorExtension
+    {
+        private const string Mesh3DShaderCode = @"
+struct VSUniforms {
+    projection: mat4x4<f32>,
+    view: mat4x4<f32>,
+};
+
+struct GpuMesh3DRecord {
+    modelTransform: mat4x4<f32>,
+    color: vec4<f32>,
+    lightDirection: vec4<f32>,
+    ambientColor: vec4<f32>,
+    opacity: f32,
+    isWireframe: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: VSUniforms;
+@group(0) @binding(1) var<storage, read> meshRecords: array<GpuMesh3DRecord>;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
+    var output: VertexOutput;
+    let record = meshRecords[instanceIdx];
+
+    // Transform position and normal to world space
+    var localPos = input.position;
+    if (record.isWireframe > 0.5) {
+        localPos += input.normal * 0.003; // Tiny normal offset to prevent z-fighting
+    }
+
+    let worldPos = record.modelTransform * vec4<f32>(localPos, 1.0);
+    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
+
+    // Dynamic 3D depth matrices transform
+    output.position = uniforms.projection * uniforms.view * worldPos;
+
+    // Calculate Gouraud diffuse + ambient lighting
+    let lightDir = normalize(record.lightDirection.xyz);
+    let diffuse = max(dot(worldNormal, lightDir), 0.0) * record.lightDirection.w;
+    
+    let ambient = record.ambientColor.rgb * record.ambientColor.w;
+    var litColor = (ambient + diffuse * record.color.rgb) * record.opacity;
+
+    if (record.isWireframe > 0.5) {
+        litColor = litColor * 1.4 + vec3<f32>(0.05, 0.05, 0.05); // Boost wireframe overlay brightness
+    }
+
+    output.color = vec4<f32>(litColor, record.opacity);
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return input.color;
+}
+";
+
+        private struct CachedGeometry
+        {
+            public GpuBuffer VertexBuffer;
+            public GpuBuffer IndexBuffer;
+            public GpuBuffer? LineIndexBuffer;
+            public uint LineIndexCount;
+        }
+
+        private readonly Dictionary<object, CachedGeometry> _geometryCache = new();
+        private GpuBuffer? _dynamicRecordsBuffer;
+        private GpuBuffer? _uniformsBuffer;
+        
+        private unsafe RenderPipeline* _cachedPipeline;
+        private unsafe RenderPipeline* _cachedWireframePipeline;
+        private unsafe BindGroup* _cachedBindGroup;
+        private unsafe BindGroup* _cachedWireframeBindGroup;
+        private int _cachedRecordGen = -1;
+
+        public void BeginFrame(Compositor compositor)
+        {
+        }
+
+        public void Dispose()
+        {
+            foreach (var cache in _geometryCache.Values)
+            {
+                cache.VertexBuffer.Dispose();
+                cache.IndexBuffer.Dispose();
+                cache.LineIndexBuffer?.Dispose();
+            }
+            _geometryCache.Clear();
+
+            _dynamicRecordsBuffer?.Dispose();
+            _uniformsBuffer?.Dispose();
+        }
+
+        public unsafe void Compile(
+            Compositor compositor,
+            IRenderDataProvider? provider,
+            Matrix4x4 transform,
+            ref RenderCommand cmd)
+        {
+            var payload = cmd.DataParam as Viewport3DCompilationPayload;
+            if (payload == null || payload.Meshes.Count == 0 || payload.ColorTexture == null || payload.DepthTexture == null) return;
+
+            var wgpu = compositor.Context.Wgpu;
+            var device = compositor.Context.Device;
+            var queue = compositor.Context.Queue;
+
+            // 1. Create or update dynamic record buffer and uniforms buffer
+            int recordCount = payload.Meshes.Count;
+            if (payload.RenderMode == RenderMode3D.SolidWireframe)
+            {
+                recordCount = payload.Meshes.Count * 2;
+            }
+
+            uint reqRecordsSize = (uint)recordCount * (uint)Marshal.SizeOf<GpuMesh3DRecord>();
+            if (_dynamicRecordsBuffer == null || _dynamicRecordsBuffer.Size < reqRecordsSize)
+            {
+                _dynamicRecordsBuffer?.Dispose();
+                _dynamicRecordsBuffer = new GpuBuffer(compositor.Context, reqRecordsSize * 2, BufferUsage.Storage | BufferUsage.CopyDst, "Dynamic Mesh3D Records Buffer");
+            }
+
+            uint uniformsSize = (uint)Marshal.SizeOf<GpuMesh3DUniforms>();
+            if (_uniformsBuffer == null)
+            {
+                _uniformsBuffer = new GpuBuffer(compositor.Context, uniformsSize, BufferUsage.Uniform | BufferUsage.CopyDst, "Mesh3D Uniforms Buffer");
+            }
+
+            // 2. Upload records data
+            var cpuRecords = new GpuMesh3DRecord[recordCount];
+            int n = payload.Meshes.Count;
+            for (int i = 0; i < n; i++)
+            {
+                var mesh = payload.Meshes[i];
+                var solidRecord = new GpuMesh3DRecord
+                {
+                    ModelTransform = mesh.ModelTransform,
+                    Color = mesh.Color,
+                    LightDirection = new Vector4(payload.LightDirection, payload.LightIntensity),
+                    AmbientColor = new Vector4(payload.AmbientColor, payload.AmbientIntensity),
+                    Opacity = mesh.Opacity * compositor.ActiveOpacity,
+                    IsWireframe = 0.0f
+                };
+
+                if (payload.RenderMode == RenderMode3D.Solid)
+                {
+                    cpuRecords[i] = solidRecord;
+                }
+                else if (payload.RenderMode == RenderMode3D.Wireframe)
+                {
+                    solidRecord.IsWireframe = 1.0f;
+                    cpuRecords[i] = solidRecord;
+                }
+                else // SolidWireframe
+                {
+                    cpuRecords[i] = solidRecord;
+
+                    var wireRecord = solidRecord;
+                    wireRecord.IsWireframe = 1.0f;
+                    cpuRecords[n + i] = wireRecord;
+                }
+            }
+            _dynamicRecordsBuffer.Write(cpuRecords);
+
+            // 3. Upload uniforms data
+            var cpuUniforms = new GpuMesh3DUniforms
+            {
+                Projection = cmd.Transform, // Perspective projection matrix
+                View = cmd.CameraView       // View matrix
+            };
+            _uniformsBuffer.WriteSingle(cpuUniforms);
+
+            // 4. Create solid pipeline if needed
+            if (_cachedPipeline == null)
+            {
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DShader_3D", Mesh3DShaderCode, "Mesh3D WGSL 3D Shader");
+
+                var layouts = new VertexBufferLayout[]
+                {
+                    new VertexBufferLayout
+                    {
+                        ArrayStride = (uint)Marshal.SizeOf<GpuVertex3D>(),
+                        StepMode = VertexStepMode.Vertex,
+                        AttributeCount = 2,
+                        Attributes = (VertexAttribute*)Marshal.AllocHGlobal(Marshal.SizeOf<VertexAttribute>() * 2)
+                    }
+                };
+
+                var attrs = layouts[0].Attributes;
+                attrs[0] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 0, ShaderLocation = 0 }; // Position
+                attrs[1] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 12, ShaderLocation = 1 }; // Normal
+
+                _cachedPipeline = compositor.PipelineCache.GetOrCreateRenderPipeline(
+                    "Mesh3DPipeline_3D",
+                    shaderModule,
+                    vertexBufferLayouts: layouts,
+                    topology: PrimitiveTopology.TriangleList,
+                    targetFormat: TextureFormat.Rgba8Unorm,
+                    enableDepthStencil: true,
+                    depthFormat: TextureFormat.Depth24PlusStencil8,
+                    sampleCount: 1u,
+                    depthWriteEnabled: true,
+                    depthCompare: CompareFunction.Less
+                );
+
+                Marshal.FreeHGlobal((IntPtr)layouts[0].Attributes);
+            }
+
+            // Create wireframe pipeline if needed
+            if (_cachedWireframePipeline == null)
+            {
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DShader_3D", Mesh3DShaderCode, "Mesh3D WGSL 3D Shader");
+
+                var layouts = new VertexBufferLayout[]
+                {
+                    new VertexBufferLayout
+                    {
+                        ArrayStride = (uint)Marshal.SizeOf<GpuVertex3D>(),
+                        StepMode = VertexStepMode.Vertex,
+                        AttributeCount = 2,
+                        Attributes = (VertexAttribute*)Marshal.AllocHGlobal(Marshal.SizeOf<VertexAttribute>() * 2)
+                    }
+                };
+
+                var attrs = layouts[0].Attributes;
+                attrs[0] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 0, ShaderLocation = 0 }; // Position
+                attrs[1] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 12, ShaderLocation = 1 }; // Normal
+
+                _cachedWireframePipeline = compositor.PipelineCache.GetOrCreateRenderPipeline(
+                    "Mesh3DWireframePipeline_3D",
+                    shaderModule,
+                    vertexBufferLayouts: layouts,
+                    topology: PrimitiveTopology.LineList,
+                    targetFormat: TextureFormat.Rgba8Unorm,
+                    enableDepthStencil: true,
+                    depthFormat: TextureFormat.Depth24PlusStencil8,
+                    sampleCount: 1u,
+                    depthWriteEnabled: true,
+                    depthCompare: CompareFunction.LessEqual
+                );
+
+                Marshal.FreeHGlobal((IntPtr)layouts[0].Attributes);
+            }
+
+            // 5. Create or get cached BindGroup
+            int currentGen = _dynamicRecordsBuffer.GetHashCode() ^ _uniformsBuffer.GetHashCode();
+            if (_cachedBindGroup == null || _cachedWireframeBindGroup == null || currentGen != _cachedRecordGen)
+            {
+                _cachedRecordGen = currentGen;
+
+                var bgEntries = stackalloc BindGroupEntry[2];
+                bgEntries[0] = new BindGroupEntry
+                {
+                    Binding = 0,
+                    Buffer = _uniformsBuffer.BufferPtr,
+                    Offset = 0,
+                    Size = uniformsSize
+                };
+                bgEntries[1] = new BindGroupEntry
+                {
+                    Binding = 1,
+                    Buffer = _dynamicRecordsBuffer.BufferPtr,
+                    Offset = 0,
+                    Size = _dynamicRecordsBuffer.Size
+                };
+
+                // Bind group for Solid Pipeline
+                var pipelineLayout = wgpu.RenderPipelineGetBindGroupLayout(_cachedPipeline, 0);
+                var bgDesc = new BindGroupDescriptor
+                {
+                    Layout = pipelineLayout,
+                    EntryCount = 2,
+                    Entries = bgEntries,
+                    Label = (byte*)SilkMarshal.StringToPtr("Mesh3D 3D BindGroup")
+                };
+
+                if (_cachedBindGroup != null) wgpu.BindGroupRelease(_cachedBindGroup);
+                _cachedBindGroup = wgpu.DeviceCreateBindGroup(device, &bgDesc);
+                SilkMarshal.Free((nint)bgDesc.Label);
+
+                // Bind group for Wireframe Pipeline
+                var wireframeLayout = wgpu.RenderPipelineGetBindGroupLayout(_cachedWireframePipeline, 0);
+                var wireframeBgDesc = new BindGroupDescriptor
+                {
+                    Layout = wireframeLayout,
+                    EntryCount = 2,
+                    Entries = bgEntries,
+                    Label = (byte*)SilkMarshal.StringToPtr("Mesh3D Wireframe BindGroup")
+                };
+
+                if (_cachedWireframeBindGroup != null) wgpu.BindGroupRelease(_cachedWireframeBindGroup);
+                _cachedWireframeBindGroup = wgpu.DeviceCreateBindGroup(device, &wireframeBgDesc);
+                SilkMarshal.Free((nint)wireframeBgDesc.Label);
+            }
+
+            // 6. Begin offscreen WebGPU Render Pass targeting the custom color and depth textures!
+            var encoderDesc = new CommandEncoderDescriptor { Label = (byte*)SilkMarshal.StringToPtr("Mesh3D Offscreen Encoder") };
+            var encoder = wgpu.DeviceCreateCommandEncoder(device, &encoderDesc);
+            SilkMarshal.Free((nint)encoderDesc.Label);
+
+            var colorAttachment = new RenderPassColorAttachment
+            {
+                View = payload.ColorTexture.ViewPtr,
+                ResolveTarget = null,
+                LoadOp = LoadOp.Clear,
+                StoreOp = StoreOp.Store,
+                ClearValue = new Silk.NET.WebGPU.Color { R = 0.05f, G = 0.05f, B = 0.06f, A = 1.0f } // Slate premium dark background
+            };
+
+            var depthAttachment = new RenderPassDepthStencilAttachment
+            {
+                View = payload.DepthTexture.ViewPtr,
+                DepthLoadOp = LoadOp.Clear,
+                DepthStoreOp = StoreOp.Store,
+                DepthClearValue = 1.0f,
+                DepthReadOnly = false,
+                StencilLoadOp = LoadOp.Clear,
+                StencilStoreOp = StoreOp.Store,
+                StencilClearValue = 0,
+                StencilReadOnly = false
+            };
+
+            var passDesc = new RenderPassDescriptor
+            {
+                ColorAttachmentCount = 1,
+                ColorAttachments = &colorAttachment,
+                DepthStencilAttachment = &depthAttachment
+            };
+
+            var pass = wgpu.CommandEncoderBeginRenderPass(encoder, &passDesc);
+
+            // 7. Compile mesh buffers on demand
+            for (int i = 0; i < payload.Meshes.Count; i++)
+            {
+                var entry = payload.Meshes[i];
+                if (entry.Geometry == null) continue;
+
+                if (!_geometryCache.TryGetValue(entry.Geometry, out var cache))
+                {
+                    // Create Vertex Buffer
+                    var cpuVertices = new GpuVertex3D[entry.Positions.Length];
+                    for (int v = 0; v < cpuVertices.Length; v++)
+                    {
+                        var norm = v < entry.Normals.Length ? entry.Normals[v] : Vector3.UnitY;
+                        cpuVertices[v] = new GpuVertex3D(entry.Positions[v], norm);
+                    }
+
+                    uint vSize = (uint)cpuVertices.Length * (uint)Marshal.SizeOf<GpuVertex3D>();
+                    var vBuffer = new GpuBuffer(compositor.Context, vSize, BufferUsage.Vertex | BufferUsage.CopyDst, "3D Mesh Vertex Buffer");
+                    vBuffer.Write(cpuVertices);
+
+                    // Create Index Buffer
+                    var cpuIndices = new uint[entry.Indices.Length];
+                    for (int idx = 0; idx < cpuIndices.Length; idx++)
+                    {
+                        cpuIndices[idx] = (uint)entry.Indices[idx];
+                    }
+
+                    uint iSize = (uint)cpuIndices.Length * 4;
+                    var iBuffer = new GpuBuffer(compositor.Context, iSize, BufferUsage.Index | BufferUsage.CopyDst, "3D Mesh Index Buffer");
+                    iBuffer.Write(cpuIndices);
+
+                    // Create Line Index Buffer
+                    var cpuLineIndices = new uint[entry.Indices.Length * 2];
+                    int lineIdx = 0;
+                    for (int t = 0; t < entry.Indices.Length; t += 3)
+                    {
+                        if (t + 2 >= entry.Indices.Length) break;
+                        uint i0 = (uint)entry.Indices[t];
+                        uint i1 = (uint)entry.Indices[t + 1];
+                        uint i2 = (uint)entry.Indices[t + 2];
+
+                        cpuLineIndices[lineIdx++] = i0;
+                        cpuLineIndices[lineIdx++] = i1;
+
+                        cpuLineIndices[lineIdx++] = i1;
+                        cpuLineIndices[lineIdx++] = i2;
+
+                        cpuLineIndices[lineIdx++] = i2;
+                        cpuLineIndices[lineIdx++] = i0;
+                    }
+
+                    uint iSizeLine = (uint)lineIdx * 4;
+                    var iBufferLine = new GpuBuffer(compositor.Context, iSizeLine, BufferUsage.Index | BufferUsage.CopyDst, "3D Mesh Line Index Buffer");
+                    iBufferLine.Write(new ReadOnlySpan<uint>(cpuLineIndices, 0, lineIdx));
+
+                    cache = new CachedGeometry
+                    {
+                        VertexBuffer = vBuffer,
+                        IndexBuffer = iBuffer,
+                        LineIndexBuffer = iBufferLine,
+                        LineIndexCount = (uint)lineIdx
+                    };
+                    _geometryCache[entry.Geometry] = cache;
+                }
+            }
+
+            // Draw Passes
+            var mode = payload.RenderMode;
+
+            // Pass A: Draw Solid Shaded Triangles
+            if (mode == RenderMode3D.Solid || mode == RenderMode3D.SolidWireframe)
+            {
+                wgpu.RenderPassEncoderSetPipeline(pass, _cachedPipeline);
+                wgpu.RenderPassEncoderSetBindGroup(pass, 0, _cachedBindGroup, 0, null);
+                for (int i = 0; i < payload.Meshes.Count; i++)
+                {
+                    var entry = payload.Meshes[i];
+                    if (entry.Geometry == null) continue;
+
+                    var cache = _geometryCache[entry.Geometry];
+
+                    wgpu.RenderPassEncoderSetVertexBuffer(pass, 0, cache.VertexBuffer.BufferPtr, 0, cache.VertexBuffer.Size);
+                    wgpu.RenderPassEncoderSetIndexBuffer(pass, cache.IndexBuffer.BufferPtr, IndexFormat.Uint32, 0, cache.IndexBuffer.Size);
+                    wgpu.RenderPassEncoderDrawIndexed(pass, (uint)entry.Indices.Length, 1, 0, 0, (uint)i);
+                }
+            }
+
+            // Pass B: Draw Wireframe Outlines
+            if (mode == RenderMode3D.Wireframe || mode == RenderMode3D.SolidWireframe)
+            {
+                wgpu.RenderPassEncoderSetPipeline(pass, _cachedWireframePipeline);
+                wgpu.RenderPassEncoderSetBindGroup(pass, 0, _cachedWireframeBindGroup, 0, null);
+                for (int i = 0; i < payload.Meshes.Count; i++)
+                {
+                    var entry = payload.Meshes[i];
+                    if (entry.Geometry == null) continue;
+
+                    var cache = _geometryCache[entry.Geometry];
+                    if (cache.LineIndexBuffer == null || cache.LineIndexCount == 0) continue;
+
+                    uint instanceIdx = (uint)i;
+                    if (mode == RenderMode3D.SolidWireframe)
+                    {
+                        instanceIdx = (uint)(payload.Meshes.Count + i);
+                    }
+
+                    wgpu.RenderPassEncoderSetVertexBuffer(pass, 0, cache.VertexBuffer.BufferPtr, 0, cache.VertexBuffer.Size);
+                    wgpu.RenderPassEncoderSetIndexBuffer(pass, cache.LineIndexBuffer.BufferPtr, IndexFormat.Uint32, 0, cache.LineIndexBuffer.Size);
+                    wgpu.RenderPassEncoderDrawIndexed(pass, cache.LineIndexCount, 1, 0, 0, instanceIdx);
+                }
+            }
+
+            wgpu.RenderPassEncoderEnd(pass);
+            wgpu.RenderPassEncoderRelease(pass);
+
+            // 8. Submit offscreen command buffer to WebGPU queue immediately!
+            var cmdDesc = new CommandBufferDescriptor { Label = (byte*)SilkMarshal.StringToPtr("Mesh3D Offscreen Command Buffer") };
+            var cmdBuffer = wgpu.CommandEncoderFinish(encoder, &cmdDesc);
+            SilkMarshal.Free((nint)cmdDesc.Label);
+
+            wgpu.QueueSubmit(queue, 1, &cmdBuffer);
+
+            wgpu.CommandBufferRelease(cmdBuffer);
+            wgpu.CommandEncoderRelease(encoder);
+
+            // DrawExtension is now a no-op in the main compositor pass since the offscreen pass is fully complete and
+            // the Viewport3D control appends a separate DrawTexture command!
+            cmd.PointBufferOffset = 0;
+            cmd.PointBufferCount = 0;
+        }
+
+        public unsafe void Render(
+            Compositor compositor,
+            void* renderPassEncoder,
+            bool isOffscreen,
+            in Compositor.CompositorDrawCall dc)
+        {
+            // Fully no-op
+        }
+    }
+
+    public class Viewport3DCompilationPayload
+    {
+        public Vector2 ViewportSize { get; set; } = new Vector2(400f, 300f);
+        public Vector3 LightDirection { get; set; } = new Vector3(0.5f, 1f, -0.5f);
+        public float LightIntensity { get; set; } = 1.0f;
+        public Vector3 AmbientColor { get; set; } = new Vector3(1f, 1f, 1f);
+        public float AmbientIntensity { get; set; } = 0.2f;
+        public List<MeshCompilationEntry> Meshes { get; } = new();
+
+        public GpuTexture? ColorTexture { get; set; }
+        public GpuTexture? DepthTexture { get; set; }
+        
+        public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
+    }
+
+    public class MeshCompilationEntry
+    {
+        public object? Geometry { get; set; }
+        public Vector3[] Positions { get; set; } = Array.Empty<Vector3>();
+        public Vector3[] Normals { get; set; } = Array.Empty<Vector3>();
+        public int[] Indices { get; set; } = Array.Empty<int>();
+        public Matrix4x4 ModelTransform { get; set; } = Matrix4x4.Identity;
+        public Vector4 Color { get; set; } = Vector4.One;
+        public float Opacity { get; set; } = 1.0f;
+    }
+}

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -16,6 +16,13 @@ namespace ProGPU.Scene.Extensions
         SolidWireframe = 2
     }
 
+    public enum ShadingMode3D
+    {
+        Shaded = 0,
+        Flat = 1,
+        Normals = 2
+    }
+
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct GpuVertex3D
     {
@@ -40,7 +47,7 @@ namespace ProGPU.Scene.Extensions
         public Vector4 MaterialAmbient;       // rgb = Material Ka, w = unused
         public float Opacity;
         public float RenderMode;              // 0.0f = Solid, 1.0f = Wireframe, 2.0f = SolidWireframe
-        private float _pad1;
+        public float ShadingMode;             // 0.0f = Shaded, 1.0f = Flat, 2.0f = Normals
         private float _pad2;
     }
 
@@ -72,7 +79,7 @@ struct GpuMesh3DRecord {
     materialAmbient: vec4<f32>,
     opacity: f32,
     renderMode: f32,
-    _pad1: f32,
+    shadingMode: f32,
     _pad2: f32,
 };
 
@@ -131,8 +138,19 @@ fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let record = meshRecords[input.instanceIdx];
+    let shading = u32(record.shadingMode + 0.5);
 
     let N = normalize(input.worldNormal);
+
+    if (shading == 2u) { // Normals diagnostic view
+        let normalColor = N * 0.5 + 0.5;
+        return vec4<f32>(normalColor, record.opacity);
+    }
+
+    if (shading == 1u) { // Flat / Unlit view
+        return vec4<f32>(record.color.rgb * record.opacity, record.opacity);
+    }
+
     let V = normalize(uniforms.cameraPosition - input.worldPosition);
 
     let shininess = record.specularColor.w;
@@ -240,7 +258,7 @@ struct GpuMesh3DRecord {
     materialAmbient: vec4<f32>,
     opacity: f32,
     renderMode: f32,
-    _pad1: f32,
+    shadingMode: f32,
     _pad2: f32,
 };
 
@@ -312,96 +330,105 @@ fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let record = meshRecords[input.instanceIdx];
     let mode = u32(input.renderMode + 0.5);
+    let shading = u32(record.shadingMode + 0.5);
 
     let N = normalize(input.worldNormal);
-    let V = normalize(uniforms.cameraPosition - input.worldPosition);
 
-    let shininess = record.specularColor.w;
-    let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
-    let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
+    var solidColor = vec4<f32>(0.0);
+    if (shading == 2u) { // Normals diagnostic view
+        solidColor = vec4<f32>(N * 0.5 + 0.5, record.opacity);
+    } else if (shading == 1u) { // Flat / Unlit view
+        solidColor = vec4<f32>(record.color.rgb * record.opacity, record.opacity);
+    } else {
+        // Shaded mode (PBR GGX)
+        let V = normalize(uniforms.cameraPosition - input.worldPosition);
 
-    // Three-Point Studio Lighting vectors and intensities
-    let keyDir = normalize(record.lightDirection.xyz);
-    let keyIntensity = record.lightDirection.w;
+        let shininess = record.specularColor.w;
+        let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
+        let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
 
-    let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
-    let fillIntensity = keyIntensity * 0.35;
-    let fillCol = vec3<f32>(0.8, 0.88, 1.0); // cool fill
+        // Three-Point Studio Lighting vectors and intensities
+        let keyDir = normalize(record.lightDirection.xyz);
+        let keyIntensity = record.lightDirection.w;
 
-    let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
-    let backIntensity = keyIntensity * 0.45;
-    let backCol = vec3<f32>(1.0, 0.95, 0.9); // warm back light
+        let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
+        let fillIntensity = keyIntensity * 0.35;
+        let fillCol = vec3<f32>(0.8, 0.88, 1.0); // cool fill
 
-    var diffuseOut = vec3<f32>(0.0);
-    var specularOut = vec3<f32>(0.0);
+        let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
+        let backIntensity = keyIntensity * 0.45;
+        let backCol = vec3<f32>(1.0, 0.95, 0.9); // warm back light
 
-    // 1. KEY LIGHT
-    {
-        let L = keyDir;
-        let H = normalize(L + V);
-        let NdotL = max(dot(N, L), 0.0);
-        let NdotV = max(dot(N, V), 0.0);
-        if (NdotL > 0.0) {
-            let D = DistributionGGX(N, H, roughness);
-            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
-            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let spec = D * V_joint * F;
-            let kS = F;
-            let kD = (vec3<f32>(1.0) - kS);
-            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
-            specularOut += spec * NdotL * keyIntensity;
+        var diffuseOut = vec3<f32>(0.0);
+        var specularOut = vec3<f32>(0.0);
+
+        // 1. KEY LIGHT
+        {
+            let L = keyDir;
+            let H = normalize(L + V);
+            let NdotL = max(dot(N, L), 0.0);
+            let NdotV = max(dot(N, V), 0.0);
+            if (NdotL > 0.0) {
+                let D = DistributionGGX(N, H, roughness);
+                let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
+                let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+                let spec = D * V_joint * F;
+                let kS = F;
+                let kD = (vec3<f32>(1.0) - kS);
+                diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
+                specularOut += spec * NdotL * keyIntensity;
+            }
         }
-    }
 
-    // 2. FILL LIGHT
-    {
-        let L = fillDir;
-        let H = normalize(L + V);
-        let NdotL = max(dot(N, L), 0.0);
-        let NdotV = max(dot(N, V), 0.0);
-        if (NdotL > 0.0) {
-            let D = DistributionGGX(N, H, roughness);
-            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
-            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let spec = D * V_joint * F;
-            let kS = F;
-            let kD = (vec3<f32>(1.0) - kS);
-            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
-            specularOut += spec * NdotL * fillIntensity * fillCol;
+        // 2. FILL LIGHT
+        {
+            let L = fillDir;
+            let H = normalize(L + V);
+            let NdotL = max(dot(N, L), 0.0);
+            let NdotV = max(dot(N, V), 0.0);
+            if (NdotL > 0.0) {
+                let D = DistributionGGX(N, H, roughness);
+                let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
+                let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+                let spec = D * V_joint * F;
+                let kS = F;
+                let kD = (vec3<f32>(1.0) - kS);
+                diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
+                specularOut += spec * NdotL * fillIntensity * fillCol;
+            }
         }
-    }
 
-    // 3. BACK LIGHT
-    {
-        let L = backDir;
-        let H = normalize(L + V);
-        let NdotL = max(dot(N, L), 0.0);
-        let NdotV = max(dot(N, V), 0.0);
-        if (NdotL > 0.0) {
-            let D = DistributionGGX(N, H, roughness);
-            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
-            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let spec = D * V_joint * F;
-            let kS = F;
-            let kD = (vec3<f32>(1.0) - kS);
-            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
-            specularOut += spec * NdotL * backIntensity * backCol;
+        // 3. BACK LIGHT
+        {
+            let L = backDir;
+            let H = normalize(L + V);
+            let NdotL = max(dot(N, L), 0.0);
+            let NdotV = max(dot(N, V), 0.0);
+            if (NdotL > 0.0) {
+                let D = DistributionGGX(N, H, roughness);
+                let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
+                let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+                let spec = D * V_joint * F;
+                let kS = F;
+                let kD = (vec3<f32>(1.0) - kS);
+                diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
+                specularOut += spec * NdotL * backIntensity * backCol;
+            }
         }
+
+        // Hemispherical sky-ground ambient
+        let skyFactor = N.y * 0.5 + 0.5;
+        let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
+        let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
+        let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
+
+        // Premium rim glow
+        let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
+        let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
+
+        let litColor = (ambient + diffuseOut + specularOut + rimColor) * record.opacity;
+        solidColor = vec4<f32>(litColor, record.opacity);
     }
-
-    // Hemispherical sky-ground ambient
-    let skyFactor = N.y * 0.5 + 0.5;
-    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
-    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
-    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
-
-    // Premium rim glow
-    let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
-    let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
-
-    let litColor = (ambient + diffuseOut + specularOut + rimColor) * record.opacity;
-    let solidColor = vec4<f32>(litColor, record.opacity);
-
     let dFdx = dpdx(input.barycentric);
     let dFdy = dpdy(input.barycentric);
     let g = max(sqrt(dFdx * dFdx + dFdy * dFdy), vec3<f32>(0.00001));
@@ -554,7 +581,8 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     SpecularColor = new Vector4(mesh.SpecularColor, mesh.Shininess),
                     MaterialAmbient = new Vector4(mesh.AmbientColor, 1.0f),
                     Opacity = mesh.Opacity * compositor.ActiveOpacity,
-                    RenderMode = rMode
+                    RenderMode = rMode,
+                    ShadingMode = (float)payload.ShadingMode
                 };
             }
             res.DynamicRecordsBuffer.Write(cpuRecords);
@@ -865,6 +893,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         public GpuTexture? DepthTexture { get; set; }
         
         public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
+        public ShadingMode3D ShadingMode { get; set; } = ShadingMode3D.Shaded;
     }
 
     public class MeshCompilationEntry

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -107,39 +107,133 @@ fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> Ver
     return output;
 }
 
+fn DistributionGGX(N: vec3<f32>, H: vec3<f32>, roughness: f32) -> f32 {
+    let alpha = roughness * roughness;
+    let alpha2 = alpha * alpha;
+    let NdotH = max(dot(N, H), 0.0);
+    let NdotH2 = NdotH * NdotH;
+    
+    let denom = (NdotH2 * (alpha2 - 1.0) + 1.0);
+    return alpha2 / (3.1415926535 * denom * denom);
+}
+
+fn GeometrySchlickGGX(NdotX: f32, roughness: f32) -> f32 {
+    let r = (roughness + 1.0);
+    let k = (r * r) / 8.0;
+    let num = NdotX;
+    let denom = NdotX * (1.0 - k) + k;
+    return num / max(denom, 0.0001);
+}
+
+fn GeometrySmith(N: vec3<f32>, V: vec3<f32>, L: vec3<f32>, roughness: f32) -> f32 {
+    let NdotV = max(dot(N, V), 0.0);
+    let NdotL = max(dot(N, L), 0.0);
+    let ggx2 = GeometrySchlickGGX(NdotV, roughness);
+    let ggx1 = GeometrySchlickGGX(NdotL, roughness);
+    return ggx1 * ggx2;
+}
+
+fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
+    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let record = meshRecords[input.instanceIdx];
 
     let N = normalize(input.worldNormal);
-    let L = normalize(record.lightDirection.xyz);
     let V = normalize(uniforms.cameraPosition - input.worldPosition);
-    let H = normalize(L + V);
-
-    // Hemispherical (sky-to-ground) ambient lighting for rich 3D shading
-    let skyFactor = N.y * 0.5 + 0.5;
-    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
-    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.45;
-    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
-
-    let diffuseIntensity = max(dot(N, L), 0.0);
-    let diffuse = diffuseIntensity * record.lightDirection.w * record.color.rgb;
 
     let shininess = record.specularColor.w;
-    let specularIntensity = pow(max(dot(N, H), 0.0), shininess);
-    
-    var specular = vec3<f32>(0.0);
-    if (diffuseIntensity > 0.0 && shininess > 0.0) {
-        // PBR-like Fresnel reflection coefficient for realistic specular glints
-        let specFresnel = 0.04 + 0.96 * pow(1.0 - max(dot(N, H), 0.0), 5.0);
-        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb * specFresnel;
+    let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
+    let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
+
+    // Three-Point Studio Lighting vectors and intensities
+    let keyDir = normalize(record.lightDirection.xyz);
+    let keyIntensity = record.lightDirection.w;
+
+    let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
+    let fillIntensity = keyIntensity * 0.35;
+    let fillCol = vec3<f32>(0.8, 0.88, 1.0); // cool fill
+
+    let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
+    let backIntensity = keyIntensity * 0.45;
+    let backCol = vec3<f32>(1.0, 0.95, 0.9); // warm back light
+
+    var diffuseOut = vec3<f32>(0.0);
+    var specularOut = vec3<f32>(0.0);
+
+    // 1. KEY LIGHT
+    {
+        let L = keyDir;
+        let H = normalize(L + V);
+        let NdotL = max(dot(N, L), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let G = GeometrySmith(N, V, L, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            let nominator = D * G * F;
+            let denominator = 4.0 * NdotV * NdotL + 0.0001;
+            let spec = nominator / denominator;
+            let kS = F;
+            let kD = (vec3<f32>(1.0) - kS);
+            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
+            specularOut += spec * NdotL * keyIntensity;
+        }
     }
 
-    // Premium iced-silver/blue Fresnel rim reflection glow
-    let F = pow(1.0 - max(dot(N, V), 0.0), 4.0);
-    let rimColor = vec3<f32>(0.82, 0.88, 1.0) * F * 0.35 * record.lightDirection.w;
+    // 2. FILL LIGHT
+    {
+        let L = fillDir;
+        let H = normalize(L + V);
+        let NdotL = max(dot(N, L), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let G = GeometrySmith(N, V, L, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            let nominator = D * G * F;
+            let denominator = 4.0 * NdotV * NdotL + 0.0001;
+            let spec = nominator / denominator;
+            let kS = F;
+            let kD = (vec3<f32>(1.0) - kS);
+            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
+            specularOut += spec * NdotL * fillIntensity * fillCol;
+        }
+    }
 
-    let litColor = (ambient + diffuse + specular + rimColor) * record.opacity;
+    // 3. BACK LIGHT
+    {
+        let L = backDir;
+        let H = normalize(L + V);
+        let NdotL = max(dot(N, L), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let G = GeometrySmith(N, V, L, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            let nominator = D * G * F;
+            let denominator = 4.0 * NdotV * NdotL + 0.0001;
+            let spec = nominator / denominator;
+            let kS = F;
+            let kD = (vec3<f32>(1.0) - kS);
+            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
+            specularOut += spec * NdotL * backIntensity * backCol;
+        }
+    }
+
+    // Hemispherical sky-ground ambient
+    let skyFactor = N.y * 0.5 + 0.5;
+    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
+    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
+    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
+
+    // Premium rim glow
+    let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
+    let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
+
+    let litColor = (ambient + diffuseOut + specularOut + rimColor) * record.opacity;
     return vec4<f32>(litColor, record.opacity);
 }
 ";
@@ -214,34 +308,98 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let mode = u32(input.renderMode + 0.5);
 
     let N = normalize(input.worldNormal);
-    let L = normalize(record.lightDirection.xyz);
     let V = normalize(uniforms.cameraPosition - input.worldPosition);
-    let H = normalize(L + V);
-
-    // Hemispherical (sky-to-ground) ambient lighting for rich 3D shading
-    let skyFactor = N.y * 0.5 + 0.5;
-    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
-    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.45;
-    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
-
-    let diffuseIntensity = max(dot(N, L), 0.0);
-    let diffuse = diffuseIntensity * record.lightDirection.w * record.color.rgb;
 
     let shininess = record.specularColor.w;
-    let specularIntensity = pow(max(dot(N, H), 0.0), shininess);
-    
-    var specular = vec3<f32>(0.0);
-    if (diffuseIntensity > 0.0 && shininess > 0.0) {
-        // PBR-like Fresnel reflection coefficient for realistic specular glints
-        let specFresnel = 0.04 + 0.96 * pow(1.0 - max(dot(N, H), 0.0), 5.0);
-        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb * specFresnel;
+    let roughness = clamp(sqrt(2.0 / (max(shininess, 0.001) + 2.0)), 0.04, 1.0);
+    let F0 = mix(vec3<f32>(0.04), record.color.rgb, 0.1);
+
+    // Three-Point Studio Lighting vectors and intensities
+    let keyDir = normalize(record.lightDirection.xyz);
+    let keyIntensity = record.lightDirection.w;
+
+    let fillDir = normalize(vec3<f32>(-keyDir.x, 0.5, -keyDir.z));
+    let fillIntensity = keyIntensity * 0.35;
+    let fillCol = vec3<f32>(0.8, 0.88, 1.0); // cool fill
+
+    let backDir = normalize(vec3<f32>(-keyDir.x, -keyDir.y, -keyDir.z));
+    let backIntensity = keyIntensity * 0.45;
+    let backCol = vec3<f32>(1.0, 0.95, 0.9); // warm back light
+
+    var diffuseOut = vec3<f32>(0.0);
+    var specularOut = vec3<f32>(0.0);
+
+    // 1. KEY LIGHT
+    {
+        let L = keyDir;
+        let H = normalize(L + V);
+        let NdotL = max(dot(N, L), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let G = GeometrySmith(N, V, L, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            let nominator = D * G * F;
+            let denominator = 4.0 * NdotV * NdotL + 0.0001;
+            let spec = nominator / denominator;
+            let kS = F;
+            let kD = (vec3<f32>(1.0) - kS);
+            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
+            specularOut += spec * NdotL * keyIntensity;
+        }
     }
 
-    // Premium iced-silver/blue Fresnel rim reflection glow
-    let F = pow(1.0 - max(dot(N, V), 0.0), 4.0);
-    let rimColor = vec3<f32>(0.82, 0.88, 1.0) * F * 0.35 * record.lightDirection.w;
+    // 2. FILL LIGHT
+    {
+        let L = fillDir;
+        let H = normalize(L + V);
+        let NdotL = max(dot(N, L), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let G = GeometrySmith(N, V, L, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            let nominator = D * G * F;
+            let denominator = 4.0 * NdotV * NdotL + 0.0001;
+            let spec = nominator / denominator;
+            let kS = F;
+            let kD = (vec3<f32>(1.0) - kS);
+            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
+            specularOut += spec * NdotL * fillIntensity * fillCol;
+        }
+    }
 
-    let litColor = (ambient + diffuse + specular + rimColor) * record.opacity;
+    // 3. BACK LIGHT
+    {
+        let L = backDir;
+        let H = normalize(L + V);
+        let NdotL = max(dot(N, L), 0.0);
+        let NdotV = max(dot(N, V), 0.0);
+        if (NdotL > 0.0) {
+            let D = DistributionGGX(N, H, roughness);
+            let G = GeometrySmith(N, V, L, roughness);
+            let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+            let nominator = D * G * F;
+            let denominator = 4.0 * NdotV * NdotL + 0.0001;
+            let spec = nominator / denominator;
+            let kS = F;
+            let kD = (vec3<f32>(1.0) - kS);
+            diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
+            specularOut += spec * NdotL * backIntensity * backCol;
+        }
+    }
+
+    // Hemispherical sky-ground ambient
+    let skyFactor = N.y * 0.5 + 0.5;
+    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
+    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.4;
+    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
+
+    // Premium rim glow
+    let F_rim = pow(1.0 - max(dot(N, V), 0.0), 4.0);
+    let rimColor = vec3<f32>(0.85, 0.90, 1.0) * F_rim * 0.25 * keyIntensity;
+
+    let litColor = (ambient + diffuseOut + specularOut + rimColor) * record.opacity;
     let solidColor = vec4<f32>(litColor, record.opacity);
 
     let dFdx = dpdx(input.barycentric);

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -116,8 +116,11 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let V = normalize(uniforms.cameraPosition - input.worldPosition);
     let H = normalize(L + V);
 
-    let ambientLight = record.ambientColor.rgb * record.ambientColor.w;
-    let ambient = ambientLight * record.materialAmbient.rgb;
+    // Hemispherical (sky-to-ground) ambient lighting for rich 3D shading
+    let skyFactor = N.y * 0.5 + 0.5;
+    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
+    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.45;
+    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
 
     let diffuseIntensity = max(dot(N, L), 0.0);
     let diffuse = diffuseIntensity * record.lightDirection.w * record.color.rgb;
@@ -127,10 +130,16 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     
     var specular = vec3<f32>(0.0);
     if (diffuseIntensity > 0.0 && shininess > 0.0) {
-        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb;
+        // PBR-like Fresnel reflection coefficient for realistic specular glints
+        let specFresnel = 0.04 + 0.96 * pow(1.0 - max(dot(N, H), 0.0), 5.0);
+        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb * specFresnel;
     }
 
-    let litColor = (ambient + diffuse + specular) * record.opacity;
+    // Premium iced-silver/blue Fresnel rim reflection glow
+    let F = pow(1.0 - max(dot(N, V), 0.0), 4.0);
+    let rimColor = vec3<f32>(0.82, 0.88, 1.0) * F * 0.35 * record.lightDirection.w;
+
+    let litColor = (ambient + diffuse + specular + rimColor) * record.opacity;
     return vec4<f32>(litColor, record.opacity);
 }
 ";
@@ -209,8 +218,11 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let V = normalize(uniforms.cameraPosition - input.worldPosition);
     let H = normalize(L + V);
 
-    let ambientLight = record.ambientColor.rgb * record.ambientColor.w;
-    let ambient = ambientLight * record.materialAmbient.rgb;
+    // Hemispherical (sky-to-ground) ambient lighting for rich 3D shading
+    let skyFactor = N.y * 0.5 + 0.5;
+    let skyAmbient = record.ambientColor.rgb * record.ambientColor.w;
+    let groundAmbient = record.ambientColor.rgb * record.ambientColor.w * 0.45;
+    let ambient = mix(groundAmbient, skyAmbient, skyFactor) * record.materialAmbient.rgb;
 
     let diffuseIntensity = max(dot(N, L), 0.0);
     let diffuse = diffuseIntensity * record.lightDirection.w * record.color.rgb;
@@ -220,10 +232,16 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     
     var specular = vec3<f32>(0.0);
     if (diffuseIntensity > 0.0 && shininess > 0.0) {
-        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb;
+        // PBR-like Fresnel reflection coefficient for realistic specular glints
+        let specFresnel = 0.04 + 0.96 * pow(1.0 - max(dot(N, H), 0.0), 5.0);
+        specular = specularIntensity * record.lightDirection.w * record.specularColor.rgb * specFresnel;
     }
 
-    let litColor = (ambient + diffuse + specular) * record.opacity;
+    // Premium iced-silver/blue Fresnel rim reflection glow
+    let F = pow(1.0 - max(dot(N, V), 0.0), 4.0);
+    let rimColor = vec3<f32>(0.82, 0.88, 1.0) * F * 0.35 * record.lightDirection.w;
+
+    let litColor = (ambient + diffuse + specular + rimColor) * record.opacity;
     let solidColor = vec4<f32>(litColor, record.opacity);
 
     let dFdx = dpdx(input.barycentric);

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -44,6 +44,7 @@ namespace ProGPU.Scene.Extensions
     public struct GpuMesh3DRecord
     {
         public Matrix4x4 ModelTransform;      // 3D Model transform for lighting
+        public Matrix4x4 NormalTransform;     // Inverse-transpose for normal transformation
         public Vector4 Color;                 // Diffuse Color Kd
         public Vector4 LightDirection;        // xyz = direction, w = intensity
         public Vector4 AmbientColor;          // rgb = color, w = intensity
@@ -76,6 +77,7 @@ struct VSUniforms {
 
 struct GpuMesh3DRecord {
     modelTransform: mat4x4<f32>,
+    normalTransform: mat4x4<f32>,
     color: vec4<f32>,
     lightDirection: vec4<f32>,
     ambientColor: vec4<f32>,
@@ -282,39 +284,40 @@ fn ComputeLighting(
 fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
     var output: VertexOutput;
     let record = meshRecords[instanceIdx];
-
+ 
     let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
-    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
-
+    let worldNormal = normalize((record.normalTransform * vec4<f32>(input.normal, 0.0)).xyz);
+ 
     output.position = uniforms.projection * uniforms.view * worldPos;
     output.worldPosition = worldPos.xyz;
     output.worldNormal = worldNormal;
     output.instanceIdx = instanceIdx;
-
+ 
     return output;
 }
-
+ 
 @fragment
-fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    return ComputeLighting(input.instanceIdx, input.worldPosition, input.worldNormal);
+fn fs_main(input: VertexOutput, @builtin(front_facing) is_front: bool) -> @location(0) vec4<f32> {
+    let normal = if (is_front) { input.worldNormal } else { -input.worldNormal };
+    return ComputeLighting(input.instanceIdx, input.worldPosition, normal);
 }
 ";
-
+ 
         private const string Mesh3DWireframeShaderCode = CommonShaderHelpers + @"
 @vertex
 fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(instance_index) instanceIdx: u32) -> VertexOutputWireframe {
     var output: VertexOutputWireframe;
     let record = meshRecords[instanceIdx];
-
+ 
     let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
-    let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
-
+    let worldNormal = normalize((record.normalTransform * vec4<f32>(input.normal, 0.0)).xyz);
+ 
     output.position = uniforms.projection * uniforms.view * worldPos;
     output.worldPosition = worldPos.xyz;
     output.worldNormal = worldNormal;
     output.renderMode = record.renderMode;
     output.instanceIdx = instanceIdx;
-
+ 
     let triVertexIdx = vertexIdx % 3u;
     if (triVertexIdx == 0u) {
         output.barycentric = vec3<f32>(1.0, 0.0, 0.0);
@@ -323,26 +326,27 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(i
     } else {
         output.barycentric = vec3<f32>(0.0, 0.0, 1.0);
     }
-
+ 
     return output;
 }
-
+ 
 @fragment
-fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
+fn fs_main(input: VertexOutputWireframe, @builtin(front_facing) is_front: bool) -> @location(0) vec4<f32> {
     let mode = u32(input.renderMode + 0.5);
-    let solidColor = ComputeLighting(input.instanceIdx, input.worldPosition, input.worldNormal);
-
+    let normal = if (is_front) { input.worldNormal } else { -input.worldNormal };
+    let solidColor = ComputeLighting(input.instanceIdx, input.worldPosition, normal);
+ 
     let dFdx = dpdx(input.barycentric);
     let dFdy = dpdy(input.barycentric);
     let g = max(sqrt(dFdx * dFdx + dFdy * dFdy), vec3<f32>(0.00001));
     let dist = input.barycentric / g;
     let minDist = min(dist.x, min(dist.y, dist.z));
-
+ 
     let lineWidth = 1.0; 
     let edge = smoothstep(lineWidth - 0.5, lineWidth + 0.5, minDist);
-
+ 
     let wireframeColor = vec4<f32>(0.85, 0.85, 0.9, solidColor.a);
-
+ 
     if (mode == 1u) {
         let alpha = (1.0 - edge) * solidColor.a;
         if (alpha < 0.01) {
@@ -350,7 +354,7 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
         }
         return vec4<f32>(wireframeColor.rgb, alpha);
     }
-
+ 
     let finalColor = mix(wireframeColor.rgb, solidColor.rgb, edge);
     return vec4<f32>(finalColor, solidColor.a);
 }
@@ -392,6 +396,7 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
         private WgpuContext? _context;
         
         private unsafe RenderPipeline* _cachedPipeline;
+        private unsafe RenderPipeline* _cachedBackFacePipeline;
         private unsafe RenderPipeline* _cachedWireframePipeline;
 
         public unsafe void BeginFrame(Compositor compositor)
@@ -476,9 +481,16 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
                     rMode = 2.0f;
                 }
 
+                Matrix4x4 normalTransform = Matrix4x4.Identity;
+                if (Matrix4x4.Invert(mesh.ModelTransform, out var invModel))
+                {
+                    normalTransform = Matrix4x4.Transpose(invModel);
+                }
+
                 cpuRecords[i] = new GpuMesh3DRecord
                 {
                     ModelTransform = mesh.ModelTransform,
+                    NormalTransform = normalTransform,
                     Color = mesh.Color,
                     LightDirection = new Vector4(payload.LightDirection, payload.LightIntensity),
                     AmbientColor = new Vector4(payload.AmbientColor, payload.AmbientIntensity),
@@ -535,6 +547,42 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
                     depthWriteEnabled: true,
                     depthCompare: CompareFunction.LessEqual,
                     cullMode: CullMode.Back
+                );
+
+                Marshal.FreeHGlobal((IntPtr)layouts[0].Attributes);
+            }
+
+            if (_cachedBackFacePipeline == null)
+            {
+                var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DSolidShader_3D_v3", Mesh3DSolidShaderCode, "Mesh3D WGSL 3D Solid Shader");
+
+                var layouts = new VertexBufferLayout[]
+                {
+                    new VertexBufferLayout
+                    {
+                        ArrayStride = (uint)Marshal.SizeOf<GpuVertex3D>(),
+                        StepMode = VertexStepMode.Vertex,
+                        AttributeCount = 2,
+                        Attributes = (VertexAttribute*)Marshal.AllocHGlobal(Marshal.SizeOf<VertexAttribute>() * 2)
+                    }
+                };
+
+                var attrs = layouts[0].Attributes;
+                attrs[0] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 0, ShaderLocation = 0 }; // Position
+                attrs[1] = new VertexAttribute { Format = VertexFormat.Float32x3, Offset = 12, ShaderLocation = 1 }; // Normal
+
+                _cachedBackFacePipeline = compositor.PipelineCache.GetOrCreateRenderPipeline(
+                    "Mesh3DBackFacePipeline_3D_v3",
+                    shaderModule,
+                    vertexBufferLayouts: layouts,
+                    topology: PrimitiveTopology.TriangleList,
+                    targetFormat: TextureFormat.Rgba8Unorm,
+                    enableDepthStencil: true,
+                    depthFormat: TextureFormat.Depth24PlusStencil8,
+                    sampleCount: 4u,
+                    depthWriteEnabled: true,
+                    depthCompare: CompareFunction.LessEqual,
+                    cullMode: CullMode.Front
                 );
 
                 Marshal.FreeHGlobal((IntPtr)layouts[0].Attributes);
@@ -720,7 +768,19 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
                 for (int i = 0; i < payload.Meshes.Count; i++)
                 {
                     var entry = payload.Meshes[i];
-                    if (entry.Geometry == null) continue;
+                    if (entry.Geometry == null || entry.IsBackFace) continue;
+
+                    var cache = _geometryCache[entry.Geometry];
+
+                    wgpu.RenderPassEncoderSetVertexBuffer(pass, 0, cache.VertexBuffer.BufferPtr, 0, cache.VertexBuffer.Size);
+                    wgpu.RenderPassEncoderDraw(pass, cache.VertexCount, 1, 0, (uint)i);
+                }
+
+                wgpu.RenderPassEncoderSetPipeline(pass, _cachedBackFacePipeline);
+                for (int i = 0; i < payload.Meshes.Count; i++)
+                {
+                    var entry = payload.Meshes[i];
+                    if (entry.Geometry == null || !entry.IsBackFace) continue;
 
                     var cache = _geometryCache[entry.Geometry];
 
@@ -828,5 +888,6 @@ fn fs_main(input: VertexOutputWireframe) -> @location(0) vec4<f32> {
         public float Shininess { get; set; } = 32.0f;
         public Vector3 AmbientColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
         public float Opacity { get; set; } = 1.0f;
+        public bool IsBackFace { get; set; } = false;
     }
 }

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -37,7 +37,7 @@ namespace ProGPU.Scene.Extensions
         public Vector4 LightDirection;        // xyz = direction, w = intensity
         public Vector4 AmbientColor;          // rgb = color, w = intensity
         public float Opacity;
-        public float IsWireframe;             // 1.0f if wireframe, 0.0f otherwise
+        public float RenderMode;              // 0.0f = Solid, 1.0f = Wireframe, 2.0f = SolidWireframe
         private float _pad1;
         private float _pad2;
     }
@@ -63,7 +63,7 @@ struct GpuMesh3DRecord {
     lightDirection: vec4<f32>,
     ambientColor: vec4<f32>,
     opacity: f32,
-    isWireframe: f32,
+    renderMode: f32,
     _pad1: f32,
     _pad2: f32,
 };
@@ -79,80 +79,140 @@ struct VertexInput {
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
+    @location(1) barycentric: vec3<f32>,
+    @location(2) renderMode: f32,
 };
 
 @vertex
-fn vs_main(input: VertexInput, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
+fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIdx: u32, @builtin(instance_index) instanceIdx: u32) -> VertexOutput {
     var output: VertexOutput;
     let record = meshRecords[instanceIdx];
 
-    // Transform position and normal to world space
-    var localPos = input.position;
-    if (record.isWireframe > 0.5) {
-        localPos += input.normal * 0.003; // Tiny normal offset to prevent z-fighting
-    }
-
-    let worldPos = record.modelTransform * vec4<f32>(localPos, 1.0);
+    let worldPos = record.modelTransform * vec4<f32>(input.position, 1.0);
     let worldNormal = normalize((record.modelTransform * vec4<f32>(input.normal, 0.0)).xyz);
 
-    // Dynamic 3D depth matrices transform
     output.position = uniforms.projection * uniforms.view * worldPos;
 
-    // Calculate Gouraud diffuse + ambient lighting
     let lightDir = normalize(record.lightDirection.xyz);
     let diffuse = max(dot(worldNormal, lightDir), 0.0) * record.lightDirection.w;
     
     let ambient = record.ambientColor.rgb * record.ambientColor.w;
-    var litColor = (ambient + diffuse * record.color.rgb) * record.opacity;
-
-    if (record.isWireframe > 0.5) {
-        litColor = litColor * 1.4 + vec3<f32>(0.05, 0.05, 0.05); // Boost wireframe overlay brightness
-    }
+    let litColor = (ambient + diffuse * record.color.rgb) * record.opacity;
 
     output.color = vec4<f32>(litColor, record.opacity);
+    output.renderMode = record.renderMode;
+
+    let triVertexIdx = vertexIdx % 3u;
+    if (triVertexIdx == 0u) {
+        output.barycentric = vec3<f32>(1.0, 0.0, 0.0);
+    } else if (triVertexIdx == 1u) {
+        output.barycentric = vec3<f32>(0.0, 1.0, 0.0);
+    } else {
+        output.barycentric = vec3<f32>(0.0, 0.0, 1.0);
+    }
+
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    return input.color;
+    let mode = u32(input.renderMode + 0.5);
+
+    if (mode == 0u) {
+        return input.color;
+    }
+
+    let dFdx = dpdx(input.barycentric);
+    let dFdy = dpdy(input.barycentric);
+    let g = max(sqrt(dFdx * dFdx + dFdy * dFdy), vec3<f32>(0.00001));
+    let dist = input.barycentric / g;
+    let minDist = min(dist.x, min(dist.y, dist.z));
+
+    let lineWidth = 1.0; 
+    let edge = smoothstep(lineWidth - 0.5, lineWidth + 0.5, minDist);
+
+    let wireframeColor = vec4<f32>(0.85, 0.85, 0.9, input.color.a);
+
+    if (mode == 1u) {
+        let alpha = (1.0 - edge) * input.color.a;
+        if (alpha < 0.01) {
+            discard;
+        }
+        return vec4<f32>(wireframeColor.rgb, alpha);
+    }
+
+    let finalColor = mix(wireframeColor.rgb, input.color.rgb, edge);
+    return vec4<f32>(finalColor, input.color.a);
 }
 ";
 
         private struct CachedGeometry
         {
             public GpuBuffer VertexBuffer;
-            public GpuBuffer IndexBuffer;
-            public GpuBuffer? LineIndexBuffer;
-            public uint LineIndexCount;
+            public uint VertexCount;
+        }
+
+        private class ViewportResource
+        {
+            public GpuBuffer UniformsBuffer;
+            public GpuBuffer? DynamicRecordsBuffer;
+            public unsafe BindGroup* SolidBindGroup;
+            public unsafe BindGroup* WireframeBindGroup;
+            public int RecordGen = -1;
+
+            public ViewportResource(WgpuContext context, uint uniformsSize)
+            {
+                UniformsBuffer = new GpuBuffer(context, uniformsSize, BufferUsage.Uniform | BufferUsage.CopyDst, "Mesh3D Uniforms Buffer");
+            }
+            
+            public unsafe void Dispose(WgpuContext context)
+            {
+                UniformsBuffer.Dispose();
+                DynamicRecordsBuffer?.Dispose();
+                if (SolidBindGroup != null) context.Wgpu.BindGroupRelease(SolidBindGroup);
+                if (WireframeBindGroup != null) context.Wgpu.BindGroupRelease(WireframeBindGroup);
+            }
         }
 
         private readonly Dictionary<object, CachedGeometry> _geometryCache = new();
-        private GpuBuffer? _dynamicRecordsBuffer;
-        private GpuBuffer? _uniformsBuffer;
+        private readonly List<ViewportResource> _viewportResources = new();
+        private readonly List<nint> _pendingCommandBuffers = new();
+        private int _currentCompileIndex;
+        private WgpuContext? _context;
         
         private unsafe RenderPipeline* _cachedPipeline;
         private unsafe RenderPipeline* _cachedWireframePipeline;
-        private unsafe BindGroup* _cachedBindGroup;
-        private unsafe BindGroup* _cachedWireframeBindGroup;
-        private int _cachedRecordGen = -1;
 
-        public void BeginFrame(Compositor compositor)
+        public unsafe void BeginFrame(Compositor compositor)
         {
+            _currentCompileIndex = 0;
+            if (_pendingCommandBuffers.Count > 0)
+            {
+                var wgpu = compositor.Context.Wgpu;
+                for (int i = 0; i < _pendingCommandBuffers.Count; i++)
+                {
+                    wgpu.CommandBufferRelease((CommandBuffer*)_pendingCommandBuffers[i]);
+                }
+                _pendingCommandBuffers.Clear();
+            }
         }
 
-        public void Dispose()
+        public unsafe void Dispose()
         {
             foreach (var cache in _geometryCache.Values)
             {
                 cache.VertexBuffer.Dispose();
-                cache.IndexBuffer.Dispose();
-                cache.LineIndexBuffer?.Dispose();
             }
             _geometryCache.Clear();
 
-            _dynamicRecordsBuffer?.Dispose();
-            _uniformsBuffer?.Dispose();
+            if (_context != null)
+            {
+                foreach (var res in _viewportResources)
+                {
+                    res.Dispose(_context);
+                }
+            }
+            _viewportResources.Clear();
         }
 
         public unsafe void Compile(
@@ -164,28 +224,29 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             var payload = cmd.DataParam as Viewport3DCompilationPayload;
             if (payload == null || payload.Meshes.Count == 0 || payload.ColorTexture == null || payload.DepthTexture == null) return;
 
+            _context = compositor.Context;
             var wgpu = compositor.Context.Wgpu;
             var device = compositor.Context.Device;
             var queue = compositor.Context.Queue;
 
-            // 1. Create or update dynamic record buffer and uniforms buffer
-            int recordCount = payload.Meshes.Count;
-            if (payload.RenderMode == RenderMode3D.SolidWireframe)
+            uint uniformsSize = (uint)Marshal.SizeOf<GpuMesh3DUniforms>();
+
+            // Ensure pooled resource exists for current viewport compile index
+            while (_viewportResources.Count <= _currentCompileIndex)
             {
-                recordCount = payload.Meshes.Count * 2;
+                _viewportResources.Add(new ViewportResource(compositor.Context, uniformsSize));
             }
+            var res = _viewportResources[_currentCompileIndex];
+
+            // 1. Create or update dynamic record buffer
+            int recordCount = payload.Meshes.Count;
 
             uint reqRecordsSize = (uint)recordCount * (uint)Marshal.SizeOf<GpuMesh3DRecord>();
-            if (_dynamicRecordsBuffer == null || _dynamicRecordsBuffer.Size < reqRecordsSize)
+            if (res.DynamicRecordsBuffer == null || res.DynamicRecordsBuffer.Size < reqRecordsSize)
             {
-                _dynamicRecordsBuffer?.Dispose();
-                _dynamicRecordsBuffer = new GpuBuffer(compositor.Context, reqRecordsSize * 2, BufferUsage.Storage | BufferUsage.CopyDst, "Dynamic Mesh3D Records Buffer");
-            }
-
-            uint uniformsSize = (uint)Marshal.SizeOf<GpuMesh3DUniforms>();
-            if (_uniformsBuffer == null)
-            {
-                _uniformsBuffer = new GpuBuffer(compositor.Context, uniformsSize, BufferUsage.Uniform | BufferUsage.CopyDst, "Mesh3D Uniforms Buffer");
+                res.DynamicRecordsBuffer?.Dispose();
+                res.DynamicRecordsBuffer = new GpuBuffer(compositor.Context, reqRecordsSize * 2, BufferUsage.Storage | BufferUsage.CopyDst, "Dynamic Mesh3D Records Buffer");
+                res.RecordGen = -1; // Force bind group recreation
             }
 
             // 2. Upload records data
@@ -194,35 +255,27 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             for (int i = 0; i < n; i++)
             {
                 var mesh = payload.Meshes[i];
-                var solidRecord = new GpuMesh3DRecord
+                float rMode = 0.0f; // Solid
+                if (payload.RenderMode == RenderMode3D.Wireframe)
+                {
+                    rMode = 1.0f;
+                }
+                else if (payload.RenderMode == RenderMode3D.SolidWireframe)
+                {
+                    rMode = 2.0f;
+                }
+
+                cpuRecords[i] = new GpuMesh3DRecord
                 {
                     ModelTransform = mesh.ModelTransform,
                     Color = mesh.Color,
                     LightDirection = new Vector4(payload.LightDirection, payload.LightIntensity),
                     AmbientColor = new Vector4(payload.AmbientColor, payload.AmbientIntensity),
                     Opacity = mesh.Opacity * compositor.ActiveOpacity,
-                    IsWireframe = 0.0f
+                    RenderMode = rMode
                 };
-
-                if (payload.RenderMode == RenderMode3D.Solid)
-                {
-                    cpuRecords[i] = solidRecord;
-                }
-                else if (payload.RenderMode == RenderMode3D.Wireframe)
-                {
-                    solidRecord.IsWireframe = 1.0f;
-                    cpuRecords[i] = solidRecord;
-                }
-                else // SolidWireframe
-                {
-                    cpuRecords[i] = solidRecord;
-
-                    var wireRecord = solidRecord;
-                    wireRecord.IsWireframe = 1.0f;
-                    cpuRecords[n + i] = wireRecord;
-                }
             }
-            _dynamicRecordsBuffer.Write(cpuRecords);
+            res.DynamicRecordsBuffer.Write(cpuRecords);
 
             // 3. Upload uniforms data
             var cpuUniforms = new GpuMesh3DUniforms
@@ -230,7 +283,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                 Projection = cmd.Transform, // Perspective projection matrix
                 View = cmd.CameraView       // View matrix
             };
-            _uniformsBuffer.WriteSingle(cpuUniforms);
+            res.UniformsBuffer.WriteSingle(cpuUniforms);
 
             // 4. Create solid pipeline if needed
             if (_cachedPipeline == null)
@@ -262,13 +315,14 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     depthFormat: TextureFormat.Depth24PlusStencil8,
                     sampleCount: 1u,
                     depthWriteEnabled: true,
-                    depthCompare: CompareFunction.Less
+                    depthCompare: CompareFunction.Less,
+                    cullMode: CullMode.Back
                 );
 
                 Marshal.FreeHGlobal((IntPtr)layouts[0].Attributes);
             }
 
-            // Create wireframe pipeline if needed
+            // Create wireframe pipeline if needed (TriangleList with double sided rendering)
             if (_cachedWireframePipeline == null)
             {
                 var shaderModule = compositor.PipelineCache.GetOrCreateShader("Mesh3DShader_3D", Mesh3DShaderCode, "Mesh3D WGSL 3D Shader");
@@ -292,38 +346,39 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     "Mesh3DWireframePipeline_3D",
                     shaderModule,
                     vertexBufferLayouts: layouts,
-                    topology: PrimitiveTopology.LineList,
+                    topology: PrimitiveTopology.TriangleList,
                     targetFormat: TextureFormat.Rgba8Unorm,
                     enableDepthStencil: true,
                     depthFormat: TextureFormat.Depth24PlusStencil8,
                     sampleCount: 1u,
                     depthWriteEnabled: true,
-                    depthCompare: CompareFunction.LessEqual
+                    depthCompare: CompareFunction.LessEqual,
+                    cullMode: CullMode.None
                 );
 
                 Marshal.FreeHGlobal((IntPtr)layouts[0].Attributes);
             }
 
             // 5. Create or get cached BindGroup
-            int currentGen = _dynamicRecordsBuffer.GetHashCode() ^ _uniformsBuffer.GetHashCode();
-            if (_cachedBindGroup == null || _cachedWireframeBindGroup == null || currentGen != _cachedRecordGen)
+            int currentGen = res.DynamicRecordsBuffer.GetHashCode() ^ res.UniformsBuffer.GetHashCode();
+            if (res.SolidBindGroup == null || res.WireframeBindGroup == null || currentGen != res.RecordGen)
             {
-                _cachedRecordGen = currentGen;
+                res.RecordGen = currentGen;
 
                 var bgEntries = stackalloc BindGroupEntry[2];
                 bgEntries[0] = new BindGroupEntry
                 {
                     Binding = 0,
-                    Buffer = _uniformsBuffer.BufferPtr,
+                    Buffer = res.UniformsBuffer.BufferPtr,
                     Offset = 0,
                     Size = uniformsSize
                 };
                 bgEntries[1] = new BindGroupEntry
                 {
                     Binding = 1,
-                    Buffer = _dynamicRecordsBuffer.BufferPtr,
+                    Buffer = res.DynamicRecordsBuffer.BufferPtr,
                     Offset = 0,
-                    Size = _dynamicRecordsBuffer.Size
+                    Size = res.DynamicRecordsBuffer.Size
                 };
 
                 // Bind group for Solid Pipeline
@@ -336,8 +391,8 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     Label = (byte*)SilkMarshal.StringToPtr("Mesh3D 3D BindGroup")
                 };
 
-                if (_cachedBindGroup != null) wgpu.BindGroupRelease(_cachedBindGroup);
-                _cachedBindGroup = wgpu.DeviceCreateBindGroup(device, &bgDesc);
+                if (res.SolidBindGroup != null) wgpu.BindGroupRelease(res.SolidBindGroup);
+                res.SolidBindGroup = wgpu.DeviceCreateBindGroup(device, &bgDesc);
                 SilkMarshal.Free((nint)bgDesc.Label);
 
                 // Bind group for Wireframe Pipeline
@@ -350,8 +405,8 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     Label = (byte*)SilkMarshal.StringToPtr("Mesh3D Wireframe BindGroup")
                 };
 
-                if (_cachedWireframeBindGroup != null) wgpu.BindGroupRelease(_cachedWireframeBindGroup);
-                _cachedWireframeBindGroup = wgpu.DeviceCreateBindGroup(device, &wireframeBgDesc);
+                if (res.WireframeBindGroup != null) wgpu.BindGroupRelease(res.WireframeBindGroup);
+                res.WireframeBindGroup = wgpu.DeviceCreateBindGroup(device, &wireframeBgDesc);
                 SilkMarshal.Free((nint)wireframeBgDesc.Label);
             }
 
@@ -399,59 +454,24 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
                 if (!_geometryCache.TryGetValue(entry.Geometry, out var cache))
                 {
-                    // Create Vertex Buffer
-                    var cpuVertices = new GpuVertex3D[entry.Positions.Length];
-                    for (int v = 0; v < cpuVertices.Length; v++)
+                    // Create De-indexed (non-indexed) Vertex Buffer
+                    var cpuVertices = new GpuVertex3D[entry.Indices.Length];
+                    for (int idx = 0; idx < entry.Indices.Length; idx++)
                     {
-                        var norm = v < entry.Normals.Length ? entry.Normals[v] : Vector3.UnitY;
-                        cpuVertices[v] = new GpuVertex3D(entry.Positions[v], norm);
+                        int vIdx = entry.Indices[idx];
+                        var pos = entry.Positions[vIdx];
+                        var norm = vIdx < entry.Normals.Length ? entry.Normals[vIdx] : Vector3.UnitY;
+                        cpuVertices[idx] = new GpuVertex3D(pos, norm);
                     }
 
                     uint vSize = (uint)cpuVertices.Length * (uint)Marshal.SizeOf<GpuVertex3D>();
                     var vBuffer = new GpuBuffer(compositor.Context, vSize, BufferUsage.Vertex | BufferUsage.CopyDst, "3D Mesh Vertex Buffer");
                     vBuffer.Write(cpuVertices);
 
-                    // Create Index Buffer
-                    var cpuIndices = new uint[entry.Indices.Length];
-                    for (int idx = 0; idx < cpuIndices.Length; idx++)
-                    {
-                        cpuIndices[idx] = (uint)entry.Indices[idx];
-                    }
-
-                    uint iSize = (uint)cpuIndices.Length * 4;
-                    var iBuffer = new GpuBuffer(compositor.Context, iSize, BufferUsage.Index | BufferUsage.CopyDst, "3D Mesh Index Buffer");
-                    iBuffer.Write(cpuIndices);
-
-                    // Create Line Index Buffer
-                    var cpuLineIndices = new uint[entry.Indices.Length * 2];
-                    int lineIdx = 0;
-                    for (int t = 0; t < entry.Indices.Length; t += 3)
-                    {
-                        if (t + 2 >= entry.Indices.Length) break;
-                        uint i0 = (uint)entry.Indices[t];
-                        uint i1 = (uint)entry.Indices[t + 1];
-                        uint i2 = (uint)entry.Indices[t + 2];
-
-                        cpuLineIndices[lineIdx++] = i0;
-                        cpuLineIndices[lineIdx++] = i1;
-
-                        cpuLineIndices[lineIdx++] = i1;
-                        cpuLineIndices[lineIdx++] = i2;
-
-                        cpuLineIndices[lineIdx++] = i2;
-                        cpuLineIndices[lineIdx++] = i0;
-                    }
-
-                    uint iSizeLine = (uint)lineIdx * 4;
-                    var iBufferLine = new GpuBuffer(compositor.Context, iSizeLine, BufferUsage.Index | BufferUsage.CopyDst, "3D Mesh Line Index Buffer");
-                    iBufferLine.Write(new ReadOnlySpan<uint>(cpuLineIndices, 0, lineIdx));
-
                     cache = new CachedGeometry
                     {
                         VertexBuffer = vBuffer,
-                        IndexBuffer = iBuffer,
-                        LineIndexBuffer = iBufferLine,
-                        LineIndexCount = (uint)lineIdx
+                        VertexCount = (uint)entry.Indices.Length
                     };
                     _geometryCache[entry.Geometry] = cache;
                 }
@@ -460,11 +480,11 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             // Draw Passes
             var mode = payload.RenderMode;
 
-            // Pass A: Draw Solid Shaded Triangles
+            // Pass A: Draw Solid Shaded Triangles or Solid + Wireframe
             if (mode == RenderMode3D.Solid || mode == RenderMode3D.SolidWireframe)
             {
                 wgpu.RenderPassEncoderSetPipeline(pass, _cachedPipeline);
-                wgpu.RenderPassEncoderSetBindGroup(pass, 0, _cachedBindGroup, 0, null);
+                wgpu.RenderPassEncoderSetBindGroup(pass, 0, res.SolidBindGroup, 0, null);
                 for (int i = 0; i < payload.Meshes.Count; i++)
                 {
                     var entry = payload.Meshes[i];
@@ -473,53 +493,69 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     var cache = _geometryCache[entry.Geometry];
 
                     wgpu.RenderPassEncoderSetVertexBuffer(pass, 0, cache.VertexBuffer.BufferPtr, 0, cache.VertexBuffer.Size);
-                    wgpu.RenderPassEncoderSetIndexBuffer(pass, cache.IndexBuffer.BufferPtr, IndexFormat.Uint32, 0, cache.IndexBuffer.Size);
-                    wgpu.RenderPassEncoderDrawIndexed(pass, (uint)entry.Indices.Length, 1, 0, 0, (uint)i);
+                    wgpu.RenderPassEncoderDraw(pass, cache.VertexCount, 1, 0, (uint)i);
                 }
             }
 
-            // Pass B: Draw Wireframe Outlines
-            if (mode == RenderMode3D.Wireframe || mode == RenderMode3D.SolidWireframe)
+            // Pass B: Draw Wireframe Only
+            if (mode == RenderMode3D.Wireframe)
             {
                 wgpu.RenderPassEncoderSetPipeline(pass, _cachedWireframePipeline);
-                wgpu.RenderPassEncoderSetBindGroup(pass, 0, _cachedWireframeBindGroup, 0, null);
+                wgpu.RenderPassEncoderSetBindGroup(pass, 0, res.WireframeBindGroup, 0, null);
                 for (int i = 0; i < payload.Meshes.Count; i++)
                 {
                     var entry = payload.Meshes[i];
                     if (entry.Geometry == null) continue;
 
                     var cache = _geometryCache[entry.Geometry];
-                    if (cache.LineIndexBuffer == null || cache.LineIndexCount == 0) continue;
-
-                    uint instanceIdx = (uint)i;
-                    if (mode == RenderMode3D.SolidWireframe)
-                    {
-                        instanceIdx = (uint)(payload.Meshes.Count + i);
-                    }
 
                     wgpu.RenderPassEncoderSetVertexBuffer(pass, 0, cache.VertexBuffer.BufferPtr, 0, cache.VertexBuffer.Size);
-                    wgpu.RenderPassEncoderSetIndexBuffer(pass, cache.LineIndexBuffer.BufferPtr, IndexFormat.Uint32, 0, cache.LineIndexBuffer.Size);
-                    wgpu.RenderPassEncoderDrawIndexed(pass, cache.LineIndexCount, 1, 0, 0, instanceIdx);
+                    wgpu.RenderPassEncoderDraw(pass, cache.VertexCount, 1, 0, (uint)i);
                 }
             }
 
             wgpu.RenderPassEncoderEnd(pass);
             wgpu.RenderPassEncoderRelease(pass);
 
-            // 8. Submit offscreen command buffer to WebGPU queue immediately!
+            // 8. Add offscreen command buffer to the deferred submission queue
             var cmdDesc = new CommandBufferDescriptor { Label = (byte*)SilkMarshal.StringToPtr("Mesh3D Offscreen Command Buffer") };
             var cmdBuffer = wgpu.CommandEncoderFinish(encoder, &cmdDesc);
             SilkMarshal.Free((nint)cmdDesc.Label);
 
-            wgpu.QueueSubmit(queue, 1, &cmdBuffer);
+            _pendingCommandBuffers.Add((nint)cmdBuffer);
 
-            wgpu.CommandBufferRelease(cmdBuffer);
             wgpu.CommandEncoderRelease(encoder);
+
+            _currentCompileIndex++;
 
             // DrawExtension is now a no-op in the main compositor pass since the offscreen pass is fully complete and
             // the Viewport3D control appends a separate DrawTexture command!
             cmd.PointBufferOffset = 0;
             cmd.PointBufferCount = 0;
+        }
+
+        public unsafe void EndFrame(Compositor compositor)
+        {
+            if (_pendingCommandBuffers.Count > 0)
+            {
+                var wgpu = compositor.Context.Wgpu;
+                var queue = compositor.Context.Queue;
+
+                int count = _pendingCommandBuffers.Count;
+                var buffers = stackalloc CommandBuffer*[count];
+                for (int i = 0; i < count; i++)
+                {
+                    buffers[i] = (CommandBuffer*)_pendingCommandBuffers[i];
+                }
+
+                wgpu.QueueSubmit(queue, (uint)count, buffers);
+
+                for (int i = 0; i < count; i++)
+                {
+                    wgpu.CommandBufferRelease((CommandBuffer*)_pendingCommandBuffers[i]);
+                }
+                _pendingCommandBuffers.Clear();
+            }
         }
 
         public unsafe void Render(

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -117,20 +117,11 @@ fn DistributionGGX(N: vec3<f32>, H: vec3<f32>, roughness: f32) -> f32 {
     return alpha2 / (3.1415926535 * denom * denom);
 }
 
-fn GeometrySchlickGGX(NdotX: f32, roughness: f32) -> f32 {
+fn VisibilitySchlickGGX(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
     let r = (roughness + 1.0);
     let k = (r * r) / 8.0;
-    let num = NdotX;
-    let denom = NdotX * (1.0 - k) + k;
-    return num / max(denom, 0.0001);
-}
-
-fn GeometrySmith(N: vec3<f32>, V: vec3<f32>, L: vec3<f32>, roughness: f32) -> f32 {
-    let NdotV = max(dot(N, V), 0.0);
-    let NdotL = max(dot(N, L), 0.0);
-    let ggx2 = GeometrySchlickGGX(NdotV, roughness);
-    let ggx1 = GeometrySchlickGGX(NdotL, roughness);
-    return ggx1 * ggx2;
+    let denom = (NdotV * (1.0 - k) + k) * (NdotL * (1.0 - k) + k) * 4.0;
+    return 1.0 / max(denom, 0.0001);
 }
 
 fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
@@ -171,11 +162,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let NdotV = max(dot(N, V), 0.0);
         if (NdotL > 0.0) {
             let D = DistributionGGX(N, H, roughness);
-            let G = GeometrySmith(N, V, L, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
             let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let nominator = D * G * F;
-            let denominator = 4.0 * NdotV * NdotL + 0.0001;
-            let spec = nominator / denominator;
+            let spec = D * V_joint * F;
             let kS = F;
             let kD = (vec3<f32>(1.0) - kS);
             diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
@@ -191,11 +180,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let NdotV = max(dot(N, V), 0.0);
         if (NdotL > 0.0) {
             let D = DistributionGGX(N, H, roughness);
-            let G = GeometrySmith(N, V, L, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
             let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let nominator = D * G * F;
-            let denominator = 4.0 * NdotV * NdotL + 0.0001;
-            let spec = nominator / denominator;
+            let spec = D * V_joint * F;
             let kS = F;
             let kD = (vec3<f32>(1.0) - kS);
             diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
@@ -211,11 +198,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let NdotV = max(dot(N, V), 0.0);
         if (NdotL > 0.0) {
             let D = DistributionGGX(N, H, roughness);
-            let G = GeometrySmith(N, V, L, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
             let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let nominator = D * G * F;
-            let denominator = 4.0 * NdotV * NdotL + 0.0001;
-            let spec = nominator / denominator;
+            let spec = D * V_joint * F;
             let kS = F;
             let kD = (vec3<f32>(1.0) - kS);
             diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
@@ -312,20 +297,11 @@ fn DistributionGGX(N: vec3<f32>, H: vec3<f32>, roughness: f32) -> f32 {
     return alpha2 / (3.1415926535 * denom * denom);
 }
 
-fn GeometrySchlickGGX(NdotX: f32, roughness: f32) -> f32 {
+fn VisibilitySchlickGGX(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
     let r = (roughness + 1.0);
     let k = (r * r) / 8.0;
-    let num = NdotX;
-    let denom = NdotX * (1.0 - k) + k;
-    return num / max(denom, 0.0001);
-}
-
-fn GeometrySmith(N: vec3<f32>, V: vec3<f32>, L: vec3<f32>, roughness: f32) -> f32 {
-    let NdotV = max(dot(N, V), 0.0);
-    let NdotL = max(dot(N, L), 0.0);
-    let ggx2 = GeometrySchlickGGX(NdotV, roughness);
-    let ggx1 = GeometrySchlickGGX(NdotL, roughness);
-    return ggx1 * ggx2;
+    let denom = (NdotV * (1.0 - k) + k) * (NdotL * (1.0 - k) + k) * 4.0;
+    return 1.0 / max(denom, 0.0001);
 }
 
 fn FresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
@@ -367,11 +343,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let NdotV = max(dot(N, V), 0.0);
         if (NdotL > 0.0) {
             let D = DistributionGGX(N, H, roughness);
-            let G = GeometrySmith(N, V, L, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
             let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let nominator = D * G * F;
-            let denominator = 4.0 * NdotV * NdotL + 0.0001;
-            let spec = nominator / denominator;
+            let spec = D * V_joint * F;
             let kS = F;
             let kD = (vec3<f32>(1.0) - kS);
             diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * keyIntensity;
@@ -387,11 +361,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let NdotV = max(dot(N, V), 0.0);
         if (NdotL > 0.0) {
             let D = DistributionGGX(N, H, roughness);
-            let G = GeometrySmith(N, V, L, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
             let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let nominator = D * G * F;
-            let denominator = 4.0 * NdotV * NdotL + 0.0001;
-            let spec = nominator / denominator;
+            let spec = D * V_joint * F;
             let kS = F;
             let kD = (vec3<f32>(1.0) - kS);
             diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * fillIntensity * fillCol;
@@ -407,11 +379,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let NdotV = max(dot(N, V), 0.0);
         if (NdotL > 0.0) {
             let D = DistributionGGX(N, H, roughness);
-            let G = GeometrySmith(N, V, L, roughness);
+            let V_joint = VisibilitySchlickGGX(NdotV, NdotL, roughness);
             let F = FresnelSchlick(max(dot(H, V), 0.0), F0);
-            let nominator = D * G * F;
-            let denominator = 4.0 * NdotV * NdotL + 0.0001;
-            let spec = nominator / denominator;
+            let spec = D * V_joint * F;
             let kS = F;
             let kD = (vec3<f32>(1.0) - kS);
             diffuseOut += (kD * record.color.rgb / 3.1415926535) * NdotL * backIntensity * backCol;
@@ -629,9 +599,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     targetFormat: TextureFormat.Rgba8Unorm,
                     enableDepthStencil: true,
                     depthFormat: TextureFormat.Depth24PlusStencil8,
-                    sampleCount: 1u,
+                    sampleCount: 4u,
                     depthWriteEnabled: true,
-                    depthCompare: CompareFunction.Less,
+                    depthCompare: CompareFunction.LessEqual,
                     cullMode: CullMode.Back
                 );
 
@@ -666,7 +636,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
                     targetFormat: TextureFormat.Rgba8Unorm,
                     enableDepthStencil: true,
                     depthFormat: TextureFormat.Depth24PlusStencil8,
-                    sampleCount: 1u,
+                    sampleCount: 4u,
                     depthWriteEnabled: true,
                     depthCompare: CompareFunction.LessEqual,
                     cullMode: CullMode.None
@@ -733,10 +703,10 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
             var colorAttachment = new RenderPassColorAttachment
             {
-                View = payload.ColorTexture.ViewPtr,
-                ResolveTarget = null,
+                View = payload.MsaaColorTexture != null ? payload.MsaaColorTexture.ViewPtr : payload.ColorTexture.ViewPtr,
+                ResolveTarget = payload.MsaaColorTexture != null ? payload.ColorTexture.ViewPtr : null,
                 LoadOp = LoadOp.Clear,
-                StoreOp = StoreOp.Store,
+                StoreOp = payload.MsaaColorTexture != null ? StoreOp.Discard : StoreOp.Store,
                 ClearValue = new Silk.NET.WebGPU.Color { R = 0.05f, G = 0.05f, B = 0.06f, A = 1.0f } // Slate premium dark background
             };
 
@@ -891,6 +861,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         public List<MeshCompilationEntry> Meshes { get; } = new();
 
         public GpuTexture? ColorTexture { get; set; }
+        public GpuTexture? MsaaColorTexture { get; set; }
         public GpuTexture? DepthTexture { get; set; }
         
         public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;

--- a/src/ProGPU.Scene/ICompositorExtension.cs
+++ b/src/ProGPU.Scene/ICompositorExtension.cs
@@ -22,6 +22,7 @@ namespace ProGPU.Scene
 
         // Optional lifecycle hooks for custom resource management
         void BeginFrame(Compositor compositor) { }
+        void EndFrame(Compositor compositor) { }
         void BeginStaticCompile(Compositor compositor, StaticCompilationContext context) { }
         void EndStaticCompile(Compositor compositor, StaticCompilationContext context, DxfStaticBuffer staticBuffer) { }
     }

--- a/src/ProGPU.Scene/IDrawingExtension.cs
+++ b/src/ProGPU.Scene/IDrawingExtension.cs
@@ -22,5 +22,6 @@ namespace ProGPU.Scene
         public const int GpuLineSeries = 5;
         public const int GpuScatterSeries = 6;
         public const int CustomGrid = 7;
+        public const int Mesh3D = 8;
     }
 }

--- a/src/ProGPU.Tests/ControlRenderTests.cs
+++ b/src/ProGPU.Tests/ControlRenderTests.cs
@@ -597,5 +597,64 @@ public class ControlRenderTests
         }
         Assert.Equal(pointCountInput, target);
     }
+
+    public struct TestEdge : IEquatable<TestEdge>
+    {
+        public uint U;
+        public uint V;
+
+        public TestEdge(uint u, uint v)
+        {
+            if (u < v) { U = u; V = v; }
+            else { U = v; V = u; }
+        }
+
+        public bool Equals(TestEdge other) => U == other.U && V == other.V;
+        public override bool Equals(object? obj) => obj is TestEdge other && Equals(other);
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                uint hash = 17;
+                hash = hash * 31 + U;
+                hash = hash * 31 + V;
+                return (int)hash;
+            }
+        }
+    }
+
+    [Fact]
+    public void Test_EdgeDeduplication()
+    {
+        // Define a simple quad with two triangles sharing an edge (1, 2)
+        // Triangle 1: (0, 1, 2)
+        // Triangle 2: (2, 1, 3)
+        uint[] indices = new uint[] { 0, 1, 2, 2, 1, 3 };
+
+        var uniqueEdges = new HashSet<TestEdge>();
+        for (int t = 0; t < indices.Length; t += 3)
+        {
+            uint i0 = indices[t];
+            uint i1 = indices[t + 1];
+            uint i2 = indices[t + 2];
+
+            uniqueEdges.Add(new TestEdge(i0, i1));
+            uniqueEdges.Add(new TestEdge(i1, i2));
+            uniqueEdges.Add(new TestEdge(i2, i0));
+        }
+
+        // Expected edges:
+        // (0, 1), (1, 2), (2, 0)
+        // (2, 1) -> duplicate of (1, 2)
+        // (1, 3), (3, 2)
+        // Total expected: 5 unique edges: (0,1), (1,2), (0,2), (1,3), (2,3)
+        Assert.Equal(5, uniqueEdges.Count);
+
+        Assert.Contains(new TestEdge(0, 1), uniqueEdges);
+        Assert.Contains(new TestEdge(1, 2), uniqueEdges);
+        Assert.Contains(new TestEdge(0, 2), uniqueEdges);
+        Assert.Contains(new TestEdge(1, 3), uniqueEdges);
+        Assert.Contains(new TestEdge(2, 3), uniqueEdges);
+    }
 }
 

--- a/src/ProGPU.Tests/ObjReaderTests.cs
+++ b/src/ProGPU.Tests/ObjReaderTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Microsoft.UI.Xaml.Media.Media3D;
+using Xunit;
+
+namespace ProGPU.Tests
+{
+    public class ObjReaderTests : IDisposable
+    {
+        private readonly string _tempDir;
+
+        public ObjReaderTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "ProGPU_ObjReaderTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_tempDir))
+                {
+                    Directory.Delete(_tempDir, true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        [Fact]
+        public void Test_NegativeVertexIndices_RelativeOffsets()
+        {
+            string objContent = @"
+v 0 0 0
+v 1 0 0
+v 1 1 0
+f -3 -2 -1
+";
+            var bytes = System.Text.Encoding.UTF8.GetBytes(objContent);
+            var model = ObjReader.LoadObj(bytes, null);
+
+            Assert.Single(model.Parts);
+            var part = model.Parts[0];
+            Assert.Equal(3, part.Geometry.Positions.Length);
+            Assert.Equal(3, part.Geometry.TriangleIndices.Length);
+            
+            Assert.Equal(0, part.Geometry.TriangleIndices[0]);
+            Assert.Equal(1, part.Geometry.TriangleIndices[1]);
+            Assert.Equal(2, part.Geometry.TriangleIndices[2]);
+        }
+
+        [Fact]
+        public void Test_TrailingComments_Parsing()
+        {
+            string objContent = @"
+v 0 0 0 # first vertex
+v 1 0 0 # second vertex
+v 1 1 0 # third vertex
+f 1 2 3 # draw face
+";
+            var bytes = System.Text.Encoding.UTF8.GetBytes(objContent);
+            var model = ObjReader.LoadObj(bytes, null);
+
+            Assert.Single(model.Parts);
+            var part = model.Parts[0];
+            Assert.Equal(3, part.Geometry.Positions.Length);
+            Assert.Equal(3, part.Geometry.TriangleIndices.Length);
+            
+            Assert.Equal(0, part.Geometry.TriangleIndices[0]);
+            Assert.Equal(1, part.Geometry.TriangleIndices[1]);
+            Assert.Equal(2, part.Geometry.TriangleIndices[2]);
+        }
+
+        [Fact]
+        public void Test_SpacesInNamesAndFiles()
+        {
+            string mtlFilename = "My Premium Material.mtl";
+            string objFilename = "My Model.obj";
+
+            string mtlPath = Path.Combine(_tempDir, mtlFilename);
+            string objPath = Path.Combine(_tempDir, objFilename);
+
+            string mtlContent = @"
+# Premium material with space in name
+newmtl Carbon Fiber
+Kd 0.1 0.1 0.1
+Ks 0.8 0.8 0.8
+Ns 128
+Tr 0.1
+illum 2
+";
+            string objContent = @"
+mtllib My Premium Material.mtl
+v 0 0 0
+v 1 0 0
+v 1 1 0
+usemtl Carbon Fiber
+f 1 2 3
+";
+
+            File.WriteAllText(mtlPath, mtlContent);
+            File.WriteAllText(objPath, objContent);
+
+            var model = ObjReader.LoadObj(objPath);
+
+            Assert.Single(model.Parts);
+            var part = model.Parts[0];
+            Assert.Equal("Carbon Fiber", part.MaterialName);
+            
+            Assert.Equal(0.1f, part.Color.X);
+            Assert.Equal(0.1f, part.Color.Y);
+            Assert.Equal(0.1f, part.Color.Z);
+
+            Assert.Equal(0.8f, part.SpecularColor.X);
+            Assert.Equal(0.8f, part.SpecularColor.Y);
+            Assert.Equal(0.8f, part.SpecularColor.Z);
+
+            Assert.Equal(128f, part.Shininess);
+
+            Assert.Equal(0.9f, part.Opacity, 2);
+        }
+
+        [Fact]
+        public void Test_IlluminationModel_Matte()
+        {
+            string mtlFilename = "illum_test.mtl";
+            string objFilename = "illum_test.obj";
+
+            string mtlPath = Path.Combine(_tempDir, mtlFilename);
+            string objPath = Path.Combine(_tempDir, objFilename);
+
+            string mtlContent = @"
+newmtl Matte Material
+Kd 0.5 0.5 0.5
+Ks 0.9 0.9 0.9
+Ns 64
+illum 1
+";
+            string objContent = @"
+mtllib illum_test.mtl
+v 0 0 0
+v 1 0 0
+v 1 1 0
+usemtl Matte Material
+f 1 2 3
+";
+
+            File.WriteAllText(mtlPath, mtlContent);
+            File.WriteAllText(objPath, objContent);
+
+            var model = ObjReader.LoadObj(objPath);
+
+            Assert.Single(model.Parts);
+            var part = model.Parts[0];
+
+            Assert.Equal(Vector3.Zero, part.SpecularColor);
+        }
+    }
+}

--- a/src/ProGPU.WinUI/Controls/Grid.cs
+++ b/src/ProGPU.WinUI/Controls/Grid.cs
@@ -127,6 +127,15 @@ public class Grid : Panel
         float remainingWidth = availableSize.X;
         float remainingHeight = availableSize.Y;
 
+        if (!float.IsInfinity(remainingWidth))
+        {
+            remainingWidth = Math.Max(0f, remainingWidth - Padding.Horizontal);
+        }
+        if (!float.IsInfinity(remainingHeight))
+        {
+            remainingHeight = Math.Max(0f, remainingHeight - Padding.Vertical);
+        }
+
         float starColsWeight = 0f;
         float starRowsWeight = 0f;
 

--- a/src/ProGPU.WinUI/Controls/ObjReader.cs
+++ b/src/ProGPU.WinUI/Controls/ObjReader.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using Microsoft.UI.Xaml.Media.Media3D;
+
+namespace Microsoft.UI.Xaml.Media.Media3D
+{
+    public struct ObjVertexKey : IEquatable<ObjVertexKey>
+    {
+        public int PositionIndex;
+        public int TextureIndex;
+        public int NormalIndex;
+
+        public ObjVertexKey(int positionIndex, int textureIndex, int normalIndex)
+        {
+            PositionIndex = positionIndex;
+            TextureIndex = textureIndex;
+            NormalIndex = normalIndex;
+        }
+
+        public bool Equals(ObjVertexKey other) =>
+            PositionIndex == other.PositionIndex &&
+            TextureIndex == other.TextureIndex &&
+            NormalIndex == other.NormalIndex;
+
+        public override bool Equals(object? obj) =>
+            obj is ObjVertexKey other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(PositionIndex, TextureIndex, NormalIndex);
+    }
+
+    public static class ObjReader
+    {
+        public static MeshGeometry3D Load(string filePath)
+        {
+            using (var stream = File.OpenRead(filePath))
+            {
+                return Load(stream);
+            }
+        }
+
+        public static MeshGeometry3D Load(Stream stream)
+        {
+            if (stream.CanSeek)
+            {
+                long length = stream.Length - stream.Position;
+                if (length > 0)
+                {
+                    byte[] rented = ArrayPool<byte>.Shared.Rent((int)length);
+                    try
+                    {
+                        int totalRead = 0;
+                        while (totalRead < length)
+                        {
+                            int read = stream.Read(rented, totalRead, (int)length - totalRead);
+                            if (read <= 0) break;
+                            totalRead += read;
+                        }
+                        return Load(new ReadOnlySpan<byte>(rented, 0, totalRead));
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(rented);
+                    }
+                }
+            }
+
+            // Fallback for non-seekable streams
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
+            int totalBytesRead = 0;
+            try
+            {
+                while (true)
+                {
+                    if (totalBytesRead == buffer.Length)
+                    {
+                        byte[] newBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length * 2);
+                        Buffer.BlockCopy(buffer, 0, newBuffer, 0, totalBytesRead);
+                        ArrayPool<byte>.Shared.Return(buffer);
+                        buffer = newBuffer;
+                    }
+
+                    int read = stream.Read(buffer, totalBytesRead, buffer.Length - totalBytesRead);
+                    if (read <= 0) break;
+                    totalBytesRead += read;
+                }
+
+                return Load(new ReadOnlySpan<byte>(buffer, 0, totalBytesRead));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        public static MeshGeometry3D Load(ReadOnlySpan<byte> fileBytes)
+        {
+            var tempPositions = new List<Vector3>(8192);
+            var tempNormals = new List<Vector3>(8192);
+            var tempTexCoords = new List<Vector2>(8192);
+
+            var outPositions = new List<Vector3>(8192);
+            var outNormals = new List<Vector3>(8192);
+            var outTexCoords = new List<Vector2>(8192);
+            var outIndices = new List<int>(16384);
+
+            var vertexCache = new Dictionary<ObjVertexKey, int>(8192);
+
+            int startOffset = 0;
+            while (startOffset < fileBytes.Length)
+            {
+                // Find next newline
+                int endOffset = startOffset;
+                while (endOffset < fileBytes.Length && fileBytes[endOffset] != '\n' && fileBytes[endOffset] != '\r')
+                {
+                    endOffset++;
+                }
+
+                ReadOnlySpan<byte> line = fileBytes.Slice(startOffset, endOffset - startOffset);
+
+                // Move startOffset past the newline characters
+                startOffset = endOffset;
+                while (startOffset < fileBytes.Length && (fileBytes[startOffset] == '\n' || fileBytes[startOffset] == '\r'))
+                {
+                    startOffset++;
+                }
+
+                line = Trim(line);
+                if (line.IsEmpty || line[0] == '#') continue;
+
+                int start = 0;
+                if (NextToken(line, ref start, out var commandToken) < 0) continue;
+
+                if (commandToken.Length == 1 && commandToken[0] == 'v')
+                {
+                    if (NextToken(line, ref start, out var xToken) == 0 &&
+                        NextToken(line, ref start, out var yToken) == 0 &&
+                        NextToken(line, ref start, out var zToken) == 0)
+                    {
+                        Utf8Parser.TryParse(xToken, out float x, out _);
+                        Utf8Parser.TryParse(yToken, out float y, out _);
+                        Utf8Parser.TryParse(zToken, out float z, out _);
+                        tempPositions.Add(new Vector3(x, y, z));
+                    }
+                }
+                else if (commandToken.Length == 2 && commandToken[0] == 'v' && commandToken[1] == 't')
+                {
+                    if (NextToken(line, ref start, out var uToken) == 0 &&
+                        NextToken(line, ref start, out var vToken) == 0)
+                    {
+                        Utf8Parser.TryParse(uToken, out float u, out _);
+                        Utf8Parser.TryParse(vToken, out float v, out _);
+                        tempTexCoords.Add(new Vector2(u, 1.0f - v)); // Flip V for WebGPU standard
+                    }
+                }
+                else if (commandToken.Length == 2 && commandToken[0] == 'v' && commandToken[1] == 'n')
+                {
+                    if (NextToken(line, ref start, out var nxToken) == 0 &&
+                        NextToken(line, ref start, out var nyToken) == 0 &&
+                        NextToken(line, ref start, out var nzToken) == 0)
+                    {
+                        Utf8Parser.TryParse(nxToken, out float nx, out _);
+                        Utf8Parser.TryParse(nyToken, out float ny, out _);
+                        Utf8Parser.TryParse(nzToken, out float nz, out _);
+                        tempNormals.Add(new Vector3(nx, ny, nz));
+                    }
+                }
+                else if (commandToken.Length == 1 && commandToken[0] == 'f')
+                {
+                    var faceIndices = new List<int>(4);
+                    while (NextToken(line, ref start, out var vToken) == 0)
+                    {
+                        faceIndices.Add(ParseVertex(vToken, tempPositions, tempTexCoords, tempNormals,
+                                                    outPositions, outTexCoords, outNormals, vertexCache));
+                    }
+
+                    // Triangulate face using a triangle fan
+                    for (int i = 1; i < faceIndices.Count - 1; i++)
+                    {
+                        outIndices.Add(faceIndices[0]);
+                        outIndices.Add(faceIndices[i]);
+                        outIndices.Add(faceIndices[i + 1]);
+                    }
+                }
+            }
+
+            var mesh = new MeshGeometry3D
+            {
+                Positions = outPositions.ToArray(),
+                TriangleIndices = outIndices.ToArray()
+            };
+
+            if (outNormals.Count == outPositions.Count) mesh.Normals = outNormals.ToArray();
+            else mesh.Normals = mesh.GetNormalsOrCompute();
+
+            if (outTexCoords.Count == outPositions.Count) mesh.TextureCoordinates = outTexCoords.ToArray();
+
+            return mesh;
+        }
+
+        private static ReadOnlySpan<byte> Trim(ReadOnlySpan<byte> span)
+        {
+            int start = 0;
+            while (start < span.Length && IsWhiteSpace(span[start]))
+            {
+                start++;
+            }
+
+            int end = span.Length - 1;
+            while (end >= start && IsWhiteSpace(span[end]))
+            {
+                end--;
+            }
+
+            return span.Slice(start, end - start + 1);
+        }
+
+        private static int NextToken(ReadOnlySpan<byte> span, ref int start, out ReadOnlySpan<byte> token)
+        {
+            while (start < span.Length && IsWhiteSpace(span[start]))
+            {
+                start++;
+            }
+
+            if (start >= span.Length)
+            {
+                token = ReadOnlySpan<byte>.Empty;
+                return -1;
+            }
+
+            int end = start;
+            while (end < span.Length && !IsWhiteSpace(span[end]))
+            {
+                end++;
+            }
+
+            token = span.Slice(start, end - start);
+            start = end;
+            return 0;
+        }
+
+        private static bool IsWhiteSpace(byte b)
+        {
+            return b == ' ' || b == '\t' || b == '\r' || b == '\n';
+        }
+
+        private static int ParseVertex(
+            ReadOnlySpan<byte> token,
+            List<Vector3> tempPositions,
+            List<Vector2> tempTexCoords,
+            List<Vector3> tempNormals,
+            List<Vector3> outPositions,
+            List<Vector2> outTexCoords,
+            List<Vector3> outNormals,
+            Dictionary<ObjVertexKey, int> vertexCache)
+        {
+            int slash1 = token.IndexOf((byte)'/');
+            int rawV = 0;
+            int rawVt = 0;
+            int rawVn = 0;
+
+            if (slash1 == -1)
+            {
+                Utf8Parser.TryParse(token, out rawV, out _);
+            }
+            else
+            {
+                Utf8Parser.TryParse(token.Slice(0, slash1), out rawV, out _);
+
+                var rest = token.Slice(slash1 + 1);
+                int slash2 = rest.IndexOf((byte)'/');
+                if (slash2 == -1)
+                {
+                    Utf8Parser.TryParse(rest, out rawVt, out _);
+                }
+                else
+                {
+                    var vtSpan = rest.Slice(0, slash2);
+                    if (!vtSpan.IsEmpty)
+                    {
+                        Utf8Parser.TryParse(vtSpan, out rawVt, out _);
+                    }
+
+                    var vnSpan = rest.Slice(slash2 + 1);
+                    if (!vnSpan.IsEmpty)
+                    {
+                        Utf8Parser.TryParse(vnSpan, out rawVn, out _);
+                    }
+                }
+            }
+
+            // Map standard OBJ 1-based or negative indices to 0-based
+            int posIndex = rawV < 0 ? tempPositions.Count + rawV : rawV - 1;
+            int texIndex = rawVt == 0 ? -1 : (rawVt < 0 ? tempTexCoords.Count + rawVt : rawVt - 1);
+            int normIndex = rawVn == 0 ? -1 : (rawVn < 0 ? tempNormals.Count + rawVn : rawVn - 1);
+
+            if (posIndex < 0 || posIndex >= tempPositions.Count) return 0;
+
+            var key = new ObjVertexKey(posIndex, texIndex, normIndex);
+
+            if (vertexCache.TryGetValue(key, out int cachedIndex))
+            {
+                return cachedIndex;
+            }
+
+            int newIndex = outPositions.Count;
+            outPositions.Add(tempPositions[posIndex]);
+            outTexCoords.Add(texIndex >= 0 && texIndex < tempTexCoords.Count ? tempTexCoords[texIndex] : Vector2.Zero);
+            outNormals.Add(normIndex >= 0 && normIndex < tempNormals.Count ? tempNormals[normIndex] : Vector3.UnitY);
+
+            vertexCache[key] = newIndex;
+            return newIndex;
+        }
+    }
+}

--- a/src/ProGPU.WinUI/Controls/ObjReader.cs
+++ b/src/ProGPU.WinUI/Controls/ObjReader.cs
@@ -186,8 +186,15 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                     startOffset++;
                 }
 
+                // Truncate trailing comment if any
+                int commentIdx = line.IndexOf((byte)'#');
+                if (commentIdx >= 0)
+                {
+                    line = line.Slice(0, commentIdx);
+                }
+
                 line = Trim(line);
-                if (line.IsEmpty || line[0] == '#') continue;
+                if (line.IsEmpty) continue;
 
                 int start = 0;
                 if (NextToken(line, ref start, out var commandToken) < 0) continue;
@@ -230,9 +237,10 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                          commandToken[0] == 'm' && commandToken[1] == 't' && commandToken[2] == 'l' &&
                          commandToken[3] == 'l' && commandToken[4] == 'i' && commandToken[5] == 'b')
                 {
-                    if (NextToken(line, ref start, out var mtlToken) == 0)
+                    var mtlNameSpan = Trim(line.Slice(start));
+                    if (!mtlNameSpan.IsEmpty)
                     {
-                        var mtlName = System.Text.Encoding.UTF8.GetString(mtlToken);
+                        var mtlName = System.Text.Encoding.UTF8.GetString(mtlNameSpan);
                         if (!string.IsNullOrEmpty(directory))
                         {
                             var mtlPath = Path.Combine(directory, mtlName);
@@ -248,9 +256,10 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                          commandToken[0] == 'u' && commandToken[1] == 's' && commandToken[2] == 'e' &&
                          commandToken[3] == 'm' && commandToken[4] == 't' && commandToken[5] == 'l')
                 {
-                    if (NextToken(line, ref start, out var mtlToken) == 0)
+                    var mtlNameSpan = Trim(line.Slice(start));
+                    if (!mtlNameSpan.IsEmpty)
                     {
-                        activeMaterial = System.Text.Encoding.UTF8.GetString(mtlToken);
+                        activeMaterial = System.Text.Encoding.UTF8.GetString(mtlNameSpan);
                     }
                 }
                 else if (commandToken.Length == 1 && commandToken[0] == 'f')
@@ -357,74 +366,120 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                 float shininess = 32.0f;
                 Vector3 ambient = new Vector3(0.2f, 0.2f, 0.2f);
                 float opacity = 1.0f;
+                int illumModel = 2; // Default to 2 (specular on)
 
                 foreach (var rawLine in lines)
                 {
-                    var line = rawLine.Trim();
-                    if (string.IsNullOrEmpty(line) || line.StartsWith('#')) continue;
+                    int hashIndex = rawLine.IndexOf('#');
+                    var line = hashIndex >= 0 ? rawLine.Substring(0, hashIndex).Trim() : rawLine.Trim();
+                    if (string.IsNullOrEmpty(line)) continue;
 
-                    var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (parts.Length == 0) continue;
+                    int firstSpace = line.IndexOfAny(new[] { ' ', '\t' });
+                    if (firstSpace == -1) continue;
 
-                    if (parts[0].Equals("newmtl", StringComparison.OrdinalIgnoreCase) && parts.Length >= 2)
+                    string cmd = line.Substring(0, firstSpace).Trim();
+                    string args = line.Substring(firstSpace).Trim();
+                    if (string.IsNullOrEmpty(cmd) || string.IsNullOrEmpty(args)) continue;
+
+                    if (cmd.Equals("newmtl", StringComparison.OrdinalIgnoreCase))
                     {
                         if (currentMaterial != null)
                         {
+                            Vector3 activeSpecular = (illumModel == 0 || illumModel == 1) ? Vector3.Zero : specular;
                             materials[currentMaterial] = new ObjMaterialInfo
                             {
                                 DiffuseColor = color,
-                                SpecularColor = specular,
+                                SpecularColor = activeSpecular,
                                 Shininess = shininess,
                                 AmbientColor = ambient,
                                 Opacity = opacity
                             };
                         }
-                        currentMaterial = parts[1];
+                        currentMaterial = args;
                         color = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
                         specular = new Vector3(0.2f, 0.2f, 0.2f);
                         shininess = 32.0f;
                         ambient = new Vector3(0.2f, 0.2f, 0.2f);
                         opacity = 1.0f;
+                        illumModel = 2;
                     }
-                    else if (parts[0].Equals("Kd", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
+                    else if (cmd.Equals("Kd", StringComparison.OrdinalIgnoreCase))
                     {
-                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
-                        float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
-                        float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
-                        color = new Vector4(r, g, b, 1.0f);
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 3)
+                        {
+                            float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
+                            float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
+                            float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
+                            color = new Vector4(r, g, b, 1.0f);
+                        }
                     }
-                    else if (parts[0].Equals("Ka", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
+                    else if (cmd.Equals("Ka", StringComparison.OrdinalIgnoreCase))
                     {
-                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
-                        float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
-                        float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
-                        ambient = new Vector3(r, g, b);
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 3)
+                        {
+                            float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
+                            float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
+                            float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
+                            ambient = new Vector3(r, g, b);
+                        }
                     }
-                    else if (parts[0].Equals("Ks", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
+                    else if (cmd.Equals("Ks", StringComparison.OrdinalIgnoreCase))
                     {
-                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
-                        float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
-                        float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
-                        specular = new Vector3(r, g, b);
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 3)
+                        {
+                            float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
+                            float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
+                            float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
+                            specular = new Vector3(r, g, b);
+                        }
                     }
-                    else if (parts[0].Equals("Ns", StringComparison.OrdinalIgnoreCase) && parts.Length >= 2)
+                    else if (cmd.Equals("Ns", StringComparison.OrdinalIgnoreCase))
                     {
-                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float nsVal);
-                        shininess = nsVal;
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 1)
+                        {
+                            float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float nsVal);
+                            shininess = nsVal;
+                        }
                     }
-                    else if ((parts[0].Equals("d", StringComparison.OrdinalIgnoreCase) || parts[0].Equals("Tr", StringComparison.OrdinalIgnoreCase)) && parts.Length >= 2)
+                    else if (cmd.Equals("d", StringComparison.OrdinalIgnoreCase))
                     {
-                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float dVal);
-                        opacity = dVal;
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 1)
+                        {
+                            float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float dVal);
+                            opacity = dVal;
+                        }
+                    }
+                    else if (cmd.Equals("Tr", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 1)
+                        {
+                            float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float trVal);
+                            opacity = 1.0f - trVal; // Tr transparency inversion
+                        }
+                    }
+                    else if (cmd.Equals("illum", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var parts = args.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 1)
+                        {
+                            int.TryParse(parts[0], out illumModel);
+                        }
                     }
                 }
 
                 if (currentMaterial != null)
                 {
+                    Vector3 activeSpecular = (illumModel == 0 || illumModel == 1) ? Vector3.Zero : specular;
                     materials[currentMaterial] = new ObjMaterialInfo
                     {
                         DiffuseColor = color,
-                        SpecularColor = specular,
+                        SpecularColor = activeSpecular,
                         Shininess = shininess,
                         AmbientColor = ambient,
                         Opacity = opacity

--- a/src/ProGPU.WinUI/Controls/ObjReader.cs
+++ b/src/ProGPU.WinUI/Controls/ObjReader.cs
@@ -4,6 +4,7 @@ using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
+using System.Globalization;
 using Microsoft.UI.Xaml.Media.Media3D;
 
 namespace Microsoft.UI.Xaml.Media.Media3D
@@ -33,17 +34,64 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             HashCode.Combine(PositionIndex, TextureIndex, NormalIndex);
     }
 
+    public class LoadedObjModel
+    {
+        public List<ObjPart> Parts { get; } = new();
+    }
+
+    public class ObjPart
+    {
+        public string Name { get; set; } = "Part";
+        public string MaterialName { get; set; } = "Default";
+        public MeshGeometry3D Geometry { get; set; } = new();
+        public Vector4 Color { get; set; } = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+        public float Opacity { get; set; } = 1.0f;
+    }
+
     public static class ObjReader
     {
-        public static MeshGeometry3D Load(string filePath)
+        private class PartBuilder
         {
-            using (var stream = File.OpenRead(filePath))
+            public string MaterialName { get; }
+            public List<int> FaceIndices { get; } = new(4096);
+            public List<Vector3> OutPositions { get; } = new(2048);
+            public List<Vector3> OutNormals { get; } = new(2048);
+            public List<Vector2> OutTexCoords { get; } = new(2048);
+            public Dictionary<ObjVertexKey, int> VertexCache { get; } = new(2048);
+
+            public PartBuilder(string materialName)
             {
-                return Load(stream);
+                MaterialName = materialName;
             }
         }
 
+        public static MeshGeometry3D Load(string filePath)
+        {
+            var model = LoadObj(filePath);
+            return MergeParts(model);
+        }
+
         public static MeshGeometry3D Load(Stream stream)
+        {
+            var model = LoadObj(stream, null);
+            return MergeParts(model);
+        }
+
+        public static MeshGeometry3D Load(ReadOnlySpan<byte> fileBytes)
+        {
+            var model = LoadObj(fileBytes, null);
+            return MergeParts(model);
+        }
+
+        public static LoadedObjModel LoadObj(string filePath)
+        {
+            using (var stream = File.OpenRead(filePath))
+            {
+                return LoadObj(stream, Path.GetDirectoryName(filePath));
+            }
+        }
+
+        public static LoadedObjModel LoadObj(Stream stream, string? directory)
         {
             if (stream.CanSeek)
             {
@@ -60,7 +108,7 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                             if (read <= 0) break;
                             totalRead += read;
                         }
-                        return Load(new ReadOnlySpan<byte>(rented, 0, totalRead));
+                        return LoadObj(new ReadOnlySpan<byte>(rented, 0, totalRead), directory);
                     }
                     finally
                     {
@@ -89,7 +137,7 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                     totalBytesRead += read;
                 }
 
-                return Load(new ReadOnlySpan<byte>(buffer, 0, totalBytesRead));
+                return LoadObj(new ReadOnlySpan<byte>(buffer, 0, totalBytesRead), directory);
             }
             finally
             {
@@ -97,18 +145,15 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             }
         }
 
-        public static MeshGeometry3D Load(ReadOnlySpan<byte> fileBytes)
+        public static LoadedObjModel LoadObj(ReadOnlySpan<byte> fileBytes, string? directory)
         {
             var tempPositions = new List<Vector3>(8192);
             var tempNormals = new List<Vector3>(8192);
             var tempTexCoords = new List<Vector2>(8192);
 
-            var outPositions = new List<Vector3>(8192);
-            var outNormals = new List<Vector3>(8192);
-            var outTexCoords = new List<Vector2>(8192);
-            var outIndices = new List<int>(16384);
-
-            var vertexCache = new Dictionary<ObjVertexKey, int>(8192);
+            var partBuilders = new Dictionary<string, PartBuilder>(StringComparer.OrdinalIgnoreCase);
+            var materials = new Dictionary<string, (Vector4 Color, float Opacity)>(StringComparer.OrdinalIgnoreCase);
+            string activeMaterial = "Default";
 
             int startOffset = 0;
             while (startOffset < fileBytes.Length)
@@ -169,37 +214,203 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                         tempNormals.Add(new Vector3(nx, ny, nz));
                     }
                 }
+                else if (commandToken.Length == 6 &&
+                         commandToken[0] == 'm' && commandToken[1] == 't' && commandToken[2] == 'l' &&
+                         commandToken[3] == 'l' && commandToken[4] == 'i' && commandToken[5] == 'b')
+                {
+                    if (NextToken(line, ref start, out var mtlToken) == 0)
+                    {
+                        var mtlName = System.Text.Encoding.UTF8.GetString(mtlToken);
+                        if (!string.IsNullOrEmpty(directory))
+                        {
+                            var mtlPath = Path.Combine(directory, mtlName);
+                            var loaded = LoadMtl(mtlPath);
+                            foreach (var pair in loaded)
+                            {
+                                materials[pair.Key] = pair.Value;
+                            }
+                        }
+                    }
+                }
+                else if (commandToken.Length == 6 &&
+                         commandToken[0] == 'u' && commandToken[1] == 's' && commandToken[2] == 'e' &&
+                         commandToken[3] == 'm' && commandToken[4] == 't' && commandToken[5] == 'l')
+                {
+                    if (NextToken(line, ref start, out var mtlToken) == 0)
+                    {
+                        activeMaterial = System.Text.Encoding.UTF8.GetString(mtlToken);
+                    }
+                }
                 else if (commandToken.Length == 1 && commandToken[0] == 'f')
                 {
+                    if (!partBuilders.TryGetValue(activeMaterial, out var builder))
+                    {
+                        builder = new PartBuilder(activeMaterial);
+                        partBuilders[activeMaterial] = builder;
+                    }
+
                     var faceIndices = new List<int>(4);
                     while (NextToken(line, ref start, out var vToken) == 0)
                     {
                         faceIndices.Add(ParseVertex(vToken, tempPositions, tempTexCoords, tempNormals,
-                                                    outPositions, outTexCoords, outNormals, vertexCache));
+                                                    builder.OutPositions, builder.OutTexCoords, builder.OutNormals, builder.VertexCache));
                     }
 
                     // Triangulate face using a triangle fan
                     for (int i = 1; i < faceIndices.Count - 1; i++)
                     {
-                        outIndices.Add(faceIndices[0]);
-                        outIndices.Add(faceIndices[i]);
-                        outIndices.Add(faceIndices[i + 1]);
+                        builder.FaceIndices.Add(faceIndices[0]);
+                        builder.FaceIndices.Add(faceIndices[i]);
+                        builder.FaceIndices.Add(faceIndices[i + 1]);
                     }
                 }
             }
 
-            var mesh = new MeshGeometry3D
+            var model = new LoadedObjModel();
+
+            foreach (var builder in partBuilders.Values)
             {
-                Positions = outPositions.ToArray(),
-                TriangleIndices = outIndices.ToArray()
+                if (builder.FaceIndices.Count == 0) continue;
+
+                var mesh = new MeshGeometry3D
+                {
+                    Positions = builder.OutPositions.ToArray(),
+                    TriangleIndices = builder.FaceIndices.ToArray()
+                };
+
+                if (builder.OutNormals.Count == builder.OutPositions.Count) mesh.Normals = builder.OutNormals.ToArray();
+                else mesh.Normals = mesh.GetNormalsOrCompute();
+
+                if (builder.OutTexCoords.Count == builder.OutPositions.Count) mesh.TextureCoordinates = builder.OutTexCoords.ToArray();
+
+                Vector4 materialColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+                float opacity = 1.0f;
+
+                if (materials.TryGetValue(builder.MaterialName, out var matInfo))
+                {
+                    materialColor = matInfo.Color;
+                    opacity = matInfo.Opacity;
+                }
+
+                model.Parts.Add(new ObjPart
+                {
+                    Name = builder.MaterialName,
+                    MaterialName = builder.MaterialName,
+                    Geometry = mesh,
+                    Color = materialColor,
+                    Opacity = opacity
+                });
+            }
+
+            // Fallback for models without faces but containing vertices
+            if (model.Parts.Count == 0 && tempPositions.Count > 0)
+            {
+                var mesh = new MeshGeometry3D
+                {
+                    Positions = tempPositions.ToArray(),
+                    TriangleIndices = Array.Empty<int>(),
+                    Normals = tempNormals.ToArray(),
+                    TextureCoordinates = tempTexCoords.ToArray()
+                };
+                model.Parts.Add(new ObjPart
+                {
+                    Name = "Default",
+                    Geometry = mesh
+                });
+            }
+
+            return model;
+        }
+
+        private static Dictionary<string, (Vector4 Color, float Opacity)> LoadMtl(string filePath)
+        {
+            var materials = new Dictionary<string, (Vector4 Color, float Opacity)>(StringComparer.OrdinalIgnoreCase);
+            if (!File.Exists(filePath)) return materials;
+
+            try
+            {
+                var lines = File.ReadAllLines(filePath);
+                string? currentMaterial = null;
+                Vector4 color = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+                float opacity = 1.0f;
+
+                foreach (var rawLine in lines)
+                {
+                    var line = rawLine.Trim();
+                    if (string.IsNullOrEmpty(line) || line.StartsWith('#')) continue;
+
+                    var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length == 0) continue;
+
+                    if (parts[0].Equals("newmtl", StringComparison.OrdinalIgnoreCase) && parts.Length >= 2)
+                    {
+                        if (currentMaterial != null)
+                        {
+                            materials[currentMaterial] = (color, opacity);
+                        }
+                        currentMaterial = parts[1];
+                        color = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+                        opacity = 1.0f;
+                    }
+                    else if (parts[0].Equals("Kd", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
+                    {
+                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
+                        float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
+                        float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
+                        color = new Vector4(r, g, b, 1.0f);
+                    }
+                    else if ((parts[0].Equals("d", StringComparison.OrdinalIgnoreCase) || parts[0].Equals("Tr", StringComparison.OrdinalIgnoreCase)) && parts.Length >= 2)
+                    {
+                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float dVal);
+                        opacity = dVal;
+                    }
+                }
+
+                if (currentMaterial != null)
+                {
+                    materials[currentMaterial] = (color, opacity);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ObjReader] Failed to parse MTL file '{filePath}': {ex.Message}");
+            }
+
+            return materials;
+        }
+
+        public static MeshGeometry3D MergeParts(LoadedObjModel model)
+        {
+            var positions = new List<Vector3>();
+            var normals = new List<Vector3>();
+            var texCoords = new List<Vector2>();
+            var indices = new List<int>();
+
+            foreach (var part in model.Parts)
+            {
+                int indexOffset = positions.Count;
+                positions.AddRange(part.Geometry.Positions);
+                if (part.Geometry.Normals != null) normals.AddRange(part.Geometry.Normals);
+                if (part.Geometry.TextureCoordinates != null) texCoords.AddRange(part.Geometry.TextureCoordinates);
+
+                foreach (var idx in part.Geometry.TriangleIndices)
+                {
+                    indices.Add(idx + indexOffset);
+                }
+            }
+
+            var merged = new MeshGeometry3D
+            {
+                Positions = positions.ToArray(),
+                TriangleIndices = indices.ToArray()
             };
 
-            if (outNormals.Count == outPositions.Count) mesh.Normals = outNormals.ToArray();
-            else mesh.Normals = mesh.GetNormalsOrCompute();
+            if (normals.Count == positions.Count) merged.Normals = normals.ToArray();
+            else merged.Normals = merged.GetNormalsOrCompute();
 
-            if (outTexCoords.Count == outPositions.Count) mesh.TextureCoordinates = outTexCoords.ToArray();
+            if (texCoords.Count == positions.Count) merged.TextureCoordinates = texCoords.ToArray();
 
-            return mesh;
+            return merged;
         }
 
         private static ReadOnlySpan<byte> Trim(ReadOnlySpan<byte> span)
@@ -293,7 +504,6 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                 }
             }
 
-            // Map standard OBJ 1-based or negative indices to 0-based
             int posIndex = rawV < 0 ? tempPositions.Count + rawV : rawV - 1;
             int texIndex = rawVt == 0 ? -1 : (rawVt < 0 ? tempTexCoords.Count + rawVt : rawVt - 1);
             int normIndex = rawVn == 0 ? -1 : (rawVn < 0 ? tempNormals.Count + rawVn : rawVn - 1);

--- a/src/ProGPU.WinUI/Controls/ObjReader.cs
+++ b/src/ProGPU.WinUI/Controls/ObjReader.cs
@@ -34,6 +34,15 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             HashCode.Combine(PositionIndex, TextureIndex, NormalIndex);
     }
 
+    public struct ObjMaterialInfo
+    {
+        public Vector4 DiffuseColor;
+        public Vector3 SpecularColor;
+        public float Shininess;
+        public Vector3 AmbientColor;
+        public float Opacity;
+    }
+
     public class LoadedObjModel
     {
         public List<ObjPart> Parts { get; } = new();
@@ -45,6 +54,9 @@ namespace Microsoft.UI.Xaml.Media.Media3D
         public string MaterialName { get; set; } = "Default";
         public MeshGeometry3D Geometry { get; set; } = new();
         public Vector4 Color { get; set; } = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+        public Vector3 SpecularColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
+        public float Shininess { get; set; } = 32.0f;
+        public Vector3 AmbientColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
         public float Opacity { get; set; } = 1.0f;
     }
 
@@ -152,7 +164,7 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             var tempTexCoords = new List<Vector2>(8192);
 
             var partBuilders = new Dictionary<string, PartBuilder>(StringComparer.OrdinalIgnoreCase);
-            var materials = new Dictionary<string, (Vector4 Color, float Opacity)>(StringComparer.OrdinalIgnoreCase);
+            var materials = new Dictionary<string, ObjMaterialInfo>(StringComparer.OrdinalIgnoreCase);
             string activeMaterial = "Default";
 
             int startOffset = 0;
@@ -284,11 +296,17 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                 if (builder.OutTexCoords.Count == builder.OutPositions.Count) mesh.TextureCoordinates = builder.OutTexCoords.ToArray();
 
                 Vector4 materialColor = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+                Vector3 specularColor = new Vector3(0.2f, 0.2f, 0.2f);
+                float shininess = 32.0f;
+                Vector3 ambientColor = new Vector3(0.2f, 0.2f, 0.2f);
                 float opacity = 1.0f;
 
                 if (materials.TryGetValue(builder.MaterialName, out var matInfo))
                 {
-                    materialColor = matInfo.Color;
+                    materialColor = matInfo.DiffuseColor;
+                    specularColor = matInfo.SpecularColor;
+                    shininess = matInfo.Shininess;
+                    ambientColor = matInfo.AmbientColor;
                     opacity = matInfo.Opacity;
                 }
 
@@ -298,6 +316,9 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                     MaterialName = builder.MaterialName,
                     Geometry = mesh,
                     Color = materialColor,
+                    SpecularColor = specularColor,
+                    Shininess = shininess,
+                    AmbientColor = ambientColor,
                     Opacity = opacity
                 });
             }
@@ -322,9 +343,9 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             return model;
         }
 
-        private static Dictionary<string, (Vector4 Color, float Opacity)> LoadMtl(string filePath)
+        private static Dictionary<string, ObjMaterialInfo> LoadMtl(string filePath)
         {
-            var materials = new Dictionary<string, (Vector4 Color, float Opacity)>(StringComparer.OrdinalIgnoreCase);
+            var materials = new Dictionary<string, ObjMaterialInfo>(StringComparer.OrdinalIgnoreCase);
             if (!File.Exists(filePath)) return materials;
 
             try
@@ -332,6 +353,9 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                 var lines = File.ReadAllLines(filePath);
                 string? currentMaterial = null;
                 Vector4 color = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+                Vector3 specular = new Vector3(0.2f, 0.2f, 0.2f);
+                float shininess = 32.0f;
+                Vector3 ambient = new Vector3(0.2f, 0.2f, 0.2f);
                 float opacity = 1.0f;
 
                 foreach (var rawLine in lines)
@@ -346,10 +370,20 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                     {
                         if (currentMaterial != null)
                         {
-                            materials[currentMaterial] = (color, opacity);
+                            materials[currentMaterial] = new ObjMaterialInfo
+                            {
+                                DiffuseColor = color,
+                                SpecularColor = specular,
+                                Shininess = shininess,
+                                AmbientColor = ambient,
+                                Opacity = opacity
+                            };
                         }
                         currentMaterial = parts[1];
                         color = new Vector4(0.70f, 0.70f, 0.72f, 1.0f);
+                        specular = new Vector3(0.2f, 0.2f, 0.2f);
+                        shininess = 32.0f;
+                        ambient = new Vector3(0.2f, 0.2f, 0.2f);
                         opacity = 1.0f;
                     }
                     else if (parts[0].Equals("Kd", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
@@ -358,6 +392,25 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                         float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
                         float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
                         color = new Vector4(r, g, b, 1.0f);
+                    }
+                    else if (parts[0].Equals("Ka", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
+                    {
+                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
+                        float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
+                        float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
+                        ambient = new Vector3(r, g, b);
+                    }
+                    else if (parts[0].Equals("Ks", StringComparison.OrdinalIgnoreCase) && parts.Length >= 4)
+                    {
+                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float r);
+                        float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float g);
+                        float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float b);
+                        specular = new Vector3(r, g, b);
+                    }
+                    else if (parts[0].Equals("Ns", StringComparison.OrdinalIgnoreCase) && parts.Length >= 2)
+                    {
+                        float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float nsVal);
+                        shininess = nsVal;
                     }
                     else if ((parts[0].Equals("d", StringComparison.OrdinalIgnoreCase) || parts[0].Equals("Tr", StringComparison.OrdinalIgnoreCase)) && parts.Length >= 2)
                     {
@@ -368,7 +421,14 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 
                 if (currentMaterial != null)
                 {
-                    materials[currentMaterial] = (color, opacity);
+                    materials[currentMaterial] = new ObjMaterialInfo
+                    {
+                        DiffuseColor = color,
+                        SpecularColor = specular,
+                        Shininess = shininess,
+                        AmbientColor = ambient,
+                        Opacity = opacity
+                    };
                 }
             }
             catch (Exception ex)

--- a/src/ProGPU.WinUI/Controls/ObjReader.cs
+++ b/src/ProGPU.WinUI/Controls/ObjReader.cs
@@ -70,6 +70,7 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             public List<Vector3> OutNormals { get; } = new(2048);
             public List<Vector2> OutTexCoords { get; } = new(2048);
             public Dictionary<ObjVertexKey, int> VertexCache { get; } = new(2048);
+            public bool HasNormals { get; set; } = false;
 
             public PartBuilder(string materialName)
             {
@@ -271,11 +272,13 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                     }
 
                     var faceIndices = new List<int>(4);
+                    bool hasNorms = builder.HasNormals;
                     while (NextToken(line, ref start, out var vToken) == 0)
                     {
                         faceIndices.Add(ParseVertex(vToken, tempPositions, tempTexCoords, tempNormals,
-                                                    builder.OutPositions, builder.OutTexCoords, builder.OutNormals, builder.VertexCache));
+                                                    builder.OutPositions, builder.OutTexCoords, builder.OutNormals, builder.VertexCache, ref hasNorms));
                     }
+                    builder.HasNormals = hasNorms;
 
                     // Triangulate face using a triangle fan
                     for (int i = 1; i < faceIndices.Count - 1; i++)
@@ -299,7 +302,7 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                     TriangleIndices = builder.FaceIndices.ToArray()
                 };
 
-                if (builder.OutNormals.Count == builder.OutPositions.Count) mesh.Normals = builder.OutNormals.ToArray();
+                if (builder.HasNormals && builder.OutNormals.Count == builder.OutPositions.Count) mesh.Normals = builder.OutNormals.ToArray();
                 else mesh.Normals = mesh.GetNormalsOrCompute();
 
                 if (builder.OutTexCoords.Count == builder.OutPositions.Count) mesh.TextureCoordinates = builder.OutTexCoords.ToArray();
@@ -582,7 +585,8 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             List<Vector3> outPositions,
             List<Vector2> outTexCoords,
             List<Vector3> outNormals,
-            Dictionary<ObjVertexKey, int> vertexCache)
+            Dictionary<ObjVertexKey, int> vertexCache,
+            ref bool hasNormals)
         {
             int slash1 = token.IndexOf((byte)'/');
             int rawV = 0;
@@ -630,6 +634,11 @@ namespace Microsoft.UI.Xaml.Media.Media3D
             if (vertexCache.TryGetValue(key, out int cachedIndex))
             {
                 return cachedIndex;
+            }
+
+            if (normIndex >= 0)
+            {
+                hasNormals = true;
             }
 
             int newIndex = outPositions.Count;

--- a/src/ProGPU.WinUI/Controls/StackPanel.cs
+++ b/src/ProGPU.WinUI/Controls/StackPanel.cs
@@ -34,20 +34,25 @@ public class StackPanel : Panel
         float totalWidth = 0f;
         float totalHeight = 0f;
 
+        float paddingH = Padding.Horizontal;
+        float paddingV = Padding.Vertical;
+
         foreach (var child in Children)
         {
             if (child is LayoutNode node)
             {
                 if (Orientation == Orientation.Vertical)
                 {
-                    node.Measure(new Vector2(availableSize.X, float.PositiveInfinity));
+                    float availW = float.IsInfinity(availableSize.X) ? availableSize.X : Math.Max(0f, availableSize.X - paddingH);
+                    node.Measure(new Vector2(availW, float.PositiveInfinity));
                     var desired = node.DesiredSize;
                     totalWidth = Math.Max(totalWidth, desired.X);
                     totalHeight += desired.Y;
                 }
                 else
                 {
-                    node.Measure(new Vector2(float.PositiveInfinity, availableSize.Y));
+                    float availH = float.IsInfinity(availableSize.Y) ? availableSize.Y : Math.Max(0f, availableSize.Y - paddingV);
+                    node.Measure(new Vector2(float.PositiveInfinity, availH));
                     var desired = node.DesiredSize;
                     totalWidth += desired.X;
                     totalHeight = Math.Max(totalHeight, desired.Y);

--- a/src/ProGPU.WinUI/Controls/TextBox.cs
+++ b/src/ProGPU.WinUI/Controls/TextBox.cs
@@ -625,6 +625,9 @@ public class TextBox : Control
         float textY = (Size.Y - FontSize) / 2f;
         if (Font != null)
         {
+            Rect textClip = new Rect(Padding.Left, 0f, Math.Max(0f, Size.X - Padding.Horizontal), Size.Y);
+            context.PushClip(textClip);
+
             // Draw selection background behind text if selection exists
             int selStart = Math.Min(SelectionStart, SelectionStart + SelectionLength);
             int selEnd = Math.Max(SelectionStart, SelectionStart + SelectionLength);
@@ -658,6 +661,8 @@ public class TextBox : Control
                 Rect caretRect = new Rect(caretX, textY - 1f, 1.5f, FontSize + 2f);
                 context.DrawRectangle(ThemeManager.GetBrush("TextBoxBorderBrushFocused"), null, caretRect);
             }
+
+            context.PopClip();
         }
 
         base.OnRender(context);

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -1,0 +1,753 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Controls;
+using ProGPU.Vector;
+using ProGPU.Text;
+using ProGPU.Scene;
+using ProGPU.Scene.Extensions;
+using ProGPU.Backend;
+using Silk.NET.WebGPU;
+
+namespace Microsoft.UI.Xaml.Media.Media3D
+{
+    public abstract class Geometry3D
+    {
+    }
+
+    public class MeshGeometry3D : Geometry3D
+    {
+        public Vector3[] Positions { get; set; } = Array.Empty<Vector3>();
+        public Vector3[] Normals { get; set; } = Array.Empty<Vector3>();
+        public Vector2[] TextureCoordinates { get; set; } = Array.Empty<Vector2>();
+        public int[] TriangleIndices { get; set; } = Array.Empty<int>();
+
+        public Vector3[] GetNormalsOrCompute()
+        {
+            if (Normals != null && Normals.Length == Positions.Length)
+                return Normals;
+
+            if (Positions.Length == 0 || TriangleIndices.Length == 0)
+                return Array.Empty<Vector3>();
+
+            var computed = new Vector3[Positions.Length];
+            
+            for (int i = 0; i < TriangleIndices.Length; i += 3)
+            {
+                if (i + 2 >= TriangleIndices.Length) break;
+                
+                int i0 = TriangleIndices[i];
+                int i1 = TriangleIndices[i + 1];
+                int i2 = TriangleIndices[i + 2];
+
+                if (i0 >= Positions.Length || i1 >= Positions.Length || i2 >= Positions.Length) continue;
+
+                var p0 = Positions[i0];
+                var p1 = Positions[i1];
+                var p2 = Positions[i2];
+
+                var u = p1 - p0;
+                var v = p2 - p0;
+                var normal = Vector3.Cross(u, v);
+                float len = normal.Length();
+                if (len > 0.0001f)
+                {
+                    normal /= len;
+                }
+
+                computed[i0] += normal;
+                computed[i1] += normal;
+                computed[i2] += normal;
+            }
+
+            for (int i = 0; i < computed.Length; i++)
+            {
+                float len = computed[i].Length();
+                if (len > 0.0001f)
+                    computed[i] /= len;
+                else
+                    computed[i] = Vector3.UnitY;
+            }
+
+            return computed;
+        }
+    }
+
+    public abstract class Material
+    {
+    }
+
+    public class DiffuseMaterial : Material
+    {
+        public Brush Brush { get; set; } = new SolidColorBrush(new Vector4(1f, 1f, 1f, 1f));
+        public Vector4 Color { get; set; } = Vector4.One;
+
+        public DiffuseMaterial()
+        {
+        }
+
+        public DiffuseMaterial(Brush brush)
+        {
+            Brush = brush;
+        }
+    }
+
+    public abstract class Model3D
+    {
+        public Matrix4x4 Transform { get; set; } = Matrix4x4.Identity;
+    }
+
+    public class GeometryModel3D : Model3D
+    {
+        public Geometry3D? Geometry { get; set; }
+        public Material? Material { get; set; }
+        public Material? BackMaterial { get; set; }
+    }
+
+    public abstract class Visual3D
+    {
+    }
+
+    public class ModelVisual3D : Visual3D
+    {
+        public Model3D? Content { get; set; }
+        public List<Visual3D> Children { get; } = new();
+    }
+
+    public abstract class Camera
+    {
+        public Matrix4x4 Transform { get; set; } = Matrix4x4.Identity;
+
+        public abstract Matrix4x4 GetProjectionMatrix(float aspectRatio);
+        public abstract Matrix4x4 GetViewMatrix();
+    }
+
+    public abstract class ProjectionCamera : Camera
+    {
+        public Vector3 Position { get; set; } = new Vector3(0, 0, -10);
+        public Vector3 LookDirection { get; set; } = new Vector3(0, 0, 1);
+        public Vector3 UpDirection { get; set; } = Vector3.UnitY;
+        public float NearPlaneDistance { get; set; } = 0.125f;
+        public float FarPlaneDistance { get; set; } = 1000f;
+
+        // Computed property to support LookAt seamlessly (such as for orbiting controller math)
+        public Vector3 LookAt
+        {
+            get => Position + LookDirection;
+            set => LookDirection = value - Position;
+        }
+
+        public override Matrix4x4 GetViewMatrix()
+        {
+            var view = Matrix4x4.CreateLookAt(Position, Position + LookDirection, UpDirection);
+            if (Transform != Matrix4x4.Identity)
+            {
+                if (Matrix4x4.Invert(Transform, out var invTransform))
+                {
+                    view = invTransform * view;
+                }
+            }
+            return view;
+        }
+    }
+
+    public class PerspectiveCamera : ProjectionCamera
+    {
+        public float FieldOfView { get; set; } = 45f;
+
+        public override Matrix4x4 GetProjectionMatrix(float aspectRatio)
+        {
+            float fovRad = FieldOfView * MathF.PI / 180f;
+            return Matrix4x4.CreatePerspectiveFieldOfView(fovRad, aspectRatio, NearPlaneDistance, FarPlaneDistance);
+        }
+    }
+
+    public class OrthographicCamera : ProjectionCamera
+    {
+        public float Width { get; set; } = 2f;
+
+        public override Matrix4x4 GetProjectionMatrix(float aspectRatio)
+        {
+            float height = Width / aspectRatio;
+            return Matrix4x4.CreateOrthographic(Width, height, NearPlaneDistance, FarPlaneDistance);
+        }
+    }
+}
+
+namespace Microsoft.UI.Xaml.Controls
+{
+    using Microsoft.UI.Xaml.Media.Media3D;
+
+    public class Viewport3D : Control
+    {
+        private Camera _camera = new PerspectiveCamera();
+        public Camera Camera
+        {
+            get => _camera;
+            set
+            {
+                if (_camera != value)
+                {
+                    _camera = value;
+                    _cameraInitialized = false;
+                    Invalidate();
+                }
+            }
+        }
+        
+        public new List<Visual3D> Children { get; } = new();
+
+        // High-performance directional + ambient lighting parameters
+        public Vector3 LightDirection { get; set; } = new Vector3(0.5f, 1f, -0.5f);
+        public float LightIntensity { get; set; } = 1.0f;
+        public Vector3 AmbientColor { get; set; } = new Vector3(1f, 1f, 1f);
+        public float AmbientIntensity { get; set; } = 0.25f;
+
+        public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
+
+        private GpuTexture? _colorTexture;
+        private GpuTexture? _depthTexture;
+
+        private bool _isOrbiting = false;
+        private bool _isPanning = false;
+        private Vector2 _lastPointerPosition;
+
+        private float _cameraTheta = 0f;
+        private float _cameraPhi = 0.5f;
+        private float _cameraRadius = 10f;
+        private bool _cameraInitialized = false;
+
+        private void InitializeCameraState()
+        {
+            if (Camera is ProjectionCamera projCamera)
+            {
+                var dir = -projCamera.LookDirection;
+                _cameraRadius = dir.Length();
+                if (_cameraRadius < 0.1f) _cameraRadius = 0.1f;
+
+                _cameraTheta = MathF.Atan2(dir.X, dir.Z);
+                float lenXZ = MathF.Sqrt(dir.X * dir.X + dir.Z * dir.Z);
+                _cameraPhi = MathF.Atan2(lenXZ, dir.Y);
+                
+                // Clamp phi to prevent crossing poles
+                _cameraPhi = Math.Clamp(_cameraPhi, 0.01f, MathF.PI - 0.01f);
+                
+                _cameraInitialized = true;
+            }
+        }
+
+        private void ApplyCameraState()
+        {
+            if (Camera is ProjectionCamera projCamera)
+            {
+                float sinPhi = MathF.Sin(_cameraPhi);
+                float cosPhi = MathF.Cos(_cameraPhi);
+                float sinTheta = MathF.Sin(_cameraTheta);
+                float cosTheta = MathF.Cos(_cameraTheta);
+
+                var target = projCamera.LookAt;
+                var offset = new Vector3(
+                    _cameraRadius * sinPhi * sinTheta,
+                    _cameraRadius * cosPhi,
+                    _cameraRadius * sinPhi * cosTheta
+                );
+
+                projCamera.Position = target + offset;
+                projCamera.LookDirection = -offset;
+                
+                Invalidate();
+            }
+        }
+
+        public Viewport3D()
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch;
+            VerticalAlignment = VerticalAlignment.Stretch;
+            IsTabStop = true;
+            Unloaded += (s, e) => DisposeTextures();
+        }
+
+        private void DisposeTextures()
+        {
+            _colorTexture?.Dispose();
+            _colorTexture = null;
+            _depthTexture?.Dispose();
+            _depthTexture = null;
+        }
+
+        protected override Vector2 MeasureOverride(Vector2 availableSize)
+        {
+            // Fills all available screen dimensions
+            float w = float.IsInfinity(availableSize.X) ? 400f : availableSize.X;
+            float h = float.IsInfinity(availableSize.Y) ? 300f : availableSize.Y;
+            return new Vector2(w, h);
+        }
+
+        protected override void ArrangeOverride(Rect arrangeRect)
+        {
+            base.ArrangeOverride(arrangeRect);
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            if (Size.X <= 0 || Size.Y <= 0 || Camera == null) return;
+
+            if (!_cameraInitialized) InitializeCameraState();
+
+            var activeWindows = WindowManager.ActiveWindows;
+            if (activeWindows.Count == 0) return;
+            var window = activeWindows[0];
+            var wgpuContext = window.WgpuContext;
+            if (wgpuContext == null) return;
+
+            uint width = (uint)Math.Max(1, Size.X);
+            uint height = (uint)Math.Max(1, Size.Y);
+
+            // Recreate offscreen textures if size changed
+            if (_colorTexture == null || _colorTexture.Width != width || _colorTexture.Height != height)
+            {
+                _colorTexture?.Dispose();
+                _colorTexture = new GpuTexture(wgpuContext, width, height, TextureFormat.Rgba8Unorm, TextureUsage.RenderAttachment | TextureUsage.TextureBinding, "Viewport3D Color Texture");
+
+                _depthTexture?.Dispose();
+                _depthTexture = new GpuTexture(wgpuContext, width, height, TextureFormat.Depth24PlusStencil8, TextureUsage.RenderAttachment, "Viewport3D Depth Texture");
+            }
+
+            float aspectRatio = Size.X / Size.Y;
+
+            // 1. Setup projection and camera view matrices
+            var projection = Camera.GetProjectionMatrix(aspectRatio);
+            var view = Camera.GetViewMatrix();
+
+            // 2. Build recursive payload for Mesh3DExtensionPipeline
+            var payload = new Viewport3DCompilationPayload
+            {
+                ViewportSize = Size,
+                LightDirection = LightDirection,
+                LightIntensity = LightIntensity,
+                AmbientColor = AmbientColor,
+                AmbientIntensity = AmbientIntensity,
+                ColorTexture = _colorTexture,
+                DepthTexture = _depthTexture,
+                RenderMode = RenderMode
+            };
+
+            foreach (var visual in Children)
+            {
+                CompileVisual(visual, Matrix4x4.Identity, payload);
+            }
+
+            if (payload.Meshes.Count > 0)
+            {
+                // Push active viewport projection onto context's command stack
+                context.Commands.Add(new RenderCommand
+                {
+                    Type = RenderCommandType.DrawExtension,
+                    ExtensionId = CompositorBuiltInExtensions.Mesh3D,
+                    UseGpuTransforms = true,
+                    CameraView = view,
+                    Transform = projection,
+                    DataParam = payload
+                });
+
+                // Render the offscreen 3D texture on the main 2D pass
+                context.Commands.Add(new RenderCommand
+                {
+                    Type = RenderCommandType.DrawTexture,
+                    Rect = new Rect(Vector2.Zero, Size),
+                    Texture = _colorTexture
+                });
+            }
+
+            DrawCoordinateCompass(context, view);
+
+            base.OnRender(context);
+        }
+
+        private void CompileVisual(Visual3D visual, Matrix4x4 parentTransform, Viewport3DCompilationPayload payload)
+        {
+            if (visual is ModelVisual3D modelVisual)
+            {
+                var localTransform = parentTransform;
+                if (modelVisual.Content != null)
+                {
+                    localTransform = modelVisual.Content.Transform * parentTransform;
+                    
+                    if (modelVisual.Content is GeometryModel3D geomModel && geomModel.Geometry != null)
+                    {
+                        var mesh = geomModel.Geometry as MeshGeometry3D;
+                        if (mesh != null)
+                        {
+                            var positions = mesh.Positions;
+                            var normals = mesh.GetNormalsOrCompute();
+                            var indices = mesh.TriangleIndices;
+
+                            if (positions.Length > 0 && indices.Length > 0)
+                            {
+                                // Dynamic WinUI 3 Palette Brush resolving to match Rule 1.C
+                                Vector4 diffuseColor = Vector4.One;
+                                float opacity = 1.0f;
+
+                                if (geomModel.Material is DiffuseMaterial diffuse && diffuse.Brush != null)
+                                {
+                                    opacity = diffuse.Brush.Opacity;
+
+                                    // If the brush is a dynamic theme resource brush, resolve it against the active theme family
+                                    Brush? activeBrush = diffuse.Brush;
+                                    if (diffuse.Brush is ThemeResourceBrush themeRes)
+                                    {
+                                        activeBrush = ThemeManager.GetBrush(themeRes.ResourceKey, ActualTheme, ActualThemeFamily);
+                                    }
+
+                                    if (activeBrush is SolidColorBrush solid)
+                                    {
+                                        diffuseColor = solid.Color;
+                                    }
+                                    else if (activeBrush is LinearGradientBrush gradient && gradient.Stops.Length > 0)
+                                    {
+                                        diffuseColor = gradient.Stops[0].Color; // Fallback to first stop for mesh base color
+                                    }
+
+                                    // Blend with DiffuseMaterial.Color if it is set
+                                    diffuseColor *= diffuse.Color;
+                                }
+
+                                payload.Meshes.Add(new MeshCompilationEntry
+                                {
+                                    Geometry = mesh,
+                                    Positions = positions,
+                                    Normals = normals,
+                                    Indices = indices,
+                                    ModelTransform = localTransform,
+                                    Color = diffuseColor,
+                                    Opacity = opacity
+                                });
+                            }
+                        }
+                    }
+                }
+
+                foreach (var child in modelVisual.Children)
+                {
+                    CompileVisual(child, localTransform, payload);
+                }
+            }
+        }
+
+        public override void OnPointerPressed(PointerRoutedEventArgs e)
+        {
+            if (IsEnabled)
+            {
+                e.Handled = true;
+                InputSystem.SetFocus(this);
+
+                bool isShift = InputSystem.Current.IsShiftPressed;
+
+                if (e.IsLeftButtonPressed)
+                {
+                    if (!_cameraInitialized) InitializeCameraState();
+
+                    if (isShift || Camera is OrthographicCamera)
+                    {
+                        _isOrbiting = false;
+                        _isPanning = true;
+                    }
+                    else
+                    {
+                        _isOrbiting = true;
+                        _isPanning = false;
+                    }
+
+                    _lastPointerPosition = e.Position;
+                    InputSystem.CapturePointer(this);
+                }
+                else if (e.IsRightButtonPressed || e.IsMiddleButtonPressed)
+                {
+                    if (!_cameraInitialized) InitializeCameraState();
+
+                    _isOrbiting = false;
+                    _isPanning = true;
+                    _lastPointerPosition = e.Position;
+                    InputSystem.CapturePointer(this);
+                }
+            }
+            base.OnPointerPressed(e);
+        }
+
+        public override void OnPointerReleased(PointerRoutedEventArgs e)
+        {
+            if (IsEnabled)
+            {
+                e.Handled = true;
+                if (_isOrbiting || _isPanning)
+                {
+                    InputSystem.ReleasePointerCapture();
+                    _isOrbiting = false;
+                    _isPanning = false;
+                }
+            }
+            base.OnPointerReleased(e);
+        }
+
+        public override void OnPointerMoved(PointerRoutedEventArgs e)
+        {
+            if (IsEnabled)
+            {
+                if (_isOrbiting)
+                {
+                    e.Handled = true;
+                    if (!_cameraInitialized) InitializeCameraState();
+
+                    var delta = e.Position - _lastPointerPosition;
+                    _lastPointerPosition = e.Position;
+
+                    _cameraTheta -= delta.X * 0.01f;
+                    _cameraPhi -= delta.Y * 0.01f;
+
+                    // Clamp Phi to prevent visual flipping/gimbal lock at the poles
+                    _cameraPhi = Math.Clamp(_cameraPhi, 0.01f, MathF.PI - 0.01f);
+
+                    ApplyCameraState();
+                }
+                else if (_isPanning && Camera is ProjectionCamera projCamera)
+                {
+                    e.Handled = true;
+                    if (!_cameraInitialized) InitializeCameraState();
+
+                    var delta = e.Position - _lastPointerPosition;
+                    _lastPointerPosition = e.Position;
+
+                    var forward = Vector3.Normalize(projCamera.LookDirection);
+                    var right = Vector3.Normalize(Vector3.Cross(forward, projCamera.UpDirection));
+                    var up = Vector3.Normalize(Vector3.Cross(right, forward));
+
+                    float panSpeed = _cameraRadius * 0.0015f;
+                    projCamera.LookAt -= right * (delta.X * panSpeed);
+                    projCamera.LookAt += up * (delta.Y * panSpeed);
+
+                    ApplyCameraState();
+                }
+            }
+            base.OnPointerMoved(e);
+        }
+
+        public override void OnPointerWheelChanged(PointerRoutedEventArgs e)
+        {
+            if (IsEnabled)
+            {
+                e.Handled = true;
+                if (!_cameraInitialized) InitializeCameraState();
+
+                float zoomFactor = e.WheelDelta > 0 ? 0.9f : 1.1f;
+
+                if (Camera is OrthographicCamera ortho)
+                {
+                    ortho.Width *= zoomFactor;
+                    ortho.Width = Math.Clamp(ortho.Width, 0.1f, 1000.0f);
+                }
+                else
+                {
+                    _cameraRadius *= zoomFactor;
+                    _cameraRadius = Math.Clamp(_cameraRadius, 1.5f, 100.0f);
+                }
+
+                ApplyCameraState();
+            }
+            base.OnPointerWheelChanged(e);
+        }
+
+        public override void OnKeyDown(KeyRoutedEventArgs e)
+        {
+            if (IsEnabled && IsFocused && Camera is ProjectionCamera projCamera)
+            {
+                if (!_cameraInitialized) InitializeCameraState();
+                
+                bool changed = false;
+                float angleSpeed = 0.05f;
+                float panSpeed = _cameraRadius * 0.03f;
+
+                var forward = Vector3.Normalize(projCamera.LookDirection);
+                var right = Vector3.Normalize(Vector3.Cross(forward, projCamera.UpDirection));
+                var up = Vector3.Normalize(Vector3.Cross(right, forward));
+
+                bool isShift = InputSystem.Current.IsShiftPressed;
+
+                if (e.Key == Silk.NET.Input.Key.Left || e.Key == Silk.NET.Input.Key.A)
+                {
+                    if (isShift || projCamera is OrthographicCamera)
+                    {
+                        projCamera.LookAt -= right * panSpeed;
+                    }
+                    else
+                    {
+                        _cameraTheta -= angleSpeed;
+                    }
+                    changed = true;
+                }
+                else if (e.Key == Silk.NET.Input.Key.Right || e.Key == Silk.NET.Input.Key.D)
+                {
+                    if (isShift || projCamera is OrthographicCamera)
+                    {
+                        projCamera.LookAt += right * panSpeed;
+                    }
+                    else
+                    {
+                        _cameraTheta += angleSpeed;
+                    }
+                    changed = true;
+                }
+                else if (e.Key == Silk.NET.Input.Key.Up || e.Key == Silk.NET.Input.Key.W)
+                {
+                    if (isShift || projCamera is OrthographicCamera)
+                    {
+                        projCamera.LookAt += up * panSpeed;
+                    }
+                    else
+                    {
+                        _cameraPhi -= angleSpeed;
+                        _cameraPhi = Math.Clamp(_cameraPhi, 0.01f, MathF.PI - 0.01f);
+                    }
+                    changed = true;
+                }
+                else if (e.Key == Silk.NET.Input.Key.Down || e.Key == Silk.NET.Input.Key.S)
+                {
+                    if (isShift || projCamera is OrthographicCamera)
+                    {
+                        projCamera.LookAt -= up * panSpeed;
+                    }
+                    else
+                    {
+                        _cameraPhi += angleSpeed;
+                        _cameraPhi = Math.Clamp(_cameraPhi, 0.01f, MathF.PI - 0.01f);
+                    }
+                    changed = true;
+                }
+                else if (e.Key == Silk.NET.Input.Key.PageUp || e.Key == Silk.NET.Input.Key.Q)
+                {
+                    if (projCamera is OrthographicCamera ortho)
+                    {
+                        ortho.Width *= 0.9f;
+                        ortho.Width = Math.Clamp(ortho.Width, 0.1f, 1000.0f);
+                    }
+                    else
+                    {
+                        _cameraRadius *= 0.9f;
+                        _cameraRadius = Math.Clamp(_cameraRadius, 1.5f, 100.0f);
+                    }
+                    changed = true;
+                }
+                else if (e.Key == Silk.NET.Input.Key.PageDown || e.Key == Silk.NET.Input.Key.E)
+                {
+                    if (projCamera is OrthographicCamera ortho)
+                    {
+                        ortho.Width *= 1.1f;
+                        ortho.Width = Math.Clamp(ortho.Width, 0.1f, 1000.0f);
+                    }
+                    else
+                    {
+                        _cameraRadius *= 1.1f;
+                        _cameraRadius = Math.Clamp(_cameraRadius, 1.5f, 100.0f);
+                    }
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    e.Handled = true;
+                    ApplyCameraState();
+                }
+            }
+            base.OnKeyDown(e);
+        }
+
+        private struct ProjectedAxis
+        {
+            public Vector4 Color;
+            public string Label;
+            public Vector3 VCam;
+            public Vector2 ProjPos;
+        }
+
+        private void DrawCoordinateCompass(DrawingContext context, Matrix4x4 view)
+        {
+            var font = Font ?? PopupService.DefaultFont;
+            if (font == null) return;
+
+            float padding = 65f;
+            float bgRadius = 38f;
+            float axisLength = 25f;
+            float tipRadius = 7f;
+
+            Vector2 center = new Vector2(Size.X - padding, padding);
+
+            // Dynamic glass backdrop background and border
+            var bgBrush = new SolidColorBrush(new Vector4(0.08f, 0.08f, 0.1f, 0.45f));
+            var borderBrush = ThemeManager.GetBrush("ControlBorder", ActualTheme, ActualThemeFamily) 
+                              ?? new SolidColorBrush(new Vector4(0.25f, 0.25f, 0.3f, 0.4f));
+            var bgPen = new Pen(borderBrush, 1f);
+
+            context.FillCircle(bgBrush, center, bgRadius);
+            context.DrawCircle(null, bgPen, center, bgRadius);
+
+            // Project axes directions in camera space
+            var axisX = new ProjectedAxis { Color = new Vector4(0.92f, 0.25f, 0.25f, 1f), Label = "X", VCam = Vector3.TransformNormal(Vector3.UnitX, view) };
+            axisX.ProjPos = new Vector2(center.X + axisX.VCam.X * axisLength, center.Y - axisX.VCam.Y * axisLength);
+
+            var axisY = new ProjectedAxis { Color = new Vector4(0.20f, 0.80f, 0.30f, 1f), Label = "Y", VCam = Vector3.TransformNormal(Vector3.UnitY, view) };
+            axisY.ProjPos = new Vector2(center.X + axisY.VCam.X * axisLength, center.Y - axisY.VCam.Y * axisLength);
+
+            var axisZ = new ProjectedAxis { Color = new Vector4(0.18f, 0.50f, 0.95f, 1f), Label = "Z", VCam = Vector3.TransformNormal(Vector3.UnitZ, view) };
+            axisZ.ProjPos = new Vector2(center.X + axisZ.VCam.X * axisLength, center.Y - axisZ.VCam.Y * axisLength);
+
+            // Zero-allocation bubble sort of three elements by depth
+            ProjectedAxis first = axisX;
+            ProjectedAxis second = axisY;
+            ProjectedAxis third = axisZ;
+
+            if (first.VCam.Z > second.VCam.Z)
+            {
+                var temp = first;
+                first = second;
+                second = temp;
+            }
+            if (second.VCam.Z > third.VCam.Z)
+            {
+                var temp = second;
+                second = third;
+                third = temp;
+            }
+            if (first.VCam.Z > second.VCam.Z)
+            {
+                var temp = first;
+                first = second;
+                second = temp;
+            }
+
+            // Draw center origin dot
+            var originBrush = new SolidColorBrush(new Vector4(0.85f, 0.85f, 0.85f, 1f));
+            context.FillCircle(originBrush, center, 3.5f);
+
+            var labelBrush = new SolidColorBrush(new Vector4(1f, 1f, 1f, 1f));
+            var tipBorderPen = new Pen(new SolidColorBrush(new Vector4(1f, 1f, 1f, 0.9f)), 1f);
+
+            // Draw axes in depth order
+            void DrawAxis(ProjectedAxis axis)
+            {
+                var linePen = new Pen(new SolidColorBrush(axis.Color), 2f);
+                context.DrawLine(linePen, center, axis.ProjPos);
+
+                var tipBrush = new SolidColorBrush(axis.Color);
+                context.FillCircle(tipBrush, axis.ProjPos, tipRadius);
+                context.DrawCircle(null, tipBorderPen, axis.ProjPos, tipRadius);
+
+                context.DrawText(axis.Label, font, 10f, labelBrush, axis.ProjPos + new Vector2(-3.5f, -5.5f), isBold: true);
+            }
+
+            DrawAxis(first);
+            DrawAxis(second);
+            DrawAxis(third);
+        }
+    }
+}

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -466,6 +466,7 @@ namespace Microsoft.UI.Xaml.Controls
 
                                     // Blend with DiffuseMaterial.Color if it is set
                                     diffuseColor *= diffuse.Color;
+                                    opacity *= diffuseColor.W;
                                 }
 
                                 payload.Meshes.Add(new MeshCompilationEntry

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -83,6 +83,9 @@ namespace Microsoft.UI.Xaml.Media.Media3D
     {
         public Brush Brush { get; set; } = new SolidColorBrush(new Vector4(1f, 1f, 1f, 1f));
         public Vector4 Color { get; set; } = Vector4.One;
+        public Vector3 SpecularColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
+        public float Shininess { get; set; } = 32.0f;
+        public Vector3 AmbientColor { get; set; } = new Vector3(0.2f, 0.2f, 0.2f);
 
         public DiffuseMaterial()
         {
@@ -388,11 +391,17 @@ namespace Microsoft.UI.Xaml.Controls
                             {
                                 // Dynamic WinUI 3 Palette Brush resolving to match Rule 1.C
                                 Vector4 diffuseColor = Vector4.One;
+                                Vector3 specularColor = new Vector3(0.2f, 0.2f, 0.2f);
+                                float shininess = 32.0f;
+                                Vector3 ambientColor = new Vector3(0.2f, 0.2f, 0.2f);
                                 float opacity = 1.0f;
 
                                 if (geomModel.Material is DiffuseMaterial diffuse && diffuse.Brush != null)
                                 {
                                     opacity = diffuse.Brush.Opacity;
+                                    specularColor = diffuse.SpecularColor;
+                                    shininess = diffuse.Shininess;
+                                    ambientColor = diffuse.AmbientColor;
 
                                     // If the brush is a dynamic theme resource brush, resolve it against the active theme family
                                     Brush? activeBrush = diffuse.Brush;
@@ -422,6 +431,9 @@ namespace Microsoft.UI.Xaml.Controls
                                     Indices = indices,
                                     ModelTransform = localTransform,
                                     Color = diffuseColor,
+                                    SpecularColor = specularColor,
+                                    Shininess = shininess,
+                                    AmbientColor = ambientColor,
                                     Opacity = opacity
                                 });
                             }

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -15,14 +15,44 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 {
     public abstract class Geometry3D
     {
+        public int Version { get; set; }
+
+        public void Invalidate()
+        {
+            Version++;
+        }
     }
 
     public class MeshGeometry3D : Geometry3D
     {
-        public Vector3[] Positions { get; set; } = Array.Empty<Vector3>();
-        public Vector3[] Normals { get; set; } = Array.Empty<Vector3>();
-        public Vector2[] TextureCoordinates { get; set; } = Array.Empty<Vector2>();
-        public int[] TriangleIndices { get; set; } = Array.Empty<int>();
+        private Vector3[] _positions = Array.Empty<Vector3>();
+        private Vector3[] _normals = Array.Empty<Vector3>();
+        private Vector2[] _textureCoordinates = Array.Empty<Vector2>();
+        private int[] _triangleIndices = Array.Empty<int>();
+
+        public Vector3[] Positions
+        {
+            get => _positions;
+            set { _positions = value; Invalidate(); }
+        }
+
+        public Vector3[] Normals
+        {
+            get => _normals;
+            set { _normals = value; Invalidate(); }
+        }
+
+        public Vector2[] TextureCoordinates
+        {
+            get => _textureCoordinates;
+            set { _textureCoordinates = value; Invalidate(); }
+        }
+
+        public int[] TriangleIndices
+        {
+            get => _triangleIndices;
+            set { _triangleIndices = value; Invalidate(); }
+        }
 
         public Vector3[] GetNormalsOrCompute()
         {
@@ -441,6 +471,7 @@ namespace Microsoft.UI.Xaml.Controls
                                 payload.Meshes.Add(new MeshCompilationEntry
                                 {
                                     Geometry = mesh,
+                                    GeometryVersion = mesh.Version,
                                     Positions = positions,
                                     Normals = normals,
                                     Indices = indices,

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -209,7 +209,7 @@ namespace Microsoft.UI.Xaml.Controls
         public float AmbientIntensity { get; set; } = 0.25f;
 
         public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
-        public ShadingMode3D ShadingMode { get; set; } = ShadingMode3D.Shaded;
+        public ShadingMode3D ShadingMode { get; set; } = ShadingMode3D.Realistic;
 
         private GpuTexture? _colorTexture;
         private GpuTexture? _msaaColorTexture;

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -209,6 +209,7 @@ namespace Microsoft.UI.Xaml.Controls
         public float AmbientIntensity { get; set; } = 0.25f;
 
         public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
+        public ShadingMode3D ShadingMode { get; set; } = ShadingMode3D.Shaded;
 
         private GpuTexture? _colorTexture;
         private GpuTexture? _msaaColorTexture;
@@ -347,7 +348,8 @@ namespace Microsoft.UI.Xaml.Controls
                 ColorTexture = _colorTexture,
                 MsaaColorTexture = _msaaColorTexture,
                 DepthTexture = _depthTexture,
-                RenderMode = RenderMode
+                RenderMode = RenderMode,
+                ShadingMode = ShadingMode
             };
 
             foreach (var visual in Children)

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -72,7 +72,7 @@ namespace Microsoft.UI.Xaml.Media.Media3D
                 int i1 = TriangleIndices[i + 1];
                 int i2 = TriangleIndices[i + 2];
 
-                if (i0 >= Positions.Length || i1 >= Positions.Length || i2 >= Positions.Length) continue;
+                if (i0 < 0 || i0 >= Positions.Length || i1 < 0 || i1 >= Positions.Length || i2 < 0 || i2 >= Positions.Length) continue;
 
                 var p0 = Positions[i0];
                 var p1 = Positions[i1];

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -151,7 +151,23 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 
     public abstract class Camera
     {
-        public Matrix4x4 Transform { get; set; } = Matrix4x4.Identity;
+        private Matrix4x4 _transform = Matrix4x4.Identity;
+        public Matrix4x4 Transform
+        {
+            get => _transform;
+            set
+            {
+                if (_transform != value)
+                {
+                    _transform = value;
+                    RaiseChanged();
+                }
+            }
+        }
+
+        public event EventHandler? Changed;
+
+        protected void RaiseChanged() => Changed?.Invoke(this, EventArgs.Empty);
 
         public abstract Matrix4x4 GetProjectionMatrix(float aspectRatio);
         public abstract Matrix4x4 GetViewMatrix();
@@ -159,11 +175,75 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 
     public abstract class ProjectionCamera : Camera
     {
-        public Vector3 Position { get; set; } = new Vector3(0, 0, -10);
-        public Vector3 LookDirection { get; set; } = new Vector3(0, 0, 1);
-        public Vector3 UpDirection { get; set; } = Vector3.UnitY;
-        public float NearPlaneDistance { get; set; } = 0.125f;
-        public float FarPlaneDistance { get; set; } = 1000f;
+        private Vector3 _position = new Vector3(0, 0, -10);
+        public Vector3 Position
+        {
+            get => _position;
+            set
+            {
+                if (_position != value)
+                {
+                    _position = value;
+                    RaiseChanged();
+                }
+            }
+        }
+
+        private Vector3 _lookDirection = new Vector3(0, 0, 1);
+        public Vector3 LookDirection
+        {
+            get => _lookDirection;
+            set
+            {
+                if (_lookDirection != value)
+                {
+                    _lookDirection = value;
+                    RaiseChanged();
+                }
+            }
+        }
+
+        private Vector3 _upDirection = Vector3.UnitY;
+        public Vector3 UpDirection
+        {
+            get => _upDirection;
+            set
+            {
+                if (_upDirection != value)
+                {
+                    _upDirection = value;
+                    RaiseChanged();
+                }
+            }
+        }
+
+        private float _nearPlaneDistance = 0.125f;
+        public float NearPlaneDistance
+        {
+            get => _nearPlaneDistance;
+            set
+            {
+                if (_nearPlaneDistance != value)
+                {
+                    _nearPlaneDistance = value;
+                    RaiseChanged();
+                }
+            }
+        }
+
+        private float _farPlaneDistance = 1000f;
+        public float FarPlaneDistance
+        {
+            get => _farPlaneDistance;
+            set
+            {
+                if (_farPlaneDistance != value)
+                {
+                    _farPlaneDistance = value;
+                    RaiseChanged();
+                }
+            }
+        }
 
         // Computed property to support LookAt seamlessly (such as for orbiting controller math)
         public Vector3 LookAt
@@ -188,7 +268,19 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 
     public class PerspectiveCamera : ProjectionCamera
     {
-        public float FieldOfView { get; set; } = 45f;
+        private float _fieldOfView = 45f;
+        public float FieldOfView
+        {
+            get => _fieldOfView;
+            set
+            {
+                if (_fieldOfView != value)
+                {
+                    _fieldOfView = value;
+                    RaiseChanged();
+                }
+            }
+        }
 
         public override Matrix4x4 GetProjectionMatrix(float aspectRatio)
         {
@@ -199,7 +291,19 @@ namespace Microsoft.UI.Xaml.Media.Media3D
 
     public class OrthographicCamera : ProjectionCamera
     {
-        public float Width { get; set; } = 2f;
+        private float _width = 2f;
+        public float Width
+        {
+            get => _width;
+            set
+            {
+                if (_width != value)
+                {
+                    _width = value;
+                    RaiseChanged();
+                }
+            }
+        }
 
         public override Matrix4x4 GetProjectionMatrix(float aspectRatio)
         {
@@ -223,10 +327,27 @@ namespace Microsoft.UI.Xaml.Controls
             {
                 if (_camera != value)
                 {
+                    if (_camera != null)
+                    {
+                        _camera.Changed -= OnCameraChanged;
+                    }
                     _camera = value;
+                    if (_camera != null)
+                    {
+                        _camera.Changed += OnCameraChanged;
+                    }
                     _cameraInitialized = false;
                     Invalidate();
                 }
+            }
+        }
+
+        private void OnCameraChanged(object? sender, EventArgs e)
+        {
+            if (!_isUpdatingCameraState)
+            {
+                _cameraInitialized = false;
+                Invalidate();
             }
         }
         
@@ -253,6 +374,7 @@ namespace Microsoft.UI.Xaml.Controls
         private float _cameraPhi = 0.5f;
         private float _cameraRadius = 10f;
         private bool _cameraInitialized = false;
+        private bool _isUpdatingCameraState = false;
 
         private void InitializeCameraState()
         {
@@ -277,27 +399,36 @@ namespace Microsoft.UI.Xaml.Controls
         {
             if (Camera is ProjectionCamera projCamera)
             {
-                float sinPhi = MathF.Sin(_cameraPhi);
-                float cosPhi = MathF.Cos(_cameraPhi);
-                float sinTheta = MathF.Sin(_cameraTheta);
-                float cosTheta = MathF.Cos(_cameraTheta);
+                _isUpdatingCameraState = true;
+                try
+                {
+                    float sinPhi = MathF.Sin(_cameraPhi);
+                    float cosPhi = MathF.Cos(_cameraPhi);
+                    float sinTheta = MathF.Sin(_cameraTheta);
+                    float cosTheta = MathF.Cos(_cameraTheta);
 
-                var target = projCamera.LookAt;
-                var offset = new Vector3(
-                    _cameraRadius * sinPhi * sinTheta,
-                    _cameraRadius * cosPhi,
-                    _cameraRadius * sinPhi * cosTheta
-                );
+                    var target = projCamera.LookAt;
+                    var offset = new Vector3(
+                        _cameraRadius * sinPhi * sinTheta,
+                        _cameraRadius * cosPhi,
+                        _cameraRadius * sinPhi * cosTheta
+                    );
 
-                projCamera.Position = target + offset;
-                projCamera.LookDirection = -offset;
-                
-                Invalidate();
+                    projCamera.Position = target + offset;
+                    projCamera.LookDirection = -offset;
+                    
+                    Invalidate();
+                }
+                finally
+                {
+                    _isUpdatingCameraState = false;
+                }
             }
         }
 
         public Viewport3D()
         {
+            _camera.Changed += OnCameraChanged;
             HorizontalAlignment = HorizontalAlignment.Stretch;
             VerticalAlignment = VerticalAlignment.Stretch;
             IsTabStop = true;
@@ -327,16 +458,35 @@ namespace Microsoft.UI.Xaml.Controls
             base.ArrangeOverride(arrangeRect);
         }
 
+        private WgpuContext? GetActiveWgpuContext()
+        {
+            var activeWindows = WindowManager.ActiveWindows;
+            if (activeWindows.Count == 0) return null;
+            if (activeWindows.Count == 1) return activeWindows[0].WgpuContext;
+
+            Visual? current = this;
+            while (current != null)
+            {
+                for (int i = 0; i < activeWindows.Count; i++)
+                {
+                    if (activeWindows[i].Content == current)
+                    {
+                        return activeWindows[i].WgpuContext;
+                    }
+                }
+                current = current.Parent;
+            }
+
+            return activeWindows[0].WgpuContext;
+        }
+
         public override void OnRender(DrawingContext context)
         {
             if (Size.X <= 0 || Size.Y <= 0 || Camera == null) return;
 
             if (!_cameraInitialized) InitializeCameraState();
 
-            var activeWindows = WindowManager.ActiveWindows;
-            if (activeWindows.Count == 0) return;
-            var window = activeWindows[0];
-            var wgpuContext = window.WgpuContext;
+            var wgpuContext = GetActiveWgpuContext();
             if (wgpuContext == null) return;
 
             float dpiScale = 1.0f;
@@ -469,20 +619,67 @@ namespace Microsoft.UI.Xaml.Controls
                                     opacity *= diffuseColor.W;
                                 }
 
-                                payload.Meshes.Add(new MeshCompilationEntry
+                                if (geomModel.Material != null || geomModel.BackMaterial == null)
                                 {
-                                    Geometry = mesh,
-                                    GeometryVersion = mesh.Version,
-                                    Positions = positions,
-                                    Normals = normals,
-                                    Indices = indices,
-                                    ModelTransform = localTransform,
-                                    Color = diffuseColor,
-                                    SpecularColor = specularColor,
-                                    Shininess = shininess,
-                                    AmbientColor = ambientColor,
-                                    Opacity = opacity
-                                });
+                                    payload.Meshes.Add(new MeshCompilationEntry
+                                    {
+                                        Geometry = mesh,
+                                        GeometryVersion = mesh.Version,
+                                        Positions = positions,
+                                        Normals = normals,
+                                        Indices = indices,
+                                        ModelTransform = localTransform,
+                                        Color = diffuseColor,
+                                        SpecularColor = specularColor,
+                                        Shininess = shininess,
+                                        AmbientColor = ambientColor,
+                                        Opacity = opacity,
+                                        IsBackFace = false
+                                    });
+                                }
+
+                                if (geomModel.BackMaterial is DiffuseMaterial backDiffuse && backDiffuse.Brush != null)
+                                {
+                                    Vector4 backDiffuseColor = Vector4.One;
+                                    Vector3 backSpecularColor = backDiffuse.SpecularColor;
+                                    float backShininess = backDiffuse.Shininess;
+                                    Vector3 backAmbientColor = backDiffuse.AmbientColor;
+                                    float backOpacity = backDiffuse.Brush.Opacity;
+
+                                    Brush? activeBackBrush = backDiffuse.Brush;
+                                    if (backDiffuse.Brush is ThemeResourceBrush themeResBack)
+                                    {
+                                        activeBackBrush = ThemeManager.GetBrush(themeResBack.ResourceKey, ActualTheme, ActualThemeFamily);
+                                    }
+
+                                    if (activeBackBrush is SolidColorBrush solidBack)
+                                    {
+                                        backDiffuseColor = solidBack.Color;
+                                    }
+                                    else if (activeBackBrush is LinearGradientBrush gradientBack && gradientBack.Stops.Length > 0)
+                                    {
+                                        backDiffuseColor = gradientBack.Stops[0].Color;
+                                    }
+
+                                    backDiffuseColor *= backDiffuse.Color;
+                                    backOpacity *= backDiffuseColor.W;
+
+                                    payload.Meshes.Add(new MeshCompilationEntry
+                                    {
+                                        Geometry = mesh,
+                                        GeometryVersion = mesh.Version,
+                                        Positions = positions,
+                                        Normals = normals,
+                                        Indices = indices,
+                                        ModelTransform = localTransform,
+                                        Color = backDiffuseColor,
+                                        SpecularColor = backSpecularColor,
+                                        Shininess = backShininess,
+                                        AmbientColor = backAmbientColor,
+                                        Opacity = backOpacity,
+                                        IsBackFace = true
+                                    });
+                                }
                             }
                         }
                     }

--- a/src/ProGPU.WinUI/Controls/Viewport3D.cs
+++ b/src/ProGPU.WinUI/Controls/Viewport3D.cs
@@ -211,6 +211,7 @@ namespace Microsoft.UI.Xaml.Controls
         public RenderMode3D RenderMode { get; set; } = RenderMode3D.Solid;
 
         private GpuTexture? _colorTexture;
+        private GpuTexture? _msaaColorTexture;
         private GpuTexture? _depthTexture;
 
         private bool _isOrbiting = false;
@@ -276,6 +277,8 @@ namespace Microsoft.UI.Xaml.Controls
         {
             _colorTexture?.Dispose();
             _colorTexture = null;
+            _msaaColorTexture?.Dispose();
+            _msaaColorTexture = null;
             _depthTexture?.Dispose();
             _depthTexture = null;
         }
@@ -305,8 +308,14 @@ namespace Microsoft.UI.Xaml.Controls
             var wgpuContext = window.WgpuContext;
             if (wgpuContext == null) return;
 
-            uint width = (uint)Math.Max(1, Size.X);
-            uint height = (uint)Math.Max(1, Size.Y);
+            float dpiScale = 1.0f;
+            if (wgpuContext.Window != null && wgpuContext.Window.Size.X > 0)
+            {
+                dpiScale = (float)wgpuContext.Window.FramebufferSize.X / wgpuContext.Window.Size.X;
+            }
+
+            uint width = (uint)Math.Max(1, Size.X * dpiScale);
+            uint height = (uint)Math.Max(1, Size.Y * dpiScale);
 
             // Recreate offscreen textures if size changed
             if (_colorTexture == null || _colorTexture.Width != width || _colorTexture.Height != height)
@@ -314,8 +323,11 @@ namespace Microsoft.UI.Xaml.Controls
                 _colorTexture?.Dispose();
                 _colorTexture = new GpuTexture(wgpuContext, width, height, TextureFormat.Rgba8Unorm, TextureUsage.RenderAttachment | TextureUsage.TextureBinding, "Viewport3D Color Texture");
 
+                _msaaColorTexture?.Dispose();
+                _msaaColorTexture = new GpuTexture(wgpuContext, width, height, TextureFormat.Rgba8Unorm, TextureUsage.RenderAttachment, "Viewport3D MSAA Color Texture", sampleCount: 4u);
+
                 _depthTexture?.Dispose();
-                _depthTexture = new GpuTexture(wgpuContext, width, height, TextureFormat.Depth24PlusStencil8, TextureUsage.RenderAttachment, "Viewport3D Depth Texture");
+                _depthTexture = new GpuTexture(wgpuContext, width, height, TextureFormat.Depth24PlusStencil8, TextureUsage.RenderAttachment, "Viewport3D Depth Texture", sampleCount: 4u);
             }
 
             float aspectRatio = Size.X / Size.Y;
@@ -333,6 +345,7 @@ namespace Microsoft.UI.Xaml.Controls
                 AmbientColor = AmbientColor,
                 AmbientIntensity = AmbientIntensity,
                 ColorTexture = _colorTexture,
+                MsaaColorTexture = _msaaColorTexture,
                 DepthTexture = _depthTexture,
                 RenderMode = RenderMode
             };


### PR DESCRIPTION
# Pull Request: WPF-Compliant 3D Object Model, Advanced Split Viewports, Viewport Rotation Compass & Fluent Custom Color Picker

This PR introduces a highly refined, state-of-the-art, and feature-rich 3D viewer workspace in ProGPU, bringing it to complete parity with professional CAD and 3D modeling environments (like Blender, Rhino, AutoCAD). 

---

## 🚀 Key Improvements & Features

### 1. WPF-Compliant 3D Media Object Model
* **Standard WPF Parity**: Implemented Microsoft-compliant classes (`Geometry3D`, `DiffuseMaterial.Color`, `GeometryModel3D.BackMaterial`, `ProjectionCamera`, `OrthographicCamera`, and `PerspectiveCamera`) inside `Microsoft.UI.Xaml.Media.Media3D`.
* **LookDirection Standard**: Replaced the custom coordinate target with the standard `LookDirection` vector, including a computed `LookAt` helper property to preserve backward compatibility.
* **Control Transition & Focus**: Transitioned `Viewport3D` to inherit from `Control` for keyboard tab-stops, native focus rings, and theme invalidations.
* **WebGPU Bind Group Safety**: Addressed implicit pipeline layout validation errors by compiling separate solid and wireframe bind groups, bound dynamically before each pipeline's draw passes.
* **Z-Fighting Mitigation**: Implemented vertex-normal offsets in the WGSL vertex shader during wireframe modes to ensure perfectly crisp lines overlaying mesh surfaces without depth-buffer flickering.

### 2. Advanced 3D Orbit, Pan & Zoom Camera Controls
* **Mouse Navigation**:
  * **Orbit** (Left-Click & Drag): Rotates the camera smoothly around the look-at target.
  * **Pan** (Right-Click, Middle-Click, or Shift + Left-Click & Drag): Translates the target proportionally across the camera's local horizontal and vertical vectors.
  * **Zoom** (Scroll Wheel): Adjusts camera distance using a robust self-scaling log multiplier.
* **Keyboard Navigation**: Focus the viewport and use Arrow/WASD keys to **Orbit**, Shift + Arrow/WASD to **Pan**, and Q/E or PageUp/PageDown to **Zoom**.

### 3. Professional 2x2 Split CAD Workspace
* Upgraded the samples mesh page to feature a signature CAD 2x2 grid housing four fully interactive, synced viewports:
  1. **Top (Orthographic)**: Locked plane orthographic top view.
  2. **Front (Orthographic)**: Locked plane orthographic front view.
  3. **Right (Orthographic)**: Locked plane orthographic right view.
  4. **3D Perspective (Perspective)**: Free-orbit perspective camera.
* Orthographic views are locked to pan/zoom navigation to prevent mathematical gimbal-lock poles.

### 4. Viewport Compass (Axis Tripod) Helper Annotation
* **3D Rotation Guide**: Renders a coordinate tripod in the top-right corner of each viewport projecting standard world directions (**X-axis/Red**, **Y-axis/Green**, **Z-axis/Blue**) into camera space.
* **Zero-Allocation Stack Sort**: Bubble-sorts the axes on the stack by their camera Z-depth to ensure correct 3D overlap occlusion without causing any garbage collection pressure.
* **Glassmorphic Contrast Plate**: Semi-transparent dark circular backdrop with a dynamically themed border ensuring high contrast in both light and dark modes.

### 5. Real-Time Mesh Statistics Card (Left Sidebar)
* Displays a metadata panel listing:
  * **Name / Source**: e.g., torus.obj, spacecraft.obj, or custom loaded `.obj` filename.
  * **Vertices / Triangles**: Total vertex and face counts with standard grouping separators.
  * **Size (Bounds)**: Accurate 3D dimension bounding box width, height, and depth.
  * **GPU Memory**: Footprint of active vertex coordinates, normals, and index buffers on the GPU.
* Dynamically invalidates container-level text block layouts to update statistics in real-time when switching shapes or manually loading files.

### 6. Fluent Custom Color Picker Popover
* Replaced preset colors with exactly one Default swatch (premium modeling clay gray `#B4B4B8`) and one **🎨 Custom** button.
* Clicking **🎨 Custom** opens a floating popover containing a color selection pad, Hue rainbow slider, and Alpha slider.
* Sliding the custom color updates all 4 viewports in real-time.
* Added a keydown submit handler to load custom `.obj` paths by pressing **Enter**.

---

## 🛠️ Verification Plan
* **Build Verification**: Compiles with `0 errors` using `dotnet build src/ProGPU.slnx`.
* **Headless/Unit Tests**: Run `dotnet test src/ProGPU.slnx` to verify that all 76 unit tests pass.
* **Manual Interaction**:
  1. Start the interactive samples: `dotnet run --project src/ProGPU.Samples`
  2. Navigate to the **3D Mesh Viewer** page.
  3. Observe the statistics card, 4-way workspace, and viewport compass tripods instantly.
  4. Try mouse orbits, keyboard pans, manual Enter-key `.obj` path loads, and custom popover color modifications.
