### PR TITLE
Defer transient surface capability changes

### DIFF
--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -375,6 +375,7 @@ public unsafe class WgpuContext : IDisposable
         Queue != null;
     private uint _lastWidth = 1;
     private uint _lastHeight = 1;
+    private bool _isSurfaceConfigured;
     private bool _vsync = false;
 
     public bool VSync
@@ -706,10 +707,15 @@ public unsafe class WgpuContext : IDisposable
 
     public void ConfigureSwapChain(uint width, uint height)
     {
-        if (Surface == null || Device == null) return;
+        _ = TryConfigureSwapChain(width, height);
+    }
 
-        _lastWidth = width;
-        _lastHeight = height;
+    public bool TryConfigureSwapChain(uint width, uint height)
+    {
+        if (Surface == null || Device == null)
+        {
+            return false;
+        }
 
         // Synchronize GLFW window VSync state with WebGPU context VSync state dynamically
         if (_window != null)
@@ -721,34 +727,38 @@ public unsafe class WgpuContext : IDisposable
         var capabilities = new SurfaceCapabilities();
         Wgpu.SurfaceGetCapabilities(Surface, Adapter, &capabilities);
         
-        SwapChainFormat = TextureFormat.Bgra8Unorm; // Default fallback
-        if (capabilities.FormatCount > 0 && capabilities.Formats != null)
-        {
-            // Prefer Bgra8Unorm or Rgba8Unorm
-            SwapChainFormat = capabilities.Formats[0];
-            for (uint i = 0; i < capabilities.FormatCount; i++)
-            {
-                if (capabilities.Formats[i] == TextureFormat.Bgra8Unorm)
-                {
-                    SwapChainFormat = TextureFormat.Bgra8Unorm;
-                    break;
-                }
-            }
-        }
-
-        ReadOnlySpan<CompositeAlphaMode> alphaModes =
-            capabilities.AlphaModeCount > 0 && capabilities.AlphaModes != null
-                ? new ReadOnlySpan<CompositeAlphaMode>(
-                    capabilities.AlphaModes,
-                    checked((int)capabilities.AlphaModeCount))
-                : ReadOnlySpan<CompositeAlphaMode>.Empty;
-        var alphaMode = ChooseCompositeAlphaMode(
-            _window?.TransparentFramebuffer == true,
-            alphaModes);
-
+        ReadOnlySpan<TextureFormat> formats = capabilities.FormatCount > 0 && capabilities.Formats != null
+            ? new ReadOnlySpan<TextureFormat>(capabilities.Formats, checked((int)capabilities.FormatCount))
+            : ReadOnlySpan<TextureFormat>.Empty;
+        ReadOnlySpan<CompositeAlphaMode> alphaModes = capabilities.AlphaModeCount > 0 && capabilities.AlphaModes != null
+            ? new ReadOnlySpan<CompositeAlphaMode>(capabilities.AlphaModes, checked((int)capabilities.AlphaModeCount))
+            : ReadOnlySpan<CompositeAlphaMode>.Empty;
         ReadOnlySpan<PresentMode> presentModes = capabilities.PresentModeCount > 0 && capabilities.PresentModes != null
             ? new ReadOnlySpan<PresentMode>(capabilities.PresentModes, checked((int)capabilities.PresentModeCount))
             : ReadOnlySpan<PresentMode>.Empty;
+
+        if (!CanConfigureSurface(formats, alphaModes, presentModes))
+        {
+            ProGpuBackendDiagnostics.WriteLine(
+                $"[WebGPU Context] Deferring SwapChain configuration for {width}x{height}: " +
+                $"formats={formats.Length}, alphaModes={alphaModes.Length}, presentModes={presentModes.Length}.");
+            Wgpu.SurfaceCapabilitiesFreeMembers(capabilities);
+            return false;
+        }
+
+        TextureFormat swapChainFormat = formats[0];
+        for (int i = 0; i < formats.Length; i++)
+        {
+            if (formats[i] == TextureFormat.Bgra8Unorm)
+            {
+                swapChainFormat = TextureFormat.Bgra8Unorm;
+                break;
+            }
+        }
+
+        var alphaMode = ChooseCompositeAlphaMode(
+            _window?.TransparentFramebuffer == true,
+            alphaModes);
         PresentMode presentMode = ChoosePresentMode(_vsync, presentModes);
 
         ProGpuBackendDiagnostics.WriteLine($"[WebGPU Context] Configuring SwapChain: {width}x{height}, VSync: {_vsync}, Selected Mode: {presentMode}");
@@ -759,7 +769,7 @@ public unsafe class WgpuContext : IDisposable
         var config = new SurfaceConfiguration
         {
             Device = Device,
-            Format = SwapChainFormat,
+            Format = swapChainFormat,
             Usage = TextureUsage.RenderAttachment,
             AlphaMode = alphaMode,
             PresentMode = presentMode,
@@ -768,6 +778,19 @@ public unsafe class WgpuContext : IDisposable
         };
 
         Wgpu.SurfaceConfigure(Surface, &config);
+        SwapChainFormat = swapChainFormat;
+        _lastWidth = config.Width;
+        _lastHeight = config.Height;
+        _isSurfaceConfigured = true;
+        return true;
+    }
+
+    public static bool CanConfigureSurface(
+        ReadOnlySpan<TextureFormat> formats,
+        ReadOnlySpan<CompositeAlphaMode> alphaModes,
+        ReadOnlySpan<PresentMode> presentModes)
+    {
+        return !formats.IsEmpty && !alphaModes.IsEmpty && !presentModes.IsEmpty;
     }
 
     public static CompositeAlphaMode ChooseCompositeAlphaMode(
@@ -894,10 +917,17 @@ public unsafe class WgpuContext : IDisposable
 
     public void ReconfigureIfNeeded(uint width, uint height)
     {
+        _ = TryReconfigureIfNeeded(width, height);
+    }
+
+    public bool TryReconfigureIfNeeded(uint width, uint height)
+    {
         if (width != _lastWidth || height != _lastHeight)
         {
-            ConfigureSwapChain(width, height);
+            return TryConfigureSwapChain(width, height);
         }
+
+        return _isSurfaceConfigured;
     }
 
     [DllImport("wgpu_native", EntryPoint = "wgpuDevicePoll")]

--- a/src/ProGPU.Tests.Headless/HeadlessWindowTests.cs
+++ b/src/ProGPU.Tests.Headless/HeadlessWindowTests.cs
@@ -296,10 +296,9 @@ public class HeadlessWindowTests : IDisposable
             height,
             renderFormat: TextureFormat.Bgra8Unorm);
 
