### PR TITLE
Fix browser benchmarks and designer input

### DIFF
--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -376,11 +376,12 @@ public unsafe class WgpuContext : IDisposable
     public bool IsDisposed => _isDisposed;
     public bool IsInitialized =>
         !_isDisposed &&
-        Wgpu != null &&
-        Instance != null &&
-        Adapter != null &&
+        Api != null &&
         Device != null &&
-        Queue != null;
+        Queue != null &&
+        (BackendKind == WgpuBackendKind.BrowserWebGpu
+            ? Surface != null
+            : Wgpu != null && Instance != null && Adapter != null);
     private uint _lastWidth = 1;
     private uint _lastHeight = 1;
     private bool _isSurfaceConfigured;

--- a/src/ProGPU.Samples/Pages/ChartShowcasePage.cs
+++ b/src/ProGPU.Samples/Pages/ChartShowcasePage.cs
@@ -2053,7 +2053,9 @@ namespace ProGPU.Samples
         {
             if (_benchmarkMetricsTimer != null) return;
 
-            var process = System.Diagnostics.Process.GetCurrentProcess();
+            System.Diagnostics.Process? process = OperatingSystem.IsBrowser()
+                ? null
+                : System.Diagnostics.Process.GetCurrentProcess();
             _benchmarkMetricsTimer = new System.Timers.Timer(100.0); // Poll metrics every 100ms
             _benchmarkMetricsTimer.Elapsed += (s, e) =>
             {
@@ -2063,8 +2065,16 @@ namespace ProGPU.Samples
                     _benchmarkElapsedMs += 100.0;
 
                     // Private memory in MB
-                    process.Refresh();
-                    double memoryMb = process.PrivateMemorySize64 / (1024.0 * 1024.0);
+                    double memoryMb;
+                    if (process != null)
+                    {
+                        process.Refresh();
+                        memoryMb = process.PrivateMemorySize64 / (1024.0 * 1024.0);
+                    }
+                    else
+                    {
+                        memoryMb = GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0);
+                    }
 
                     // Compositor metrics
                     double frameTimeMs = 1.0;

--- a/src/ProGPU.Samples/Pages/GdiShowcasePage.cs
+++ b/src/ProGPU.Samples/Pages/GdiShowcasePage.cs
@@ -107,7 +107,7 @@ public class GdiShowcaseVisual : FrameworkElement
 
             // Draw text string using Font
             using (var textBrush = new System.Drawing.SolidBrush(System.Drawing.Color.White))
-            using (var font = new System.Drawing.Font("Arial", 13f))
+            using (var font = new System.Drawing.Font(AppState._font!, 13f))
             {
                 g.DrawString("GPU-Accelerated GDI+ Shim", font, textBrush, new System.Drawing.PointF(-92, -155));
             }

--- a/src/ProGPU.Samples/Pages/LolsPage.cs
+++ b/src/ProGPU.Samples/Pages/LolsPage.cs
@@ -27,6 +27,7 @@ public static class LolsPage
     private static bool _isRunning = false;
     private static readonly System.Diagnostics.Stopwatch _stopwatch = new();
     private static readonly System.Timers.Timer _timer = new(500);
+    private static readonly System.Timers.Timer _browserPumpTimer = new(16);
 
     private static RichTextBlock? _scoreLabel;
     private static RichTextBlock? _progressLabel;
@@ -46,6 +47,9 @@ public static class LolsPage
         // Setup timer once
         _timer.Elapsed -= OnTimer;
         _timer.Elapsed += OnTimer;
+        _browserPumpTimer.AutoReset = true;
+        _browserPumpTimer.Elapsed -= OnBrowserPumpTimer;
+        _browserPumpTimer.Elapsed += OnBrowserPumpTimer;
 
         var mainGrid = new Microsoft.UI.Xaml.Controls.Grid { Margin = new Thickness(12) };
         mainGrid.RowDefinitions.Add(new GridLength(50, GridUnitType.Absolute));   // Header description
@@ -213,7 +217,14 @@ public static class LolsPage
         if (_startStopRun != null) _startStopRun.Text = "Stop Benchmark";
         if (_startStopBtn != null) _startStopBtn.Invalidate();
 
-        _ = Task.Factory.StartNew(RunBenchmarkLoop, TaskCreationOptions.LongRunning);
+        if (OperatingSystem.IsBrowser())
+        {
+            _browserPumpTimer.Start();
+        }
+        else
+        {
+            _ = Task.Factory.StartNew(RunBenchmarkLoop, TaskCreationOptions.LongRunning);
+        }
     }
 
     public static void Stop()