-        string fontPath = "/System/Library/Fonts/Supplemental/Arial.ttf";
-        if (!File.Exists(fontPath)) fontPath = "Arial.ttf";
-        Assert.True(File.Exists(fontPath), "Arial font file must exist for text rendering tests");
-        var font = new ProGPU.Text.TtfFont(fontPath);
+        string? fontPath = TryFindTextRenderingTestFont();
+        Assert.False(string.IsNullOrWhiteSpace(fontPath), "A renderable system font must exist for text rendering tests");
+        var font = new ProGPU.Text.TtfFont(fontPath!);
 
         window.Compositor.VectorEngine = ProGPU.Scene.Compositor.VectorRenderingEngine.Wavefront;
 
@@ -337,6 +336,31 @@ public class HeadlessWindowTests : IDisposable
         {
             window.Content = null;
         }
+    }
+
+    private static string? TryFindTextRenderingTestFont()
+    {
+        string[] candidates =
+        {
+            "/System/Library/Fonts/Supplemental/Arial.ttf",
+            "/System/Library/Fonts/Supplemental/Helvetica.ttf",
+            "/Library/Fonts/Arial.ttf",
+            "C:\\Windows\\Fonts\\arial.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "Arial.ttf"
+        };
+
+        foreach (string candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return ProGPU.Text.FontApi.GetSystemFonts()
+            .FirstOrDefault(font => File.Exists(font.FilePath))
+            ?.FilePath;
     }
 
     [System.Runtime.InteropServices.DllImport("wgpu_native", EntryPoint = "wgpuDevicePoll")]

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -53,6 +53,27 @@ public sealed class WgpuContextTests
         Assert.Equal(PresentMode.Fifo, selected);
     }
 
+    [Fact]
+    public void SurfaceConfigurationRequiresEveryCapabilityInventory()
+    {
+        Assert.True(WgpuContext.CanConfigureSurface(
+            [TextureFormat.Bgra8Unorm],
+            [CompositeAlphaMode.Opaque],
+            [PresentMode.Fifo]));
+        Assert.False(WgpuContext.CanConfigureSurface(
+            [],
+            [CompositeAlphaMode.Opaque],
+            [PresentMode.Fifo]));
+        Assert.False(WgpuContext.CanConfigureSurface(
+            [TextureFormat.Bgra8Unorm],
+            [],
+            [PresentMode.Fifo]));
+        Assert.False(WgpuContext.CanConfigureSurface(
+            [TextureFormat.Bgra8Unorm],
+            [CompositeAlphaMode.Opaque],
+            []));
+    }
+
     [Theory]
     [InlineData(15, 16u, 16u, 4u, true)]
     [InlineData(16, 16u, 16u, 4u, false)]

--- a/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
+++ b/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
@@ -40,7 +40,8 @@ public sealed class WindowsDpiAwarenessTests
         string devTools = File.ReadAllText(FindRepoFile("src", "ProGPU.Samples", "Windows", "DevToolsWindowController.cs"));
 
         Assert.Contains(".FramebufferResize += OnFramebufferResize", window, StringComparison.Ordinal);
-        Assert.Contains("wgpuContext.ReconfigureIfNeeded((uint)framebufferSize.X, (uint)framebufferSize.Y)", window, StringComparison.Ordinal);
+        Assert.Contains("!wgpuContext.TryReconfigureIfNeeded((uint)framebufferSize.X, (uint)framebufferSize.Y)", window, StringComparison.Ordinal);
+        Assert.Contains("return;", window, StringComparison.Ordinal);
         Assert.Contains("DisplayScaleResolver.ResolveWindowDisplayScale(_silkWindow, monitorScale)", window, StringComparison.Ordinal);
         Assert.Contains("(uint)framebufferSize.X", window, StringComparison.Ordinal);
         Assert.Contains("dpiScale,", window, StringComparison.Ordinal);

--- a/src/ProGPU.WinUI/Core/Window.cs
+++ b/src/ProGPU.WinUI/Core/Window.cs
@@ -442,7 +442,10 @@ public class Window
 
         phaseStart = System.Diagnostics.Stopwatch.GetTimestamp();
         var framebufferSize = GetCurrentFramebufferSize();
-        wgpuContext.ReconfigureIfNeeded((uint)framebufferSize.X, (uint)framebufferSize.Y);
+        if (!wgpuContext.TryReconfigureIfNeeded((uint)framebufferSize.X, (uint)framebufferSize.Y))
+        {
+            return;
+        }
         float dpiScale = ResolveWindowDpiScale(framebufferSize);
         Vector2 logicalSize = ResolveLogicalClientSize(framebufferSize, dpiScale);
         double frameSetupTimeMs = System.Diagnostics.Stopwatch.GetElapsedTime(phaseStart).TotalMilliseconds;


### PR DESCRIPTION
Prevents native `wgpuSurfaceConfigure` aborts during maximize/resize transitions when a platform temporarily reports an empty format, alpha-mode, or present-mode inventory. Existing void APIs remain compatible; new try APIs let WinUI and LibreWPF skip the invalid frame and retry. Includes focused capability-inventory coverage.

Addresses the ProGPU portion of wieslawsoltes/wpf#20.