@@ -222,6 +233,7 @@ public static class LolsPage
         _isRunning = false;
         Interlocked.Exchange(ref _pendingElementCount, 0);
         _timer.Stop();
+        _browserPumpTimer.Stop();
         _stopwatch.Stop();
 
         if (_startStopRun != null) _startStopRun.Text = "Start Benchmark";
@@ -307,6 +319,36 @@ public static class LolsPage
             }
 
             SchedulePendingDrain();
+        }
+    }
+
+    private static void OnBrowserPumpTimer(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (!_isRunning)
+        {
+            return;
+        }
+
+        int maxPendingElements = AppState._wgpuContext?.VSync == true
+            ? VSyncPendingElements
+            : UncappedPendingElements;
+
+        while (true)
+        {
+            int pending = Volatile.Read(ref _pendingElementCount);
+            if (pending >= maxPendingElements)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(
+                    ref _pendingElementCount,
+                    maxPendingElements,
+                    pending) == pending)
+            {
+                SchedulePendingDrain();
+                return;
+            }
         }
     }
 

--- a/src/ProGPU.Tests.Headless/DesignerCanvasTests.cs
+++ b/src/ProGPU.Tests.Headless/DesignerCanvasTests.cs
@@ -177,6 +177,56 @@ public class DesignerCanvasTests
     }
 
     [Fact]
+    public void Test_DesignerCanvas_DesignMode_RoutesSelectionAndToolDropThroughInputSystem()
+    {
+        var canvas = new DesignerCanvas
+        {
+            Width = 800f,
+            Height = 600f,
+            AllowDrop = true
+        };
+        var existing = new Button { Width = 120f, Height = 36f };
+        Canvas.SetLeft(existing, 100f);
+        Canvas.SetTop(existing, 80f);
+        canvas.AddChild(existing);
+        canvas.Measure(new Vector2(800f, 600f));
+        canvas.Arrange(new ProGPU.Scene.Rect(0f, 0f, 800f, 600f));
+
+        InputSystem.Current = InputSystem.CreateExternalState(canvas);
+        try
+        {
+            var selectPoint = new Vector2(120f, 96f);
+            Assert.Same(canvas, InputSystem.HitTest(selectPoint));
+
+            InputSystem.InjectMouseMove(selectPoint);
+            InputSystem.InjectMouseDown(Silk.NET.Input.MouseButton.Left);
+            InputSystem.InjectMouseUp(Silk.NET.Input.MouseButton.Left);
+
+            Assert.Same(existing, canvas.SelectedElement);
+
+            var data = new DataPackage();
+            data.SetData(StandardDataFormats.Tool, "TextBox");
+            DragDropManager.StartDrag(existing, data, DragDropEffects.Copy);
+
+            var dropPoint = new Vector2(253f, 204f);
+            InputSystem.InjectMouseMove(dropPoint);
+            InputSystem.InjectMouseUp(Silk.NET.Input.MouseButton.Left);
+
+            Assert.Equal(2, canvas.DesignSurface.Children.Count);
+            var dropped = Assert.IsType<TextBox>(canvas.DesignSurface.Children[1]);
+            Assert.Equal(250f, Canvas.GetLeft(dropped));
+            Assert.Equal(200f, Canvas.GetTop(dropped));
+            Assert.Same(dropped, canvas.SelectedElement);
+        }
+        finally
+        {
+            DragDropManager.CancelDrag();
+            InputSystem.SetFocus(null);
+            InputSystem.Current = InputSystem.CreateExternalState();
+        }
+    }
+
+    [Fact]
     public void Test_DesignerHost_InteractionMode_RoutesTextAndButtonInput()
     {
         var font = PopupService.DefaultFont;

--- a/src/ProGPU.Tests/BrowserWebGpuApiTests.cs
+++ b/src/ProGPU.Tests/BrowserWebGpuApiTests.cs
@@ -1,4 +1,5 @@
 using ProGPU.Browser;
+using ProGPU.Backend;
 using Silk.NET.WebGPU;
 using Xunit;
 using WgpuBuffer = Silk.NET.WebGPU.Buffer;
@@ -7,6 +8,23 @@ namespace ProGPU.Tests;
 
 public unsafe sealed class BrowserWebGpuApiTests
 {
+    [Fact]
+    public void ExternalBrowserContextReportsInitializedForContextBoundResources()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        using var context = new WgpuContext();
+
+        context.InitializeExternal(
+            api,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm);
+
+        Assert.True(context.IsInitialized);
+        Assert.Same(context, WgpuContext.Current);
+    }
+
     [Fact]
     public void ResourceCopyUploadAndSubmitUseOneTypedPacket()
     {

--- a/src/ProGPU.WinUI.Designer/DesignerCanvas.cs
+++ b/src/ProGPU.WinUI.Designer/DesignerCanvas.cs
@@ -32,9 +32,10 @@ public static class StandardDataFormats
     public const string Tool = "Tool";
 }
 
-public class DesignerCanvas : Panel
+public class DesignerCanvas : Panel, IHitTestBackgroundProvider
 {
     public Brush? Background { get; set; }
+    public bool HasHitTestBackground => Background != null;
     public Canvas DesignSurface { get; }
     public Canvas AdornerSurface { get; }
 

--- a/src/ProGPU.WinUI/Input/IHitTestBackgroundProvider.cs
+++ b/src/ProGPU.WinUI/Input/IHitTestBackgroundProvider.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.UI.Xaml.Input;
+
+/// <summary>
+/// Identifies custom containers that paint a background and should remain
+/// pointer hit-test targets when none of their children is hit-testable.
+/// </summary>
+public interface IHitTestBackgroundProvider
+{
+    bool HasHitTestBackground { get; }
+}

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -319,6 +319,7 @@ public static class InputSystem
     {
         return fe switch
         {
+            IHitTestBackgroundProvider provider => provider.HasHitTestBackground,
             Control control => control.Background != null,
             Border border => border.Background != null,
             ContentPresenter presenter => presenter.Background != null,

--- a/src/System.Drawing.Common/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/System/Drawing/Font.cs
@@ -66,6 +66,25 @@ public class Font : IDisposable
     {
     }
 
+    /// <summary>
+    /// Creates a GDI-compatible font from an already loaded ProGPU typeface.
+    /// This avoids a second platform font lookup on runtimes such as WebAssembly
+    /// that do not expose operating-system font discovery.
+    /// </summary>
+    public Font(TtfFont typeface, float emSize, FontStyle style = FontStyle.Regular, GraphicsUnit unit = GraphicsUnit.Point)
+    {
+        ArgumentNullException.ThrowIfNull(typeface);
+
+        FontFamily = new FontFamily(
+            string.IsNullOrWhiteSpace(typeface.FamilyName) ? "ProGPU Font" : typeface.FamilyName);
+        Size = emSize;
+        Style = style;
+        Unit = unit;
+        GdiCharSet = 1;
+        GdiVerticalFont = false;
+        TtfFont = typeface;
+    }
+
     public Font(FontFamily family, float emSize, FontStyle style = FontStyle.Regular, GraphicsUnit unit = GraphicsUnit.Point)
         : this(family, emSize, style, unit, 1)
     {


### PR DESCRIPTION
## What changed

- make external browser WebGPU contexts report initialized so context-bound GDI textures reuse the active browser device
- make the GDI showcase reuse the already loaded ProGPU typeface instead of performing browser system-font discovery
- replace unsupported process memory telemetry with managed heap telemetry in the browser chart benchmark
- drive the LOL/s producer with a browser-safe timer pump while retaining the desktop long-running stress worker
- restore Visual Designer canvas hit testing through a typed background-provider contract
- add regression coverage for external browser context initialization and real designer selection/drop routing

## Root causes

The browser chart benchmark called `Process.GetCurrentProcess()`, the GDI showcase performed unavailable system-font discovery and treated an externally initialized browser context as uninitialized, and LOL/s used a `LongRunning` worker unsuitable for the browser runtime. The designer canvas paints a custom panel background, but the reflection-free hit tester only recognized backgrounds on built-in control types, so the design surface could not become the routed input target.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release` — 1,805 passed
- `dotnet test src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj -c Release` — 185 passed
- Release browser AOT publish with trimming/SIMD/native relinking succeeded
- served the AOT artifact and verified in Chromium:
  - GDI Shim Showcase renders
  - Ultimate Benchmark generates 1,000,000 points and updates telemetry
  - LOL/s runs with live elements and score updates
  - Visual Designer selects existing controls and drops/selects a toolbox control
  - no browser console errors