### PR TITLE
Add WinUI-aligned touch, gestures, mobile input, and responsive layouts

### DIFF
--- a/docs/TOUCH_GESTURES_RESPONSIVE_PLAN.md
+++ b/docs/TOUCH_GESTURES_RESPONSIVE_PLAN.md
@@ -1,0 +1,123 @@
+# Touch, Gestures, Mobile Input, and Responsive UI Plan
+
+## Goal
+
+Provide one WinUI-aligned input and adaptive-layout surface for ProGPU applications on
+desktop, embedded hosts, and browser/mobile. Platform hosts translate native events
+into neutral pointer and text-edit records; the retained WinUI layer owns hit testing,
+routing, capture, recognition, focus, control behavior, and invalidation.
+
+## Compatibility target
+
+The public surface follows the current WinUI concepts and names where ProGPU already
+owns the corresponding namespace:
+
+- unified `Pointer`, `PointerPoint`, `PointerPointProperties`, stable `PointerId`, and
+  `PointerDeviceType` data on every routed pointer event;
+- per-pointer capture plus `PointerCanceled` and `PointerCaptureLost`;
+- `Tapped`, `DoubleTapped`, `RightTapped`, and `Holding` routed gestures;
+- `ManipulationMode` and the Starting/Started/Delta/InertiaStarting/Completed event
+  sequence, with translation, scale, rotation, expansion, velocity, and cumulative data;
+- WinUI `ScrollViewer` touch panning, pinch zoom, view-changing/view-changed events,
+  inertia, and `ChangeView`;
+- `VisualStateManager`, `VisualStateGroup`, setters, state triggers, and
+  `AdaptiveTrigger` breakpoints in effective pixels;
+- adaptive `NavigationView` pane modes and the WinUI 640/1008 effective-pixel defaults;
+- `InputScope`/enter-key/autocorrection metadata for editable controls and a neutral
+  text-edit/composition channel for software keyboards and IMEs.
+
+Existing mouse injection, `PointerRoutedEventArgs.Position`, control overrides, and
+single-pointer `InputSystem.CapturePointer` calls remain source compatible.
+
+## Architecture
+
+1. **Platform records.** Hosts emit pointer ID, device kind, primary/contact state,
+   buttons, pressure, contact rectangle, wheel data, modifiers, and a monotonic
+   timestamp. Motion can be coalesced per pointer; down/up/cancel remain ordered.
+2. **Window state.** Each `WindowInputState` owns active contacts, captures, hover,
+   tap history, hold timers, and manipulation sessions. No interaction state is shared
+   between windows.
+3. **Routed input.** Hit testing occurs once at contact start. Pointer capture is keyed
+   by ID. Event coordinates are transformed for each route target without changing the
+   immutable screen-space point.
+4. **Recognition.** Tap/hold thresholds and manipulation deltas are evaluated in
+   logical pixels. Multi-contact scale/rotation use centroid and contact-vector changes.
+   Gesture recognition remains CPU-side `O(P)` per sample for `P` active contacts (in
+   normal UI use, `P` is a small bounded device count) and uses `O(P)` window storage.
+5. **Controls.** Controls opt into manipulation through `ManipulationMode`. ScrollViewer
+   owns pan/zoom policy and clamps offsets transactionally; other controls continue to
+   consume ordinary routed pointer events.
+6. **Browser text.** A DOM textarea is focused only when ProGPU focus selects an editable
+   client during a user activation. `input`, `beforeinput`, and composition events are
+   translated into explicit insert/delete/line-break/composition operations. Input
+   scope maps to `inputmode`, enter-key hints, capitalization, spellcheck, and password
+   behavior.
+7. **Responsive metrics.** The browser canvas follows the visual viewport while the
+   on-screen keyboard is visible and exposes safe-area/keyboard occlusion metrics.
+   Adaptive triggers are reevaluated before layout when effective window metrics change.
+
+## Delivery stages
+
+- [x] Add pointer, gesture, manipulation, text-edit, viewport, and responsive public APIs.
+- [x] Replace the single mouse/capture state with compatible per-pointer routing.
+- [x] Add browser Pointer Events metadata, cancellation, coalescing, IME/software-keyboard
+      input, VisualViewport/VirtualKeyboard geometry, and safe-area CSS behavior.
+- [x] Adapt Avalonia and native desktop seams to preserve pointer device identity where
+      their host APIs expose it.
+- [x] Add touch pan/pinch/inertia to ScrollViewer and adaptive behavior to NavigationView.
+- [x] Add VisualStateManager and AdaptiveTrigger evaluation and use them in Samples.
+- [x] Make the Samples shell and representative fixed two-column pages usable at narrow
+      portrait widths with minimal view churn; add an interactive input/gesture page.
+- [x] Add focused API, routing, multi-touch, capture/cancel, recognition, mobile-edit,
+      responsive-state, NavigationView, and ScrollViewer tests.
+- [x] Build desktop and browser heads, run Release unit/headless suites, and record the
+      exact totals and any environment-specific browser verification limitations.
+
+## Primary sources and adopted decisions
+
+- [WinUI pointer input](https://learn.microsoft.com/en-us/windows/apps/develop/input/handle-pointer-input):
+  adopt device-neutral pointers, one ID per contact, per-pointer capture, cancellation,
+  and extended point properties.
+- [WinUI touch interactions](https://learn.microsoft.com/en-us/windows/apps/develop/input/touch-interactions):
+  adopt direct manipulation, immediate feedback, standard tap/hold/pan/pinch conventions,
+  touch targets, and portrait reflow guidance.
+- [WinUI `UIElement.Tapped`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.tapped):
+  preserve routed gesture ordering and the tap/hold exclusivity model.
+- [WinUI `GestureRecognizer`](https://learn.microsoft.com/en-us/uwp/api/windows.ui.input.gesturerecognizer):
+  adapt the settings and manipulation event model to ProGPU's retained visual tree.
+- [WinUI responsive layouts](https://learn.microsoft.com/en-us/windows/apps/develop/ui/layouts-with-xaml):
+  adopt VisualStateManager plus effective-pixel adaptive triggers.
+- [WinUI NavigationView](https://learn.microsoft.com/en-us/windows/apps/develop/ui/controls/navigationview):
+  adopt `Auto`, `Left`, `LeftCompact`, `LeftMinimal`, and the 640/1008 defaults.
+- [W3C Pointer Events 3](https://www.w3.org/TR/pointerevents3/): adopt Pointer Events,
+  pointer capture/cancel semantics, primary/contact metadata, coalesced motion, and
+  explicit `touch-action` ownership at the canvas.
+- [W3C UI Events](https://www.w3.org/TR/uievents/) and
+  [Input Events Level 2](https://www.w3.org/TR/input-events-2/): keep physical key events
+  distinct from text edits and represent IME composition as an explicit session.
+- [W3C VirtualKeyboard API](https://w3c.github.io/editing/docs/virtualkeyboard/): use
+  keyboard geometry when available while retaining VisualViewport fallback behavior.
+
+## Validation contract
+
+- Event routing and capture are deterministic for simultaneous pointers and cancellation.
+- Mouse behavior and existing controls remain source-compatible.
+- Touch scrolling does not activate a child button after the pan threshold is crossed.
+- A manipulation invalidates only the affected control/visual; no root-per-frame
+  invalidation is introduced.
+- Browser text entry covers insertion, surrogate pairs, backward/forward deletion,
+  paste, line break, and composition without relying on mobile `KeyDown`/`KeyUp`.
+- Layout breakpoints use logical/effective pixels, not framebuffer pixels.
+- Browser rendering continues to size its swapchain in physical pixels at the active DPI.
+
+## Completed verification
+
+- Release desktop, Avalonia host, and browser builds completed with zero compile errors.
+- The default trimmed WebAssembly AOT publish completed for all 68 compiled assemblies;
+  the existing dependency-property and third-party trim-analysis warnings remain.
+- `ProGPU.Tests` Release: 2,005 passed, 0 failed.
+- `ProGPU.Tests.Headless` Release: 185 passed, 0 failed.
+- A Chromium smoke run at 390 x 844 effective pixels verified the stacked Samples layout,
+  scrollable navigation/content, focused DOM-to-ProGPU text entry with Unicode, and a
+  touch Pointer Events sequence carrying identity, pressure, and contact dimensions with
+  no browser console errors.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -10,6 +10,34 @@ DOM pointer, wheel, keyboard, text/IME, focus, cursor, clipboard, resize, and fi
 
 `MainThread`, `Worker`, and `IsolatedWorker` execution modes are implemented. `Auto` selects an isolated worker when cross-origin isolation and shared memory are available, an ordinary OffscreenCanvas worker otherwise, and the main thread when canvas transfer is unavailable. All GPU packets produced during one managed frame are coalesced into one worker task so the current surface texture remains valid across multiple internal queue submissions. Device loss reports diagnostics and reloads the retained application to reconstruct device-owned resources.
 
+## Touch, gestures, and mobile text
+
+The browser lane uses Pointer Events as its native input source. Every record preserves
+the browser pointer ID, mouse/touch/pen device kind, primary/contact state, buttons,
+pressure, contact rectangle, modifiers, and monotonic timestamp. Pointer down, up, and
+cancel enter managed code synchronously; coalesced moves are drained in bounded batches.
+The WinUI layer then owns hit testing, per-pointer capture, routed pointer events,
+tap/double-tap/right-tap/hold recognition, and multi-contact manipulations.
+
+Set `ManipulationMode` on a `FrameworkElement` to opt into direct manipulation. The
+standard `ScrollViewer` opts in automatically for touch panning and inertia; enable
+`ZoomMode` when pinch zoom is desired. `PointerCanceled` and `PointerCaptureLost` must
+be handled wherever a control keeps contact-specific state.
+
+`TextBox` and `PasswordBox` expose `InputScope`, `EnterKeyHint`, capitalization, and
+spell-check options. When one of these controls receives focus, the browser host focuses
+its DOM text-input seam during the initiating pointer event and maps these properties to
+`inputmode`, `enterkeyhint`, `autocapitalize`, and `spellcheck`. Text insertion,
+surrogate pairs, deletion, paste, line breaks, and IME composition use DOM input and
+composition events; they do not depend on a mobile browser synthesizing physical key
+events. The sink is blurred when focus leaves an editable control.
+
+The canvas follows `VisualViewport` while an on-screen keyboard is visible and combines
+that with CSS safe-area insets. Application layout still uses logical/effective pixels.
+Use `VisualStateManager` and `AdaptiveTrigger` for responsive changes, and use
+`NavigationViewPaneDisplayMode.Auto` for the standard WinUI minimal/compact/expanded
+breakpoints at 640 and 1008 effective pixels.
+
 ## Samples
 
 - `ProGPU.Samples` is the shared gallery library and has no executable entry point.

--- a/docs/presentations/progpu-browser-rendering-level-400/source/build.mjs
+++ b/docs/presentations/progpu-browser-rendering-level-400/source/build.mjs
@@ -237,7 +237,7 @@ setNotes(17, 'This coarse seam is intentionally separate from the packet protoco
 
 // 18 — input
 setJourney(18, 'DOM input is batched into the neutral WinUI input seam', [
-  '1  Queue DOM records\nListeners append fixed 32-byte events. Pointer moves replace the previous move; adjacent wheel deltas accumulate; queue caps at 4096.',
+  '1  Queue DOM records\nListeners append fixed 64-byte events. Pointer moves coalesce per pointer while identity, device, pressure, contact, and time metadata remain intact; queue caps at 4096.',
   '2  Drain per frame\nBrowserInputDispatcher stackallocs 256 records and drains at most four batches before injecting InputSystem events.',
   '3  Install platform services\nBrowserWindowHost wires cursor, focus/text, clipboard, storage/file pickers, canvas metrics, and the bundled Inter UI fallback.',
 ], ['DOM', 'FRAME BATCH', 'HOST SERVICES']);

--- a/docs/presentations/progpu-browser-rendering-level-400/source/source-notes.txt
+++ b/docs/presentations/progpu-browser-rendering-level-400/source/source-notes.txt
@@ -20,7 +20,7 @@ src/ProGPU.Browser/BrowserWebGpuApi.cs: Silk pointer values are opaque generatio
 
 src/ProGPU.Browser/BrowserAssets/progpu-browser.js: feature-based transport selection; direct view of current WASM memory on main thread; packet copy and one microtask-coalesced dispatch-batch to worker; navigator.gpu adapter/device negotiation; createShaderModule({code}); requireResource stale-handle guard; current surface texture acquisition; async map/copy/write; serialized worker message chain; device-loss reload.
 
-src/ProGPU.Browser/BrowserWindowHost.cs and BrowserInputDispatcher.cs: requestAnimationFrame loop; physical framebuffer metrics and DPR; dispatcher/input/layout/render call order; 32-byte input records, 256 records per stack batch, max four batches/frame; pointer move and wheel coalescing in JavaScript.
+src/ProGPU.Browser/BrowserWindowHost.cs and BrowserInputDispatcher.cs: requestAnimationFrame loop; physical framebuffer metrics and DPR; dispatcher/input/layout/render call order; 64-byte input records with pointer identity/device/contact metadata, 256 records per stack batch, max four batches/frame; per-pointer move coalescing in JavaScript.
 
 src/ProGPU.WinUI/Core/Window.cs: UIThread, callbacks, swapchain setup, animation, layout, surface acquire, compositor, present, and release sequencing; external host uses identical RenderFrameCore.
 

--- a/src/ProGPU.Avalonia/ProGpuHostControl.cs
+++ b/src/ProGPU.Avalonia/ProGpuHostControl.cs
@@ -29,6 +29,7 @@ using WinuiCompositor = ProGPU.Scene.Compositor;
 using AvaloniaDrawingContext = Avalonia.Media.DrawingContext;
 using GpuBuffer = Silk.NET.WebGPU.Buffer;
 using AvaloniaVector = Avalonia.Vector;
+using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 
 namespace ProGPU.Avalonia;
 
@@ -1136,8 +1137,9 @@ public class ProGpuHostControl : Control
 
     protected override void OnPointerMoved(PointerEventArgs e)
     {
-        SyncInputState(e.GetPosition(this));
-        InputSystem.InjectMouseMove(new Vector2((float)e.GetPosition(this).X, (float)e.GetPosition(this).Y));
+        var position = e.GetPosition(this);
+        SyncInputState(position);
+        InputSystem.InjectPointer(CreatePointerInput(e, PointerInputKind.Moved));
         
         QueueRenderUpdate();
         e.Handled = true;
@@ -1147,13 +1149,7 @@ public class ProGpuHostControl : Control
     {
         SyncInputState(e.GetPosition(this));
         
-        var props = e.GetCurrentPoint(this).Properties;
-        var button = SilkInput.MouseButton.Left;
-        if (props.IsLeftButtonPressed) button = SilkInput.MouseButton.Left;
-        else if (props.IsRightButtonPressed) button = SilkInput.MouseButton.Right;
-        else if (props.IsMiddleButtonPressed) button = SilkInput.MouseButton.Middle;
-        
-        InputSystem.InjectMouseDown(button);
+        InputSystem.InjectPointer(CreatePointerInput(e, PointerInputKind.Pressed));
         Focus();
 
         QueueRenderUpdate();
@@ -1164,14 +1160,7 @@ public class ProGpuHostControl : Control
     {
         SyncInputState(e.GetPosition(this));
         
-        var props = e.GetCurrentPoint(this).Properties;
-        var button = SilkInput.MouseButton.Left;
-        var updateKind = props.PointerUpdateKind;
-        if (updateKind == PointerUpdateKind.LeftButtonReleased) button = SilkInput.MouseButton.Left;
-        else if (updateKind == PointerUpdateKind.RightButtonReleased) button = SilkInput.MouseButton.Right;
-        else if (updateKind == PointerUpdateKind.MiddleButtonReleased) button = SilkInput.MouseButton.Middle;
-        
-        InputSystem.InjectMouseUp(button);
+        InputSystem.InjectPointer(CreatePointerInput(e, PointerInputKind.Released));
         
         QueueRenderUpdate();
         e.Handled = true;
@@ -1198,6 +1187,63 @@ public class ProGpuHostControl : Control
         InputSystem.InjectMouseMove(new Vector2(-1f, -1f));
         QueueRenderUpdate();
         base.OnPointerExited(e);
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        if (_winuiInputState != null)
+        {
+            InputSystem.Current = _winuiInputState;
+            var deviceType = e.Pointer.Type switch
+            {
+                PointerType.Touch => PointerDeviceType.Touch,
+                PointerType.Pen => PointerDeviceType.Pen,
+                _ => PointerDeviceType.Mouse
+            };
+            InputSystem.InjectPointer(new PointerInputEvent(
+                PointerInputKind.Canceled,
+                unchecked((uint)Math.Max(1, e.Pointer.Id)),
+                deviceType,
+                _winuiInputState.LastMousePos,
+                (ulong)(Stopwatch.GetTimestamp() * 1_000_000L / Stopwatch.Frequency),
+                IsPrimary: true));
+        }
+        QueueRenderUpdate();
+        base.OnPointerCaptureLost(e);
+    }
+
+    private PointerInputEvent CreatePointerInput(PointerEventArgs e, PointerInputKind kind)
+    {
+        var point = e.GetCurrentPoint(this);
+        var position = point.Position;
+        var properties = point.Properties;
+        var deviceType = e.Pointer.Type switch
+        {
+            PointerType.Touch => PointerDeviceType.Touch,
+            PointerType.Pen => PointerDeviceType.Pen,
+            _ => PointerDeviceType.Mouse
+        };
+        var modifiers = VirtualKeyModifiers.None;
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift)) modifiers |= VirtualKeyModifiers.Shift;
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control)) modifiers |= VirtualKeyModifiers.Control;
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Alt)) modifiers |= VirtualKeyModifiers.Menu;
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Meta)) modifiers |= VirtualKeyModifiers.Windows;
+        var inContact = kind == PointerInputKind.Pressed ||
+            (kind == PointerInputKind.Moved &&
+             (deviceType != PointerDeviceType.Mouse || properties.IsLeftButtonPressed || properties.IsMiddleButtonPressed || properties.IsRightButtonPressed));
+        return new PointerInputEvent(
+            kind,
+            unchecked((uint)Math.Max(1, e.Pointer.Id)),
+            deviceType,
+            new Vector2((float)position.X, (float)position.Y),
+            e.Timestamp,
+            IsPrimary: true,
+            IsInContact: inContact,
+            IsLeftButtonPressed: properties.IsLeftButtonPressed || (kind == PointerInputKind.Pressed && deviceType != PointerDeviceType.Mouse),
+            IsMiddleButtonPressed: properties.IsMiddleButtonPressed,
+            IsRightButtonPressed: properties.IsRightButtonPressed,
+            Pressure: deviceType == PointerDeviceType.Mouse ? (properties.IsLeftButtonPressed ? 0.5f : 0f) : 1f,
+            Modifiers: modifiers);
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ProGPU.Avalonia/ProGpuHostControl.cs
+++ b/src/ProGPU.Avalonia/ProGpuHostControl.cs
@@ -1236,7 +1236,7 @@ public class ProGpuHostControl : Control
             unchecked((uint)Math.Max(1, e.Pointer.Id)),
             deviceType,
             new Vector2((float)position.X, (float)position.Y),
-            e.Timestamp,
+            (ulong)e.Timestamp * 1_000UL,
             IsPrimary: true,
             IsInContact: inContact,
             IsLeftButtonPressed: properties.IsLeftButtonPressed || (kind == PointerInputKind.Pressed && deviceType != PointerDeviceType.Mouse),

--- a/src/ProGPU.Avalonia/ProGpuHostControl.cs
+++ b/src/ProGPU.Avalonia/ProGpuHostControl.cs
@@ -991,6 +991,7 @@ public class ProGpuHostControl : Control
 
         // 1. Force layout and animations updates recursively on WinUI Controls
         WinuiRoot.UpdateAnimations(0.016f); // Pass baseline delta time
+        VisualStateManager.UpdateAdaptiveStates(WinuiRoot, hostFrame.LogicalSize);
         WinuiRoot.Measure(hostFrame.LogicalSize);
         WinuiRoot.Arrange(new WinuiRect(0, 0, hostFrame.LogicalWidth, hostFrame.LogicalHeight));
 

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -424,6 +424,13 @@ function dispatchPointerEvent(kind, event, point) {
   queuePointerEvent(kind, event, point);
 }
 
+function discardQueuedPointerMoves(pointerId) {
+  for (let index = state.inputEvents.length - 1; index >= 0; index--) {
+    const queued = state.inputEvents[index];
+    if (queued.kind === 1 && queued.data === pointerId) state.inputEvents.splice(index, 1);
+  }
+}
+
 function installBrowserInput() {
   if (state.inputInstalled) return;
   state.inputInstalled = true;
@@ -456,12 +463,14 @@ function installBrowserInput() {
   });
   state.canvas.addEventListener('pointerup', event => {
     const point = pointerPosition(event);
+    if (state.dispatchImmediatePointer) discardQueuedPointerMoves(event.pointerId);
     dispatchPointerEvent(3, event, point);
     try { state.canvas.releasePointerCapture(event.pointerId); } catch { }
     event.preventDefault();
   });
   state.canvas.addEventListener('pointercancel', event => {
     const point = pointerPosition(event);
+    if (state.dispatchImmediatePointer) discardQueuedPointerMoves(event.pointerId);
     dispatchPointerEvent(9, event, point);
     try { state.canvas.releasePointerCapture(event.pointerId); } catch { }
     event.preventDefault();
@@ -580,8 +589,11 @@ function configureTextInput(inputMode, enterKeyHint, autoCapitalize, spellCheck,
   const viewportTop = viewport?.offsetTop || 0;
   const viewportWidth = viewport?.width || globalThis.innerWidth;
   const viewportHeight = viewport?.height || globalThis.innerHeight;
-  textSink.style.left = `${Math.max(viewportLeft, Math.min(viewportLeft + viewportWidth - 2, x))}px`;
-  textSink.style.top = `${Math.max(viewportTop, Math.min(viewportTop + viewportHeight - 2, y + height))}px`;
+  const canvasBounds = state.canvas?.getBoundingClientRect();
+  const sinkX = (canvasBounds?.left || 0) + x;
+  const sinkY = (canvasBounds?.top || 0) + y + height;
+  textSink.style.left = `${Math.max(viewportLeft, Math.min(viewportLeft + viewportWidth - 2, sinkX))}px`;
+  textSink.style.top = `${Math.max(viewportTop, Math.min(viewportTop + viewportHeight - 2, sinkY))}px`;
   textSink.style.width = `${Math.max(2, Math.min(width || 2, viewportWidth))}px`;
   textSink.style.height = '2px';
   textSink.value = '';

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -477,7 +477,9 @@ function installBrowserInput() {
   }, { passive: false });
 
   globalThis.addEventListener('keydown', event => {
-    if (document.activeElement === textSink && (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter')) return;
+    const textSinkOwnsPaste = document.activeElement === textSink && event.code === 'KeyV' && (event.ctrlKey || event.metaKey);
+    if (document.activeElement === textSink &&
+      (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter' || textSinkOwnsPaste)) return;
     const key = browserKeyCodes.get(event.code) || 0;
     if (key !== 0) queueInputEvent(5, 0, 0, 0, 0, key, eventModifiers(event), event.repeat ? 1 : 0);
     if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', 'Space'].includes(event.code)) {
@@ -485,7 +487,9 @@ function installBrowserInput() {
     }
   }, true);
   globalThis.addEventListener('keyup', event => {
-    if (document.activeElement === textSink && (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter')) return;
+    const textSinkOwnsPaste = document.activeElement === textSink && event.code === 'KeyV' && (event.ctrlKey || event.metaKey);
+    if (document.activeElement === textSink &&
+      (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter' || textSinkOwnsPaste)) return;
     const key = browserKeyCodes.get(event.code) || 0;
     if (key !== 0) queueInputEvent(6, 0, 0, 0, 0, key, eventModifiers(event));
   }, true);

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -19,7 +19,9 @@ const state = {
   inputEvents: [],
   inputInstalled: false,
   dispatchImmediatePointer: null,
+  dispatchTextInput: null,
   textSink: null,
+  isComposing: false,
   clipboardText: '',
   pickedStorageBytes: null,
   worker: null,
@@ -342,6 +344,20 @@ function resizeCanvas() {
   }
 }
 
+function updateVisualViewport() {
+  if (!state.canvas) return;
+  const viewport = globalThis.visualViewport;
+  const keyboardRect = navigator.virtualKeyboard?.boundingRect;
+  const keyboardInset = keyboardRect && keyboardRect.height > 0 ? keyboardRect.height : 0;
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--progpu-viewport-left', `${viewport?.offsetLeft || 0}px`);
+  rootStyle.setProperty('--progpu-viewport-top', `${viewport?.offsetTop || 0}px`);
+  rootStyle.setProperty('--progpu-viewport-width', `${viewport?.width || globalThis.innerWidth}px`);
+  rootStyle.setProperty('--progpu-viewport-height', `${viewport?.height || globalThis.innerHeight}px`);
+  rootStyle.setProperty('--progpu-keyboard-inset', `${keyboardInset}px`);
+  resizeCanvas();
+}
+
 const browserKeyCodes = (() => {
   const result = new Map();
   for (let index = 0; index < 26; index++) result.set(`Key${String.fromCharCode(65 + index)}`, 1 + index);
@@ -357,10 +373,11 @@ const browserKeyCodes = (() => {
   return result;
 })();
 
-function queueInputEvent(kind, x = 0, y = 0, a = 0, b = 0, data = 0, modifiers = 0, flags = 0) {
-  const event = { kind, x, y, a, b, data, modifiers, flags };
+function queueInputEvent(kind, x = 0, y = 0, a = 0, b = 0, data = 0, modifiers = 0, flags = 0,
+  timestamp = performance.now(), pressure = 0, width = 0, height = 0, pointerType = 0, button = -1) {
+  const event = { kind, x, y, a, b, data, modifiers, flags, timestamp, pressure, width, height, pointerType, button };
   const last = state.inputEvents[state.inputEvents.length - 1];
-  if (kind === 1 && last?.kind === 1) {
+  if (kind === 1 && last?.kind === 1 && last.data === data) {
     state.inputEvents[state.inputEvents.length - 1] = event;
     return;
   }
@@ -382,15 +399,29 @@ function eventModifiers(event) {
     (event.altKey ? 4 : 0) | (event.metaKey ? 8 : 0);
 }
 
+function pointerTypeValue(type) {
+  return type === 'touch' ? 1 : type === 'pen' ? 2 : 0;
+}
+
+function queuePointerEvent(kind, event, point) {
+  const flags = event.buttons | (event.isPrimary ? 0x10000 : 0);
+  queueInputEvent(kind, point.x, point.y, 0, 0, event.pointerId, eventModifiers(event), flags,
+    event.timeStamp, event.pressure || 0, event.width || 0, event.height || 0,
+    pointerTypeValue(event.pointerType), event.button);
+}
+
 function dispatchPointerEvent(kind, event, point) {
   if (state.dispatchImmediatePointer) {
     try {
-      if (state.dispatchImmediatePointer(kind, point.x, point.y, event.button)) return;
+      if (state.dispatchImmediatePointer(kind, point.x, point.y, event.button, event.buttons,
+        event.pointerId, pointerTypeValue(event.pointerType), event.pressure || 0,
+        event.width || 0, event.height || 0, event.isPrimary, event.timeStamp,
+        eventModifiers(event))) return;
     } catch (error) {
       globalThis.console.error('[ProGPU] Immediate pointer dispatch failed.', error);
     }
   }
-  queueInputEvent(kind, point.x, point.y, 0, 0, event.button, eventModifiers(event), event.buttons);
+  queuePointerEvent(kind, event, point);
 }
 
 function installBrowserInput() {
@@ -410,13 +441,17 @@ function installBrowserInput() {
 
   state.canvas.addEventListener('pointermove', event => {
     const point = pointerPosition(event);
-    queueInputEvent(1, point.x, point.y, 0, 0, 0, eventModifiers(event), event.buttons);
+    const coalesced = typeof event.getCoalescedEvents === 'function' ? event.getCoalescedEvents() : [];
+    if (coalesced.length > 1) {
+      for (const sample of coalesced) queuePointerEvent(1, sample, pointerPosition(sample));
+    } else {
+      queuePointerEvent(1, event, point);
+    }
   });
   state.canvas.addEventListener('pointerdown', event => {
     const point = pointerPosition(event);
     dispatchPointerEvent(2, event, point);
     try { state.canvas.setPointerCapture(event.pointerId); } catch { }
-    textSink.focus({ preventScroll: true });
     event.preventDefault();
   });
   state.canvas.addEventListener('pointerup', event => {
@@ -427,18 +462,22 @@ function installBrowserInput() {
   });
   state.canvas.addEventListener('pointercancel', event => {
     const point = pointerPosition(event);
-    queueInputEvent(3, point.x, point.y, 0, 0, event.button, eventModifiers(event), event.buttons);
+    dispatchPointerEvent(9, event, point);
+    try { state.canvas.releasePointerCapture(event.pointerId); } catch { }
+    event.preventDefault();
   });
   state.canvas.addEventListener('contextmenu', event => event.preventDefault());
   state.canvas.addEventListener('wheel', event => {
     const point = pointerPosition(event);
     const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 :
       event.deltaMode === WheelEvent.DOM_DELTA_PAGE ? state.canvas.clientHeight : 1;
-    queueInputEvent(4, point.x, point.y, -event.deltaX * unit / 100, -event.deltaY * unit / 100, 0, eventModifiers(event));
+    queueInputEvent(4, point.x, point.y, -event.deltaX * unit / 100, -event.deltaY * unit / 100,
+      1, eventModifiers(event), 0, event.timeStamp, 0, 0, 0, 0, -1);
     event.preventDefault();
   }, { passive: false });
 
   globalThis.addEventListener('keydown', event => {
+    if (document.activeElement === textSink && (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter')) return;
     const key = browserKeyCodes.get(event.code) || 0;
     if (key !== 0) queueInputEvent(5, 0, 0, 0, 0, key, eventModifiers(event), event.repeat ? 1 : 0);
     if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', 'Space'].includes(event.code)) {
@@ -446,15 +485,45 @@ function installBrowserInput() {
     }
   }, true);
   globalThis.addEventListener('keyup', event => {
+    if (document.activeElement === textSink && (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter')) return;
     const key = browserKeyCodes.get(event.code) || 0;
     if (key !== 0) queueInputEvent(6, 0, 0, 0, 0, key, eventModifiers(event));
   }, true);
-  textSink.addEventListener('input', () => {
-    for (const character of textSink.value) queueInputEvent(7, 0, 0, 0, 0, character.codePointAt(0));
+  textSink.addEventListener('beforeinput', event => {
+    if (!state.dispatchTextInput || event.isComposing) return;
+    const kind = event.inputType === 'deleteContentBackward' ? 1 :
+      event.inputType === 'deleteContentForward' ? 2 :
+      event.inputType === 'insertLineBreak' || event.inputType === 'insertParagraph' ? 3 : -1;
+    if (kind >= 0) {
+      state.dispatchTextInput(kind, '', false);
+      event.preventDefault();
+    }
+  });
+  textSink.addEventListener('input', event => {
+    if (state.isComposing || event.isComposing) return;
+    if (event.inputType === 'insertCompositionText' || event.inputType === 'insertFromComposition') {
+      textSink.value = '';
+      return;
+    }
+    const text = event.data ?? textSink.value;
+    if (text && state.dispatchTextInput) state.dispatchTextInput(0, text, false);
+    textSink.value = '';
+  });
+  textSink.addEventListener('compositionstart', () => {
+    state.isComposing = true;
+    if (state.dispatchTextInput) state.dispatchTextInput(4, '', true);
+  });
+  textSink.addEventListener('compositionupdate', event => {
+    if (state.dispatchTextInput) state.dispatchTextInput(5, event.data || '', true);
+  });
+  textSink.addEventListener('compositionend', event => {
+    if (state.dispatchTextInput) state.dispatchTextInput(6, event.data || '', false);
+    state.isComposing = false;
     textSink.value = '';
   });
   textSink.addEventListener('paste', event => {
     state.clipboardText = event.clipboardData?.getData('text/plain') || '';
+    if (state.clipboardText && state.dispatchTextInput) state.dispatchTextInput(0, state.clipboardText, false);
     event.preventDefault();
   });
   globalThis.addEventListener('blur', () => queueInputEvent(8));
@@ -462,13 +531,13 @@ function installBrowserInput() {
 
 function drainInputEvents(destination, capacity) {
   const count = Math.min(Math.max(0, capacity | 0), state.inputEvents.length);
-  const byteLength = count * 32;
+  const byteLength = count * 64;
   const heap = runtime.localHeapViewU8();
   if (destination < 0 || destination + byteLength > heap.byteLength) throw new RangeError('Input destination is outside WASM memory.');
   const view = new DataView(heap.buffer, heap.byteOffset + destination, byteLength);
   for (let index = 0; index < count; index++) {
     const event = state.inputEvents[index];
-    const offset = index * 32;
+    const offset = index * 64;
     view.setUint32(offset, event.kind, true);
     view.setFloat32(offset + 4, event.x, true);
     view.setFloat32(offset + 8, event.y, true);
@@ -477,6 +546,13 @@ function drainInputEvents(destination, capacity) {
     view.setUint32(offset + 20, event.data, true);
     view.setUint32(offset + 24, event.modifiers, true);
     view.setUint32(offset + 28, event.flags, true);
+    view.setFloat64(offset + 32, event.timestamp, true);
+    view.setFloat32(offset + 40, event.pressure, true);
+    view.setFloat32(offset + 44, event.width, true);
+    view.setFloat32(offset + 48, event.height, true);
+    view.setUint32(offset + 52, event.pointerType, true);
+    view.setInt32(offset + 56, event.button, true);
+    view.setUint32(offset + 60, 0, true);
   }
   if (count !== 0) state.inputEvents.splice(0, count);
   return count;
@@ -484,6 +560,44 @@ function drainInputEvents(destination, capacity) {
 
 function setCanvasCursor(cursor) {
   if (state.canvas) state.canvas.style.cursor = cursor;
+}
+
+function configureTextInput(inputMode, enterKeyHint, autoCapitalize, spellCheck, isPassword, acceptsReturn, x, y, width, height) {
+  const textSink = state.textSink;
+  if (!textSink) return;
+  textSink.inputMode = inputMode || 'text';
+  textSink.enterKeyHint = enterKeyHint || (acceptsReturn ? 'enter' : 'done');
+  textSink.autocapitalize = autoCapitalize || 'off';
+  textSink.spellcheck = Boolean(spellCheck);
+  textSink.autocomplete = isPassword ? 'current-password' : 'off';
+  textSink.setAttribute('aria-label', isPassword ? 'ProGPU password input' : 'ProGPU text input');
+  const viewport = globalThis.visualViewport;
+  const viewportLeft = viewport?.offsetLeft || 0;
+  const viewportTop = viewport?.offsetTop || 0;
+  const viewportWidth = viewport?.width || globalThis.innerWidth;
+  const viewportHeight = viewport?.height || globalThis.innerHeight;
+  textSink.style.left = `${Math.max(viewportLeft, Math.min(viewportLeft + viewportWidth - 2, x))}px`;
+  textSink.style.top = `${Math.max(viewportTop, Math.min(viewportTop + viewportHeight - 2, y + height))}px`;
+  textSink.style.width = `${Math.max(2, Math.min(width || 2, viewportWidth))}px`;
+  textSink.style.height = '2px';
+  textSink.value = '';
+  textSink.focus({ preventScroll: true });
+  if (navigator.virtualKeyboard) {
+    try { navigator.virtualKeyboard.overlaysContent = true; } catch { }
+    try { navigator.virtualKeyboard.show(); } catch { }
+  }
+}
+
+function hideTextInput() {
+  const sink = state.textSink;
+  if (!sink) return;
+  if (state.isComposing && state.dispatchTextInput) state.dispatchTextInput(7, '', false);
+  state.isComposing = false;
+  sink.value = '';
+  sink.blur();
+  if (navigator.virtualKeyboard) {
+    try { navigator.virtualKeyboard.hide(); } catch { }
+  }
 }
 
 function setClipboardText(text) {
@@ -674,6 +788,11 @@ async function initialize(requestJson) {
   const executionMode = chooseExecutionMode(request, diagnostics);
   state.canvas = document.querySelector(request.canvasSelector);
   if (!(state.canvas instanceof HTMLCanvasElement)) throw new Error(`Canvas not found: ${request.canvasSelector}`);
+  updateVisualViewport();
+  globalThis.visualViewport?.addEventListener('resize', updateVisualViewport);
+  globalThis.visualViewport?.addEventListener('scroll', updateVisualViewport);
+  globalThis.addEventListener('orientationchange', updateVisualViewport);
+  navigator.virtualKeyboard?.addEventListener('geometrychange', updateVisualViewport);
   installBrowserInput();
   resizeCanvas();
   new ResizeObserver(resizeCanvas).observe(state.canvas);
@@ -1387,8 +1506,9 @@ if (isDispatcherWorker) {
 } else {
   initializeDiagnosticsVisibility();
   runtime = await dotnet.withEnvironmentVariables(readBenchmarkEnvironment()).create();
-  runtime.setModuleImports('progpu-browser', { initialize, dispatch, dispatchUpload, mapBuffer, copyMappedBuffer, writeMappedBuffer, releaseMappedBuffer, nextAnimationFrame, writeCanvasMetrics, drainInputEvents, setCanvasCursor, setClipboardText, getClipboardText, pickStorage, getPickedStorageLength, copyPickedStorage, clearPickedStorage, downloadText, getDiagnosticsVisible, setDiagnosticsVisible, setStatus, updateCounters });
+  runtime.setModuleImports('progpu-browser', { initialize, dispatch, dispatchUpload, mapBuffer, copyMappedBuffer, writeMappedBuffer, releaseMappedBuffer, nextAnimationFrame, writeCanvasMetrics, drainInputEvents, setCanvasCursor, configureTextInput, hideTextInput, setClipboardText, getClipboardText, pickStorage, getPickedStorageLength, copyPickedStorage, clearPickedStorage, downloadText, getDiagnosticsVisible, setDiagnosticsVisible, setStatus, updateCounters });
   const browserExports = await runtime.getAssemblyExports('ProGPU.Browser.dll');
   state.dispatchImmediatePointer = browserExports.ProGPU.Browser.BrowserInputDispatcher.DispatchImmediatePointer;
+  state.dispatchTextInput = browserExports.ProGPU.Browser.BrowserInputDispatcher.DispatchTextInput;
   await runtime.runMain();
 }

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -21,6 +21,7 @@ const state = {
   dispatchImmediatePointer: null,
   dispatchTextInput: null,
   textSink: null,
+  textInputBounds: null,
   isComposing: false,
   clipboardText: '',
   pickedStorageBytes: null,
@@ -356,6 +357,7 @@ function updateVisualViewport() {
   rootStyle.setProperty('--progpu-viewport-height', `${viewport?.height || globalThis.innerHeight}px`);
   rootStyle.setProperty('--progpu-keyboard-inset', `${keyboardInset}px`);
   resizeCanvas();
+  positionTextInput();
 }
 
 const browserKeyCodes = (() => {
@@ -424,11 +426,38 @@ function dispatchPointerEvent(kind, event, point) {
   queuePointerEvent(kind, event, point);
 }
 
-function discardQueuedPointerMoves(pointerId) {
-  for (let index = state.inputEvents.length - 1; index >= 0; index--) {
+function flushQueuedPointerMoves(pointerId) {
+  let flushed = true;
+  const retained = [];
+  for (let index = 0; index < state.inputEvents.length; index++) {
     const queued = state.inputEvents[index];
-    if (queued.kind === 1 && queued.data === pointerId) state.inputEvents.splice(index, 1);
+    if (queued.kind !== 1 || queued.data !== pointerId) {
+      retained.push(queued);
+      continue;
+    }
+
+    try {
+      if (state.dispatchImmediatePointer(queued.kind, queued.x, queued.y, queued.button,
+        queued.flags & 0xffff, queued.data, queued.pointerType, queued.pressure,
+        queued.width, queued.height, (queued.flags & 0x10000) !== 0,
+        queued.timestamp, queued.modifiers)) continue;
+    } catch (error) {
+      globalThis.console.error('[ProGPU] Immediate queued pointer move dispatch failed.', error);
+    }
+
+    retained.push(queued);
+    flushed = false;
   }
+  state.inputEvents = retained;
+  return flushed;
+}
+
+function dispatchTerminalPointerEvent(kind, event, point) {
+  if (state.dispatchImmediatePointer && !flushQueuedPointerMoves(event.pointerId)) {
+    queuePointerEvent(kind, event, point);
+    return;
+  }
+  dispatchPointerEvent(kind, event, point);
 }
 
 function installBrowserInput() {
@@ -463,15 +492,13 @@ function installBrowserInput() {
   });
   state.canvas.addEventListener('pointerup', event => {
     const point = pointerPosition(event);
-    if (state.dispatchImmediatePointer) discardQueuedPointerMoves(event.pointerId);
-    dispatchPointerEvent(3, event, point);
+    dispatchTerminalPointerEvent(3, event, point);
     try { state.canvas.releasePointerCapture(event.pointerId); } catch { }
     event.preventDefault();
   });
   state.canvas.addEventListener('pointercancel', event => {
     const point = pointerPosition(event);
-    if (state.dispatchImmediatePointer) discardQueuedPointerMoves(event.pointerId);
-    dispatchPointerEvent(9, event, point);
+    dispatchTerminalPointerEvent(9, event, point);
     try { state.canvas.releasePointerCapture(event.pointerId); } catch { }
     event.preventDefault();
   });
@@ -575,6 +602,24 @@ function setCanvasCursor(cursor) {
   if (state.canvas) state.canvas.style.cursor = cursor;
 }
 
+function positionTextInput() {
+  const textSink = state.textSink;
+  const bounds = state.textInputBounds;
+  if (!textSink || !bounds) return;
+  const viewport = globalThis.visualViewport;
+  const viewportLeft = viewport?.offsetLeft || 0;
+  const viewportTop = viewport?.offsetTop || 0;
+  const viewportWidth = viewport?.width || globalThis.innerWidth;
+  const viewportHeight = viewport?.height || globalThis.innerHeight;
+  const canvasBounds = state.canvas?.getBoundingClientRect();
+  const sinkX = (canvasBounds?.left || 0) + bounds.x;
+  const sinkY = (canvasBounds?.top || 0) + bounds.y + bounds.height;
+  textSink.style.left = `${Math.max(viewportLeft, Math.min(viewportLeft + viewportWidth - 2, sinkX))}px`;
+  textSink.style.top = `${Math.max(viewportTop, Math.min(viewportTop + viewportHeight - 2, sinkY))}px`;
+  textSink.style.width = `${Math.max(2, Math.min(bounds.width || 2, viewportWidth))}px`;
+  textSink.style.height = '2px';
+}
+
 function configureTextInput(inputMode, enterKeyHint, autoCapitalize, spellCheck, isPassword, acceptsReturn, x, y, width, height) {
   const textSink = state.textSink;
   if (!textSink) return;
@@ -584,18 +629,8 @@ function configureTextInput(inputMode, enterKeyHint, autoCapitalize, spellCheck,
   textSink.spellcheck = Boolean(spellCheck);
   textSink.autocomplete = isPassword ? 'current-password' : 'off';
   textSink.setAttribute('aria-label', isPassword ? 'ProGPU password input' : 'ProGPU text input');
-  const viewport = globalThis.visualViewport;
-  const viewportLeft = viewport?.offsetLeft || 0;
-  const viewportTop = viewport?.offsetTop || 0;
-  const viewportWidth = viewport?.width || globalThis.innerWidth;
-  const viewportHeight = viewport?.height || globalThis.innerHeight;
-  const canvasBounds = state.canvas?.getBoundingClientRect();
-  const sinkX = (canvasBounds?.left || 0) + x;
-  const sinkY = (canvasBounds?.top || 0) + y + height;
-  textSink.style.left = `${Math.max(viewportLeft, Math.min(viewportLeft + viewportWidth - 2, sinkX))}px`;
-  textSink.style.top = `${Math.max(viewportTop, Math.min(viewportTop + viewportHeight - 2, sinkY))}px`;
-  textSink.style.width = `${Math.max(2, Math.min(width || 2, viewportWidth))}px`;
-  textSink.style.height = '2px';
+  state.textInputBounds = { x, y, width, height };
+  positionTextInput();
   textSink.value = '';
   textSink.focus({ preventScroll: true });
   if (navigator.virtualKeyboard) {
@@ -609,6 +644,7 @@ function hideTextInput() {
   if (!sink) return;
   if (state.isComposing && state.dispatchTextInput) state.dispatchTextInput(7, '', false);
   state.isComposing = false;
+  state.textInputBounds = null;
   sink.value = '';
   sink.blur();
   if (navigator.virtualKeyboard) {

--- a/src/ProGPU.Browser/BrowserInputDispatcher.cs
+++ b/src/ProGPU.Browser/BrowserInputDispatcher.cs
@@ -2,7 +2,10 @@ using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.InteropServices.JavaScript;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml;
 using Silk.NET.Input;
+using Windows.Devices.Input;
+using ProGPU.Scene;
 
 namespace ProGPU.Browser;
 
@@ -14,7 +17,7 @@ namespace ProGPU.Browser;
 /// </summary>
 public static partial class BrowserInputDispatcher
 {
-    private const int EventSize = 32;
+    private const int EventSize = 64;
     private const int EventsPerBatch = 256;
     private const int MaximumBatchesPerFrame = 4;
     private static WindowInputState? s_attachedState;
@@ -24,6 +27,7 @@ public static partial class BrowserInputDispatcher
         ArgumentNullException.ThrowIfNull(state);
         s_attachedState = state;
         state.CursorChanged = cursor => SetCanvasCursor(ToCssCursor(cursor));
+        state.FocusChanged = OnFocusChanged;
     }
 
     public static void Detach(WindowInputState state)
@@ -31,18 +35,55 @@ public static partial class BrowserInputDispatcher
         ArgumentNullException.ThrowIfNull(state);
         if (!ReferenceEquals(s_attachedState, state)) return;
         state.CursorChanged = null;
+        state.FocusChanged = null;
+        HideTextInput();
         s_attachedState = null;
     }
 
     [JSExport]
-    public static bool DispatchImmediatePointer(int kind, double x, double y, int button)
+    public static bool DispatchTextInput(int kind, string? text, bool isComposing)
     {
         var state = s_attachedState;
-        if (state == null || (kind != (int)BrowserInputKind.PointerDown && kind != (int)BrowserInputKind.PointerUp))
+        if (state == null || !Enum.IsDefined(typeof(TextInputEventKind), kind)) return false;
+        InputSystem.Current = state;
+        InputSystem.InjectTextInput((TextInputEventKind)kind, text, isComposing);
+        return true;
+    }
+
+    [JSExport]
+    public static bool DispatchImmediatePointer(
+        int kind,
+        double x,
+        double y,
+        int button,
+        int buttons,
+        int pointerId,
+        int pointerType,
+        double pressure,
+        double width,
+        double height,
+        bool isPrimary,
+        double timestamp,
+        int modifiers)
+    {
+        var state = s_attachedState;
+        if (state == null || (kind != (int)BrowserInputKind.PointerDown && kind != (int)BrowserInputKind.PointerUp && kind != (int)BrowserInputKind.PointerCancel))
             return false;
 
         InputSystem.Current = state;
-        DispatchPointer((BrowserInputKind)kind, new Vector2((float)x, (float)y), unchecked((uint)button));
+        InputSystem.InjectPointer(CreatePointerEvent(
+            (BrowserInputKind)kind,
+            new Vector2((float)x, (float)y),
+            button,
+            buttons,
+            pointerId,
+            pointerType,
+            (float)pressure,
+            (float)width,
+            (float)height,
+            isPrimary,
+            timestamp,
+            modifiers));
         return true;
     }
 
@@ -75,15 +116,33 @@ public static partial class BrowserInputDispatcher
         switch (kind)
         {
             case BrowserInputKind.PointerMove:
-                InputSystem.InjectMouseMove(position);
-                break;
             case BrowserInputKind.PointerDown:
             case BrowserInputKind.PointerUp:
-                DispatchPointer(kind, position, ReadUInt32(record, 20));
+            case BrowserInputKind.PointerCancel:
+                InputSystem.InjectPointer(CreatePointerEvent(
+                    kind,
+                    position,
+                    ReadInt32(record, 56),
+                    ReadInt32(record, 28),
+                    ReadInt32(record, 20),
+                    ReadInt32(record, 52),
+                    ReadSingle(record, 40),
+                    ReadSingle(record, 44),
+                    ReadSingle(record, 48),
+                    (ReadUInt32(record, 28) & 0x10000u) != 0,
+                    ReadDouble(record, 32),
+                    ReadInt32(record, 24)));
                 break;
             case BrowserInputKind.Wheel:
-                InputSystem.InjectMouseMove(position);
-                InputSystem.InjectMouseScroll(new Vector2(ReadSingle(record, 12), ReadSingle(record, 16)));
+                InputSystem.InjectPointer(new PointerInputEvent(
+                    PointerInputKind.Wheel,
+                    1,
+                    PointerDeviceType.Mouse,
+                    position,
+                    ToMicroseconds(ReadDouble(record, 32)),
+                    WheelDeltaX: ReadSingle(record, 12),
+                    WheelDeltaY: ReadSingle(record, 16),
+                    Modifiers: ReadModifiers(ReadUInt32(record, 24))));
                 break;
             case BrowserInputKind.KeyDown:
                 if (TryMapKey((BrowserKey)ReadUInt32(record, 20), out var downKey)) InputSystem.InjectKeyDown(downKey);
@@ -104,12 +163,66 @@ public static partial class BrowserInputDispatcher
         }
     }
 
-    private static void DispatchPointer(BrowserInputKind kind, Vector2 position, uint button)
+    private static PointerInputEvent CreatePointerEvent(
+        BrowserInputKind kind,
+        Vector2 position,
+        int button,
+        int buttons,
+        int pointerId,
+        int pointerType,
+        float pressure,
+        float width,
+        float height,
+        bool isPrimary,
+        double timestamp,
+        int modifiers)
     {
-        InputSystem.InjectMouseMove(position);
-        if (!TryMapButton(button, out var mappedButton)) return;
-        if (kind == BrowserInputKind.PointerDown) InputSystem.InjectMouseDown(mappedButton);
-        else InputSystem.InjectMouseUp(mappedButton);
+        var inputKind = kind switch
+        {
+            BrowserInputKind.PointerDown => PointerInputKind.Pressed,
+            BrowserInputKind.PointerUp => PointerInputKind.Released,
+            BrowserInputKind.PointerCancel => PointerInputKind.Canceled,
+            _ => PointerInputKind.Moved
+        };
+        var deviceType = pointerType switch
+        {
+            1 => PointerDeviceType.Touch,
+            2 => PointerDeviceType.Pen,
+            _ => PointerDeviceType.Mouse
+        };
+        var buttonMask = buttons & 0xffff;
+        var left = (buttonMask & 1) != 0 || (inputKind == PointerInputKind.Pressed && button == 0);
+        var right = (buttonMask & 2) != 0 || (inputKind == PointerInputKind.Pressed && button == 2);
+        var middle = (buttonMask & 4) != 0 || (inputKind == PointerInputKind.Pressed && button == 1);
+        var isInContact = inputKind == PointerInputKind.Pressed ||
+            (inputKind == PointerInputKind.Moved && (deviceType != PointerDeviceType.Mouse || buttonMask != 0));
+        return new PointerInputEvent(
+            inputKind,
+            unchecked((uint)Math.Max(1, pointerId)),
+            deviceType,
+            position,
+            ToMicroseconds(timestamp),
+            isPrimary,
+            isInContact,
+            left,
+            middle,
+            right,
+            pressure,
+            new Rect(position.X - width * 0.5f, position.Y - height * 0.5f, Math.Max(0, width), Math.Max(0, height)),
+            Modifiers: ReadModifiers(unchecked((uint)modifiers)));
+    }
+
+    private static ulong ToMicroseconds(double timestampMilliseconds) =>
+        (ulong)Math.Max(0d, timestampMilliseconds * 1000d);
+
+    private static VirtualKeyModifiers ReadModifiers(uint value)
+    {
+        var result = VirtualKeyModifiers.None;
+        if ((value & 1) != 0) result |= VirtualKeyModifiers.Shift;
+        if ((value & 2) != 0) result |= VirtualKeyModifiers.Control;
+        if ((value & 4) != 0) result |= VirtualKeyModifiers.Menu;
+        if ((value & 8) != 0) result |= VirtualKeyModifiers.Windows;
+        return result;
     }
 
     private static bool TryMapButton(uint button, out MouseButton result)
@@ -189,17 +302,72 @@ public static partial class BrowserInputDispatcher
         _ => "default"
     };
 
+    private static void OnFocusChanged(FrameworkElement? element)
+    {
+        if (element is not ITextInputClient client)
+        {
+            HideTextInput();
+            return;
+        }
+
+        var options = client.GetTextInputOptions();
+        ConfigureTextInput(
+            ToInputMode(options.InputScope),
+            options.EnterKeyHint,
+            options.AutoCapitalize,
+            options.IsSpellCheckEnabled,
+            options.IsPassword,
+            options.AcceptsReturn,
+            options.Bounds.X,
+            options.Bounds.Y,
+            options.Bounds.Width,
+            options.Bounds.Height);
+    }
+
+    private static string ToInputMode(InputScopeNameValue scope) => scope switch
+    {
+        InputScopeNameValue.Url => "url",
+        InputScopeNameValue.EmailSmtpAddress => "email",
+        InputScopeNameValue.Number => "decimal",
+        InputScopeNameValue.NumericPin => "numeric",
+        InputScopeNameValue.TelephoneNumber => "tel",
+        InputScopeNameValue.Search => "search",
+        _ => "text"
+    };
+
     private static uint ReadUInt32(ReadOnlySpan<byte> bytes, int offset) =>
         BinaryPrimitives.ReadUInt32LittleEndian(bytes[offset..]);
 
     private static float ReadSingle(ReadOnlySpan<byte> bytes, int offset) =>
         BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(bytes[offset..]));
 
+    private static int ReadInt32(ReadOnlySpan<byte> bytes, int offset) =>
+        BinaryPrimitives.ReadInt32LittleEndian(bytes[offset..]);
+
+    private static double ReadDouble(ReadOnlySpan<byte> bytes, int offset) =>
+        BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(bytes[offset..]));
+
     [JSImport("drainInputEvents", "progpu-browser")]
     private static partial int DrainInputEvents(nint destination, int capacity);
 
     [JSImport("setCanvasCursor", "progpu-browser")]
     private static partial void SetCanvasCursor(string cursor);
+
+    [JSImport("configureTextInput", "progpu-browser")]
+    private static partial void ConfigureTextInput(
+        string inputMode,
+        string enterKeyHint,
+        string autoCapitalize,
+        bool spellCheck,
+        bool isPassword,
+        bool acceptsReturn,
+        float x,
+        float y,
+        float width,
+        float height);
+
+    [JSImport("hideTextInput", "progpu-browser")]
+    private static partial void HideTextInput();
 
     private enum BrowserInputKind : uint
     {
@@ -210,7 +378,8 @@ public static partial class BrowserInputDispatcher
         KeyDown = 5,
         KeyUp = 6,
         Text = 7,
-        FocusLost = 8
+        FocusLost = 8,
+        PointerCancel = 9
     }
 
     private enum BrowserKey : uint

--- a/src/ProGPU.Browser/BrowserInputDispatcher.cs
+++ b/src/ProGPU.Browser/BrowserInputDispatcher.cs
@@ -67,7 +67,7 @@ public static partial class BrowserInputDispatcher
         int modifiers)
     {
         var state = s_attachedState;
-        if (state == null || (kind != (int)BrowserInputKind.PointerDown && kind != (int)BrowserInputKind.PointerUp && kind != (int)BrowserInputKind.PointerCancel))
+        if (state == null || (kind != (int)BrowserInputKind.PointerMove && kind != (int)BrowserInputKind.PointerDown && kind != (int)BrowserInputKind.PointerUp && kind != (int)BrowserInputKind.PointerCancel))
             return false;
 
         InputSystem.Current = state;

--- a/src/ProGPU.Samples.Browser/wwwroot/styles.css
+++ b/src/ProGPU.Samples.Browser/wwwroot/styles.css
@@ -16,17 +16,26 @@ html, body, #progpu-canvas {
 #progpu-canvas {
   display: block;
   position: fixed;
-  inset: 0;
+  left: calc(var(--progpu-viewport-left, 0px) + env(safe-area-inset-left));
+  top: calc(var(--progpu-viewport-top, 0px) + env(safe-area-inset-top));
+  width: calc(var(--progpu-viewport-width, 100vw) - env(safe-area-inset-left) - env(safe-area-inset-right));
+  height: calc(var(--progpu-viewport-height, 100dvh) - var(--progpu-keyboard-inset, 0px) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  touch-action: none;
+  overscroll-behavior: none;
 }
 
 #progpu-text-input {
   position: fixed;
-  left: -10000px;
+  left: 0;
   top: 0;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
+  width: 2px;
+  height: 2px;
+  opacity: .01;
   pointer-events: none;
+  border: 0;
+  padding: 0;
+  resize: none;
+  z-index: 1;
 }
 
 #diagnostics {

--- a/src/ProGPU.Samples/Pages/ComputeFxPage.cs
+++ b/src/ProGPU.Samples/Pages/ComputeFxPage.cs
@@ -27,10 +27,6 @@ public static class ComputeFxPage
         {
             MainWindowController.EnsureEffectResources();
 
-            var grid = new Microsoft.UI.Xaml.Controls.Grid();
-            grid.ColumnDefinitions.Add(new GridLength(280, GridUnitType.Absolute)); // Compute adjust sliders
-            grid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // WebGPU offscreen effect canvas
-    
             var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(8) };
             var computeTitle = new RichTextBlock { Font = AppState._font, FontSize = 14f, Margin = new Thickness(0, 0, 0, 5) };
             computeTitle.Inlines.Add(new Bold(new Run("WGSL Compute Accelerator")));
@@ -112,9 +108,6 @@ public static class ComputeFxPage
             };
             leftStack.AddChild(toggleAnimBtn);
     
-            grid.AddChild(leftStack);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
-    
             // Center WebGPU texture offscreen render Canvas (Column 1)
             AppState._gearCanvasVisual ??= new GearCanvasVisual(AppState._font!)
             {
@@ -134,9 +127,11 @@ public static class ComputeFxPage
                 Child = displayCanvas
             };
     
-            grid.AddChild(canvasContainer);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(canvasContainer, 1);
-    
-            return grid;
+            return new ResponsiveSplitView
+            {
+                OpenPaneLength = 280f,
+                PaneContent = leftStack,
+                MainContent = canvasContainer
+            };
         }
 }

--- a/src/ProGPU.Samples/Pages/DxfViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/DxfViewerPage.cs
@@ -463,9 +463,7 @@ public static class DxfViewerPage
     {
         var mainGrid = new Grid();
 
-        var grid = new Grid();
-        grid.ColumnDefinitions.Add(new GridLength(280f, GridUnitType.Absolute)); // Sidebar
-        grid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));       // Main canvas card
+        var grid = new ResponsiveSplitView { OpenPaneLength = 280f };
 
         mainGrid.AddChild(grid);
 
@@ -618,13 +616,11 @@ public static class DxfViewerPage
         _statusText.Inlines.Add(new Run("Status: Ready"));
         sidebarStack.AddChild(_statusText);
 
-        grid.AddChild(sidebarCard);
-        Grid.SetColumn(sidebarCard, 0);
+        grid.PaneContent = sidebarCard;
 
         // 2. MAIN CAD CANVAS PANEL
         _canvas = new DxfCanvasControl();
-        grid.AddChild(_canvas);
-        Grid.SetColumn(_canvas, 1);
+        grid.MainContent = _canvas;
 
         // Hookup actions
         sampleBtn.Click += (s, e) =>

--- a/src/ProGPU.Samples/Pages/FontGlyphBrowserPage.cs
+++ b/src/ProGPU.Samples/Pages/FontGlyphBrowserPage.cs
@@ -291,17 +291,8 @@ public static class FontGlyphBrowserPage
         _selectedFont = AppState._font ?? PopupService.DefaultFont;
         _systemFonts = new List<FontInfo>();
 
-        // 2. Main Page Layout Root
-        var mainGrid = new Grid
-        {
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch
-        };
-        mainGrid.ColumnDefinitions.Add(new GridLength(1.4f, GridUnitType.Star)); // Left Pane: Controls + Grid
-        mainGrid.ColumnDefinitions.Add(new GridLength(20f, GridUnitType.Absolute)); // Spacer
-        mainGrid.ColumnDefinitions.Add(new GridLength(0.8f, GridUnitType.Star)); // Right Pane: Large Preview
-
-        // Left Container
+        // 2. Main browser workspace. Selected-glyph details live in the collapsible
+        // SplitView pane so the virtualized glyph surface owns compact screens.
         var leftStack = new Grid
         {
             Margin = new Thickness(20),
@@ -314,10 +305,7 @@ public static class FontGlyphBrowserPage
         leftStack.RowDefinitions.Add(new GridLength(1f, GridUnitType.Auto)); // Row 3: Path status
         leftStack.RowDefinitions.Add(new GridLength(1f, GridUnitType.Auto)); // Row 4: Metadata (Metrics Dashboard)
         leftStack.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star)); // Row 5: Glyph grid!
-        mainGrid.AddChild(leftStack);
-        Grid.SetColumn(leftStack, 0);
-
-        // Right Container Card
+        // Selected-glyph information pane
         var previewCard = new Border
         {
             Background = new ThemeResourceBrush("CardBackground"),
@@ -329,9 +317,6 @@ public static class FontGlyphBrowserPage
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch
         };
-        mainGrid.AddChild(previewCard);
-        Grid.SetColumn(previewCard, 2);
-
         var previewStack = new StackPanel
         {
             Orientation = Orientation.Vertical,
@@ -673,7 +658,14 @@ public static class FontGlyphBrowserPage
         UpdateSelectedFontDetails();
         UpdateSelectedGlyph(_selectedGlyphIndex);
 
-        return mainGrid;
+        return new ResponsiveSplitView
+        {
+            OpenPaneLength = 380f,
+            CompactModeThreshold = 900f,
+            PanePlacement = PanePlacement.Left,
+            PaneContent = previewCard,
+            MainContent = leftStack
+        };
     }
 
     private static void OnItemHover(object? sender, PointerRoutedEventArgs e)

--- a/src/ProGPU.Samples/Pages/FrameworkEffectsPage.cs
+++ b/src/ProGPU.Samples/Pages/FrameworkEffectsPage.cs
@@ -25,10 +25,6 @@ public static class FrameworkEffectsPage
 {
         public static FrameworkElement Create()
         {
-            var grid = new Microsoft.UI.Xaml.Controls.Grid();
-            grid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Adjustments panel
-            grid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));      // Effect Showroom
-    
             // ================= LEFT: Adjustments Panel =================
             var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(12) };
             
@@ -91,9 +87,6 @@ public static class FrameworkEffectsPage
             colorButtonsStack.AddChild(greenBtn);
     
             leftStack.AddChild(colorButtonsStack);
-            grid.AddChild(leftStack);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
-    
             // ================= RIGHT: Effect Showroom =================
             var showroomGrid = new Microsoft.UI.Xaml.Controls.Grid { Margin = new Thickness(12) };
             showroomGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
@@ -214,9 +207,6 @@ public static class FrameworkEffectsPage
             showroomGrid.AddChild(blurCard);
             Microsoft.UI.Xaml.Controls.Grid.SetColumn(blurCard, 2);
     
-            grid.AddChild(showroomGrid);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(showroomGrid, 1);
-    
             // ================= Interactivity Hookups =================
             blurSlider.ValueChanged += (s, e) =>
             {
@@ -285,6 +275,11 @@ public static class FrameworkEffectsPage
                 neonCard.Invalidate();
             };
     
-            return grid;
+            return new ResponsiveSplitView
+            {
+                OpenPaneLength = 300f,
+                PaneContent = leftStack,
+                MainContent = showroomGrid
+            };
         }
 }

--- a/src/ProGPU.Samples/Pages/GdiShowcasePage.cs
+++ b/src/ProGPU.Samples/Pages/GdiShowcasePage.cs
@@ -129,10 +129,6 @@ public static class GdiShowcasePage
 {
     public static FrameworkElement Create()
     {
-        var grid = new Microsoft.UI.Xaml.Controls.Grid();
-        grid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Left Adjust pane
-        grid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // Right Visual preview
-
         var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(12) };
 
         var title = new RichTextBlock { Font = AppState._font, FontSize = 15f, Margin = new Thickness(0, 0, 0, 5) };
@@ -294,9 +290,6 @@ public static class GdiShowcasePage
         };
         leftStack.AddChild(resetBtn);
 
-        grid.AddChild(leftStack);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
-
         var previewContainer = new Border
         {
             CornerRadius = 8f,
@@ -307,9 +300,11 @@ public static class GdiShowcasePage
             Child = visual
         };
 
-        grid.AddChild(previewContainer);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(previewContainer, 1);
-
-        return grid;
+        return new ResponsiveSplitView
+        {
+            OpenPaneLength = 300f,
+            PaneContent = leftStack,
+            MainContent = previewContainer
+        };
     }
 }

--- a/src/ProGPU.Samples/Pages/GlyphRunShowcasePage.cs
+++ b/src/ProGPU.Samples/Pages/GlyphRunShowcasePage.cs
@@ -150,10 +150,6 @@ public static class GlyphRunShowcasePage
 {
     public static FrameworkElement Create()
     {
-        var grid = new Microsoft.UI.Xaml.Controls.Grid();
-        grid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Left adjust panel
-        grid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // Right Visual preview
-
         var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(12) };
 
         var title = new RichTextBlock { Font = AppState._font, FontSize = 15f, Margin = new Thickness(0, 0, 0, 5) };
@@ -316,9 +312,6 @@ public static class GlyphRunShowcasePage
         };
         leftStack.AddChild(animBtn);
 
-        grid.AddChild(leftStack);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
-
         var previewContainer = new Border
         {
             CornerRadius = 8f,
@@ -329,13 +322,15 @@ public static class GlyphRunShowcasePage
             Child = visual
         };
 
-        grid.AddChild(previewContainer);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(previewContainer, 1);
-
         // We can hook a global loop or animation tick to this visual in the Page lifecycle
         // Since FrameworkElement has layout animation tick, we can hook it up via MainWindowController OnWindowUpdate.
         // Handled automatically via IAnimatedElement traversal in UpdateSampleAnimations.
 
-        return grid;
+        return new ResponsiveSplitView
+        {
+            OpenPaneLength = 300f,
+            PaneContent = leftStack,
+            MainContent = previewContainer
+        };
     }
 }

--- a/src/ProGPU.Samples/Pages/ImageEffectsPage.cs
+++ b/src/ProGPU.Samples/Pages/ImageEffectsPage.cs
@@ -19,10 +19,6 @@ public static class ImageEffectsPage
     {
         MainWindowController.EnsureEffectResources();
 
-        var grid = new Microsoft.UI.Xaml.Controls.Grid();
-        grid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Adjust sliders
-        grid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // Live Preview Area
-
         var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(12) };
         
         var title = new RichTextBlock { Font = AppState._font, FontSize = 14f, Margin = new Thickness(0, 0, 0, 5) };
@@ -148,9 +144,6 @@ public static class ImageEffectsPage
         };
         leftStack.AddChild(blurSlider);
 
-        grid.AddChild(leftStack);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
-
         // Right Preview Area (Column 1)
         var previewContainer = new Border
         {
@@ -162,9 +155,11 @@ public static class ImageEffectsPage
             Child = previewImage
         };
 
-        grid.AddChild(previewContainer);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(previewContainer, 1);
-
-        return grid;
+        return new ResponsiveSplitView
+        {
+            OpenPaneLength = 300f,
+            PaneContent = leftStack,
+            MainContent = previewContainer
+        };
     }
 }

--- a/src/ProGPU.Samples/Pages/LolsPage.cs
+++ b/src/ProGPU.Samples/Pages/LolsPage.cs
@@ -63,9 +63,7 @@ public static class LolsPage
         Microsoft.UI.Xaml.Controls.Grid.SetRow(headerText, 0);
 
         // 2. Main Content Grid
-        var contentGrid = new Microsoft.UI.Xaml.Controls.Grid();
-        contentGrid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Settings Panel
-        contentGrid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // Visual Canvas Panel
+        var contentSplit = new ResponsiveSplitView { OpenPaneLength = 300f };
 
         // --- Column 0: Settings Panel ---
         var settingsCard = new Border
@@ -174,8 +172,7 @@ public static class LolsPage
         };
         settingsStack.AddChild(resetBtn);
 
-        contentGrid.AddChild(settingsCard);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(settingsCard, 0);
+        contentSplit.PaneContent = settingsCard;
 
         // --- Column 1: Visual Canvas Card ---
         var canvasCard = new Border
@@ -196,11 +193,10 @@ public static class LolsPage
         };
         canvasCard.Child = _canvas;
 
-        contentGrid.AddChild(canvasCard);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(canvasCard, 1);
+        contentSplit.MainContent = canvasCard;
 
-        mainGrid.AddChild(contentGrid);
-        Microsoft.UI.Xaml.Controls.Grid.SetRow(contentGrid, 1);
+        mainGrid.AddChild(contentSplit);
+        Microsoft.UI.Xaml.Controls.Grid.SetRow(contentSplit, 1);
 
         return mainGrid;
     }

--- a/src/ProGPU.Samples/Pages/MarkdownPage.cs
+++ b/src/ProGPU.Samples/Pages/MarkdownPage.cs
@@ -211,7 +211,8 @@ namespace ProGPU.Samples
             {
                 Margin = new Thickness(12),
                 OpenPaneLength = 460f,
-                CompactModeThreshold = 900f
+                CompactModeThreshold = 900f,
+                IsPaneScrollEnabled = false
             };
 
             // LEFT PANE: EDITOR CARD WITH TOOLBAR (using Grid to fill panel space dynamically)

--- a/src/ProGPU.Samples/Pages/MarkdownPage.cs
+++ b/src/ProGPU.Samples/Pages/MarkdownPage.cs
@@ -207,9 +207,12 @@ namespace ProGPU.Samples
             Microsoft.UI.Xaml.Controls.Grid.SetRow(configBar, 1);
 
             // ================= ROW 2: DUAL-PANE EDITOR & PREVIEW =================
-            var workspaceGrid = new Microsoft.UI.Xaml.Controls.Grid { Margin = new Thickness(12) };
-            workspaceGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star)); // Left Pane: Editor
-            workspaceGrid.ColumnDefinitions.Add(new GridLength(1.1f, GridUnitType.Star)); // Right Pane: Previewer
+            var workspaceSplit = new ResponsiveSplitView
+            {
+                Margin = new Thickness(12),
+                OpenPaneLength = 460f,
+                CompactModeThreshold = 900f
+            };
 
             // LEFT PANE: EDITOR CARD WITH TOOLBAR (using Grid to fill panel space dynamically)
             var editorContainerGrid = new Microsoft.UI.Xaml.Controls.Grid { Margin = new Thickness(0, 0, 10, 0) };
@@ -269,8 +272,7 @@ namespace ProGPU.Samples
                 : string.Empty));
             editorContainerGrid.AddChild(_editorControl);
             Microsoft.UI.Xaml.Controls.Grid.SetRow(_editorControl, 1);
-            workspaceGrid.AddChild(editorContainerGrid);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(editorContainerGrid, 0);
+            workspaceSplit.PaneContent = editorContainerGrid;
 
             // RIGHT PANE: PREVIEW CARD
             var previewBorder = new Border
@@ -300,11 +302,10 @@ namespace ProGPU.Samples
                 : string.Empty;
             _previewScroll.Content = _previewControl;
 
-            workspaceGrid.AddChild(previewBorder);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(previewBorder, 1);
+            workspaceSplit.MainContent = previewBorder;
 
-            rootGrid.AddChild(workspaceGrid);
-            Microsoft.UI.Xaml.Controls.Grid.SetRow(workspaceGrid, 2);
+            rootGrid.AddChild(workspaceSplit);
+            Microsoft.UI.Xaml.Controls.Grid.SetRow(workspaceSplit, 2);
 
             // ================= ASYNC ACTIONS & PRESETS SYNC =================
 

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -589,23 +589,23 @@ public static class Mesh3DViewerPage
         statsStack.AddChild(statsTitle);
 
         _statsNameRun = new Run("-");
-        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsNameBlock.Inlines.Add(new Bold(_statsNameRun));
 
         _statsVerticesRun = new Run("0");
-        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsVerticesBlock.Inlines.Add(new Bold(_statsVerticesRun));
 
         _statsTrianglesRun = new Run("0");
-        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsTrianglesBlock.Inlines.Add(new Bold(_statsTrianglesRun));
 
         _statsBoundsRun = new Run("0.0 x 0.0 x 0.0");
-        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsBoundsBlock.Inlines.Add(new Bold(_statsBoundsRun));
 
         _statsMemoryRun = new Run("0 KB");
-        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsMemoryBlock.Inlines.Add(new Bold(_statsMemoryRun));
 
         statsStack.AddChild(CreateStatRow("Name:", _statsNameBlock));

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -512,7 +512,7 @@ public static class Mesh3DViewerPage
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
         var browseBtnRun = new Run("Browse") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        browseBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(browseBtnRun) } };
+        browseBtn.Content = new RichTextBlock { TextWrapping = TextWrapping.NoWrap, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(browseBtnRun) } };
         pathGrid.AddChild(browseBtn);
         Grid.SetColumn(browseBtn, 2);
         
@@ -650,7 +650,7 @@ public static class Mesh3DViewerPage
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
         var customBtnRun = new Run("Custom") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        customBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(customBtnRun) } };
+        customBtn.Content = new RichTextBlock { TextWrapping = TextWrapping.NoWrap, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(customBtnRun) } };
 
         customBtn.Click += (s, e) => { ShowColorPickerPopup(customBtn); };
         colorGrid.AddChild(customBtn);
@@ -1621,7 +1621,7 @@ public static class Mesh3DViewerPage
             Background = new ThemeResourceBrush(mode == LayoutMode3D.Quad ? "ControlBackgroundPressed" : "ControlBackgroundHover")
         };
         var textRun = new Run(label) { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        btn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(textRun) } };
+        btn.Content = new RichTextBlock { TextWrapping = TextWrapping.NoWrap, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(textRun) } };
         btn.Click += (s, e) => { SetLayoutMode(mode); };
         return btn;
     }

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -223,6 +223,7 @@ public class Mesh3DViewerPageGrid : ResponsiveSplitView, IAnimatedElement
     {
         OpenPaneLength = 300f;
         CompactModeThreshold = 720f;
+        IsPaneScrollEnabled = false;
     }
 
     public void Update(float delta)

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -217,16 +217,12 @@ public enum LayoutMode3D
     Perspective
 }
 
-public class Mesh3DViewerPageGrid : Grid, IAnimatedElement
+public class Mesh3DViewerPageGrid : ResponsiveSplitView, IAnimatedElement
 {
-    private bool? _isNarrow;
-
-    public FrameworkElement? Sidebar { get; set; }
-    public FrameworkElement? Workspace { get; set; }
-
     public Mesh3DViewerPageGrid()
     {
-        ApplyResponsiveStructure(isNarrow: false);
+        OpenPaneLength = 300f;
+        CompactModeThreshold = 720f;
     }
 
     public void Update(float delta)
@@ -234,35 +230,6 @@ public class Mesh3DViewerPageGrid : Grid, IAnimatedElement
         Mesh3DViewerPage.UpdateAnimations((float)delta);
     }
 
-    protected override Vector2 MeasureOverride(Vector2 availableSize)
-    {
-        var isNarrow = availableSize.X < 720f;
-        if (_isNarrow != isNarrow) ApplyResponsiveStructure(isNarrow);
-        return base.MeasureOverride(availableSize);
-    }
-
-    private void ApplyResponsiveStructure(bool isNarrow)
-    {
-        _isNarrow = isNarrow;
-        ColumnDefinitions.Clear();
-        RowDefinitions.Clear();
-        if (isNarrow)
-        {
-            ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-            RowDefinitions.Add(new GridLength(0.55f, GridUnitType.Star));
-            RowDefinitions.Add(new GridLength(0.45f, GridUnitType.Star));
-            if (Sidebar != null) { SetColumn(Sidebar, 0); SetRow(Sidebar, 0); }
-            if (Workspace != null) { SetColumn(Workspace, 0); SetRow(Workspace, 1); }
-        }
-        else
-        {
-            ColumnDefinitions.Add(new GridLength(300f, GridUnitType.Absolute));
-            ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-            RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-            if (Sidebar != null) { SetColumn(Sidebar, 0); SetRow(Sidebar, 0); }
-            if (Workspace != null) { SetColumn(Workspace, 1); SetRow(Workspace, 0); }
-        }
-    }
 }
 
 public static class Mesh3DViewerPage
@@ -741,8 +708,7 @@ public static class Mesh3DViewerPage
         animStack.AddChild(animChk);
         sidebarStack.AddChild(animStack);
 
-        mainGrid.AddChild(sidebar);
-        Grid.SetColumn(sidebar, 0);
+        mainGrid.PaneContent = sidebar;
 
         // 2. MAIN 4-WAY SPLIT VIEW WORKSPACE (3x3 CAD NESTED GRIDS FOR SPLITTING)
         _viewportsGrid = new Grid { Margin = new Thickness(16f) };
@@ -1038,10 +1004,7 @@ public static class Mesh3DViewerPage
         Grid.SetRow(_rowSplitterRight, 1);
         Grid.SetColumn(_rowSplitterRight, 0);
 
-        mainGrid.AddChild(_viewportsGrid);
-        Grid.SetColumn(_viewportsGrid, 1);
-        mainGrid.Sidebar = sidebar;
-        mainGrid.Workspace = _viewportsGrid;
+        mainGrid.MainContent = _viewportsGrid;
 
         // Populate initial 3D geometries and register layout animation callbacks
         UpdateViewportModels();

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -511,7 +511,8 @@ public static class Mesh3DViewerPage
             CornerRadius = 4f,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        browseBtn.Content = "Browse";
+        var browseBtnRun = new Run("Browse") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        browseBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(browseBtnRun) } };
         pathGrid.AddChild(browseBtn);
         Grid.SetColumn(browseBtn, 2);
         
@@ -588,23 +589,23 @@ public static class Mesh3DViewerPage
         statsStack.AddChild(statsTitle);
 
         _statsNameRun = new Run("-");
-        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
+        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsNameBlock.Inlines.Add(new Bold(_statsNameRun));
 
         _statsVerticesRun = new Run("0");
-        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
+        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsVerticesBlock.Inlines.Add(new Bold(_statsVerticesRun));
 
         _statsTrianglesRun = new Run("0");
-        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
+        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsTrianglesBlock.Inlines.Add(new Bold(_statsTrianglesRun));
 
         _statsBoundsRun = new Run("0.0 x 0.0 x 0.0");
-        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
+        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsBoundsBlock.Inlines.Add(new Bold(_statsBoundsRun));
 
         _statsMemoryRun = new Run("0 KB");
-        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
+        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
         _statsMemoryBlock.Inlines.Add(new Bold(_statsMemoryRun));
 
         statsStack.AddChild(CreateStatRow("Name:", _statsNameBlock));
@@ -648,7 +649,8 @@ public static class Mesh3DViewerPage
             Margin = new Thickness(4f),
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        customBtn.Content = "Custom";
+        var customBtnRun = new Run("Custom") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        customBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(customBtnRun) } };
 
         customBtn.Click += (s, e) => { ShowColorPickerPopup(customBtn); };
         colorGrid.AddChild(customBtn);
@@ -1618,7 +1620,8 @@ public static class Mesh3DViewerPage
             Padding = new Thickness(0),
             Background = new ThemeResourceBrush(mode == LayoutMode3D.Quad ? "ControlBackgroundPressed" : "ControlBackgroundHover")
         };
-        btn.Content = label;
+        var textRun = new Run(label) { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
+        btn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(textRun) } };
         btn.Click += (s, e) => { SetLayoutMode(mode); };
         return btn;
     }

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -10,7 +10,6 @@ using ProGPU.Vector;
 using ProGPU.Layout;
 using ProGPU.Scene;
 using ProGPU.Scene.Extensions;
-using ProGPU.Text;
 using System.IO;
 
 namespace ProGPU.Samples;
@@ -590,23 +589,23 @@ public static class Mesh3DViewerPage
         statsStack.AddChild(statsTitle);
 
         _statsNameRun = new Run("-");
-        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsNameBlock.Inlines.Add(new Bold(_statsNameRun));
 
         _statsVerticesRun = new Run("0");
-        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsVerticesBlock.Inlines.Add(new Bold(_statsVerticesRun));
 
         _statsTrianglesRun = new Run("0");
-        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsTrianglesBlock.Inlines.Add(new Bold(_statsTrianglesRun));
 
         _statsBoundsRun = new Run("0.0 x 0.0 x 0.0");
-        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsBoundsBlock.Inlines.Add(new Bold(_statsBoundsRun));
 
         _statsMemoryRun = new Run("0 KB");
-        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
+        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsMemoryBlock.Inlines.Add(new Bold(_statsMemoryRun));
 
         statsStack.AddChild(CreateStatRow("Name:", _statsNameBlock));
@@ -1069,8 +1068,8 @@ public static class Mesh3DViewerPage
     private static Grid CreateStatRow(string label, RichTextBlock valBlock)
     {
         var rowGrid = new Grid { Margin = new Thickness(0, 2f, 0, 2f) };
-        rowGrid.ColumnDefinitions.Add(new GridLength(100f, GridUnitType.Absolute));
         rowGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        rowGrid.ColumnDefinitions.Add(new GridLength(0f, GridUnitType.Auto));
 
         var labelBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextSecondary") };
         labelBlock.Inlines.Add(new Run(label));

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -10,6 +10,7 @@ using ProGPU.Vector;
 using ProGPU.Layout;
 using ProGPU.Scene;
 using ProGPU.Scene.Extensions;
+using ProGPU.Text;
 using System.IO;
 
 namespace ProGPU.Samples;
@@ -589,23 +590,23 @@ public static class Mesh3DViewerPage
         statsStack.AddChild(statsTitle);
 
         _statsNameRun = new Run("-");
-        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsNameBlock.Inlines.Add(new Bold(_statsNameRun));
 
         _statsVerticesRun = new Run("0");
-        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsVerticesBlock.Inlines.Add(new Bold(_statsVerticesRun));
 
         _statsTrianglesRun = new Run("0");
-        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsTrianglesBlock.Inlines.Add(new Bold(_statsTrianglesRun));
 
         _statsBoundsRun = new Run("0.0 x 0.0 x 0.0");
-        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsBoundsBlock.Inlines.Add(new Bold(_statsBoundsRun));
 
         _statsMemoryRun = new Run("0 KB");
-        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, TextWrapping = TextWrapping.NoWrap, TextAlignment = TextAlignment.Right, Foreground = new ThemeResourceBrush("TextPrimary") };
         _statsMemoryBlock.Inlines.Add(new Bold(_statsMemoryRun));
 
         statsStack.AddChild(CreateStatRow("Name:", _statsNameBlock));

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -511,8 +511,7 @@ public static class Mesh3DViewerPage
             CornerRadius = 4f,
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var browseBtnRun = new Run("Browse") { FontSize = 12f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        browseBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(browseBtnRun) } };
+        browseBtn.Content = "Browse";
         pathGrid.AddChild(browseBtn);
         Grid.SetColumn(browseBtn, 2);
         
@@ -589,23 +588,23 @@ public static class Mesh3DViewerPage
         statsStack.AddChild(statsTitle);
 
         _statsNameRun = new Run("-");
-        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsNameBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
         _statsNameBlock.Inlines.Add(new Bold(_statsNameRun));
 
         _statsVerticesRun = new Run("0");
-        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsVerticesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
         _statsVerticesBlock.Inlines.Add(new Bold(_statsVerticesRun));
 
         _statsTrianglesRun = new Run("0");
-        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsTrianglesBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
         _statsTrianglesBlock.Inlines.Add(new Bold(_statsTrianglesRun));
 
         _statsBoundsRun = new Run("0.0 x 0.0 x 0.0");
-        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsBoundsBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
         _statsBoundsBlock.Inlines.Add(new Bold(_statsBoundsRun));
 
         _statsMemoryRun = new Run("0 KB");
-        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Right };
+        _statsMemoryBlock = new RichTextBlock { Font = AppState.GetFont(), FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary"), HorizontalAlignment = HorizontalAlignment.Stretch };
         _statsMemoryBlock.Inlines.Add(new Bold(_statsMemoryRun));
 
         statsStack.AddChild(CreateStatRow("Name:", _statsNameBlock));
@@ -649,8 +648,7 @@ public static class Mesh3DViewerPage
             Margin = new Thickness(4f),
             Background = new ThemeResourceBrush("ControlBackgroundHover")
         };
-        var customBtnRun = new Run("Custom") { FontSize = 11f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        customBtn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(customBtnRun) } };
+        customBtn.Content = "Custom";
 
         customBtn.Click += (s, e) => { ShowColorPickerPopup(customBtn); };
         colorGrid.AddChild(customBtn);
@@ -1620,8 +1618,7 @@ public static class Mesh3DViewerPage
             Padding = new Thickness(0),
             Background = new ThemeResourceBrush(mode == LayoutMode3D.Quad ? "ControlBackgroundPressed" : "ControlBackgroundHover")
         };
-        var textRun = new Run(label) { FontSize = 10f, Foreground = new ThemeResourceBrush("TextPrimary") };
-        btn.Content = new RichTextBlock { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center, Inlines = { new Bold(textRun) } };
+        btn.Content = label;
         btn.Click += (s, e) => { SetLayoutMode(mode); };
         return btn;
     }

--- a/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
+++ b/src/ProGPU.Samples/Pages/Mesh3DViewerPage.cs
@@ -219,9 +219,49 @@ public enum LayoutMode3D
 
 public class Mesh3DViewerPageGrid : Grid, IAnimatedElement
 {
+    private bool? _isNarrow;
+
+    public FrameworkElement? Sidebar { get; set; }
+    public FrameworkElement? Workspace { get; set; }
+
+    public Mesh3DViewerPageGrid()
+    {
+        ApplyResponsiveStructure(isNarrow: false);
+    }
+
     public void Update(float delta)
     {
         Mesh3DViewerPage.UpdateAnimations((float)delta);
+    }
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        var isNarrow = availableSize.X < 720f;
+        if (_isNarrow != isNarrow) ApplyResponsiveStructure(isNarrow);
+        return base.MeasureOverride(availableSize);
+    }
+
+    private void ApplyResponsiveStructure(bool isNarrow)
+    {
+        _isNarrow = isNarrow;
+        ColumnDefinitions.Clear();
+        RowDefinitions.Clear();
+        if (isNarrow)
+        {
+            ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+            RowDefinitions.Add(new GridLength(0.55f, GridUnitType.Star));
+            RowDefinitions.Add(new GridLength(0.45f, GridUnitType.Star));
+            if (Sidebar != null) { SetColumn(Sidebar, 0); SetRow(Sidebar, 0); }
+            if (Workspace != null) { SetColumn(Workspace, 0); SetRow(Workspace, 1); }
+        }
+        else
+        {
+            ColumnDefinitions.Add(new GridLength(300f, GridUnitType.Absolute));
+            ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+            RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+            if (Sidebar != null) { SetColumn(Sidebar, 0); SetRow(Sidebar, 0); }
+            if (Workspace != null) { SetColumn(Workspace, 1); SetRow(Workspace, 0); }
+        }
     }
 }
 
@@ -294,8 +334,6 @@ public static class Mesh3DViewerPage
     public static FrameworkElement Create()
     {
         var mainGrid = new Mesh3DViewerPageGrid();
-        mainGrid.ColumnDefinitions.Add(new GridLength(300f, GridUnitType.Absolute)); // Sidebar parameters
-        mainGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));       // Main dual viewports
 
         // Load default shape
         RegenerateMeshGeometry();
@@ -1002,6 +1040,8 @@ public static class Mesh3DViewerPage
 
         mainGrid.AddChild(_viewportsGrid);
         Grid.SetColumn(_viewportsGrid, 1);
+        mainGrid.Sidebar = sidebar;
+        mainGrid.Workspace = _viewportsGrid;
 
         // Populate initial 3D geometries and register layout animation callbacks
         UpdateViewportModels();

--- a/src/ProGPU.Samples/Pages/PictureShowcasePage.cs
+++ b/src/ProGPU.Samples/Pages/PictureShowcasePage.cs
@@ -327,9 +327,11 @@ public static class PictureShowcasePage
         Grid.SetRow(descText, 0);
 
         // Body Content Columns
-        var contentGrid = new Grid { Margin = new Thickness(12) };
-        contentGrid.ColumnDefinitions.Add(new GridLength(280, GridUnitType.Absolute)); // Sidebar controller
-        contentGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));       // Vector visual canvas
+        var contentSplit = new ResponsiveSplitView
+        {
+            Margin = new Thickness(12),
+            OpenPaneLength = 280f
+        };
 
         // Sidebar Panel
         var sidebarBorder = new Border
@@ -444,8 +446,7 @@ public static class PictureShowcasePage
         sidebarStack.AddChild(zoomStack);
 
         sidebarBorder.Child = sidebarStack;
-        contentGrid.AddChild(sidebarBorder);
-        Grid.SetColumn(sidebarBorder, 0);
+        contentSplit.PaneContent = sidebarBorder;
 
         // Canvas container border
         var canvasBorder = new Border
@@ -456,11 +457,10 @@ public static class PictureShowcasePage
             CornerRadius = 8f,
             Child = pictureVisual
         };
-        contentGrid.AddChild(canvasBorder);
-        Grid.SetColumn(canvasBorder, 1);
+        contentSplit.MainContent = canvasBorder;
 
-        mainGrid.AddChild(contentGrid);
-        Grid.SetRow(contentGrid, 1);
+        mainGrid.AddChild(contentSplit);
+        Grid.SetRow(contentSplit, 1);
 
         return mainGrid;
     }

--- a/src/ProGPU.Samples/Pages/SamplePagePresenter.cs
+++ b/src/ProGPU.Samples/Pages/SamplePagePresenter.cs
@@ -285,9 +285,11 @@ public static class SamplePagePresenter
         description.Inlines.Add(new Run("This MotionMark-inspired benchmark renders thousands of animated line and Bezier segments through the public DrawingContext path API. Retained PathGeometry instances avoid rebuilding segment objects while preserving the normal renderer and cache behavior."));
         stack.AddChild(description);
 
-        var grid = new Microsoft.UI.Xaml.Controls.Grid { HeightConstraint = 620f };
-        grid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Column 0: Settings Panel
-        grid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // Column 1: Visual Canvas Card
+        var grid = new ResponsiveSplitView
+        {
+            HeightConstraint = 620f,
+            OpenPaneLength = 300f
+        };
 
         var visual = new MotionMarkShowcaseVisual();
 
@@ -437,11 +439,8 @@ public static class SamplePagePresenter
         };
         settingsStack.AddChild(gpuToggle);
 
-        grid.AddChild(settingsCard);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(settingsCard, 0);
-
-        grid.AddChild(visual);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(visual, 1);
+        grid.PaneContent = settingsCard;
+        grid.MainContent = visual;
 
         stack.AddChild(grid);
 
@@ -450,9 +449,12 @@ public static class SamplePagePresenter
 
     public static FrameworkElement CreateTypographyScriptsView()
     {
-        var scroll = new ScrollViewer { HorizontalAlignment = HorizontalAlignment.Stretch, VerticalAlignment = VerticalAlignment.Stretch };
+        var root = new Microsoft.UI.Xaml.Controls.Grid();
+        root.RowDefinitions.Add(GridLength.Auto);
+        root.RowDefinitions.Add(GridLength.Star(1f));
         var stack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(16) };
-        scroll.Content = stack;
+        root.AddChild(stack);
+        Microsoft.UI.Xaml.Controls.Grid.SetRow(stack, 0);
 
         var title = new RichTextBlock { Font = AppState.GetFont(), FontSize = 18f, Margin = new Thickness(0, 0, 0, 8) };
         title.Inlines.Add(new Bold(new Run("Advanced Typography, Unicode & Language Scripts")));
@@ -462,9 +464,11 @@ public static class SamplePagePresenter
         description.Inlines.Add(new Run("This page showcases the high-performance rendering of different language scripts, custom system fonts, and Unicode symbol outlines on the GPU. Settings altered in the configuration card apply dynamically to all script panels."));
         stack.AddChild(description);
 
-        var grid = new Microsoft.UI.Xaml.Controls.Grid();
-        grid.ColumnDefinitions.Add(new GridLength(280f, GridUnitType.Absolute)); // Settings Sidebar
-        grid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));       // Scripts Dashboard
+        var grid = new ResponsiveSplitView
+        {
+            Margin = new Thickness(16, 0, 16, 16),
+            OpenPaneLength = 280f
+        };
 
         // Left Panel: Configuration Card
         var settingsCard = new Border
@@ -542,13 +546,17 @@ public static class SamplePagePresenter
         var gammaSlider = new Microsoft.UI.Xaml.Controls.Slider { Minimum = 1.0f, Maximum = 3.0f, Value = Compositor.DefaultTextGamma, Margin = new Thickness(0, 0, 0, 16) };
         settingsStack.AddChild(gammaSlider);
 
-        grid.AddChild(settingsCard);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(settingsCard, 0);
+        grid.PaneContent = settingsCard;
 
         // Right Panel: Scripts List
         var dashboardStack = new StackPanel { Orientation = Orientation.Vertical };
-        grid.AddChild(dashboardStack);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(dashboardStack, 1);
+        var dashboardScroll = new ScrollViewer
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Content = dashboardStack
+        };
+        grid.MainContent = dashboardScroll;
 
         var textBlocks = new List<RichTextBlock>();
 
@@ -714,8 +722,9 @@ public static class SamplePagePresenter
         contrastSlider.ValueChanged += (s, e) => updateVisuals();
         gammaSlider.ValueChanged += (s, e) => updateVisuals();
 
-        stack.AddChild(grid);
-        return scroll;
+        root.AddChild(grid);
+        Microsoft.UI.Xaml.Controls.Grid.SetRow(grid, 1);
+        return root;
     }
 
     public static FrameworkElement CreateInteractiveInputView()

--- a/src/ProGPU.Samples/Pages/ShaderToyPlaygroundPage.cs
+++ b/src/ProGPU.Samples/Pages/ShaderToyPlaygroundPage.cs
@@ -16,7 +16,7 @@ using Microsoft.UI.Xaml.Documents;
 
 namespace ProGPU.Samples
 {
-    public class ShaderToyPlaygroundPageGrid : Grid, IAnimatedElement
+    public class ShaderToyPlaygroundPageGrid : ResponsiveSplitView, IAnimatedElement
     {
         private readonly ShaderToyControl _toyControl;
         private readonly RichEditBox _editor;
@@ -75,10 +75,8 @@ namespace ProGPU.Samples
             _pauseBtn.Content = new TextBlock { Text = "Pause", Font = AppState._font, FontSize = 11f, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
 
             Margin = new Thickness(12);
-
-            // Columns: Left (Code & Controls) / Right (Canvas & Console)
-            ColumnDefinitions.Add(new GridLength(460, GridUnitType.Absolute));
-            ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+            OpenPaneLength = 460f;
+            CompactModeThreshold = 900f;
 
             // ----------------------------------------------------
             // LEFT COLUMN: Controls & Code Editor
@@ -243,8 +241,7 @@ namespace ProGPU.Samples
             leftGrid.AddChild(editorBorder);
             Grid.SetRow(editorBorder, 2);
 
-            AddChild(leftGrid);
-            Grid.SetColumn(leftGrid, 0);
+            PaneContent = leftGrid;
 
             // ----------------------------------------------------
             // RIGHT COLUMN: Live Canvas & Console Log
@@ -288,8 +285,7 @@ namespace ProGPU.Samples
             rightGrid.AddChild(consoleCard);
             Grid.SetRow(consoleCard, 1);
 
-            AddChild(rightGrid);
-            Grid.SetColumn(rightGrid, 1);
+            MainContent = rightGrid;
 
             // Handle dropdown Preset changes
             presetCombo.SelectionChanged += (s, e) =>

--- a/src/ProGPU.Samples/Pages/ShaderToyPlaygroundPage.cs
+++ b/src/ProGPU.Samples/Pages/ShaderToyPlaygroundPage.cs
@@ -77,6 +77,7 @@ namespace ProGPU.Samples
             Margin = new Thickness(12);
             OpenPaneLength = 460f;
             CompactModeThreshold = 900f;
+            IsPaneScrollEnabled = false;
 
             // ----------------------------------------------------
             // LEFT COLUMN: Controls & Code Editor

--- a/src/ProGPU.Samples/Pages/TextDocumentsPage.cs
+++ b/src/ProGPU.Samples/Pages/TextDocumentsPage.cs
@@ -25,10 +25,6 @@ public static class TextDocumentsPage
 {
         public static FrameworkElement Create()
         {
-            var grid = new Microsoft.UI.Xaml.Controls.Grid();
-            grid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
-            grid.ColumnDefinitions.Add(new GridLength(1.1f, GridUnitType.Star));
-    
             // Column 0: Interactive text typing editors
             var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(8) };
             
@@ -123,9 +119,6 @@ public static class TextDocumentsPage
             actionBtns2.AddChild(cutBtn);
             actionBtns2.AddChild(pasteBtn);
             leftStack.AddChild(actionBtns2);
-    
-            grid.AddChild(leftStack);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
     
             // Column 1: Multi-column FlowDocument
             var rightStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(8) };
@@ -223,9 +216,11 @@ public static class TextDocumentsPage
             docBorder.Child = flowDoc;
             rightStack.AddChild(docBorder);
     
-            grid.AddChild(rightStack);
-            Microsoft.UI.Xaml.Controls.Grid.SetColumn(rightStack, 1);
-    
-            return grid;
+            return new ResponsiveSplitView
+            {
+                OpenPaneLength = 420f,
+                PaneContent = leftStack,
+                MainContent = rightStack
+            };
         }
 }

--- a/src/ProGPU.Samples/Pages/TouchGesturesPage.cs
+++ b/src/ProGPU.Samples/Pages/TouchGesturesPage.cs
@@ -1,0 +1,230 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Input;
+using ProGPU.Scene;
+using ProGPU.Vector;
+
+namespace ProGPU.Samples;
+
+public static class TouchGesturesPage
+{
+    public static FrameworkElement Create()
+    {
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Thickness(16),
+            Spacing = 12
+        };
+        var title = new RichTextBlock { FontSize = 24f };
+        title.Inlines.Add(new Bold(new Run("Touch, gestures & mobile input")));
+        content.AddChild(title);
+
+        var description = new RichTextBlock { FontSize = 13f };
+        description.Inlines.Add(new Run("Use one or two contacts on the gesture surface. Drag pans, pinch scales, twist rotates, tap/double-tap/hold are routed independently, and the cards reflow at the WinUI adaptive breakpoint."));
+        content.AddChild(description);
+
+        var responsiveRow = new StackPanel
+        {
+            Name = "ResponsiveGestureRow",
+            Orientation = Orientation.Vertical,
+            Spacing = 12,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        var gesturePad = new GesturePad
+        {
+            Height = 260f,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        responsiveRow.AddChild(CreateCard("DIRECT MANIPULATION", gesturePad));
+
+        var inputStack = new StackPanel { Orientation = Orientation.Vertical, Spacing = 10 };
+        var email = new TextBox
+        {
+            PlaceholderText = "Email address",
+            Width = float.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            EnterKeyHint = "next",
+            AutoCapitalization = "off"
+        };
+        email.InputScope.Names.Add(new InputScopeName { NameValue = InputScopeNameValue.EmailSmtpAddress });
+        var number = new TextBox
+        {
+            PlaceholderText = "Decimal number",
+            Width = float.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            EnterKeyHint = "done",
+            IsSpellCheckEnabled = false
+        };
+        number.InputScope.Names.Add(new InputScopeName { NameValue = InputScopeNameValue.Number });
+        var multiline = new TextBox
+        {
+            PlaceholderText = "Multiline mobile input",
+            Width = float.NaN,
+            Height = 72f,
+            AcceptsReturn = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        inputStack.AddChild(email);
+        inputStack.AddChild(number);
+        inputStack.AddChild(multiline);
+        inputStack.AddChild(new PasswordBox { Width = float.NaN, HorizontalAlignment = HorizontalAlignment.Stretch });
+        responsiveRow.AddChild(CreateCard("SOFTWARE KEYBOARD SCOPES", inputStack));
+        content.AddChild(responsiveRow);
+
+        var states = new VisualStateGroup { Name = "ResponsiveColumns" };
+        var narrow = new VisualState { Name = "Narrow" };
+        narrow.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 0 });
+        narrow.Setters.Add(new Setter("Orientation", Orientation.Vertical));
+        var wide = new VisualState { Name = "Wide" };
+        wide.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 720 });
+        wide.Setters.Add(new Setter("Orientation", Orientation.Horizontal));
+        states.States.Add(narrow);
+        states.States.Add(wide);
+        VisualStateManager.GetVisualStateGroups(responsiveRow).Add(states);
+
+        for (var index = 0; index < 8; index++)
+        {
+            var line = new RichTextBlock { FontSize = 13f, Margin = new Thickness(4) };
+            line.Inlines.Add(new Run($"Scrollable touch row {index + 1} — pan anywhere outside the gesture surface."));
+            content.AddChild(line);
+        }
+
+        return new ScrollViewer
+        {
+            Content = content,
+            HorizontalScrollMode = ScrollMode.Disabled,
+            VerticalScrollMode = ScrollMode.Auto,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+    }
+
+    private static Border CreateCard(string header, FrameworkElement child)
+    {
+        var stack = new StackPanel { Orientation = Orientation.Vertical, Spacing = 8 };
+        var title = new RichTextBlock { FontSize = 12f };
+        title.Inlines.Add(new Bold(new Run(header)));
+        stack.AddChild(title);
+        stack.AddChild(child);
+        return new Border
+        {
+            Child = stack,
+            Background = new ThemeResourceBrush("CardBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(1f),
+            CornerRadius = 10f,
+            Padding = new Thickness(12),
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+    }
+
+    private sealed class GesturePad : Control
+    {
+        private readonly Brush _background = new ThemeResourceBrush("ControlBackground");
+        private readonly Brush _accent = new ThemeResourceBrush("SystemAccentColor");
+        private readonly Brush _foreground = new ThemeResourceBrush("TextPrimary");
+        private readonly Brush _contact = new ThemeResourceBrush("SelectionHighlight");
+        private readonly Pen _border = new(new ThemeResourceBrush("ControlBorder"), 1f);
+        private readonly Pen _direction = new(new ThemeResourceBrush("TextPrimary"), 3f);
+        private readonly Dictionary<uint, Vector2> _contacts = new();
+        private string _status = "Ready — tap, hold, drag, pinch, or rotate";
+        private Vector2 _translation;
+        private float _scale = 1f;
+        private float _rotation;
+
+        public GesturePad()
+        {
+            ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY |
+                ManipulationModes.Rotate | ManipulationModes.Scale |
+                ManipulationModes.TranslateInertia | ManipulationModes.RotateInertia | ManipulationModes.ScaleInertia;
+            CornerRadius = 12f;
+            IsTabStop = true;
+        }
+
+        public override void OnPointerPressed(PointerRoutedEventArgs e)
+        {
+            _contacts[e.Pointer.PointerId] = e.Position;
+            CapturePointer(e.Pointer);
+            _status = $"Pointer {e.Pointer.PointerId} · {e.Pointer.PointerDeviceType} · pressure {e.Pressure:0.00}";
+            Invalidate();
+            base.OnPointerPressed(e);
+        }
+
+        public override void OnPointerMoved(PointerRoutedEventArgs e)
+        {
+            if (_contacts.ContainsKey(e.Pointer.PointerId)) _contacts[e.Pointer.PointerId] = e.Position;
+            Invalidate();
+            base.OnPointerMoved(e);
+        }
+
+        public override void OnPointerReleased(PointerRoutedEventArgs e)
+        {
+            _contacts.Remove(e.Pointer.PointerId);
+            ReleasePointerCapture(e.Pointer);
+            Invalidate();
+            base.OnPointerReleased(e);
+        }
+
+        public override void OnPointerCanceled(PointerRoutedEventArgs e)
+        {
+            _contacts.Remove(e.Pointer.PointerId);
+            Invalidate();
+            base.OnPointerCanceled(e);
+        }
+
+        public override void OnTapped(TappedRoutedEventArgs e)
+        {
+            _status = $"Tapped with {e.PointerDeviceType}";
+            Invalidate();
+            base.OnTapped(e);
+        }
+
+        public override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+        {
+            _translation = Vector2.Zero;
+            _scale = 1f;
+            _rotation = 0f;
+            _status = "Double tapped — transform reset";
+            Invalidate();
+            base.OnDoubleTapped(e);
+        }
+
+        public override void OnHolding(HoldingRoutedEventArgs e)
+        {
+            _status = $"Holding {e.HoldingState}";
+            Invalidate();
+            base.OnHolding(e);
+        }
+
+        public override void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)
+        {
+            _translation += e.Delta.Translation;
+            _scale = Math.Clamp(_scale * e.Delta.Scale, 0.5f, 2.5f);
+            _rotation += e.Delta.Rotation;
+            _status = $"Δ {e.Delta.Translation.X:0.0},{e.Delta.Translation.Y:0.0} · scale {_scale:0.00} · rotation {_rotation:0.0}°";
+            Invalidate();
+            e.Handled = true;
+            base.OnManipulationDelta(e);
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRoundedRectangle(_background, _border, new Rect(Vector2.Zero, Size), CornerRadius);
+
+            var center = Size * 0.5f + _translation * 0.2f;
+            var radius = 34f * _scale;
+            context.DrawEllipse(_accent, null, center, radius, radius);
+            var angle = _rotation * MathF.PI / 180f;
+            var direction = new Vector2(MathF.Cos(angle), MathF.Sin(angle)) * radius;
+            context.DrawLine(_direction, center - direction, center + direction);
+            foreach (var contact in _contacts.Values)
+                context.DrawEllipse(_contact, null, contact, 14f, 14f);
+            if (Font != null)
+                context.DrawText(_status, Font, 12f, _foreground, new Vector2(14f, Math.Max(14f, Size.Y - 30f)));
+            base.OnRender(context);
+        }
+    }
+}

--- a/src/ProGPU.Samples/Pages/WpfShowcasePage.cs
+++ b/src/ProGPU.Samples/Pages/WpfShowcasePage.cs
@@ -119,10 +119,6 @@ public static class WpfShowcasePage
 {
     public static FrameworkElement Create()
     {
-        var grid = new Microsoft.UI.Xaml.Controls.Grid();
-        grid.ColumnDefinitions.Add(new GridLength(300, GridUnitType.Absolute)); // Left adjust pane
-        grid.ColumnDefinitions.Add(new GridLength(1, GridUnitType.Star));      // Right Visual preview
-
         var leftStack = new StackPanel { Orientation = Orientation.Vertical, Margin = new Thickness(12) };
 
         var title = new RichTextBlock { Font = AppState._font, FontSize = 15f, Margin = new Thickness(0, 0, 0, 5) };
@@ -287,9 +283,6 @@ public static class WpfShowcasePage
         };
         leftStack.AddChild(resetBtn);
 
-        grid.AddChild(leftStack);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(leftStack, 0);
-
         var previewContainer = new Border
         {
             CornerRadius = 8f,
@@ -300,9 +293,11 @@ public static class WpfShowcasePage
             Child = visual
         };
 
-        grid.AddChild(previewContainer);
-        Microsoft.UI.Xaml.Controls.Grid.SetColumn(previewContainer, 1);
-
-        return grid;
+        return new ResponsiveSplitView
+        {
+            OpenPaneLength = 300f,
+            PaneContent = leftStack,
+            MainContent = previewContainer
+        };
     }
 }

--- a/src/ProGPU.Samples/Windows/MainWindowController.cs
+++ b/src/ProGPU.Samples/Windows/MainWindowController.cs
@@ -279,6 +279,7 @@ public static unsafe class MainWindowController
         AppState._navigationView = new NavigationView
         {
             Font = AppState._font,
+            IsPaneToggleButtonVisible = false,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch
         };

--- a/src/ProGPU.Samples/Windows/MainWindowController.cs
+++ b/src/ProGPU.Samples/Windows/MainWindowController.cs
@@ -129,9 +129,9 @@ public static unsafe class MainWindowController
         var headerGrid = new Microsoft.UI.Xaml.Controls.Grid();
         headerGrid.ColumnDefinitions.Add(new GridLength(45f, GridUnitType.Absolute));  // Column 0: Hamburger Button
         headerGrid.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));       // Column 1: Title Logo
-        headerGrid.ColumnDefinitions.Add(new GridLength(120f, GridUnitType.Absolute)); // Column 2: Theme Family Selector
-        headerGrid.ColumnDefinitions.Add(new GridLength(120f, GridUnitType.Absolute)); // Column 3: Theme Selector
-        headerGrid.ColumnDefinitions.Add(new GridLength(300f, GridUnitType.Absolute)); // Column 4: Subtitle text
+        headerGrid.ColumnDefinitions.Add(GridLength.Auto); // Column 2: Theme Family Selector
+        headerGrid.ColumnDefinitions.Add(GridLength.Auto); // Column 3: Theme Selector
+        headerGrid.ColumnDefinitions.Add(GridLength.Auto); // Column 4: Subtitle text
 
         var hamburgerBtn = new Button
         {
@@ -153,7 +153,7 @@ public static unsafe class MainWindowController
         headerGrid.AddChild(hamburgerBtn);
         Microsoft.UI.Xaml.Controls.Grid.SetColumn(hamburgerBtn, 0);
 
-        var titleText = new RichTextBlock { Font = AppState._font, FontSize = 20f, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(10, 0, 0, 0) };
+        var titleText = new RichTextBlock { Name = "GalleryTitle", Font = AppState._font, FontSize = 20f, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(10, 0, 0, 0) };
         var logoRun = new Run("Pro") { Foreground = new ProGPU.Vector.ThemeResourceBrush("SystemAccentColor") };
         titleText.Inlines.Add(new Bold(logoRun));
         titleText.Inlines.Add(new Bold(new Run("GPU WinUI Gallery")));
@@ -163,6 +163,7 @@ public static unsafe class MainWindowController
         // Theme Family selector button [ WinUI / macOS ]
         var familyBtn = new Button
         {
+            Name = "FamilySelector",
             Width = 100f,
             Height = 32f,
             CornerRadius = 6f,
@@ -198,6 +199,7 @@ public static unsafe class MainWindowController
         // Sun/Moon dynamic theme selector toggle button
         var themeBtn = new Button
         {
+            Name = "ThemeSelector",
             Width = 100f,
             Height = 32f,
             CornerRadius = 6f,
@@ -238,6 +240,7 @@ public static unsafe class MainWindowController
 
         var subtitleText = new RichTextBlock 
         { 
+            Name = "GallerySubtitle",
             Font = AppState._font, 
             FontSize = 11f, 
             VerticalAlignment = VerticalAlignment.Center,
@@ -246,6 +249,27 @@ public static unsafe class MainWindowController
         subtitleText.Inlines.Add(new Run(".NET 10 cross-platform high-performance engine showcase"));
         headerGrid.AddChild(subtitleText);
         Microsoft.UI.Xaml.Controls.Grid.SetColumn(subtitleText, 4);
+
+        var headerStates = new VisualStateGroup { Name = "WindowWidthStates" };
+        var narrowHeader = new VisualState { Name = "Narrow" };
+        narrowHeader.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 0 });
+        narrowHeader.Setters.Add(new Setter("FamilySelector.Visibility", Visibility.Collapsed));
+        narrowHeader.Setters.Add(new Setter("ThemeSelector.Visibility", Visibility.Collapsed));
+        narrowHeader.Setters.Add(new Setter("GallerySubtitle.Visibility", Visibility.Collapsed));
+        var mediumHeader = new VisualState { Name = "Medium" };
+        mediumHeader.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 560 });
+        mediumHeader.Setters.Add(new Setter("FamilySelector.Visibility", Visibility.Collapsed));
+        mediumHeader.Setters.Add(new Setter("ThemeSelector.Visibility", Visibility.Visible));
+        mediumHeader.Setters.Add(new Setter("GallerySubtitle.Visibility", Visibility.Collapsed));
+        var wideHeader = new VisualState { Name = "Wide" };
+        wideHeader.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 900 });
+        wideHeader.Setters.Add(new Setter("FamilySelector.Visibility", Visibility.Visible));
+        wideHeader.Setters.Add(new Setter("ThemeSelector.Visibility", Visibility.Visible));
+        wideHeader.Setters.Add(new Setter("GallerySubtitle.Visibility", Visibility.Visible));
+        headerStates.States.Add(narrowHeader);
+        headerStates.States.Add(mediumHeader);
+        headerStates.States.Add(wideHeader);
+        VisualStateManager.GetVisualStateGroups(headerGrid).Add(headerStates);
 
         headerBar.Child = headerGrid;
         AppState._rootGrid.AddChild(headerBar);
@@ -280,6 +304,7 @@ public static unsafe class MainWindowController
         var motionAnimationsItem = PageItem("Motion & Animations", "🎬", MotionAnimationsPage.Create);
         var advancedItem = PageItem("Advanced Controls", "🛠", AdvancedControlsPage.Create);
         var keyboardParityItem = PageItem("Keyboard & Focus", "⌨️", KeyboardParityPage.Create);
+        var touchGesturesItem = PageItem("Touch & Gestures", "☝", TouchGesturesPage.Create);
         var themeShowcaseItem = PageItem("Theme Showcase", "🎨", ThemeShowcasePage.Create);
         var compositorItem = PageItem("Compositor API", "🎨", CompositorShowcasePage.Create);
         var splitViewItem = PageItem("SplitView Layout", "🪟", SplitViewShowcasePage.Create);
@@ -334,6 +359,7 @@ public static unsafe class MainWindowController
         AppState._navigationView.MenuItems.Add(motionAnimationsItem);
         AppState._navigationView.MenuItems.Add(advancedItem);
         AppState._navigationView.MenuItems.Add(keyboardParityItem);
+        AppState._navigationView.MenuItems.Add(touchGesturesItem);
         AppState._navigationView.MenuItems.Add(themeShowcaseItem);
         AppState._navigationView.MenuItems.Add(compositorItem);
         AppState._navigationView.MenuItems.Add(splitViewItem);

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -172,6 +172,7 @@ public readonly record struct RenderTargetViewport(float X, float Y, float Width
 
 public unsafe class Compositor : IDisposable
 {
+    private const float MaximumGlyphAtlasRasterSize = 128f;
     public enum VectorRenderingEngine
     {
         Atlas,
@@ -386,9 +387,11 @@ public unsafe class Compositor : IDisposable
         // Rasterize ordinary atlas text at its actual physical size. Coarsely
         // quantizing high-DPI UI text (for example 11 DIP * 3 = 33 px) and then
         // scaling the bitmap back to the requested size softens every edge. The
-        // atlas remains bounded by its existing capacity/LRU policy, while text
-        // above the 64 px bitmap ceiling continues through the vector fallback.
-        return Math.Clamp(targetRasterFontSize, 4f, 64f);
+        // atlas remains bounded by its existing capacity/LRU policy. Keeping
+        // common mobile display text (for example 26 DIP at DPR 3) in the glyph
+        // atlas also lets viewport culling run before residency is requested;
+        // exceptionally large text continues through the vector fallback.
+        return Math.Clamp(targetRasterFontSize, 4f, MaximumGlyphAtlasRasterSize);
     }
 
     private readonly List<StaticTextRecord> _compiledTextRecords = new();
@@ -5569,7 +5572,8 @@ SceneStateUploadComplete:
         RenderCommand cmd,
         Matrix4x4 transform,
         uint subpixelPhaseGrid = PathAtlas.DefaultSubpixelPhaseGrid,
-        bool quantizeScale = false)
+        bool quantizeScale = false,
+        float rasterScale = 1f)
     {
         SwitchBatch(BatchType.Vector);
         if (cmd.Path == null) return;
@@ -5633,12 +5637,18 @@ SceneStateUploadComplete:
                 scaleX = scaleY = Math.Max(scaleX, scaleY);
             }
 
+            rasterScale = float.IsFinite(rasterScale) && rasterScale > 0f
+                ? rasterScale
+                : 1f;
+            scaleX *= rasterScale;
+            scaleY *= rasterScale;
+
             var info = _pathAtlas.GetOrCreatePath(
                 cmd.Path,
                 scaleX,
                 scaleY,
-                GetSubpixelPhase(transform.M41),
-                GetSubpixelPhase(transform.M42),
+                GetSubpixelPhase(transform.M41 * rasterScale),
+                GetSubpixelPhase(transform.M42 * rasterScale),
                 cmd.PathSampleGrid,
                 subpixelPhaseGrid,
                 quantizeScale);
@@ -5739,7 +5749,12 @@ SceneStateUploadComplete:
                     }
                 }
 
-                CompilePathCommand(dashedCmd, transform);
+                CompilePathCommand(
+                    dashedCmd,
+                    transform,
+                    subpixelPhaseGrid,
+                    quantizeScale,
+                    rasterScale);
                 return;
             }
 
@@ -9401,6 +9416,9 @@ SceneStateUploadComplete:
             rasterFontSize = ResolveGlyphRasterSize(logicalTargetSize);
             atlasToLogicalScale = cmd.FontSize / MathF.Max(rasterFontSize, 0.0001f);
         }
+        var vectorGlyphRasterScale = cmd.UseLogicalGlyphAtlasResolution
+            ? (float.IsFinite(staticZoom) && staticZoom > 0f ? staticZoom : 1f)
+            : dpiScale;
         var fontScaleX = cmd.HasFontTransform && float.IsFinite(cmd.FontTransform.X)
             ? cmd.FontTransform.X
             : 1f;
@@ -9442,6 +9460,15 @@ SceneStateUploadComplete:
 
             if (colorLayers != null && colorLayers.Count > 0)
             {
+                if (IsVectorGlyphOutsideActiveClip(
+                    runGlyph.Position + cmd.Position,
+                    cmd.FontSize,
+                    activeTransform,
+                    fontScaleX))
+                {
+                    continue;
+                }
+
                 for (int layerIndex = 0; layerIndex < colorLayers.Count; layerIndex++)
                 {
                     var layer = colorLayers[layerIndex];
@@ -9470,7 +9497,12 @@ SceneStateUploadComplete:
                             : PathAtlas.HighPrecisionCoverageSampleGrid,
                         PathCoverageGamma = textPathCoverageGamma
                     };
-                    CompilePathCommand(pathCmd, activeTransform);
+                    CompilePathCommand(
+                        pathCmd,
+                        activeTransform,
+                        subpixelPhaseGrid: VectorGlyphDeviceSubpixelPhaseGrid,
+                        quantizeScale: true,
+                        rasterScale: vectorGlyphRasterScale);
                 }
 
                 continue;
@@ -9528,7 +9560,8 @@ SceneStateUploadComplete:
                     glyphItalicSkew,
                     textPathCoverageGamma,
                     activeTransform,
-                    fontScaleX);
+                    fontScaleX,
+                    vectorGlyphRasterScale);
 
                 continue;
             }
@@ -9563,7 +9596,8 @@ SceneStateUploadComplete:
                     glyphItalicSkew,
                     textPathCoverageGamma,
                     activeTransform,
-                    fontScaleX);
+                    fontScaleX,
+                    vectorGlyphRasterScale);
                 continue;
             }
             var glyphAtlasScale = atlasToLogicalScale * (info.RasterScale > 0f ? info.RasterScale : 1f);
@@ -9642,6 +9676,9 @@ SceneStateUploadComplete:
             rasterFontSize = ResolveGlyphRasterSize(logicalTargetSize);
             atlasToLogicalScale = cmd.FontSize / MathF.Max(rasterFontSize, 0.0001f);
         }
+        var vectorGlyphRasterScale = cmd.UseLogicalGlyphAtlasResolution
+            ? (float.IsFinite(staticZoom) && staticZoom > 0f ? staticZoom : 1f)
+            : dpiScale;
         var fontScaleX = cmd.HasFontTransform && float.IsFinite(cmd.FontTransform.X)
             ? cmd.FontTransform.X
             : 1f;
@@ -9684,6 +9721,15 @@ SceneStateUploadComplete:
 
             if (colorLayers != null && colorLayers.Count > 0)
             {
+                if (IsVectorGlyphOutsideActiveClip(
+                    position + cmd.Position,
+                    cmd.FontSize,
+                    activeTransform,
+                    fontScaleX))
+                {
+                    continue;
+                }
+
                 for (int layerIndex = 0; layerIndex < colorLayers.Count; layerIndex++)
                 {
                     var layer = colorLayers[layerIndex];
@@ -9712,7 +9758,12 @@ SceneStateUploadComplete:
                             : PathAtlas.HighPrecisionCoverageSampleGrid,
                         PathCoverageGamma = textPathCoverageGamma
                     };
-                    CompilePathCommand(pathCmd, activeTransform);
+                    CompilePathCommand(
+                        pathCmd,
+                        activeTransform,
+                        subpixelPhaseGrid: VectorGlyphDeviceSubpixelPhaseGrid,
+                        quantizeScale: true,
+                        rasterScale: vectorGlyphRasterScale);
                 }
 
                 continue;
@@ -9750,7 +9801,8 @@ SceneStateUploadComplete:
                     glyphItalicSkew,
                     textPathCoverageGamma,
                     activeTransform,
-                    fontScaleX);
+                    fontScaleX,
+                    vectorGlyphRasterScale);
 
                 continue;
             }
@@ -9788,7 +9840,8 @@ SceneStateUploadComplete:
                     glyphItalicSkew,
                     textPathCoverageGamma,
                     activeTransform,
-                    fontScaleX);
+                    fontScaleX,
+                    vectorGlyphRasterScale);
                 continue;
             }
             var glyphAtlasScale = atlasToLogicalScale * (info.RasterScale > 0f ? info.RasterScale : 1f);
@@ -9846,6 +9899,19 @@ SceneStateUploadComplete:
         float clipRight = clip.X + clip.Width;
         float clipBottom = clip.Y + clip.Height;
         return maxX <= clip.X || minX >= clipRight || maxY <= clip.Y || minY >= clipBottom;
+    }
+
+    private bool IsVectorGlyphOutsideActiveClip(
+        Vector2 position,
+        float fontSize,
+        Matrix4x4 transform,
+        float scaleX)
+    {
+        var transformedPosition = Vector2.Transform(position, transform);
+        var transformedFontSize = fontSize
+            * TransformMetrics.GetStrokeScale(transform)
+            * MathF.Max(1f, MathF.Abs(scaleX));
+        return IsTextGlyphOutsideActiveClip(transformedPosition, transformedFontSize);
     }
 
     private static bool TryCompileRetainedGlyph(
@@ -9906,8 +9972,18 @@ SceneStateUploadComplete:
         float italicSkew,
         float pathCoverageGamma,
         Matrix4x4 activeTransform,
-        float scaleX)
+        float scaleX,
+        float rasterScale)
     {
+        if (IsVectorGlyphOutsideActiveClip(
+            position,
+            command.FontSize,
+            activeTransform,
+            scaleX))
+        {
+            return;
+        }
+
         var outline = font.GetGlyphOutline(glyphIndex);
         if (outline is null)
         {
@@ -9927,7 +10003,8 @@ SceneStateUploadComplete:
                 pass * boldOffset,
                 pathCoverageGamma,
                 activeTransform,
-                scaleX);
+                scaleX,
+                rasterScale);
         }
     }
 
@@ -9940,7 +10017,8 @@ SceneStateUploadComplete:
         float xOffset,
         float pathCoverageGamma,
         Matrix4x4 activeTransform,
-        float scaleX = 1f)
+        float scaleX = 1f,
+        float rasterScale = 1f)
     {
         var positioned = position + new Vector2(xOffset, 0f);
         PathGeometry positionedOutline;
@@ -10007,7 +10085,8 @@ SceneStateUploadComplete:
             },
             placementTransform,
             subpixelPhaseGrid: VectorGlyphDeviceSubpixelPhaseGrid,
-            quantizeScale: true);
+            quantizeScale: true,
+            rasterScale: rasterScale);
     }
 
     private static float GetTextPathCoverageGamma(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -376,24 +376,19 @@ public unsafe class Compositor : IDisposable
         var transformScale = TransformMetrics.GetStrokeScale(transform);
         var untransformedPhysicalFontSize = fontSize * dpiScale;
         var targetRasterFontSize = untransformedPhysicalFontSize * transformScale * staticZoom;
-        var rasterFontSize = QuantizeGlyphRasterSize(targetRasterFontSize);
+        var rasterFontSize = ResolveGlyphRasterSize(targetRasterFontSize);
         var atlasToLogicalScale = untransformedPhysicalFontSize / MathF.Max(rasterFontSize, 0.0001f);
         return (dpiScale * staticZoom, rasterFontSize, atlasToLogicalScale);
     }
 
-    private static float QuantizeGlyphRasterSize(float targetRasterFontSize)
+    private static float ResolveGlyphRasterSize(float targetRasterFontSize)
     {
-        var rasterFontSize = Math.Clamp(targetRasterFontSize, 4f, 64f);
-        if (rasterFontSize <= 24f)
-        {
-            rasterFontSize = MathF.Round(rasterFontSize * 2f) / 2f;
-        }
-        else
-        {
-            rasterFontSize = MathF.Round(rasterFontSize / 2f) * 2f;
-        }
-
-        return rasterFontSize;
+        // Rasterize ordinary atlas text at its actual physical size. Coarsely
+        // quantizing high-DPI UI text (for example 11 DIP * 3 = 33 px) and then
+        // scaling the bitmap back to the requested size softens every edge. The
+        // atlas remains bounded by its existing capacity/LRU policy, while text
+        // above the 64 px bitmap ceiling continues through the vector fallback.
+        return Math.Clamp(targetRasterFontSize, 4f, 64f);
     }
 
     private readonly List<StaticTextRecord> _compiledTextRecords = new();
@@ -9403,7 +9398,7 @@ SceneStateUploadComplete:
         {
             var logicalTargetSize = cmd.FontSize *
                 TransformMetrics.GetStrokeScale(activeTransform) * staticZoom;
-            rasterFontSize = QuantizeGlyphRasterSize(logicalTargetSize);
+            rasterFontSize = ResolveGlyphRasterSize(logicalTargetSize);
             atlasToLogicalScale = cmd.FontSize / MathF.Max(rasterFontSize, 0.0001f);
         }
         var fontScaleX = cmd.HasFontTransform && float.IsFinite(cmd.FontTransform.X)
@@ -9644,7 +9639,7 @@ SceneStateUploadComplete:
         {
             var logicalTargetSize = cmd.FontSize *
                 TransformMetrics.GetStrokeScale(activeTransform) * staticZoom;
-            rasterFontSize = QuantizeGlyphRasterSize(logicalTargetSize);
+            rasterFontSize = ResolveGlyphRasterSize(logicalTargetSize);
             atlasToLogicalScale = cmd.FontSize / MathF.Max(rasterFontSize, 0.0001f);
         }
         var fontScaleX = cmd.HasFontTransform && float.IsFinite(cmd.FontTransform.X)

--- a/src/ProGPU.Scene/Visual.cs
+++ b/src/ProGPU.Scene/Visual.cs
@@ -403,6 +403,7 @@ public class Visual
 
     public void UpdateAnimations(float elapsedSeconds)
     {
+        OnUpdateAnimations(elapsedSeconds);
         TickAnimations(elapsedSeconds);
 
         if (this is ContainerVisual container)
@@ -413,6 +414,10 @@ public class Visual
                 children[i].UpdateAnimations(elapsedSeconds);
             }
         }
+    }
+
+    protected virtual void OnUpdateAnimations(float elapsedSeconds)
+    {
     }
 
     public void TickAnimations(float elapsedSeconds)

--- a/src/ProGPU.Tests.Headless/HeadlessWindow.cs
+++ b/src/ProGPU.Tests.Headless/HeadlessWindow.cs
@@ -192,6 +192,23 @@ public unsafe class HeadlessWindow : IDisposable
         _compositor.RenderScene(_content, _width, _height, _offscreenTexture!.ViewPtr);
     }
 
+    public void RenderAtDpi(uint logicalWidth, uint logicalHeight, float dpiScale, float deltaTime = 0.016f)
+    {
+        if (_content == null) return;
+
+        _content.UpdateAnimations(deltaTime);
+        _content.Measure(new Vector2(logicalWidth, logicalHeight));
+        _content.Arrange(new Rect(0, 0, logicalWidth, logicalHeight));
+        _compositor.RenderScene(
+            _content,
+            logicalWidth,
+            logicalHeight,
+            _width,
+            _height,
+            dpiScale,
+            _offscreenTexture!.ViewPtr);
+    }
+
     public byte[] ReadPixels(TimeSpan? mapTimeout = null)
     {
         if (_offscreenTexture == null || _readbackBuffer == null)

--- a/src/ProGPU.Tests.Headless/SamplePagesTests.cs
+++ b/src/ProGPU.Tests.Headless/SamplePagesTests.cs
@@ -1926,17 +1926,13 @@ public class SamplePagesTests : IDisposable
                     return;
                 }
             }
-            if (visual is Panel panel)
+            if (visual is ContainerVisual container)
             {
-                foreach (var child in panel.Children)
+                foreach (var child in container.Children)
                 {
                     FindTranspileBtn(child);
                     if (transpileBtn != null) return;
                 }
-            }
-            else if (visual is Border border && border.Child != null)
-            {
-                FindTranspileBtn(border.Child);
             }
         }
 

--- a/src/ProGPU.Tests.Headless/SamplePagesTests.cs
+++ b/src/ProGPU.Tests.Headless/SamplePagesTests.cs
@@ -1569,11 +1569,11 @@ public class SamplePagesTests : IDisposable
         window.Render();
 
         // Initially pointer is not over scrollbar, vertical offset is 0
-        var isPointerOverField = typeof(ScrollViewer).GetField("_isPointerOverScrollbar", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var isDraggingField = typeof(ScrollViewer).GetField("_isDraggingVert", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var isPointerOverField = typeof(ScrollViewer).GetField("_isPointerOverVerticalScrollbar", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var isDraggingField = typeof(ScrollViewer).GetField("_draggingScrollBar", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
         Assert.False((bool?)isPointerOverField?.GetValue(scrollViewer) ?? true);
-        Assert.False((bool?)isDraggingField?.GetValue(scrollViewer) ?? true);
+        Assert.Null(isDraggingField?.GetValue(scrollViewer));
         Assert.Equal(0f, scrollViewer.VerticalOffset);
 
         // Simulate pointer entering the scrollbar area (right edge, e.g. x = 195, y = 10)
@@ -1592,9 +1592,9 @@ public class SamplePagesTests : IDisposable
 
         // Simulate pointer pressing the scrollbar thumb
         // When contentHeight = 1000, viewportHeight = 100.
-        // thumbHeight = Max(20, (100 / 1000) * 100) = Max(20, 10) = 20.
-        // thumbY = (0 / 900) * (100 - 20) = 0.
-        // So thumb is at Y in [0, 20]. A press at (195, 10) should hit the thumb.
+        // thumbHeight = Max(24, (100 / 1000) * 100) = Max(24, 10) = 24.
+        // thumbY = (0 / 900) * (100 - 24) = 0.
+        // So thumb is at Y in [0, 24]. A press at (195, 10) should hit the thumb.
         var pointerPressedArgs = new PointerRoutedEventArgs
         {
             ScreenPosition = new Vector2(195f, 10f),
@@ -1603,12 +1603,12 @@ public class SamplePagesTests : IDisposable
         scrollViewer.OnPointerPressed(pointerPressedArgs);
 
         // Verify it started dragging!
-        Assert.True((bool?)isDraggingField?.GetValue(scrollViewer) ?? false);
+        Assert.Equal(Orientation.Vertical, isDraggingField?.GetValue(scrollViewer));
 
         // Simulate dragging the scrollbar thumb down by 20px (from y = 10 to y = 30)
-        // trackLength = viewportHeight - thumbHeight = 100 - 20 = 80.
+        // trackLength = viewportHeight - thumbHeight = 100 - 24 = 76.
         // deltaY = 30 - 10 = 20.
-        // Expected scroll = 0 + (20 / 80) * scrollableHeight = 0.25 * (1000 - 100) = 0.25 * 900 = 225.
+        // Expected scroll = 0 + (20 / 76) * scrollableHeight = 236.8421.
         var dragMovedArgs = new PointerRoutedEventArgs
         {
             ScreenPosition = new Vector2(195f, 30f),
@@ -1616,7 +1616,7 @@ public class SamplePagesTests : IDisposable
         };
         scrollViewer.OnPointerMoved(dragMovedArgs);
 
-        Assert.Equal(225f, scrollViewer.VerticalOffset);
+        Assert.Equal(236.8421f, scrollViewer.VerticalOffset, 3);
 
         // Release the drag
         var pointerReleasedArgs = new PointerRoutedEventArgs
@@ -1625,7 +1625,7 @@ public class SamplePagesTests : IDisposable
             Position = new Vector2(195f, 30f)
         };
         scrollViewer.OnPointerReleased(pointerReleasedArgs);
-        Assert.False((bool?)isDraggingField?.GetValue(scrollViewer) ?? true);
+        Assert.Null(isDraggingField?.GetValue(scrollViewer));
 
         // Exit pointer
         var pointerExitedArgs = new PointerRoutedEventArgs();

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -177,6 +177,23 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void OffscreenVectorGlyphsAreCulledBeforePathAtlasCompilation()
+    {
+        var font = new TtfFont(BuildMissingGlyphOutlineFont());
+        using var window = new HeadlessWindow(64, 48);
+        window.Content = new ClippedGlyphRunVisual(font, useVectorGlyphRendering: true);
+
+        window.Render();
+
+        var compiledGlyphCount = GetDrawCalls(window.Compositor)
+            .Where(static drawCall => drawCall.Type == Compositor.DrawCallType.Vector)
+            .Sum(static drawCall => (long)drawCall.IndexCount) / 6;
+        Assert.Equal(1, compiledGlyphCount);
+        Assert.Equal(1, window.Compositor.PathAtlas.CachedPathCount);
+        Assert.False(window.Compositor.PathAtlas.CapacityExceeded);
+    }
+
+    [Fact]
     public void TextLayoutCacheMemoryStaysBoundedAcrossDistinctVirtualizedRows()
     {
         const int visibleRows = 128;
@@ -5554,10 +5571,12 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     private sealed class ClippedGlyphRunVisual : FrameworkElement
     {
         private readonly TtfFont _font;
+        private readonly bool _useVectorGlyphRendering;
 
-        public ClippedGlyphRunVisual(TtfFont font)
+        public ClippedGlyphRunVisual(TtfFont font, bool useVectorGlyphRendering = false)
         {
             _font = font;
+            _useVectorGlyphRendering = useVectorGlyphRendering;
             Width = 64f;
             Height = 48f;
         }
@@ -5576,7 +5595,8 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                 _font,
                 24f,
                 new SolidColorBrush(Vector4.One),
-                Vector2.Zero);
+                Vector2.Zero,
+                useVectorGlyphRendering: _useVectorGlyphRendering);
             context.PopClip();
         }
     }

--- a/src/ProGPU.Tests/ProGpuHostControlTests.cs
+++ b/src/ProGPU.Tests/ProGpuHostControlTests.cs
@@ -115,6 +115,17 @@ public class ProGpuHostControlTests
     }
 
     [Fact]
+    public void AvaloniaHostUpdatesAdaptiveStatesBeforeFrameLayout()
+    {
+        string source = File.ReadAllText(FindProGpuHostControlSource()).Replace("\r\n", "\n");
+
+        Assert.Contains(
+            "VisualStateManager.UpdateAdaptiveStates(WinuiRoot, hostFrame.LogicalSize);\n        WinuiRoot.Measure(hostFrame.LogicalSize);",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AvaloniaHostExposesTypedCompositorFrameDiagnostics()
     {
         string source = File.ReadAllText(FindProGpuHostControlSource()).Replace("\r\n", "\n");

--- a/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
+++ b/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
@@ -697,6 +697,53 @@ public sealed class SamplePerformanceRegressionTests
     }
 
     [Fact]
+    public void NoWrapRichTextKeepsControlContentOnOneLine()
+    {
+        var text = new RichTextBlock
+        {
+            Font = LoadTestFont(),
+            FontSize = 14f,
+            TextWrapping = TextWrapping.NoWrap
+        };
+        text.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run("Browse"));
+
+        text.Measure(new Vector2(12f, 80f));
+        text.Arrange(new Rect(0f, 0f, 12f, 80f));
+
+        Assert.True(text.DesiredSize.X > 12f);
+        Assert.Single(text.PositionedChars.Select(static character => character.Position.Y).Distinct());
+    }
+
+    [Fact]
+    public void WrappedRichTextRetainsItsFiniteMeasureWidth()
+    {
+        var text = new RichTextBlock
+        {
+            Font = LoadTestFont(),
+            FontSize = 14f,
+            HorizontalAlignment = HorizontalAlignment.Right
+        };
+        text.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run("Responsive controls remain readable"));
+
+        text.Measure(new Vector2(64f, 200f));
+        text.Arrange(new Rect(0f, 0f, 160f, 200f));
+
+        Assert.InRange(text.DesiredSize.X, 63.99f, 64.01f);
+        Assert.InRange(text.Size.X, 63.99f, 64.01f);
+        Assert.True(text.PositionedChars.Select(static character => character.Position.Y).Distinct().Count() > 1);
+    }
+
+    [Fact]
+    public void ContentPresenterUsesWinUiNoWrapDefaultForTextContent()
+    {
+        var presenter = new ContentPresenter { Content = "Button label" };
+
+        var generatedText = Assert.IsType<RichTextBlock>(Assert.Single(presenter.Children));
+        Assert.Equal(TextWrapping.NoWrap, presenter.TextWrapping);
+        Assert.Equal(TextWrapping.NoWrap, generatedText.TextWrapping);
+    }
+
+    [Fact]
     public void MutableRunInvalidatesAndRelayoutsItsOwningTextBlock()
     {
         var font = LoadTestFont();

--- a/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
+++ b/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
@@ -715,6 +715,37 @@ public sealed class SamplePerformanceRegressionTests
     }
 
     [Fact]
+    public void NoWrapRightAlignedRichTextExpandsAfterMutableRunUpdate()
+    {
+        var run = new Microsoft.UI.Xaml.Documents.Run("0");
+        var text = new RichTextBlock
+        {
+            Font = LoadTestFont(),
+            FontSize = 11f,
+            TextWrapping = TextWrapping.NoWrap,
+            HorizontalAlignment = HorizontalAlignment.Right
+        };
+        text.Inlines.Add(new Microsoft.UI.Xaml.Documents.Bold(run));
+
+        var row = new Grid();
+        row.ColumnDefinitions.Add(new GridLength(100f, GridUnitType.Absolute));
+        row.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        row.AddChild(text);
+        Grid.SetColumn(text, 1);
+
+        row.Measure(new Vector2(337f, 100f));
+        row.Arrange(new Rect(0f, 0f, 337f, 100f));
+        var initialWidth = text.Size.X;
+
+        run.Text = "5.80 x 1.40 x 5.80";
+        row.Measure(new Vector2(337f, 100f));
+        row.Arrange(new Rect(0f, 0f, 337f, 100f));
+
+        Assert.True(text.Size.X > initialWidth);
+        Assert.Single(text.PositionedChars.Select(static character => character.Position.Y).Distinct());
+    }
+
+    [Fact]
     public void WrappedRichTextRetainsItsFiniteMeasureWidth()
     {
         var text = new RichTextBlock

--- a/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
+++ b/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
@@ -715,21 +715,20 @@ public sealed class SamplePerformanceRegressionTests
     }
 
     [Fact]
-    public void NoWrapTextAlignedRichTextStaysInsideItsGridCellAfterMutableRunUpdate()
+    public void NoWrapRichTextStaysInsideAnAutoSizedTrailingGridColumnAfterMutableRunUpdate()
     {
         var run = new Microsoft.UI.Xaml.Documents.Run("0");
         var text = new RichTextBlock
         {
             Font = LoadTestFont(),
             FontSize = 11f,
-            TextWrapping = TextWrapping.NoWrap,
-            TextAlignment = TextAlignment.Right
+            TextWrapping = TextWrapping.NoWrap
         };
         text.Inlines.Add(new Microsoft.UI.Xaml.Documents.Bold(run));
 
         var row = new Grid();
-        row.ColumnDefinitions.Add(new GridLength(100f, GridUnitType.Absolute));
         row.ColumnDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+        row.ColumnDefinitions.Add(new GridLength(0f, GridUnitType.Auto));
         row.AddChild(text);
         Grid.SetColumn(text, 1);
 
@@ -739,7 +738,8 @@ public sealed class SamplePerformanceRegressionTests
         row.Measure(new Vector2(337f, 100f));
         row.Arrange(new Rect(0f, 0f, 337f, 100f));
 
-        Assert.InRange(text.Size.X, 236.99f, 237.01f);
+        Assert.True(text.Offset.X > 100f);
+        Assert.InRange(text.Offset.X + text.Size.X, 336.99f, 337.01f);
         Assert.Single(text.PositionedChars.Select(static character => character.Position.Y).Distinct());
         Assert.All(text.PositionedChars, character => Assert.InRange(character.Position.X, 0f, text.Size.X));
     }

--- a/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
+++ b/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
@@ -715,7 +715,7 @@ public sealed class SamplePerformanceRegressionTests
     }
 
     [Fact]
-    public void NoWrapRightAlignedRichTextExpandsAfterMutableRunUpdate()
+    public void NoWrapTextAlignedRichTextStaysInsideItsGridCellAfterMutableRunUpdate()
     {
         var run = new Microsoft.UI.Xaml.Documents.Run("0");
         var text = new RichTextBlock
@@ -723,7 +723,7 @@ public sealed class SamplePerformanceRegressionTests
             Font = LoadTestFont(),
             FontSize = 11f,
             TextWrapping = TextWrapping.NoWrap,
-            HorizontalAlignment = HorizontalAlignment.Right
+            TextAlignment = TextAlignment.Right
         };
         text.Inlines.Add(new Microsoft.UI.Xaml.Documents.Bold(run));
 
@@ -735,14 +735,13 @@ public sealed class SamplePerformanceRegressionTests
 
         row.Measure(new Vector2(337f, 100f));
         row.Arrange(new Rect(0f, 0f, 337f, 100f));
-        var initialWidth = text.Size.X;
-
         run.Text = "5.80 x 1.40 x 5.80";
         row.Measure(new Vector2(337f, 100f));
         row.Arrange(new Rect(0f, 0f, 337f, 100f));
 
-        Assert.True(text.Size.X > initialWidth);
+        Assert.InRange(text.Size.X, 236.99f, 237.01f);
         Assert.Single(text.PositionedChars.Select(static character => character.Position.Y).Distinct());
+        Assert.All(text.PositionedChars, character => Assert.InRange(character.Position.X, 0f, text.Size.X));
     }
 
     [Fact]

--- a/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
+++ b/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
@@ -715,6 +715,34 @@ public sealed class SamplePerformanceRegressionTests
     }
 
     [Fact]
+    public void WrapWholeWordsDoesNotSplitAnUnspacedToken()
+    {
+        var wholeWord = new RichTextBlock
+        {
+            Font = LoadTestFont(),
+            FontSize = 14f,
+            TextWrapping = TextWrapping.WrapWholeWords
+        };
+        wholeWord.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run("LongFilenameWithoutBreaks.txt"));
+
+        var characterWrap = new RichTextBlock
+        {
+            Font = wholeWord.Font,
+            FontSize = wholeWord.FontSize,
+            TextWrapping = TextWrapping.Wrap
+        };
+        characterWrap.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run("LongFilenameWithoutBreaks.txt"));
+
+        wholeWord.Measure(new Vector2(48f, 200f));
+        wholeWord.Arrange(new Rect(0f, 0f, 48f, 200f));
+        characterWrap.Measure(new Vector2(48f, 200f));
+        characterWrap.Arrange(new Rect(0f, 0f, 48f, 200f));
+
+        Assert.Single(wholeWord.PositionedChars.Select(static character => character.Position.Y).Distinct());
+        Assert.True(characterWrap.PositionedChars.Select(static character => character.Position.Y).Distinct().Count() > 1);
+    }
+
+    [Fact]
     public void NoWrapRichTextStaysInsideAnAutoSizedTrailingGridColumnAfterMutableRunUpdate()
     {
         var run = new Microsoft.UI.Xaml.Documents.Run("0");

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -96,6 +96,25 @@ public sealed class SampleProjectSplitTests
     }
 
     [Fact]
+    public void BrowserTerminalPointersDiscardQueuedMovesBeforeImmediateDispatch()
+    {
+        var browserAsset = Read("src", "ProGPU.Browser", "BrowserAssets", "progpu-browser.js");
+
+        Assert.Contains("function discardQueuedPointerMoves(pointerId)", browserAsset, StringComparison.Ordinal);
+        Assert.Equal(2, browserAsset.Split("if (state.dispatchImmediatePointer) discardQueuedPointerMoves(event.pointerId);", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void BrowserTextSinkIncludesCanvasOriginBeforeViewportClamping()
+    {
+        var browserAsset = Read("src", "ProGPU.Browser", "BrowserAssets", "progpu-browser.js");
+
+        Assert.Contains("const canvasBounds = state.canvas?.getBoundingClientRect();", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("const sinkX = (canvasBounds?.left || 0) + x;", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("const sinkY = (canvasBounds?.top || 0) + y + height;", browserAsset, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BrowserHostRegistersBundledInterForSkiaSharpDefaults()
     {
         var browserHost = Read("src", "ProGPU.Browser", "BrowserWindowHost.cs");

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -96,12 +96,17 @@ public sealed class SampleProjectSplitTests
     }
 
     [Fact]
-    public void BrowserTerminalPointersDiscardQueuedMovesBeforeImmediateDispatch()
+    public void BrowserTerminalPointersFlushQueuedMovesBeforeImmediateDispatch()
     {
         var browserAsset = Read("src", "ProGPU.Browser", "BrowserAssets", "progpu-browser.js");
+        var dispatcher = Read("src", "ProGPU.Browser", "BrowserInputDispatcher.cs");
 
-        Assert.Contains("function discardQueuedPointerMoves(pointerId)", browserAsset, StringComparison.Ordinal);
-        Assert.Equal(2, browserAsset.Split("if (state.dispatchImmediatePointer) discardQueuedPointerMoves(event.pointerId);", StringSplitOptions.None).Length - 1);
+        Assert.Contains("function flushQueuedPointerMoves(pointerId)", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("state.dispatchImmediatePointer(queued.kind, queued.x, queued.y, queued.button", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("function dispatchTerminalPointerEvent(kind, event, point)", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("dispatchTerminalPointerEvent(3, event, point);", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("dispatchTerminalPointerEvent(9, event, point);", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("kind != (int)BrowserInputKind.PointerMove", dispatcher, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -110,8 +115,20 @@ public sealed class SampleProjectSplitTests
         var browserAsset = Read("src", "ProGPU.Browser", "BrowserAssets", "progpu-browser.js");
 
         Assert.Contains("const canvasBounds = state.canvas?.getBoundingClientRect();", browserAsset, StringComparison.Ordinal);
-        Assert.Contains("const sinkX = (canvasBounds?.left || 0) + x;", browserAsset, StringComparison.Ordinal);
-        Assert.Contains("const sinkY = (canvasBounds?.top || 0) + y + height;", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("const sinkX = (canvasBounds?.left || 0) + bounds.x;", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("const sinkY = (canvasBounds?.top || 0) + bounds.y + bounds.height;", browserAsset, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BrowserTextSinkRepositionsWithVisualViewport()
+    {
+        var browserAsset = Read("src", "ProGPU.Browser", "BrowserAssets", "progpu-browser.js");
+
+        Assert.Contains("textInputBounds: null", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("function positionTextInput()", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("resizeCanvas();\n  positionTextInput();", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("state.textInputBounds = { x, y, width, height };", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("state.textInputBounds = null;", browserAsset, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -177,7 +194,7 @@ public sealed class SampleProjectSplitTests
         Assert.Contains("input.addEventListener('cancel'", browserAsset, StringComparison.Ordinal);
         Assert.DoesNotContain("globalThis.addEventListener('focus'", browserAsset, StringComparison.Ordinal);
         Assert.Contains("runtime.getAssemblyExports('ProGPU.Browser.dll')", browserAsset, StringComparison.Ordinal);
-        Assert.Contains("dispatchPointerEvent(3, event, point)", browserAsset, StringComparison.Ordinal);
+        Assert.Contains("dispatchTerminalPointerEvent(3, event, point)", browserAsset, StringComparison.Ordinal);
         Assert.Contains("DispatchImmediatePointer", browserInput, StringComparison.Ordinal);
         Assert.Contains("heap.set(bytes, destination);", browserAsset, StringComparison.Ordinal);
         Assert.DoesNotContain("bytesToBase64", browserAsset, StringComparison.Ordinal);

--- a/src/ProGPU.Tests/TextRenderingModeRenderTests.cs
+++ b/src/ProGPU.Tests/TextRenderingModeRenderTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using Microsoft.UI.Xaml;
+using ProGPU.Fonts.Inter;
 using ProGPU.Scene;
 using ProGPU.Tests.Headless;
 using ProGPU.Text;
@@ -229,6 +230,73 @@ public sealed class TextRenderingModeRenderTests
         }
     }
 
+    [Fact]
+    public void OddPixelHighDpiRasterSizeRendersRegularAndBoldFaces()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(660, 270);
+        window.Content = CreateHighDpiRichTextFaces();
+
+        try
+        {
+            window.RenderAtDpi(220, 90, 3f);
+            var pixels = window.ReadPixels();
+            var regularPixels = CountVisiblePixels(pixels, 660, 0, 135);
+            var boldPixels = CountVisiblePixels(pixels, 660, 135, 270);
+
+            Assert.True(regularPixels > 20, $"Expected regular text pixels, found {regularPixels}; vertices={window.Compositor.TextVertexCount}.");
+            Assert.True(boldPixels > 20, $"Expected bold text pixels, found {boldPixels}; vertices={window.Compositor.TextVertexCount}.");
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    private static int CountVisiblePixels(byte[] pixels, int width, int startY, int endY)
+    {
+        var count = 0;
+        for (var y = startY; y < endY; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var offset = (y * width + x) * 4;
+                if (pixels[offset] > 12 || pixels[offset + 1] > 12 || pixels[offset + 2] > 12)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static Microsoft.UI.Xaml.Controls.Grid CreateHighDpiRichTextFaces()
+    {
+        var root = new Microsoft.UI.Xaml.Controls.Grid();
+        root.RowDefinitions.Add(new GridLength(45f, GridUnitType.Absolute));
+        root.RowDefinitions.Add(new GridLength(45f, GridUnitType.Absolute));
+
+        var regular = new Microsoft.UI.Xaml.Controls.RichTextBlock
+        {
+            Font = InterFontFamily.Regular,
+            FontSize = 11f
+        };
+        regular.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run("Regular eleven"));
+        root.AddChild(regular);
+
+        var bold = new Microsoft.UI.Xaml.Controls.RichTextBlock
+        {
+            Font = InterFontFamily.Regular,
+            FontSize = 11f
+        };
+        bold.Inlines.Add(new Microsoft.UI.Xaml.Documents.Bold(new Microsoft.UI.Xaml.Documents.Run("Bold eleven")));
+        root.AddChild(bold);
+        Microsoft.UI.Xaml.Controls.Grid.SetRow(bold, 1);
+
+        return root;
+    }
+
     private static bool ContainsSubpixelCoverage(byte[] pixels)
     {
         for (var i = 0; i < pixels.Length; i += 4)
@@ -299,4 +367,5 @@ public sealed class TextRenderingModeRenderTests
                 textRenderingMode: TextRenderingMode.ClearType);
         }
     }
+
 }

--- a/src/ProGPU.Tests/TextRenderingModeRenderTests.cs
+++ b/src/ProGPU.Tests/TextRenderingModeRenderTests.cs
@@ -43,6 +43,7 @@ public sealed class TextRenderingModeRenderTests
     [InlineData(11f, 3f, 33f)]
     [InlineData(11.5f, 3f, 34.5f)]
     [InlineData(14f, 2.625f, 36.75f)]
+    [InlineData(26f, 3f, 78f)]
     public void UiTextRasterizationPreservesItsPhysicalFontSize(
         float fontSize,
         float dpiScale,
@@ -253,6 +254,41 @@ public sealed class TextRenderingModeRenderTests
         }
     }
 
+    [Fact]
+    public void HighDpiVectorFallbackRetainsOpaqueThinStemCoverage()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(900, 240);
+        window.Content = new ForcedVectorTextVisual();
+
+        try
+        {
+            window.RenderAtDpi(300, 80, 3f);
+            var pixels = window.ReadPixels();
+            var maximumCoverage = 0;
+            var opaqueCoveragePixels = 0;
+            for (var offset = 0; offset < pixels.Length; offset += 4)
+            {
+                maximumCoverage = Math.Max(maximumCoverage, pixels[offset]);
+                if (pixels[offset] >= 240)
+                {
+                    opaqueCoveragePixels++;
+                }
+            }
+
+            Assert.True(
+                maximumCoverage >= 240,
+                $"Expected device-scale vector text to retain opaque stem coverage, found {maximumCoverage}.");
+            Assert.True(
+                opaqueCoveragePixels >= 100,
+                $"Expected substantial opaque thin-stem coverage, found {opaqueCoveragePixels} pixels.");
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static int CountVisiblePixels(byte[] pixels, int width, int startY, int endY)
     {
         var count = 0;
@@ -295,6 +331,28 @@ public sealed class TextRenderingModeRenderTests
         Microsoft.UI.Xaml.Controls.Grid.SetRow(bold, 1);
 
         return root;
+    }
+
+    private sealed class ForcedVectorTextVisual : FrameworkElement
+    {
+        private readonly TtfFont _font = InterFontFamily.GetVariableFont(100f, 18f);
+
+        public ForcedVectorTextVisual()
+        {
+            Width = 300f;
+            Height = 80f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawText(
+                "Designing clear interfaces 0123456789",
+                _font,
+                26f,
+                new SolidColorBrush(Vector4.One),
+                new Vector2(0f, 36f),
+                useVectorGlyphRendering: true);
+        }
     }
 
     private static bool ContainsSubpixelCoverage(byte[] pixels)

--- a/src/ProGPU.Tests/TextRenderingModeRenderTests.cs
+++ b/src/ProGPU.Tests/TextRenderingModeRenderTests.cs
@@ -33,9 +33,37 @@ public sealed class TextRenderingModeRenderTests
             }));
 
         Assert.Equal(1f, result.Item1);
-        Assert.Equal(21.5f, result.Item2);
-        Assert.Equal(30f / 21.5f, result.Item3, 5);
+        Assert.Equal(30f * (5f / 7f), result.Item2, 5);
+        Assert.Equal(7f / 5f, result.Item3, 5);
         Assert.Equal(30f, result.Item2 * result.Item3, 5);
+    }
+
+    [Theory]
+    [InlineData(11f, 3f, 33f)]
+    [InlineData(11.5f, 3f, 34.5f)]
+    [InlineData(14f, 2.625f, 36.75f)]
+    public void UiTextRasterizationPreservesItsPhysicalFontSize(
+        float fontSize,
+        float dpiScale,
+        float expectedRasterSize)
+    {
+        var method = typeof(Compositor).GetMethod(
+            "ResolveTextRasterization",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var result = Assert.IsType<ValueTuple<float, float, float>>(method.Invoke(
+            null,
+            new object[]
+            {
+                fontSize,
+                Matrix4x4.Identity,
+                dpiScale,
+                1f
+            }));
+
+        Assert.Equal(expectedRasterSize, result.Item2, 5);
+        Assert.Equal(1f, result.Item3, 5);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -13,7 +13,7 @@ public sealed class TouchGestureResponsiveTests
     [Fact]
     public void TouchPointerPreservesIdentityCaptureAndCancellation()
     {
-        var target = new TrackingControl { Width = 120, Height = 120 };
+        var target = new TrackingControl { Width = 120, Height = 120, CaptureOnPress = true };
         ArrangeRoot(target, new Vector2(240, 240));
         UseInputRoot(target);
 
@@ -108,6 +108,133 @@ public sealed class TouchGestureResponsiveTests
     }
 
     [Fact]
+    public void TouchTapActivatesButtonsTogglesCheckBoxesAndDropDowns()
+    {
+        var button = new Button
+        {
+            Width = 120,
+            Height = 48,
+            Content = new Border()
+        };
+        var clicks = 0;
+        button.Click += (_, _) => clicks++;
+        Tap(button, 1, 20, 20);
+        Assert.Equal(1, clicks);
+
+        var checkBox = new CheckBox { Width = 120, Height = 48, Content = new Border() };
+        Tap(checkBox, 2, 20, 20);
+        Assert.True(checkBox.IsChecked);
+
+        var toggleButton = new ToggleButton { Width = 120, Height = 48, Content = new Border() };
+        Tap(toggleButton, 3, 20, 20);
+        Assert.True(toggleButton.IsChecked);
+
+        var toggleSwitch = new ToggleSwitch { Width = 120, Height = 48, Content = new Border() };
+        Tap(toggleSwitch, 4, 20, 20);
+        Assert.True(toggleSwitch.IsOn);
+
+        var comboBox = new ComboBox { Width = 160, Height = 40 };
+        comboBox.Items.Add(new ComboBoxItem("One"));
+        Tap(comboBox, 5, 20, 20);
+        Assert.True(comboBox.IsDropDownOpen);
+    }
+
+    [Fact]
+    public void TouchScrollCancelsNavigationSelectionAndScrollsPane()
+    {
+        var navigation = new NavigationView
+        {
+            PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+            IsPaneOpen = true
+        };
+        for (var index = 0; index < 20; index++)
+        {
+            navigation.MenuItems.Add(new NavigationViewItem($"Item {index}", string.Empty));
+        }
+        ArrangeRoot(navigation, new Vector2(500, 220));
+        UseInputRoot(navigation);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 20, 80, 190, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 20, 80, 50, 30_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 20, 80, 50, 40_000, false));
+
+        Assert.Null(navigation.SelectedItem);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 21, 80, 30, 100_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 21, 80, 30, 140_000, false));
+        Assert.NotNull(navigation.SelectedItem);
+    }
+
+    [Fact]
+    public void DataGridTouchDragScrollsWithoutSelectingAndTapStillSelects()
+    {
+        var dataGrid = new DataGrid { Width = 320, Height = 180 };
+        dataGrid.Columns.Add(new DataGridColumn("Value", 280f, "Value"));
+        for (var index = 0; index < 100; index++) dataGrid.ItemsSource.Add($"Row {index}");
+        ArrangeRoot(dataGrid, new Vector2(320, 180));
+        UseInputRoot(dataGrid);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 30, 80, 150, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 30, 80, 60, 30_000, true));
+        Assert.True(dataGrid.ScrollOffset > 0f);
+        Assert.Equal(-1, dataGrid.SelectedIndex);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 30, 80, 60, 40_000, false));
+        Assert.Equal(-1, dataGrid.SelectedIndex);
+
+        var tapY = 48f;
+        var expectedRow = (int)((tapY - 32f + dataGrid.ScrollOffset) / dataGrid.RowHeight);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 31, 80, tapY, 100_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 31, 80, tapY, 140_000, false));
+        Assert.Equal(expectedRow, dataGrid.SelectedIndex);
+    }
+
+    [Fact]
+    public void ChartTouchCaptureKeepsPanInteractionOwnedByChart()
+    {
+        var chart = new ChartControl { Width = 280, Height = 180, ZoomStart = 20, ZoomEnd = 80 };
+        var viewer = new ScrollViewer { Content = chart, Width = 280, Height = 140 };
+        ArrangeRoot(viewer, new Vector2(280, 140));
+        var plotArea = typeof(ChartControl).GetField("_plotArea", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(plotArea);
+        plotArea.SetValue(chart, new Rect(10, 10, 250, 110));
+        UseInputRoot(viewer);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 40, 100, 60, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 40, 140, 60, 30_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 40, 140, 60, 40_000, false));
+
+        Assert.NotEqual(20d, chart.ZoomStart);
+        Assert.Equal(0f, viewer.VerticalOffset);
+    }
+
+    [Fact]
+    public void UncapturedMouseReleaseUsesCurrentHitAndMouseJitterDoesNotStartManipulation()
+    {
+        var button = new Button { Width = 100, Height = 60, Content = new Border() };
+        var filler = new Border { Width = 100, Height = 60 };
+        var root = new StackPanel { Orientation = Orientation.Horizontal };
+        root.Children.Add(button);
+        root.Children.Add(filler);
+        var viewer = new ScrollViewer { Content = root, Width = 200, Height = 60 };
+        ArrangeRoot(viewer, new Vector2(200, 60));
+        UseInputRoot(viewer);
+        var clicks = 0;
+        button.Click += (_, _) => clicks++;
+
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Moved, 20, 20, 1_000, false));
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Pressed, 20, 20, 2_000, true));
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Moved, 20.5f, 20, 3_000, true));
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Released, 20.5f, 20, 4_000, false));
+        Assert.Equal(1, clicks);
+
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Pressed, 20, 20, 10_000, true));
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Moved, 150, 20, 20_000, true));
+        InputSystem.InjectPointer(Mouse(PointerInputKind.Released, 150, 20, 30_000, false));
+        Assert.Equal(1, clicks);
+        Assert.False(button.IsPointerOver);
+    }
+
+    [Fact]
     public void VisualStatesRestoreSettersAndNavigationViewUsesWinUiBreakpoints()
     {
         var control = new Button();
@@ -145,6 +272,25 @@ public sealed class TouchGestureResponsiveTests
         Pressure: contact ? 0.6f : 0f,
         ContactRect: new Rect(x - 5, y - 5, 10, 10));
 
+    private static PointerInputEvent Mouse(PointerInputKind kind, float x, float y, ulong timestamp, bool contact) => new(
+        kind,
+        1,
+        PointerDeviceType.Mouse,
+        new Vector2(x, y),
+        timestamp,
+        IsPrimary: true,
+        IsInContact: contact,
+        IsLeftButtonPressed: contact,
+        Pressure: contact ? 0.5f : 0f);
+
+    private static void Tap(FrameworkElement root, uint id, float x, float y)
+    {
+        ArrangeRoot(root, new Vector2(root.Width > 0f ? root.Width : 200f, root.Height > 0f ? root.Height : 80f));
+        UseInputRoot(root);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, id, x, y, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, id, x, y, 40_000, false));
+    }
+
     private static void ArrangeRoot(FrameworkElement root, Vector2 size)
     {
         root.Measure(size);
@@ -163,6 +309,7 @@ public sealed class TouchGestureResponsiveTests
         public PointerDeviceType LastDeviceType { get; private set; }
         public Vector2 LastScreenPosition { get; private set; }
         public bool CaptureSucceeded { get; private set; }
+        public bool CaptureOnPress { get; init; }
         public int CanceledCount { get; private set; }
         public int CaptureLostCount { get; private set; }
         public int TappedCount { get; private set; }
@@ -175,7 +322,7 @@ public sealed class TouchGestureResponsiveTests
         {
             LastPointerId = e.Pointer.PointerId;
             LastDeviceType = e.Pointer.PointerDeviceType;
-            CaptureSucceeded = CapturePointer(e.Pointer);
+            CaptureSucceeded = !CaptureOnPress || CapturePointer(e.Pointer);
             base.OnPointerPressed(e);
         }
 

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -235,6 +235,45 @@ public sealed class TouchGestureResponsiveTests
     }
 
     [Fact]
+    public void TouchDragDropTracksAndCompletesTheOwningPointer()
+    {
+        var source = new TouchDragSource
+        {
+            Width = 100,
+            Height = 80,
+            Background = new ProGPU.Vector.ThemeResourceBrush("ControlBackground")
+        };
+        var target = new Border
+        {
+            Width = 100,
+            Height = 80,
+            AllowDrop = true,
+            Background = new ProGPU.Vector.ThemeResourceBrush("ControlBackground")
+        };
+        var root = new StackPanel { Orientation = Orientation.Horizontal };
+        root.Children.Add(source);
+        root.Children.Add(target);
+        ArrangeRoot(root, new Vector2(200, 80));
+        UseInputRoot(root);
+        var drops = 0;
+        target.Drop += (_, e) =>
+        {
+            Assert.Equal("Button", e.Data.GetData("Tool"));
+            drops++;
+        };
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 50, 20, 30, 1_000, true));
+        Assert.True(DragDropManager.IsDragging);
+        Assert.Equal((uint)50, DragDropManager.ActivePointerId);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 50, 150, 30, 20_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 50, 150, 30, 30_000, false));
+
+        Assert.Equal(1, drops);
+        Assert.False(DragDropManager.IsDragging);
+        Assert.Equal(0u, DragDropManager.ActivePointerId);
+    }
+
+    [Fact]
     public void VisualStatesRestoreSettersAndNavigationViewUsesWinUiBreakpoints()
     {
         var control = new Button();
@@ -372,6 +411,18 @@ public sealed class TouchGestureResponsiveTests
         {
             ManipulationCompletedCount++;
             base.OnManipulationCompleted(e);
+        }
+    }
+
+    private sealed class TouchDragSource : Border
+    {
+        public override void OnPointerPressed(PointerRoutedEventArgs e)
+        {
+            var data = new DataPackage();
+            data.SetData("Tool", "Button");
+            DragDropManager.StartDrag(this, data, DragDropEffects.Copy);
+            e.Handled = true;
+            base.OnPointerPressed(e);
         }
     }
 }

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -108,6 +108,81 @@ public sealed class TouchGestureResponsiveTests
     }
 
     [Fact]
+    public void TouchCanDragAndPageVerticalAndHorizontalScrollBars()
+    {
+        var verticalContent = new Border { Width = 220, Height = 900 };
+        var vertical = new ScrollViewer { Content = verticalContent, Width = 220, Height = 180 };
+        ArrangeRoot(vertical, new Vector2(220, 180));
+        UseInputRoot(vertical);
+
+        // Twenty-five pixels from the edge is intentionally outside the mouse hit strip,
+        // but inside the expanded touch target around the first thumb.
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 70, 195, 18, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 70, 195, 90, 20_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 70, 195, 90, 30_000, false));
+        Assert.InRange(vertical.VerticalOffset, 350f, 370f);
+
+        vertical.VerticalOffset = 0f;
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 71, 195, 150, 50_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 71, 195, 150, 60_000, false));
+        Assert.InRange(vertical.VerticalOffset, 160f, 164f);
+
+        var horizontalContent = new Border { Width = 900, Height = 100 };
+        var horizontal = new ScrollViewer { Content = horizontalContent, Width = 220, Height = 100 };
+        ArrangeRoot(horizontal, new Vector2(220, 100));
+        UseInputRoot(horizontal);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 72, 18, 75, 100_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 72, 90, 75, 120_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 72, 90, 75, 130_000, false));
+        Assert.InRange(horizontal.HorizontalOffset, 290f, 300f);
+    }
+
+    [Fact]
+    public void DataGridTouchCanDragThumbAndPageTrackWithoutSelectingRows()
+    {
+        var dataGrid = new DataGrid { Width = 320, Height = 180 };
+        dataGrid.Columns.Add(new DataGridColumn("Value", 280f, "Value"));
+        for (var index = 0; index < 100; index++) dataGrid.ItemsSource.Add($"Row {index}");
+        ArrangeRoot(dataGrid, new Vector2(320, 180));
+        UseInputRoot(dataGrid);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 73, 295, 44, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 73, 295, 110, 20_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 73, 295, 110, 30_000, false));
+        Assert.True(dataGrid.ScrollOffset > 1_300f);
+        Assert.Equal(-1, dataGrid.SelectedIndex);
+
+        dataGrid.ScrollOffset = 0f;
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 74, 295, 150, 50_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 74, 295, 150, 60_000, false));
+        Assert.InRange(dataGrid.ScrollOffset, 132f, 134f);
+        Assert.Equal(-1, dataGrid.SelectedIndex);
+    }
+
+    [Fact]
+    public void StandaloneVirtualizingPanelScrollbarAcceptsTouchDrag()
+    {
+        var panel = new VirtualizingStackPanel
+        {
+            Width = 220,
+            Height = 180,
+            ItemsCount = 100,
+            ItemHeight = 40f,
+            CreateVisualFactory = static () => new Border(),
+            BindVisualCallback = static (_, _) => { }
+        };
+        ArrangeRoot(panel, new Vector2(220, 180));
+        UseInputRoot(panel);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 75, 195, 18, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 75, 195, 90, 20_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 75, 195, 90, 30_000, false));
+
+        Assert.True(panel.ScrollOffset > 1_500f);
+    }
+
+    [Fact]
     public void TouchTapActivatesButtonsTogglesCheckBoxesAndDropDowns()
     {
         var button = new Button
@@ -137,6 +212,57 @@ public sealed class TouchGestureResponsiveTests
         comboBox.Items.Add(new ComboBoxItem("One"));
         Tap(comboBox, 5, 20, 20);
         Assert.True(comboBox.IsDropDownOpen);
+    }
+
+    [Fact]
+    public void TouchClickClearsTransientStatesAndDoesNotUseKeyboardFocusVisuals()
+    {
+        var button = new Button { Width = 120, Height = 48, Content = new Border() };
+        ArrangeRoot(button, new Vector2(120, 48));
+        UseInputRoot(button);
+        var normalBorder = button.GetCurrentBorderBrush();
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 76, 20, 20, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 76, 20, 20, 30_000, false));
+
+        Assert.True(button.IsFocused);
+        Assert.False(InputSystem.IsKeyboardFocusActive);
+        Assert.False(button.IsPointerPressed);
+        Assert.False(button.IsPointerOver);
+        Assert.Same(normalBorder, button.GetCurrentBorderBrush());
+    }
+
+    [Fact]
+    public void RadioButtonDefaultsContentToLeftAlignment()
+    {
+        var content = new Border { Width = 80, Height = 20 };
+        var radioButton = new RadioButton { Width = 360, Height = 40, Content = content };
+        ArrangeRoot(radioButton, new Vector2(360, 40));
+
+        Assert.Equal(HorizontalAlignment.Left, radioButton.HorizontalContentAlignment);
+        Assert.InRange(content.Offset.X, 0f, 12f);
+    }
+
+    [Fact]
+    public void RatingControlTouchTapSelectsEveryRatingIncludingOneWithoutMove()
+    {
+        var rating = new RatingControl { Width = 118, Height = 28, MaxRating = 5 };
+        ArrangeRoot(rating, new Vector2(118, 28));
+        UseInputRoot(rating);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 77, 13, 13, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 77, 13, 13, 20_000, false));
+        Assert.Equal(1d, rating.Value);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 78, 34, 13, 30_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 78, 34, 13, 40_000, false));
+        Assert.Equal(2d, rating.Value);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 79, 105, 13, 50_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 79, 105, 13, 60_000, false));
+        Assert.Equal(5d, rating.Value);
+        Assert.False(rating.IsPointerPressed);
+        Assert.False(rating.IsPointerOver);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -577,9 +577,9 @@ public sealed class TouchGestureResponsiveTests
         Assert.True(splitView.IsPaneOpen);
 
         ArrangeRoot(splitView, new Vector2(360, 400));
-        Assert.Equal(312f, splitView.Pane?.Size.X);
-        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 82, 292, 20, 30_000, true));
-        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 82, 292, 20, 50_000, false));
+        Assert.Equal(360f, splitView.Pane?.Size.X);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 82, 340, 20, 30_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 82, 340, 20, 50_000, false));
         Assert.False(splitView.IsPaneOpen);
     }
 

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -299,6 +299,22 @@ public sealed class TouchGestureResponsiveTests
         Assert.Equal(NavigationViewDisplayMode.Expanded, navigation.DisplayMode);
     }
 
+    [Fact]
+    public void StandaloneMinimalNavigationViewKeepsTouchPaneOpener()
+    {
+        var navigation = new NavigationView();
+        navigation.MenuItems.Add(new NavigationViewItem("Item", string.Empty));
+        ArrangeRoot(navigation, new Vector2(500, 300));
+        UseInputRoot(navigation);
+        Assert.Equal(NavigationViewDisplayMode.Minimal, navigation.DisplayMode);
+        Assert.False(navigation.IsPaneOpen);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 60, 24, 24, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 60, 24, 24, 30_000, false));
+
+        Assert.True(navigation.IsPaneOpen);
+    }
+
     private static PointerInputEvent Touch(PointerInputKind kind, uint id, float x, float y, ulong timestamp, bool contact) => new(
         kind,
         id,

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -554,7 +554,7 @@ public sealed class TouchGestureResponsiveTests
     {
         var splitView = new ResponsiveSplitView
         {
-            OpenPaneLength = 460f,
+            OpenPaneLength = 300f,
             CompactModeThreshold = 700f,
             PaneContent = new Border(),
             MainContent = new Border()
@@ -563,7 +563,7 @@ public sealed class TouchGestureResponsiveTests
         ArrangeRoot(splitView, new Vector2(900, 400));
         Assert.Equal(SplitViewDisplayMode.Inline, splitView.DisplayMode);
         Assert.True(splitView.IsPaneOpen);
-        Assert.Equal(460f, splitView.Pane?.Size.X);
+        Assert.Equal(300f, splitView.Pane?.Size.X);
 
         ArrangeRoot(splitView, new Vector2(360, 400));
         Assert.Equal(SplitViewDisplayMode.Overlay, splitView.DisplayMode);

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Reflection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -57,6 +58,19 @@ public sealed class TouchGestureResponsiveTests
         InputSystem.InjectPointer(Touch(PointerInputKind.Released, 3, 60, 80, 1_050_000, false));
         InputSystem.InjectPointer(Touch(PointerInputKind.Released, 4, 180, 80, 1_060_000, false));
         Assert.Equal(1, target.ManipulationCompletedCount);
+    }
+
+    [Fact]
+    public void TouchReleaseBeyondTapThresholdWithoutMoveDoesNotTap()
+    {
+        var target = new TrackingControl { Width = 220, Height = 220 };
+        ArrangeRoot(target, new Vector2(220, 220));
+        UseInputRoot(target);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 5, 20, 20, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 5, 180, 180, 30_000, false));
+
+        Assert.Equal(0, target.TappedCount);
     }
 
     [Fact]
@@ -423,6 +437,32 @@ public sealed class TouchGestureResponsiveTests
         Assert.Equal(NavigationViewDisplayMode.Compact, navigation.DisplayMode);
         navigation.Measure(new Vector2(1200, 500));
         Assert.Equal(NavigationViewDisplayMode.Expanded, navigation.DisplayMode);
+    }
+
+    [Fact]
+    public void VisualStateUsesOrSemanticsAcrossMultipleTriggers()
+    {
+        var control = new Button();
+        var group = new VisualStateGroup { Name = "ResponsiveStates" };
+        var fallback = new VisualState { Name = "Fallback" };
+        var responsive = new VisualState { Name = "WideOrTall" };
+        responsive.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 1_000 });
+        responsive.StateTriggers.Add(new AdaptiveTrigger { MinWindowHeight = 700 });
+        group.States.Add(fallback);
+        group.States.Add(responsive);
+        VisualStateManager.GetVisualStateGroups(control).Add(group);
+
+        var update = typeof(VisualStateManager).GetMethod(
+            "UpdateAdaptiveStates",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(update);
+
+        update.Invoke(null, [control, new Vector2(1_100, 500)]);
+        Assert.Same(responsive, group.CurrentState);
+        update.Invoke(null, [control, new Vector2(500, 800)]);
+        Assert.Same(responsive, group.CurrentState);
+        update.Invoke(null, [control, new Vector2(500, 500)]);
+        Assert.Same(fallback, group.CurrentState);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -1,0 +1,230 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using ProGPU.Scene;
+using Windows.Devices.Input;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class TouchGestureResponsiveTests
+{
+    [Fact]
+    public void TouchPointerPreservesIdentityCaptureAndCancellation()
+    {
+        var target = new TrackingControl { Width = 120, Height = 120 };
+        ArrangeRoot(target, new Vector2(240, 240));
+        UseInputRoot(target);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 17, 20, 20, 1_000, true));
+        Assert.Equal((uint)17, target.LastPointerId);
+        Assert.Equal(PointerDeviceType.Touch, target.LastDeviceType);
+        Assert.True(target.CaptureSucceeded);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 17, 210, 210, 20_000, true));
+        Assert.Equal(new Vector2(210, 210), target.LastScreenPosition);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Canceled, 17, 210, 210, 30_000, false));
+        Assert.Equal(1, target.CanceledCount);
+        Assert.Equal(1, target.CaptureLostCount);
+    }
+
+    [Fact]
+    public void TouchRecognizesTapDoubleTapAndTwoPointerScale()
+    {
+        var target = new TrackingControl
+        {
+            Width = 220,
+            Height = 220,
+            ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY | ManipulationModes.Scale | ManipulationModes.Rotate
+        };
+        ArrangeRoot(target, new Vector2(240, 240));
+        UseInputRoot(target);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 1, 30, 30, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 1, 30, 30, 60_000, false));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 2, 31, 30, 200_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 2, 31, 30, 250_000, false));
+        Assert.Equal(2, target.TappedCount);
+        Assert.Equal(1, target.DoubleTappedCount);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 3, 60, 80, 1_000_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 4, 120, 80, 1_010_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 4, 180, 80, 1_030_000, true));
+        Assert.True(target.ManipulationStartedCount > 0);
+        Assert.True(target.LastManipulationScale > 1.5f);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 3, 60, 80, 1_050_000, false));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 4, 180, 80, 1_060_000, false));
+        Assert.Equal(1, target.ManipulationCompletedCount);
+    }
+
+    [Fact]
+    public void MobileTextOperationsDoNotDependOnPhysicalKeyEvents()
+    {
+        var textBox = new TextBox();
+        ArrangeRoot(textBox, new Vector2(240, 80));
+        UseInputRoot(textBox);
+        InputSystem.SetFocus(textBox);
+
+        InputSystem.InjectTextInput(TextInputEventKind.InsertText, "A😀");
+        InputSystem.InjectTextInput(TextInputEventKind.DeleteContentBackward);
+        Assert.Equal("A", textBox.Text);
+
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionStarted, isComposing: true);
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionUpdated, "に", true);
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionUpdated, "日本", true);
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionCompleted, "日本");
+        Assert.Equal("A日本", textBox.Text);
+
+        textBox.SelectionStart = 1;
+        textBox.SelectionLength = 2;
+        textBox.CaretIndex = 3;
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionStarted, isComposing: true);
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionUpdated, "に", true);
+        InputSystem.InjectTextInput(TextInputEventKind.CompositionCanceled);
+        Assert.Equal("A日本", textBox.Text);
+    }
+
+    [Fact]
+    public void ScrollViewerConsumesTouchManipulationAndSupportsChangeView()
+    {
+        var content = new Border
+        {
+            Height = 900,
+            Background = new ProGPU.Vector.ThemeResourceBrush("ControlBackground")
+        };
+        var viewer = new ScrollViewer { Content = content, Width = 220, Height = 180 };
+        ArrangeRoot(viewer, new Vector2(220, 180));
+        UseInputRoot(viewer);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 8, 100, 130, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 8, 100, 60, 30_000, true));
+        Assert.True(viewer.VerticalOffset >= 60f);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 8, 100, 60, 40_000, false));
+
+        Assert.True(viewer.ChangeView(null, 200, null));
+        Assert.Equal(200f, viewer.VerticalOffset);
+    }
+
+    [Fact]
+    public void VisualStatesRestoreSettersAndNavigationViewUsesWinUiBreakpoints()
+    {
+        var control = new Button();
+        var group = new VisualStateGroup { Name = "States" };
+        var compact = new VisualState { Name = "Compact" };
+        compact.Setters.Add(new Setter(nameof(FrameworkElement.Visibility), Visibility.Collapsed));
+        var normal = new VisualState { Name = "Normal" };
+        group.States.Add(compact);
+        group.States.Add(normal);
+        VisualStateManager.GetVisualStateGroups(control).Add(group);
+
+        Assert.True(VisualStateManager.GoToState(control, "Compact", false));
+        Assert.Equal(Visibility.Collapsed, control.Visibility);
+        Assert.True(VisualStateManager.GoToState(control, "Normal", false));
+        Assert.Equal(Visibility.Visible, control.Visibility);
+
+        var navigation = new NavigationView();
+        navigation.Measure(new Vector2(500, 500));
+        Assert.Equal(NavigationViewDisplayMode.Minimal, navigation.DisplayMode);
+        navigation.Measure(new Vector2(800, 500));
+        Assert.Equal(NavigationViewDisplayMode.Compact, navigation.DisplayMode);
+        navigation.Measure(new Vector2(1200, 500));
+        Assert.Equal(NavigationViewDisplayMode.Expanded, navigation.DisplayMode);
+    }
+
+    private static PointerInputEvent Touch(PointerInputKind kind, uint id, float x, float y, ulong timestamp, bool contact) => new(
+        kind,
+        id,
+        PointerDeviceType.Touch,
+        new Vector2(x, y),
+        timestamp,
+        IsPrimary: id == 1,
+        IsInContact: contact,
+        IsLeftButtonPressed: contact,
+        Pressure: contact ? 0.6f : 0f,
+        ContactRect: new Rect(x - 5, y - 5, 10, 10));
+
+    private static void ArrangeRoot(FrameworkElement root, Vector2 size)
+    {
+        root.Measure(size);
+        root.Arrange(new Rect(0, 0, size.X, size.Y));
+    }
+
+    private static void UseInputRoot(FrameworkElement root)
+    {
+        InputSystem.Current = InputSystem.CreateExternalState(root);
+        InputSystem.Root = root;
+    }
+
+    private sealed class TrackingControl : Control
+    {
+        public uint LastPointerId { get; private set; }
+        public PointerDeviceType LastDeviceType { get; private set; }
+        public Vector2 LastScreenPosition { get; private set; }
+        public bool CaptureSucceeded { get; private set; }
+        public int CanceledCount { get; private set; }
+        public int CaptureLostCount { get; private set; }
+        public int TappedCount { get; private set; }
+        public int DoubleTappedCount { get; private set; }
+        public int ManipulationStartedCount { get; private set; }
+        public int ManipulationCompletedCount { get; private set; }
+        public float LastManipulationScale { get; private set; } = 1f;
+
+        public override void OnPointerPressed(PointerRoutedEventArgs e)
+        {
+            LastPointerId = e.Pointer.PointerId;
+            LastDeviceType = e.Pointer.PointerDeviceType;
+            CaptureSucceeded = CapturePointer(e.Pointer);
+            base.OnPointerPressed(e);
+        }
+
+        public override void OnPointerMoved(PointerRoutedEventArgs e)
+        {
+            LastScreenPosition = e.ScreenPosition;
+            base.OnPointerMoved(e);
+        }
+
+        public override void OnPointerCanceled(PointerRoutedEventArgs e)
+        {
+            CanceledCount++;
+            base.OnPointerCanceled(e);
+        }
+
+        public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+        {
+            CaptureLostCount++;
+            base.OnPointerCaptureLost(e);
+        }
+
+        public override void OnTapped(TappedRoutedEventArgs e)
+        {
+            TappedCount++;
+            base.OnTapped(e);
+        }
+
+        public override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+        {
+            DoubleTappedCount++;
+            base.OnDoubleTapped(e);
+        }
+
+        public override void OnManipulationStarted(ManipulationStartedRoutedEventArgs e)
+        {
+            ManipulationStartedCount++;
+            base.OnManipulationStarted(e);
+        }
+
+        public override void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)
+        {
+            LastManipulationScale = e.Delta.Scale;
+            base.OnManipulationDelta(e);
+        }
+
+        public override void OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e)
+        {
+            ManipulationCompletedCount++;
+            base.OnManipulationCompleted(e);
+        }
+    }
+}

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -573,9 +573,9 @@ public sealed class TouchGestureResponsiveTests
         Assert.True(splitView.IsPaneOpen);
 
         ArrangeRoot(splitView, new Vector2(360, 400));
-        Assert.Equal(360f, splitView.Pane?.Size.X);
-        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 82, 340, 20, 30_000, true));
-        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 82, 340, 20, 50_000, false));
+        Assert.Equal(312f, splitView.Pane?.Size.X);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 82, 292, 20, 30_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 82, 292, 20, 50_000, false));
         Assert.False(splitView.IsPaneOpen);
     }
 

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -486,6 +486,23 @@ public sealed class TouchGestureResponsiveTests
     }
 
     [Fact]
+    public void HiddenNavigationPaneToggleClearsItsHitTestBounds()
+    {
+        var navigation = new NavigationView();
+        ArrangeRoot(navigation, new Vector2(500, 300));
+        Assert.False(navigation.IsPaneOpen);
+
+        navigation.IsPaneToggleButtonVisible = false;
+        ArrangeRoot(navigation, new Vector2(500, 300));
+        UseInputRoot(navigation);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 61, 24, 24, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 61, 24, 24, 30_000, false));
+
+        Assert.False(navigation.IsPaneOpen);
+    }
+
+    [Fact]
     public void ContactJoiningActiveManipulationIsCanceledImmediately()
     {
         var target = new TrackingControl

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -429,7 +429,8 @@ public sealed class TouchGestureResponsiveTests
     public void StandaloneMinimalNavigationViewKeepsTouchPaneOpener()
     {
         var navigation = new NavigationView();
-        navigation.MenuItems.Add(new NavigationViewItem("Item", string.Empty));
+        var item = new NavigationViewItem("Item", string.Empty);
+        navigation.MenuItems.Add(item);
         ArrangeRoot(navigation, new Vector2(500, 300));
         UseInputRoot(navigation);
         Assert.Equal(NavigationViewDisplayMode.Minimal, navigation.DisplayMode);
@@ -439,6 +440,9 @@ public sealed class TouchGestureResponsiveTests
         InputSystem.InjectPointer(Touch(PointerInputKind.Released, 60, 24, 24, 30_000, false));
 
         Assert.True(navigation.IsPaneOpen);
+
+        navigation.SelectedItem = item;
+        Assert.False(navigation.IsPaneOpen);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
+++ b/src/ProGPU.Tests/TouchGestureResponsiveTests.cs
@@ -441,6 +441,144 @@ public sealed class TouchGestureResponsiveTests
         Assert.True(navigation.IsPaneOpen);
     }
 
+    [Fact]
+    public void ContactJoiningActiveManipulationIsCanceledImmediately()
+    {
+        var target = new TrackingControl
+        {
+            Width = 220,
+            Height = 220,
+            ManipulationMode = ManipulationModes.TranslateY | ManipulationModes.Scale
+        };
+        ArrangeRoot(target, new Vector2(220, 220));
+        UseInputRoot(target);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 90, 100, 150, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Moved, 90, 100, 80, 30_000, true));
+        Assert.Equal(1, target.CanceledCount);
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 91, 120, 80, 40_000, true));
+        Assert.Equal(2, target.CanceledCount);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 91, 120, 80, 50_000, false));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 90, 100, 80, 60_000, false));
+        Assert.Equal(0, target.TappedCount);
+    }
+
+    [Fact]
+    public void CollapsedStackPanelChildClearsBoundsAndStopsHitTesting()
+    {
+        var first = new Border { Width = 100f, Height = 40f };
+        var second = new Border { Width = 100f, Height = 40f };
+        var panel = new StackPanel { Width = 100f, Height = 80f };
+        panel.Children.Add(first);
+        panel.Children.Add(second);
+        ArrangeRoot(panel, new Vector2(100, 80));
+        Assert.Equal(new Vector2(100, 40), first.Size);
+
+        first.Visibility = Visibility.Collapsed;
+        ArrangeRoot(panel, new Vector2(100, 80));
+        UseInputRoot(panel);
+
+        Assert.Equal(Vector2.Zero, first.Size);
+        Assert.NotSame(first, InputSystem.HitTest(new Vector2(10, 10)));
+    }
+
+    [Fact]
+    public void CanceledThumbDragRaisesCanceledCompletionOnce()
+    {
+        var thumb = new Thumb { Width = 44f, Height = 44f };
+        ArrangeRoot(thumb, new Vector2(44, 44));
+        UseInputRoot(thumb);
+        DragCompletedEventArgs? completed = null;
+        var completedCount = 0;
+        thumb.DragCompleted += (_, args) =>
+        {
+            completed = args;
+            completedCount++;
+        };
+
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 92, 20, 20, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Canceled, 92, 24, 26, 20_000, false));
+
+        Assert.Equal(1, completedCount);
+        Assert.NotNull(completed);
+        Assert.True(completed.Canceled);
+    }
+
+    [Fact]
+    public void SplitViewUsesWinUiOpenPaneLengthAndCancelableLifecycleEvents()
+    {
+        var opening = 0;
+        var opened = 0;
+        var closing = 0;
+        var closed = 0;
+        var cancelClose = true;
+        var splitView = new SplitView
+        {
+            Pane = new Border(),
+            Content = new Border(),
+            OpenPaneLength = 320f
+        };
+        splitView.PaneOpening += (_, _) => opening++;
+        splitView.PaneOpened += (_, _) => opened++;
+        splitView.PaneClosing += (_, args) =>
+        {
+            closing++;
+            args.Cancel = cancelClose;
+        };
+        splitView.PaneClosed += (_, _) => closed++;
+
+        splitView.IsPaneOpen = true;
+        Assert.Equal(1, opening);
+        Assert.Equal(1, opened);
+        Assert.Equal(320f, splitView.PaneWidth);
+
+        splitView.IsPaneOpen = false;
+        Assert.True(splitView.IsPaneOpen);
+        Assert.Equal(1, closing);
+        Assert.Equal(0, closed);
+
+        cancelClose = false;
+        splitView.IsPaneOpen = false;
+        Assert.False(splitView.IsPaneOpen);
+        Assert.Equal(2, closing);
+        Assert.Equal(1, closed);
+    }
+
+    [Fact]
+    public void ResponsiveSplitViewAdaptsToOverlayAndTouchTogglesItsPane()
+    {
+        var splitView = new ResponsiveSplitView
+        {
+            OpenPaneLength = 460f,
+            CompactModeThreshold = 700f,
+            PaneContent = new Border(),
+            MainContent = new Border()
+        };
+
+        ArrangeRoot(splitView, new Vector2(900, 400));
+        Assert.Equal(SplitViewDisplayMode.Inline, splitView.DisplayMode);
+        Assert.True(splitView.IsPaneOpen);
+        Assert.Equal(460f, splitView.Pane?.Size.X);
+
+        ArrangeRoot(splitView, new Vector2(360, 400));
+        Assert.Equal(SplitViewDisplayMode.Overlay, splitView.DisplayMode);
+        Assert.False(splitView.IsPaneOpen);
+        Assert.Equal(Visibility.Visible, splitView.OpenPaneButton.Visibility);
+        Assert.Equal(360f, splitView.MainContent?.Size.X);
+
+        UseInputRoot(splitView);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 81, 20, 20, 1_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 81, 20, 20, 20_000, false));
+        Assert.True(splitView.IsPaneOpen);
+
+        ArrangeRoot(splitView, new Vector2(360, 400));
+        Assert.Equal(360f, splitView.Pane?.Size.X);
+        InputSystem.InjectPointer(Touch(PointerInputKind.Pressed, 82, 340, 20, 30_000, true));
+        InputSystem.InjectPointer(Touch(PointerInputKind.Released, 82, 340, 20, 50_000, false));
+        Assert.False(splitView.IsPaneOpen);
+    }
+
     private static PointerInputEvent Touch(PointerInputKind kind, uint id, float x, float y, ulong timestamp, bool contact) => new(
         kind,
         id,

--- a/src/ProGPU.WinUI.Charts/ChartControl.cs
+++ b/src/ProGPU.WinUI.Charts/ChartControl.cs
@@ -255,11 +255,13 @@ namespace Microsoft.UI.Xaml.Controls
                 if (_sliderLeftHandle.Contains(pos))
                 {
                     _isDraggingSliderLeft = true;
+                    CapturePointer(e.Pointer);
                     e.Handled = true;
                 }
                 else if (_sliderRightHandle.Contains(pos))
                 {
                     _isDraggingSliderRight = true;
+                    CapturePointer(e.Pointer);
                     e.Handled = true;
                 }
                 else if (pos.X >= _sliderLeftHandle.X && pos.X <= _sliderRightHandle.X + _sliderRightHandle.Width)
@@ -267,6 +269,7 @@ namespace Microsoft.UI.Xaml.Controls
                     _isDraggingSliderMiddle = true;
                     _dragStartZoomStart = _zoomStart;
                     _dragStartZoomEnd = _zoomEnd;
+                    CapturePointer(e.Pointer);
                     e.Handled = true;
                 }
                 else
@@ -294,6 +297,8 @@ namespace Microsoft.UI.Xaml.Controls
                 _isPanning = true;
                 _dragStartZoomStart = _zoomStart;
                 _dragStartZoomEnd = _zoomEnd;
+                SetCrosshairX(InvertX(pos.X));
+                CapturePointer(e.Pointer);
                 e.Handled = true;
             }
 
@@ -402,12 +407,33 @@ namespace Microsoft.UI.Xaml.Controls
 
         public override void OnPointerReleased(PointerRoutedEventArgs e)
         {
+            var hadInteraction = HasActivePointerInteraction();
+            ResetPointerInteraction();
+            if (hadInteraction) ReleasePointerCapture(e.Pointer);
+            base.OnPointerReleased(e);
+        }
+
+        public override void OnPointerCanceled(PointerRoutedEventArgs e)
+        {
+            ResetPointerInteraction();
+            base.OnPointerCanceled(e);
+        }
+
+        public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+        {
+            ResetPointerInteraction();
+            base.OnPointerCaptureLost(e);
+        }
+
+        private bool HasActivePointerInteraction() =>
+            _isDraggingSliderLeft || _isDraggingSliderRight || _isDraggingSliderMiddle || _isPanning;
+
+        private void ResetPointerInteraction()
+        {
             _isDraggingSliderLeft = false;
             _isDraggingSliderRight = false;
             _isDraggingSliderMiddle = false;
             _isPanning = false;
-
-            base.OnPointerReleased(e);
         }
 
         public override void OnPointerWheelChanged(PointerRoutedEventArgs e)

--- a/src/ProGPU.WinUI.Designer/DesignerHost.cs
+++ b/src/ProGPU.WinUI.Designer/DesignerHost.cs
@@ -102,35 +102,23 @@ public class DesignerHost : Grid
         RowDefinitions.Add(GridLength.Star(1f));
         RowDefinitions.Add(GridLength.Auto);
         
-        var contentGrid = new Grid();
-        contentGrid.ColumnDefinitions.Add(new GridLength(260f, GridUnitType.Absolute));
-        contentGrid.ColumnDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
-        contentGrid.ColumnDefinitions.Add(GridLength.Star(1f));
-        contentGrid.ColumnDefinitions.Add(new GridLength(6f, GridUnitType.Absolute));
-        contentGrid.ColumnDefinitions.Add(new GridLength(280f, GridUnitType.Absolute));
-        
-        Grid.SetRow(contentGrid, 0);
-        AddChild(contentGrid);
-
-        var leftSplitter = new GridSplitter
+        var leftSplitView = new ResponsiveSplitView
         {
-            WidthConstraint = 6f,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            ResizeDirection = GridSplitterResizeDirection.Columns
+            OpenPaneLength = 260f,
+            CompactModeThreshold = 900f,
+            PanePlacement = PanePlacement.Left,
+            IsPaneScrollEnabled = false
         };
-        Grid.SetColumn(leftSplitter, 1);
-        contentGrid.AddChild(leftSplitter);
-
-        var rightSplitter = new GridSplitter
+        var rightSplitView = new ResponsiveSplitView
         {
-            WidthConstraint = 6f,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            ResizeDirection = GridSplitterResizeDirection.Columns
+            OpenPaneLength = 280f,
+            CompactModeThreshold = 700f,
+            PanePlacement = PanePlacement.Right,
+            IsPaneScrollEnabled = false
         };
-        Grid.SetColumn(rightSplitter, 3);
-        contentGrid.AddChild(rightSplitter);
+        leftSplitView.MainContent = rightSplitView;
+        Grid.SetRow(leftSplitView, 0);
+        AddChild(leftSplitView);
 
         // 1. Left Sidebar
         _sidebarLeftBorder = new Border
@@ -144,8 +132,7 @@ public class DesignerHost : Grid
 
         _sidebarLeft.RowDefinitions.Add(GridLength.Star(1.0f));
         _sidebarLeft.RowDefinitions.Add(GridLength.Star(1.0f));
-        Grid.SetColumn(_sidebarLeftBorder, 0);
-        contentGrid.AddChild(_sidebarLeftBorder);
+        leftSplitView.PaneContent = _sidebarLeftBorder;
 
         // Top half: Toolbox
         _toolbox = new Toolbox(DesignerFont);
@@ -180,8 +167,7 @@ public class DesignerHost : Grid
         _workspaceCenter = new Grid();
         _workspaceCenter.RowDefinitions.Add(GridLength.Auto);
         _workspaceCenter.RowDefinitions.Add(GridLength.Star(1f));
-        Grid.SetColumn(_workspaceCenter, 2);
-        contentGrid.AddChild(_workspaceCenter);
+        rightSplitView.MainContent = _workspaceCenter;
 
         // Reorganized elegant top visual designer settings bar
         var toolbarBorder = new Border
@@ -568,8 +554,7 @@ public class DesignerHost : Grid
             BorderBrush = new ThemeResourceBrush("ControlBorder"),
             Child = sidebarPivot
         };
-        Grid.SetColumn(_sidebarRightBorder, 4);
-        contentGrid.AddChild(_sidebarRightBorder);
+        rightSplitView.PaneContent = _sidebarRightBorder;
 
         // 4. Bottom Collapsible Panel - C# Script Preview
         _bottomPanel = new Border { Background = new ThemeResourceBrush("CardBackground"), Height = 20f };
@@ -879,12 +864,14 @@ public class DesignerHost : Grid
         if (focused == null) return false;
 
         var current = focused;
+        var isTextInput = false;
         while (current != null)
         {
             if (current is TextBox || current is PasswordBox || current is VirtualizedCodeEditor)
             {
-                return true;
+                isTextInput = true;
             }
+            if (ReferenceEquals(current, this)) return isTextInput;
             current = current.Parent as FrameworkElement;
         }
         return false;

--- a/src/ProGPU.WinUI.Designer/Toolbox.cs
+++ b/src/ProGPU.WinUI.Designer/Toolbox.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Documents;
 using ProGPU.Vector;
+using Windows.Devices.Input;
 
 public class ToolboxItem : Border
 {
@@ -77,7 +78,7 @@ public class ToolboxItem : Border
 
     public override void OnPointerPressed(PointerRoutedEventArgs e)
     {
-        if (e.IsLeftButtonPressed)
+        if (e.IsLeftButtonPressed || e.Pointer.PointerDeviceType is PointerDeviceType.Touch or PointerDeviceType.Pen)
         {
             var dp = new DataPackage();
             dp.SetData(StandardDataFormats.Tool, _controlName);

--- a/src/ProGPU.WinUI/Controls/Border.cs
+++ b/src/ProGPU.WinUI/Controls/Border.cs
@@ -306,7 +306,7 @@ public class Border : FrameworkElement
         }
 
         // Draw context-aware cascading focus rings
-        if (Parent is Control pControl && pControl.IsFocused && pControl.IsEnabled)
+        if (Parent is Control pControl && pControl.IsKeyboardFocusVisualVisible && pControl.IsEnabled)
         {
             var accentColor = ThemeManager.GetBrush("SystemAccentColor", activeTheme, activeFamily);
             if (activeFamily == VisualThemeFamily.macOS)

--- a/src/ProGPU.WinUI/Controls/ColorPicker.cs
+++ b/src/ProGPU.WinUI/Controls/ColorPicker.cs
@@ -484,6 +484,18 @@ public class ColorPicker : Control
             base.OnPointerReleased(e);
         }
 
+        public override void OnPointerCanceled(PointerRoutedEventArgs e)
+        {
+            _isDragging = false;
+            base.OnPointerCanceled(e);
+        }
+
+        public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+        {
+            _isDragging = false;
+            base.OnPointerCaptureLost(e);
+        }
+
         public override void OnPointerMoved(PointerRoutedEventArgs e)
         {
             if (_isDragging && IsEnabled)

--- a/src/ProGPU.WinUI/Controls/ComboBox.cs
+++ b/src/ProGPU.WinUI/Controls/ComboBox.cs
@@ -11,6 +11,7 @@ using Silk.NET.Input;
 using ProGPU.Layout;
 using ProGPU.Vector;
 using ProGPU.Scene;
+using Windows.Devices.Input;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -21,6 +22,7 @@ public class ComboBox : Control
     private string _placeholderText = "Select item...";
     private float _fontSize = 14f;
     private Border? _dropDownPopup;
+    private uint _pendingTouchPointerId;
     public Border? DropDownPopup => _dropDownPopup;
 
     public ObservableCollection<ComboBoxItem> Items { get; }
@@ -245,8 +247,16 @@ public class ComboBox : Control
     {
         if (IsEnabled)
         {
+            if (e.Pointer.PointerDeviceType is PointerDeviceType.Touch or PointerDeviceType.Pen)
+            {
+                _pendingTouchPointerId = e.Pointer.PointerId;
+                e.Handled = true;
+                base.OnPointerPressed(e);
+                return;
+            }
+
             // Toggle dropdown if clicked on the header button area
-            if (e.Position.Y < 32f)
+            if (e.GetCurrentPoint(this).Position.Y < 32f)
             {
                 IsDropDownOpen = !IsDropDownOpen;
                 e.Handled = true;
@@ -254,6 +264,26 @@ public class ComboBox : Control
 
             base.OnPointerPressed(e); // Sets focus to this ComboBox
         }
+    }
+
+    public override void OnPointerReleased(PointerRoutedEventArgs e)
+    {
+        if (_pendingTouchPointerId == e.Pointer.PointerId)
+        {
+            if (IsEnabled && IsPointerPressed && IsPointerOver && e.GetCurrentPoint(this).Position.Y < 32f)
+            {
+                IsDropDownOpen = !IsDropDownOpen;
+                e.Handled = true;
+            }
+            _pendingTouchPointerId = 0;
+        }
+        base.OnPointerReleased(e);
+    }
+
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        if (_pendingTouchPointerId == e.Pointer.PointerId) _pendingTouchPointerId = 0;
+        base.OnPointerCanceled(e);
     }
 
     public override void OnKeyDown(KeyRoutedEventArgs e)

--- a/src/ProGPU.WinUI/Controls/ContentControl.cs
+++ b/src/ProGPU.WinUI/Controls/ContentControl.cs
@@ -48,7 +48,7 @@ public class ContentControl : Control
             else
             {
                 // Auto-wrap non-FrameworkElement content in a RichTextBlock
-                var tb = new RichTextBlock();
+                var tb = new RichTextBlock { TextWrapping = TextWrapping.NoWrap };
                 tb.Inlines.Add(new Run { Text = newValue.ToString() ?? string.Empty });
                 AddChild(tb);
             }

--- a/src/ProGPU.WinUI/Controls/ContentPresenter.cs
+++ b/src/ProGPU.WinUI/Controls/ContentPresenter.cs
@@ -13,6 +13,7 @@ namespace Microsoft.UI.Xaml.Controls;
 
 public class ContentPresenter : FrameworkElement
 {
+    private RichTextBlock? _generatedText;
     public static readonly DependencyProperty BackgroundProperty =
         DependencyProperty.Register(
             "Background",
@@ -90,6 +91,11 @@ public class ContentPresenter : FrameworkElement
         {
             RemoveChild(oldFe);
         }
+        else if (_generatedText != null)
+        {
+            RemoveChild(_generatedText);
+            _generatedText = null;
+        }
 
         if (newValue != null)
         {
@@ -100,10 +106,32 @@ public class ContentPresenter : FrameworkElement
             else
             {
                 // Auto-wrap non-FrameworkElement content in a RichTextBlock
-                var tb = new RichTextBlock();
-                tb.Inlines.Add(new Run { Text = newValue.ToString() ?? string.Empty });
-                AddChild(tb);
+                _generatedText = new RichTextBlock { TextWrapping = TextWrapping };
+                _generatedText.Inlines.Add(new Run { Text = newValue.ToString() ?? string.Empty });
+                AddChild(_generatedText);
             }
+        }
+    }
+
+    public static readonly DependencyProperty TextWrappingProperty =
+        DependencyProperty.Register(
+            nameof(TextWrapping),
+            typeof(TextWrapping),
+            typeof(ContentPresenter),
+            new PropertyMetadata(TextWrapping.NoWrap, OnTextWrappingChanged) { AffectsMeasure = true, AffectsArrange = true, AffectsRender = true });
+
+    public TextWrapping TextWrapping
+    {
+        get => (TextWrapping)(GetValue(TextWrappingProperty) ?? TextWrapping.NoWrap);
+        set => SetValue(TextWrappingProperty, value);
+    }
+
+    private static void OnTextWrappingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var presenter = (ContentPresenter)d;
+        if (presenter._generatedText != null)
+        {
+            presenter._generatedText.TextWrapping = (TextWrapping)(e.NewValue ?? TextWrapping.NoWrap);
         }
     }
 

--- a/src/ProGPU.WinUI/Controls/Control.cs
+++ b/src/ProGPU.WinUI/Controls/Control.cs
@@ -150,6 +150,11 @@ public class Control : FrameworkElement, ITemplatedControl
         internal set => SetValue(IsFocusedProperty, value);
     }
 
+    internal bool IsFocusedVisualStateActive => IsFocused &&
+        (InputSystem.IsKeyboardFocusActive || this is ITextInputClient);
+
+    internal bool IsKeyboardFocusVisualVisible => IsFocused && InputSystem.IsKeyboardFocusActive;
+
     private bool _isTabStop = true;
     public bool IsTabStop
     {
@@ -354,7 +359,7 @@ public class Control : FrameworkElement, ITemplatedControl
         if (!IsEnabled) return (ThemeManager.GetResource($"{prefix}BackgroundDisabled", theme) as Brush) ?? Background;
         if (IsPointerPressed) return (ThemeManager.GetResource($"{prefix}BackgroundPressed", theme) as Brush) ?? Background;
         if (IsPointerOver) return (ThemeManager.GetResource($"{prefix}BackgroundPointerOver", theme) as Brush) ?? Background;
-        if (IsFocused) return (ThemeManager.GetResource($"{prefix}BackgroundFocused", theme) as Brush) ?? (ThemeManager.GetResource($"{prefix}BackgroundPressed", theme) as Brush) ?? Background;
+        if (IsFocusedVisualStateActive) return (ThemeManager.GetResource($"{prefix}BackgroundFocused", theme) as Brush) ?? (ThemeManager.GetResource($"{prefix}BackgroundPressed", theme) as Brush) ?? Background;
         return Background;
     }
 
@@ -367,7 +372,7 @@ public class Control : FrameworkElement, ITemplatedControl
         if (!IsEnabled) return (ThemeManager.GetResource($"{prefix}ForegroundDisabled", theme) as Brush) ?? Foreground;
         if (IsPointerPressed) return (ThemeManager.GetResource($"{prefix}ForegroundPressed", theme) as Brush) ?? Foreground;
         if (IsPointerOver) return (ThemeManager.GetResource($"{prefix}ForegroundPointerOver", theme) as Brush) ?? Foreground;
-        if (IsFocused) return (ThemeManager.GetResource($"{prefix}ForegroundFocused", theme) as Brush) ?? Foreground;
+        if (IsFocusedVisualStateActive) return (ThemeManager.GetResource($"{prefix}ForegroundFocused", theme) as Brush) ?? Foreground;
         return Foreground;
     }
 
@@ -380,7 +385,7 @@ public class Control : FrameworkElement, ITemplatedControl
         if (!IsEnabled) return (ThemeManager.GetResource($"{prefix}BorderBrushDisabled", theme) as Brush) ?? BorderBrush;
         if (IsPointerPressed) return (ThemeManager.GetResource($"{prefix}BorderBrushPressed", theme) as Brush) ?? BorderBrush;
         if (IsPointerOver) return (ThemeManager.GetResource($"{prefix}BorderBrushPointerOver", theme) as Brush) ?? BorderBrush;
-        if (IsFocused) return (ThemeManager.GetResource($"{prefix}BorderBrushFocused", theme) as Brush) ?? (ThemeManager.GetResource($"{prefix}BorderBrushPressed", theme) as Brush) ?? BorderBrush;
+        if (IsFocusedVisualStateActive) return (ThemeManager.GetResource($"{prefix}BorderBrushFocused", theme) as Brush) ?? (ThemeManager.GetResource($"{prefix}BorderBrushPressed", theme) as Brush) ?? BorderBrush;
         return BorderBrush;
     }
 
@@ -410,7 +415,7 @@ public class Control : FrameworkElement, ITemplatedControl
         base.OnRender(context);
 
         // Draw dynamic high-contrast keyboard focus visual borders 2px outside the control
-        if (IsFocused && InputSystem.IsKeyboardFocusActive)
+        if (IsKeyboardFocusVisualVisible)
         {
             var accentColor = ThemeManager.GetBrush("SystemAccentColor");
             context.DrawRectangle(null, new Pen(accentColor, 1.5f), new Rect(-2f, -2f, Size.X + 4f, Size.Y + 4f));

--- a/src/ProGPU.WinUI/Controls/DataGrid.cs
+++ b/src/ProGPU.WinUI/Controls/DataGrid.cs
@@ -16,6 +16,7 @@ using ProGPU.Scene;
 using ProGPU.Text;
 using System.Collections.Concurrent;
 using System.Globalization;
+using Windows.Devices.Input;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -71,6 +72,11 @@ public class DataGrid : Control
     private DateTime _lastClickTime = DateTime.MinValue;
     private int _lastClickRow = -1;
     private int _lastClickCol = -1;
+    private uint _pendingTouchPointerId;
+    private int _pendingTouchRow = -1;
+    private int _pendingTouchColumn = -1;
+    private int _pendingTouchSortColumn = -1;
+    private float _touchInertiaVelocity;
 
     public List<DataGridColumn> Columns { get; } = new();
 
@@ -149,6 +155,9 @@ public class DataGrid : Control
     public DataGrid()
     {
         Padding = new Thickness(0);
+        ManipulationMode = ManipulationModes.TranslateY |
+            ManipulationModes.TranslateRailsY |
+            ManipulationModes.TranslateInertia;
 
         var defaultStyle = ThemeManager.GetDefaultStyle(GetType());
         if (defaultStyle != null)
@@ -514,6 +523,29 @@ public class DataGrid : Control
 
     public override void OnPointerPressed(PointerRoutedEventArgs e)
     {
+        var position = e.GetCurrentPoint(this).Position;
+        if (IsEnabled && e.Pointer.PointerDeviceType is PointerDeviceType.Touch or PointerDeviceType.Pen)
+        {
+            ClearPendingTouchAction();
+            _pendingTouchPointerId = e.Pointer.PointerId;
+            if (position.Y <= _headerHeight)
+            {
+                _pendingTouchSortColumn = GetColumnIndexAt(position.X);
+            }
+            else if (position.X < Size.X - 12f)
+            {
+                _pendingTouchRow = GetRowIndexAt(position.Y);
+                _pendingTouchColumn = GetColumnIndexAt(position.X);
+            }
+
+            if (_pendingTouchSortColumn >= 0 || _pendingTouchRow >= 0)
+            {
+                e.Handled = true;
+            }
+            base.OnPointerPressed(e);
+            return;
+        }
+
         if (IsEnabled)
         {
             // Click inside Header: Column Sorting / Resizing
@@ -619,6 +651,26 @@ public class DataGrid : Control
 
     public override void OnPointerReleased(PointerRoutedEventArgs e)
     {
+        if (_pendingTouchPointerId == e.Pointer.PointerId)
+        {
+            var position = e.GetCurrentPoint(this).Position;
+            if (IsEnabled && IsPointerPressed && IsPointerOver)
+            {
+                if (_pendingTouchSortColumn >= 0 && position.Y <= _headerHeight &&
+                    GetColumnIndexAt(position.X) == _pendingTouchSortColumn)
+                {
+                    SortColumn(_pendingTouchSortColumn);
+                    e.Handled = true;
+                }
+                else if (_pendingTouchRow >= 0 && GetRowIndexAt(position.Y) == _pendingTouchRow &&
+                    GetColumnIndexAt(position.X) == _pendingTouchColumn)
+                {
+                    SelectRow(_pendingTouchRow, _pendingTouchColumn);
+                    e.Handled = true;
+                }
+            }
+            ClearPendingTouchAction();
+        }
         _isDraggingScroll = false;
         if (_resizingColumnIndex != -1)
         {
@@ -626,6 +678,53 @@ public class DataGrid : Control
             InputSystem.ReleasePointerCapture();
         }
         base.OnPointerReleased(e);
+    }
+
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        ClearPendingTouchAction();
+        _isDraggingScroll = false;
+        _resizingColumnIndex = -1;
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnManipulationStarted(ManipulationStartedRoutedEventArgs e)
+    {
+        _touchInertiaVelocity = 0f;
+        base.OnManipulationStarted(e);
+    }
+
+    public override void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)
+    {
+        var oldOffset = ScrollOffset;
+        ScrollOffset -= e.Delta.Translation.Y;
+        if (oldOffset != ScrollOffset) e.Handled = true;
+        base.OnManipulationDelta(e);
+    }
+
+    public override void OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e)
+    {
+        _touchInertiaVelocity = e.IsInertial ? -e.Velocities.Linear.Y : 0f;
+        base.OnManipulationCompleted(e);
+    }
+
+    protected override void OnUpdateAnimations(float elapsedSeconds)
+    {
+        base.OnUpdateAnimations(elapsedSeconds);
+        if (elapsedSeconds <= 0f || MathF.Abs(_touchInertiaVelocity) < 2f)
+        {
+            _touchInertiaVelocity = 0f;
+            return;
+        }
+
+        var oldOffset = ScrollOffset;
+        ScrollOffset += _touchInertiaVelocity * elapsedSeconds;
+        if (oldOffset == ScrollOffset)
+        {
+            _touchInertiaVelocity = 0f;
+            return;
+        }
+        _touchInertiaVelocity *= MathF.Pow(0.88f, elapsedSeconds * 60f);
     }
 
     public override void OnPointerExited(PointerRoutedEventArgs e)
@@ -728,6 +827,60 @@ public class DataGrid : Control
             return;
         }
         base.OnPointerMoved(e);
+    }
+
+    private int GetRowIndexAt(float y)
+    {
+        if (y <= _headerHeight) return -1;
+        var row = (int)((y - _headerHeight + ScrollOffset) / _rowHeight);
+        return row >= 0 && row < _itemsSource.Count ? row : -1;
+    }
+
+    private int GetColumnIndexAt(float x)
+    {
+        var runningX = Padding.Left;
+        for (var index = 0; index < Columns.Count; index++)
+        {
+            if (x >= runningX && x <= runningX + Columns[index].ActualWidth) return index;
+            runningX += Columns[index].ActualWidth;
+        }
+        return -1;
+    }
+
+    private void SortColumn(int columnIndex)
+    {
+        if (columnIndex < 0 || columnIndex >= Columns.Count) return;
+        var column = Columns[columnIndex];
+        if (SortingColumn == column) column.IsAscending = !column.IsAscending;
+        else column.IsAscending = true;
+        SortItems(column);
+    }
+
+    private void SelectRow(int row, int columnIndex)
+    {
+        if (row < 0 || row >= _itemsSource.Count) return;
+        SelectedIndex = row;
+        if (columnIndex < 0) return;
+
+        var now = DateTime.UtcNow;
+        if ((now - _lastClickTime).TotalMilliseconds < 300 && row == _lastClickRow && columnIndex == _lastClickCol)
+        {
+            BeginEdit(row, columnIndex);
+        }
+        else
+        {
+            _lastClickTime = now;
+            _lastClickRow = row;
+            _lastClickCol = columnIndex;
+        }
+    }
+
+    private void ClearPendingTouchAction()
+    {
+        _pendingTouchPointerId = 0;
+        _pendingTouchRow = -1;
+        _pendingTouchColumn = -1;
+        _pendingTouchSortColumn = -1;
     }
 
     private float MeasureTextWidth(string text, TtfFont font, float fontSize)

--- a/src/ProGPU.WinUI/Controls/DataGrid.cs
+++ b/src/ProGPU.WinUI/Controls/DataGrid.cs
@@ -54,6 +54,7 @@ public class DataGrid : Control
     private int _selectedIndex = -1;
     private float _scrollOffset;
     private bool _isDraggingScroll;
+    private uint _scrollbarPointerId;
     private float _dragStartOffset;
     private float _dragStartMouseY;
     private int _hoveredRowIndex = -1;
@@ -524,6 +525,11 @@ public class DataGrid : Control
     public override void OnPointerPressed(PointerRoutedEventArgs e)
     {
         var position = e.GetCurrentPoint(this).Position;
+        if (IsEnabled && TryStartScrollbarInteraction(e, position))
+        {
+            return;
+        }
+
         if (IsEnabled && e.Pointer.PointerDeviceType is PointerDeviceType.Touch or PointerDeviceType.Pen)
         {
             ClearPendingTouchAction();
@@ -589,23 +595,6 @@ public class DataGrid : Control
                     runningX += col.ActualWidth;
                 }
             }
-            // Click in Scrollbar area
-            else if (TotalBodyHeight > ViewportHeight && e.Position.X >= Size.X - 10f)
-            {
-                float viewportH = ViewportHeight;
-                float thumbHeight = Math.Max(24f, (viewportH / TotalBodyHeight) * viewportH);
-                float scrollableHeight = TotalBodyHeight - viewportH;
-                float thumbY = _headerHeight + (ScrollOffset / scrollableHeight) * (viewportH - thumbHeight);
-
-                if (e.Position.Y >= thumbY && e.Position.Y <= thumbY + thumbHeight)
-                {
-                    _isDraggingScroll = true;
-                    _dragStartOffset = ScrollOffset;
-                    _dragStartMouseY = e.Position.Y;
-                    e.Handled = true;
-                    return;
-                }
-            }
             // Click in Body rows
             else
             {
@@ -651,6 +640,15 @@ public class DataGrid : Control
 
     public override void OnPointerReleased(PointerRoutedEventArgs e)
     {
+        if (_scrollbarPointerId == e.Pointer.PointerId)
+        {
+            _scrollbarPointerId = 0;
+            _isDraggingScroll = false;
+            ScrollBarInteraction.ReleasePointer(this, e);
+            e.Handled = true;
+            Invalidate();
+        }
+
         if (_pendingTouchPointerId == e.Pointer.PointerId)
         {
             var position = e.GetCurrentPoint(this).Position;
@@ -671,7 +669,6 @@ public class DataGrid : Control
             }
             ClearPendingTouchAction();
         }
-        _isDraggingScroll = false;
         if (_resizingColumnIndex != -1)
         {
             _resizingColumnIndex = -1;
@@ -683,9 +680,58 @@ public class DataGrid : Control
     public override void OnPointerCanceled(PointerRoutedEventArgs e)
     {
         ClearPendingTouchAction();
-        _isDraggingScroll = false;
+        if (_scrollbarPointerId == e.Pointer.PointerId)
+        {
+            _scrollbarPointerId = 0;
+            _isDraggingScroll = false;
+            Invalidate();
+        }
         _resizingColumnIndex = -1;
         base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        if (_scrollbarPointerId == e.Pointer.PointerId)
+        {
+            _scrollbarPointerId = 0;
+            _isDraggingScroll = false;
+            Invalidate();
+        }
+        base.OnPointerCaptureLost(e);
+    }
+
+    private bool TryStartScrollbarInteraction(PointerRoutedEventArgs e, Vector2 position)
+    {
+        if (!ScrollBarInteraction.TryCreateMetrics(
+                _headerHeight, ViewportHeight, TotalBodyHeight, ScrollOffset, out var metrics) ||
+            !ScrollBarInteraction.IsVerticalTrackHit(position.X, Size.X, e.Pointer.PointerDeviceType) ||
+            position.Y < metrics.TrackStart || position.Y > metrics.TrackStart + metrics.TrackLength ||
+            !ScrollBarInteraction.CapturePointer(this, e))
+        {
+            return false;
+        }
+
+        _scrollbarPointerId = e.Pointer.PointerId;
+        _touchInertiaVelocity = 0f;
+        if (ScrollBarInteraction.IsThumbHit(position.Y, metrics, e.Pointer.PointerDeviceType))
+        {
+            _isDraggingScroll = true;
+            _dragStartOffset = ScrollOffset;
+            _dragStartMouseY = position.Y;
+        }
+        else
+        {
+            _isDraggingScroll = false;
+            ScrollOffset = ScrollBarInteraction.ValueFromTrackPress(
+                ScrollOffset, position.Y, metrics, ViewportHeight);
+        }
+
+        ClearPendingTouchAction();
+        _isPointerOverScrollbar = true;
+        e.Handled = true;
+        Invalidate();
+        return true;
     }
 
     public override void OnManipulationStarted(ManipulationStartedRoutedEventArgs e)
@@ -737,13 +783,17 @@ public class DataGrid : Control
 
     public override void OnPointerMoved(PointerRoutedEventArgs e)
     {
+        var position = e.ScreenPosition == Vector2.Zero && e.Position != Vector2.Zero
+            ? e.Position
+            : e.GetCurrentPoint(this).Position;
         if (IsEnabled)
         {
-            _isPointerOverScrollbar = e.Position.X >= Size.X - 12f;
+            _isPointerOverScrollbar = TotalBodyHeight > ViewportHeight &&
+                ScrollBarInteraction.IsVerticalTrackHit(position.X, Size.X, e.Pointer.PointerDeviceType);
 
             if (_resizingColumnIndex != -1)
             {
-                float deltaX = e.Position.X - _resizeStartMouseX;
+                float deltaX = position.X - _resizeStartMouseX;
                 float newWidth = Math.Max(20f, _resizeStartWidth + deltaX);
                 Columns[_resizingColumnIndex].Width = newWidth;
 
@@ -760,13 +810,13 @@ public class DataGrid : Control
 
             // Detect mouse movement in column headers for resize zones
             int hoveredSep = -1;
-            if (e.Position.Y <= _headerHeight)
+            if (position.Y <= _headerHeight)
             {
                 float runningX = Padding.Left;
                 for (int i = 0; i < Columns.Count; i++)
                 {
                     float separatorX = runningX + Columns[i].ActualWidth;
-                    if (Math.Abs(e.Position.X - separatorX) <= 4f)
+                    if (Math.Abs(position.X - separatorX) <= 4f)
                     {
                         hoveredSep = i;
                         break;
@@ -781,9 +831,10 @@ public class DataGrid : Control
                 Invalidate();
             }
 
-            if (e.Position.Y > _headerHeight && e.Position.X < Size.X - 12f)
+            if (position.Y > _headerHeight &&
+                !ScrollBarInteraction.IsVerticalTrackHit(position.X, Size.X, e.Pointer.PointerDeviceType))
             {
-                int r = (int)((e.Position.Y - _headerHeight + ScrollOffset) / _rowHeight);
+                int r = (int)((position.Y - _headerHeight + ScrollOffset) / _rowHeight);
                 if (r >= 0 && r < _itemsSource.Count)
                 {
                     if (_hoveredRowIndex != r)
@@ -811,17 +862,13 @@ public class DataGrid : Control
             }
         }
 
-        if (_isDraggingScroll && IsEnabled)
+        if (_isDraggingScroll && _scrollbarPointerId == e.Pointer.PointerId && IsEnabled)
         {
-            float viewportH = ViewportHeight;
-            float thumbHeight = Math.Max(24f, (viewportH / TotalBodyHeight) * viewportH);
-            float scrollableHeight = TotalBodyHeight - viewportH;
-            float trackLength = viewportH - thumbHeight;
-
-            if (trackLength > 0f)
+            if (ScrollBarInteraction.TryCreateMetrics(
+                    _headerHeight, ViewportHeight, TotalBodyHeight, _dragStartOffset, out var metrics))
             {
-                float deltaY = e.Position.Y - _dragStartMouseY;
-                ScrollOffset = _dragStartOffset + (deltaY / trackLength) * scrollableHeight;
+                ScrollOffset = ScrollBarInteraction.ValueFromDrag(
+                    _dragStartOffset, position.Y - _dragStartMouseY, metrics);
             }
             e.Handled = true;
             return;
@@ -995,7 +1042,7 @@ public class DataGrid : Control
         if (activeFont == null) return;
 
         // 1. Draw DataGrid outer card background & border
-        Pen outerPen = IsFocused 
+        Pen outerPen = IsKeyboardFocusVisualVisible
             ? new Pen(BorderBrush ?? ThemeManager.GetBrush("SystemAccentColor"), 2f) // Glowing Segoe Blue active focus ring
             : new Pen(BorderBrush ?? ThemeManager.GetBrush("ControlBorder"), 1f); // Thin outline
 

--- a/src/ProGPU.WinUI/Controls/HyperlinkButton.cs
+++ b/src/ProGPU.WinUI/Controls/HyperlinkButton.cs
@@ -59,7 +59,7 @@ public class HyperlinkButton : Button
         }
 
         // Active focus indicator
-        if (IsEnabled && IsFocused)
+        if (IsEnabled && IsKeyboardFocusVisualVisible)
         {
             var focusPen = ThemeManager.GetPen("SystemAccentColor", 1f);
             context.DrawRectangle(null, focusPen, new Rect(0f, 0f, Size.X, Size.Y));

--- a/src/ProGPU.WinUI/Controls/NavigationView.cs
+++ b/src/ProGPU.WinUI/Controls/NavigationView.cs
@@ -14,10 +14,28 @@ using ProGPU.Vector;
 
 namespace Microsoft.UI.Xaml.Controls;
 
+public enum NavigationViewPaneDisplayMode
+{
+    Auto,
+    Left,
+    Top,
+    LeftCompact,
+    LeftMinimal
+}
+
+public enum NavigationViewDisplayMode
+{
+    Minimal,
+    Compact,
+    Expanded
+}
+
 public class NavigationView : FrameworkElement
 {
     private class HamburgerButton : Button
     {
+        private readonly Brush _glyphBrush = new ThemeResourceBrush("TextPrimary");
+
         public HamburgerButton()
         {
             CornerRadius = 4f;
@@ -32,17 +50,18 @@ public class NavigationView : FrameworkElement
             base.OnRender(context);
             
             // Draw custom three-bar Fluent hamburger lines in theme-aware TextPrimary
-            var brush = ThemeManager.GetBrush("TextPrimary", this.ActualTheme);
             // Centered nicely inside 40x40 area
-            context.DrawRectangle(brush, null, new Rect(11f, 14f, 18f, 2f));
-            context.DrawRectangle(brush, null, new Rect(11f, 19f, 18f, 2f));
-            context.DrawRectangle(brush, null, new Rect(11f, 24f, 18f, 2f));
+            context.DrawRectangle(_glyphBrush, null, new Rect(11f, 14f, 18f, 2f));
+            context.DrawRectangle(_glyphBrush, null, new Rect(11f, 19f, 18f, 2f));
+            context.DrawRectangle(_glyphBrush, null, new Rect(11f, 24f, 18f, 2f));
         }
     }
 
     private class NavigationViewPane : Panel
     {
         private readonly NavigationView _navigationView;
+        private readonly Brush _background = new ThemeResourceBrush("HeaderBackground");
+        private readonly Brush _separator = new ThemeResourceBrush("ControlBorder");
 
         public NavigationViewPane(NavigationView navigationView)
         {
@@ -87,23 +106,8 @@ public class NavigationView : FrameworkElement
 
         public override void OnRender(DrawingContext context)
         {
-            var activeTheme = _navigationView.ActualTheme;
-            var activeFamily = _navigationView.ActualThemeFamily;
-            Brush paneBg;
-            if (activeFamily == VisualThemeFamily.macOS)
-            {
-                paneBg = new SolidColorBrush(activeTheme == ElementTheme.Light
-                    ? new Vector4(0.953f, 0.953f, 0.953f, 1f) // #F3F3F3
-                    : new Vector4(0.118f, 0.118f, 0.118f, 1f)); // #1E1E1E
-            }
-            else
-            {
-                paneBg = ThemeManager.GetBrush("HeaderBackground", activeTheme);
-            }
-            context.DrawRectangle(paneBg, null, new Rect(0f, 0f, Size.X, Size.Y));
-            
-            var sepBrush = ThemeManager.GetBrush("ControlBorder", activeTheme, activeFamily);
-            context.DrawRectangle(sepBrush, null, new Rect(Size.X - 1f, 0f, 1f, Size.Y));
+            context.DrawRectangle(_background, null, new Rect(0f, 0f, Size.X, Size.Y));
+            context.DrawRectangle(_separator, null, new Rect(Size.X - 1f, 0f, 1f, Size.Y));
 
             base.OnRender(context);
         }
@@ -118,8 +122,50 @@ public class NavigationView : FrameworkElement
     private FrameworkElement? _content;
     private readonly SplitView _splitView;
     private readonly NavigationViewPane _panePanel;
+    private NavigationViewPaneDisplayMode _paneDisplayMode = NavigationViewPaneDisplayMode.Auto;
+    private NavigationViewDisplayMode _displayMode = NavigationViewDisplayMode.Minimal;
+    private bool _hasResolvedDisplayMode;
+    private double _openPaneLength = 240d;
+    private double _compactPaneLength = 60d;
 
     public ObservableCollection<NavigationViewItem> MenuItems { get; }
+
+    public NavigationViewPaneDisplayMode PaneDisplayMode
+    {
+        get => _paneDisplayMode;
+        set
+        {
+            if (_paneDisplayMode == value) return;
+            _paneDisplayMode = value;
+            _hasResolvedDisplayMode = false;
+            InvalidateMeasure();
+            InvalidateArrange();
+        }
+    }
+
+    public NavigationViewDisplayMode DisplayMode => _displayMode;
+    public double CompactModeThresholdWidth { get; set; } = 641d;
+    public double ExpandedModeThresholdWidth { get; set; } = 1008d;
+
+    public double OpenPaneLength
+    {
+        get => _openPaneLength;
+        set
+        {
+            _openPaneLength = Math.Max(0d, value);
+            _splitView.PaneWidth = (float)_openPaneLength;
+        }
+    }
+
+    public double CompactPaneLength
+    {
+        get => _compactPaneLength;
+        set
+        {
+            _compactPaneLength = Math.Max(0d, value);
+            if (_displayMode != NavigationViewDisplayMode.Minimal) _splitView.CompactPaneLength = (float)_compactPaneLength;
+        }
+    }
 
     public bool IsPaneOpen
     {
@@ -213,6 +259,7 @@ public class NavigationView : FrameworkElement
     }
 
     public event EventHandler? SelectionChanged;
+    public event EventHandler? DisplayModeChanged;
 
     public NavigationView()
     {
@@ -338,12 +385,50 @@ public class NavigationView : FrameworkElement
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
+        UpdateDisplayMode(availableSize.X);
         _splitView.Measure(availableSize);
         return availableSize;
     }
 
     protected override void ArrangeOverride(Rect arrangeRect)
     {
+        UpdateDisplayMode(arrangeRect.Width);
         _splitView.Arrange(arrangeRect);
+    }
+
+    private void UpdateDisplayMode(float width)
+    {
+        var next = PaneDisplayMode switch
+        {
+            NavigationViewPaneDisplayMode.Left => NavigationViewDisplayMode.Expanded,
+            NavigationViewPaneDisplayMode.LeftCompact => NavigationViewDisplayMode.Compact,
+            NavigationViewPaneDisplayMode.LeftMinimal or NavigationViewPaneDisplayMode.Top => NavigationViewDisplayMode.Minimal,
+            _ when width >= ExpandedModeThresholdWidth => NavigationViewDisplayMode.Expanded,
+            _ when width >= CompactModeThresholdWidth => NavigationViewDisplayMode.Compact,
+            _ => NavigationViewDisplayMode.Minimal
+        };
+        if (_hasResolvedDisplayMode && next == _displayMode) return;
+        var firstResolution = !_hasResolvedDisplayMode;
+        _hasResolvedDisplayMode = true;
+        _displayMode = next;
+        switch (next)
+        {
+            case NavigationViewDisplayMode.Expanded:
+                _splitView.DisplayMode = SplitViewDisplayMode.CompactInline;
+                _splitView.CompactPaneLength = (float)_compactPaneLength;
+                if (firstResolution || PaneDisplayMode == NavigationViewPaneDisplayMode.Auto) IsPaneOpen = true;
+                break;
+            case NavigationViewDisplayMode.Compact:
+                _splitView.DisplayMode = SplitViewDisplayMode.CompactInline;
+                _splitView.CompactPaneLength = (float)_compactPaneLength;
+                IsPaneOpen = false;
+                break;
+            default:
+                _splitView.DisplayMode = SplitViewDisplayMode.Overlay;
+                _splitView.CompactPaneLength = 0f;
+                IsPaneOpen = false;
+                break;
+        }
+        DisplayModeChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/ProGPU.WinUI/Controls/NavigationView.cs
+++ b/src/ProGPU.WinUI/Controls/NavigationView.cs
@@ -71,7 +71,7 @@ public class NavigationView : FrameworkElement
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
             float w = availableSize.X;
-            float h = 10f; // top margin
+            float h = _navigationView.IsPaneToggleButtonVisible ? 58f : 10f;
             
             foreach (var item in _navigationView._flatVisibleItems)
             {
@@ -90,7 +90,7 @@ public class NavigationView : FrameworkElement
 
         protected override void ArrangeOverride(Rect arrangeRect)
         {
-            float cursorY = arrangeRect.Y + 10f;
+            float cursorY = arrangeRect.Y + (_navigationView.IsPaneToggleButtonVisible ? 58f : 10f);
             foreach (var item in _navigationView._flatVisibleItems)
             {
                 item.Arrange(new Rect(arrangeRect.X, cursorY, arrangeRect.Width, 40f));
@@ -127,6 +127,7 @@ public class NavigationView : FrameworkElement
     private bool _hasResolvedDisplayMode;
     private double _openPaneLength = 240d;
     private double _compactPaneLength = 60d;
+    private bool _isPaneToggleButtonVisible = true;
 
     public ObservableCollection<NavigationViewItem> MenuItems { get; }
 
@@ -144,6 +145,19 @@ public class NavigationView : FrameworkElement
     }
 
     public NavigationViewDisplayMode DisplayMode => _displayMode;
+    public bool IsPaneToggleButtonVisible
+    {
+        get => _isPaneToggleButtonVisible;
+        set
+        {
+            if (_isPaneToggleButtonVisible == value) return;
+            _isPaneToggleButtonVisible = value;
+            _hamburgerButton.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+            _panePanel.InvalidateMeasure();
+            InvalidateMeasure();
+            InvalidateArrange();
+        }
+    }
     public double CompactModeThresholdWidth { get; set; } = 641d;
     public double ExpandedModeThresholdWidth { get; set; } = 1008d;
 
@@ -290,6 +304,7 @@ public class NavigationView : FrameworkElement
             VerticalAlignment = VerticalAlignment.Stretch
         };
         AddChild(_splitView);
+        AddChild(_hamburgerButton);
 
         RebuildPaneChildren();
     }
@@ -387,6 +402,7 @@ public class NavigationView : FrameworkElement
     {
         UpdateDisplayMode(availableSize.X);
         _splitView.Measure(availableSize);
+        if (IsPaneToggleButtonVisible) _hamburgerButton.Measure(new Vector2(40f, 40f));
         return availableSize;
     }
 
@@ -394,6 +410,10 @@ public class NavigationView : FrameworkElement
     {
         UpdateDisplayMode(arrangeRect.Width);
         _splitView.Arrange(arrangeRect);
+        if (IsPaneToggleButtonVisible)
+        {
+            _hamburgerButton.Arrange(new Rect(arrangeRect.X + 8f, arrangeRect.Y + 8f, 40f, 40f));
+        }
     }
 
     private void UpdateDisplayMode(float width)

--- a/src/ProGPU.WinUI/Controls/NavigationView.cs
+++ b/src/ProGPU.WinUI/Controls/NavigationView.cs
@@ -229,6 +229,11 @@ public class NavigationView : FrameworkElement
                         Content = page;
                     }
                 }
+
+                if (DisplayMode != NavigationViewDisplayMode.Expanded)
+                {
+                    IsPaneOpen = false;
+                }
                 
                 SelectionChanged?.Invoke(this, EventArgs.Empty);
                 UpdateTabStops();

--- a/src/ProGPU.WinUI/Controls/NavigationView.cs
+++ b/src/ProGPU.WinUI/Controls/NavigationView.cs
@@ -419,6 +419,10 @@ public class NavigationView : FrameworkElement
         {
             _hamburgerButton.Arrange(new Rect(arrangeRect.X + 8f, arrangeRect.Y + 8f, 40f, 40f));
         }
+        else
+        {
+            _hamburgerButton.Arrange(new Rect(arrangeRect.X + 8f, arrangeRect.Y + 8f, 0f, 0f));
+        }
     }
 
     private void UpdateDisplayMode(float width)

--- a/src/ProGPU.WinUI/Controls/NavigationViewItem.cs
+++ b/src/ProGPU.WinUI/Controls/NavigationViewItem.cs
@@ -11,6 +11,7 @@ using ProGPU.Layout;
 using ProGPU.Scene;
 using ProGPU.Vector;
 using ProGPU.Text;
+using Windows.Devices.Input;
 using static System.FormattableString;
 
 namespace Microsoft.UI.Xaml.Controls;
@@ -24,6 +25,7 @@ public class NavigationViewItem : Control
     private int _level;
     private FrameworkElement? _page;
     private Func<FrameworkElement?>? _pageFactory;
+    private uint _pendingTouchPointerId;
 
     private float _cachedIconStartX = -9999f;
     private float _cachedIconStartY = -9999f;
@@ -189,39 +191,69 @@ public class NavigationViewItem : Control
 
     public override void OnPointerPressed(PointerRoutedEventArgs e)
     {
-        if (IsEnabled)
-        {
-            base.OnPointerPressed(e);
-            
-            var nav = FindParentNavigationView();
-            if (nav != null)
-            {
-                var activeFamily = nav.ActualThemeFamily;
-                bool isChevronClick = false;
-                if (Items.Count > 0 && nav.IsPaneOpen)
-                {
-                    if (activeFamily == VisualThemeFamily.macOS)
-                    {
-                        float baseIndent = 16f + (Level * 16f);
-                        isChevronClick = e.Position.X >= baseIndent - 8f && e.Position.X <= baseIndent + 20f;
-                    }
-                    else
-                    {
-                        isChevronClick = e.Position.X >= Size.X - 40f;
-                    }
-                }
+        if (!IsEnabled) return;
 
-                if (isChevronClick)
-                {
-                    IsExpanded = !IsExpanded;
-                    nav.OnItemExpandedChanged(this);
-                }
-                else
-                {
-                    nav.SelectedItem = this;
-                }
+        if (e.Pointer.PointerDeviceType is PointerDeviceType.Touch or PointerDeviceType.Pen)
+        {
+            _pendingTouchPointerId = e.Pointer.PointerId;
+            e.Handled = true;
+            base.OnPointerPressed(e);
+            return;
+        }
+
+        base.OnPointerPressed(e);
+        Activate(e.GetCurrentPoint(this).Position);
+        e.Handled = true;
+    }
+
+    public override void OnPointerReleased(PointerRoutedEventArgs e)
+    {
+        if (_pendingTouchPointerId == e.Pointer.PointerId)
+        {
+            if (IsEnabled && IsPointerPressed && IsPointerOver)
+            {
+                Activate(e.GetCurrentPoint(this).Position);
                 e.Handled = true;
             }
+            _pendingTouchPointerId = 0;
+        }
+        base.OnPointerReleased(e);
+    }
+
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        if (_pendingTouchPointerId == e.Pointer.PointerId) _pendingTouchPointerId = 0;
+        base.OnPointerCanceled(e);
+    }
+
+    private void Activate(Vector2 position)
+    {
+        var nav = FindParentNavigationView();
+        if (nav == null) return;
+
+        var activeFamily = nav.ActualThemeFamily;
+        var isChevronClick = false;
+        if (Items.Count > 0 && nav.IsPaneOpen)
+        {
+            if (activeFamily == VisualThemeFamily.macOS)
+            {
+                var baseIndent = 16f + (Level * 16f);
+                isChevronClick = position.X >= baseIndent - 8f && position.X <= baseIndent + 20f;
+            }
+            else
+            {
+                isChevronClick = position.X >= Size.X - 40f;
+            }
+        }
+
+        if (isChevronClick)
+        {
+            IsExpanded = !IsExpanded;
+            nav.OnItemExpandedChanged(this);
+        }
+        else
+        {
+            nav.SelectedItem = this;
         }
     }
 

--- a/src/ProGPU.WinUI/Controls/PasswordBox.cs
+++ b/src/ProGPU.WinUI/Controls/PasswordBox.cs
@@ -15,7 +15,7 @@ using static System.FormattableString;
 
 namespace Microsoft.UI.Xaml.Controls;
 
-public class PasswordBox : Control
+public class PasswordBox : Control, ITextInputClient
 {
     public static readonly DependencyProperty PasswordProperty =
         DependencyProperty.Register(
@@ -92,6 +92,7 @@ public class PasswordBox : Control
     private int _selectionAnchor;
     private bool _isDraggingSelection;
     private readonly HashSet<Key> _pressedKeys = new();
+    private string _pendingComposition = string.Empty;
 
     // Multi-step Undo/Redo stack for security-minded editing
     private class UndoState
@@ -263,6 +264,81 @@ public class PasswordBox : Control
         CaretIndex += insert.Length;
         SelectionStart = CaretIndex;
         SelectionLength = 0;
+    }
+
+    TextInputOptions ITextInputClient.GetTextInputOptions()
+    {
+        var matrix = GetGlobalTransformMatrix();
+        var origin = Vector2.Transform(Vector2.Zero, matrix);
+        var end = Vector2.Transform(Size, matrix);
+        return new TextInputOptions(
+            InputScopeNameValue.Password,
+            "done",
+            "off",
+            false,
+            true,
+            false,
+            string.Empty,
+            0,
+            0,
+            new Rect(origin.X, origin.Y, Math.Max(1f, end.X - origin.X), Math.Max(1f, end.Y - origin.Y)));
+    }
+
+    void ITextInputClient.OnTextInput(TextInputRoutedEventArgs args)
+    {
+        if (!IsEnabled || !IsFocused) return;
+        switch (args.Kind)
+        {
+            case TextInputEventKind.InsertText:
+                if (!string.IsNullOrEmpty(args.Text))
+                {
+                    SaveUndoState();
+                    InsertText(args.Text);
+                }
+                break;
+            case TextInputEventKind.DeleteContentBackward:
+            case TextInputEventKind.DeleteContentForward:
+                if (SelectionLength != 0)
+                {
+                    SaveUndoState();
+                    DeleteSelection();
+                }
+                else if (args.Kind == TextInputEventKind.DeleteContentBackward && CaretIndex > 0)
+                {
+                    SaveUndoState();
+                    var length = CaretIndex >= 2 && char.IsLowSurrogate(Password[CaretIndex - 1]) && char.IsHighSurrogate(Password[CaretIndex - 2]) ? 2 : 1;
+                    SelectionStart = CaretIndex - length;
+                    SelectionLength = length;
+                    DeleteSelection();
+                }
+                else if (args.Kind == TextInputEventKind.DeleteContentForward && CaretIndex < Password.Length)
+                {
+                    SaveUndoState();
+                    SelectionStart = CaretIndex;
+                    SelectionLength = CaretIndex + 1 < Password.Length && char.IsHighSurrogate(Password[CaretIndex]) && char.IsLowSurrogate(Password[CaretIndex + 1]) ? 2 : 1;
+                    DeleteSelection();
+                }
+                break;
+            case TextInputEventKind.CompositionStarted:
+                _pendingComposition = string.Empty;
+                break;
+            case TextInputEventKind.CompositionUpdated:
+                _pendingComposition = args.Text;
+                break;
+            case TextInputEventKind.CompositionCompleted:
+                var committed = string.IsNullOrEmpty(args.Text) ? _pendingComposition : args.Text;
+                if (!string.IsNullOrEmpty(committed))
+                {
+                    SaveUndoState();
+                    InsertText(committed);
+                }
+                _pendingComposition = string.Empty;
+                break;
+            case TextInputEventKind.CompositionCanceled:
+                _pendingComposition = string.Empty;
+                break;
+        }
+        args.Handled = true;
     }
 
     public override void OnVisualStateChanged()

--- a/src/ProGPU.WinUI/Controls/PasswordBox.cs
+++ b/src/ProGPU.WinUI/Controls/PasswordBox.cs
@@ -431,6 +431,20 @@ public class PasswordBox : Control, ITextInputClient
         }
     }
 
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        _isDraggingSelection = false;
+        _isRevealPressed = false;
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        _isDraggingSelection = false;
+        _isRevealPressed = false;
+        base.OnPointerCaptureLost(e);
+    }
+
     public override void OnPointerMoved(PointerRoutedEventArgs e)
     {
         if (IsEnabled)

--- a/src/ProGPU.WinUI/Controls/RatingControl.cs
+++ b/src/ProGPU.WinUI/Controls/RatingControl.cs
@@ -112,53 +112,74 @@ public class RatingControl : Control
         }
     }
 
+    private double GetRatingAtPosition(Vector2 position)
+    {
+        var localX = position.X - BorderThickness.Left - Padding.Left;
+        var pitch = StarSize + StarSpacing;
+        var rating = MathF.Floor(Math.Max(0f, localX) / pitch) + 1f;
+        return Math.Clamp(rating, 1f, MaxRating);
+    }
+
+    public override void OnPointerPressed(PointerRoutedEventArgs e)
+    {
+        if (IsEnabled && !IsReadOnly)
+        {
+            _hoverValue = GetRatingAtPosition(e.GetCurrentPoint(this).Position);
+            Invalidate();
+        }
+        base.OnPointerPressed(e);
+    }
+
     public override void OnPointerMoved(PointerRoutedEventArgs e)
     {
         if (IsEnabled && !IsReadOnly)
         {
-            base.OnPointerMoved(e);
-            float localX = e.Position.X - BorderThickness.Left - Padding.Left;
-            
-            // Determine which star is hovered
-            double rawVal = (localX / (StarSize + StarSpacing)) + 1.0;
-            double clamped = Math.Clamp(Math.Ceiling(rawVal), 1.0, MaxRating);
+            var rating = GetRatingAtPosition(e.GetCurrentPoint(this).Position);
 
-            if (_hoverValue != clamped)
+            if (_hoverValue != rating)
             {
-                _hoverValue = clamped;
+                _hoverValue = rating;
                 Invalidate();
             }
         }
+        base.OnPointerMoved(e);
     }
 
     public override void OnPointerExited(PointerRoutedEventArgs e)
     {
         if (IsEnabled && !IsReadOnly)
         {
-            base.OnPointerExited(e);
             if (_hoverValue >= 0.0)
             {
                 _hoverValue = -1.0;
                 Invalidate();
             }
         }
+        base.OnPointerExited(e);
     }
 
     public override void OnPointerReleased(PointerRoutedEventArgs e)
     {
-        if (IsEnabled && !IsReadOnly && IsPointerPressed && IsPointerOver)
+        var shouldCommit = IsEnabled && !IsReadOnly && IsPointerPressed && IsPointerOver;
+        var rating = shouldCommit ? GetRatingAtPosition(e.GetCurrentPoint(this).Position) : -1.0;
+        base.OnPointerReleased(e);
+        if (shouldCommit)
         {
-            base.OnPointerReleased(e);
-            if (_hoverValue >= 1.0 && _hoverValue <= MaxRating)
+            var oldVal = Value;
+            Value = rating;
+            if (oldVal != Value)
             {
-                var oldVal = Value;
-                Value = _hoverValue;
-                if (oldVal != Value)
-                {
-                    ValueChanged?.Invoke(this, Value);
-                }
+                ValueChanged?.Invoke(this, Value);
             }
+            e.Handled = true;
         }
+    }
+
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        _hoverValue = -1.0;
+        Invalidate();
+        base.OnPointerCanceled(e);
     }
 
     public override void OnKeyDown(KeyRoutedEventArgs e)

--- a/src/ProGPU.WinUI/Controls/RepeatButton.cs
+++ b/src/ProGPU.WinUI/Controls/RepeatButton.cs
@@ -80,6 +80,18 @@ public class RepeatButton : Button
         base.OnPointerExited(e);
     }
 
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        CancelRepeat();
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        CancelRepeat();
+        base.OnPointerCaptureLost(e);
+    }
+
     private void CancelRepeat()
     {
         _cts?.Cancel();

--- a/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
+++ b/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
@@ -1,0 +1,196 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Documents;
+using ProGPU.Vector;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+/// <summary>
+/// Applies an AdaptiveTrigger-style width policy to WinUI SplitView. Wide layouts use
+/// Inline mode; compact layouts use Overlay mode and initially reserve all width for
+/// the primary content. Both states retain explicit, touch-sized pane toggle buttons.
+/// </summary>
+public class ResponsiveSplitView : SplitView
+{
+    private readonly Grid _paneHost = new();
+    private readonly Grid _contentHost = new();
+    private readonly ScrollViewer _paneScroller = new()
+    {
+        HorizontalAlignment = HorizontalAlignment.Stretch,
+        VerticalAlignment = VerticalAlignment.Stretch
+    };
+    private readonly Button _openPaneButton;
+    private readonly Button _closePaneButton;
+    private FrameworkElement? _paneContent;
+    private FrameworkElement? _mainContent;
+    private bool? _isCompact;
+    private bool _widePaneOpen = true;
+    private bool _isPaneScrollEnabled = true;
+
+    public ResponsiveSplitView()
+    {
+        OpenPaneLength = 300f;
+        CompactPaneLength = 0f;
+        DisplayMode = SplitViewDisplayMode.Inline;
+        IsPaneOpen = true;
+
+        _openPaneButton = CreatePaneButton("☰", "Open controls pane");
+        _openPaneButton.Click += (_, _) => SetPaneOpen(true);
+        _contentHost.AddChild(_openPaneButton);
+
+        _closePaneButton = CreatePaneButton("‹", "Close controls pane");
+        _closePaneButton.Click += (_, _) => SetPaneOpen(false);
+        _paneHost.AddChild(_paneScroller);
+        _paneHost.AddChild(_closePaneButton);
+
+        base.Pane = _paneHost;
+        base.Content = _contentHost;
+        PaneOpened += (_, _) => RefreshPaneButtons();
+        PaneClosed += (_, _) => RefreshPaneButtons();
+        RefreshPaneButtons();
+    }
+
+    public FrameworkElement? PaneContent
+    {
+        get => _paneContent;
+        set
+        {
+            if (ReferenceEquals(_paneContent, value)) return;
+            if (_paneContent?.Parent == _paneHost) _paneHost.RemoveChild(_paneContent);
+            _paneContent = value;
+            RehostPaneContent();
+            InvalidateMeasure();
+        }
+    }
+
+    public FrameworkElement? MainContent
+    {
+        get => _mainContent;
+        set
+        {
+            if (ReferenceEquals(_mainContent, value)) return;
+            if (_mainContent != null) _contentHost.RemoveChild(_mainContent);
+            _mainContent = value;
+            if (_mainContent != null) _contentHost.InsertChild(0, _mainContent);
+            InvalidateMeasure();
+        }
+    }
+
+    public float CompactModeThreshold { get; set; } = 760f;
+
+    public bool IsPaneScrollEnabled
+    {
+        get => _isPaneScrollEnabled;
+        set
+        {
+            if (_isPaneScrollEnabled == value) return;
+            _isPaneScrollEnabled = value;
+            RehostPaneContent();
+            InvalidateMeasure();
+        }
+    }
+
+    public Button OpenPaneButton => _openPaneButton;
+
+    public Button ClosePaneButton => _closePaneButton;
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        ApplyAdaptiveState(availableSize.X);
+        ApplyButtonPlacement();
+        return base.MeasureOverride(availableSize);
+    }
+
+    private void ApplyAdaptiveState(float width)
+    {
+        var compact = !float.IsPositiveInfinity(width) && width < CompactModeThreshold;
+        if (_isCompact == compact) return;
+
+        if (compact)
+        {
+            if (_isCompact == false) _widePaneOpen = IsPaneOpen;
+            DisplayMode = SplitViewDisplayMode.Overlay;
+            IsPaneOpen = false;
+        }
+        else
+        {
+            DisplayMode = SplitViewDisplayMode.Inline;
+            IsPaneOpen = _widePaneOpen;
+        }
+
+        _isCompact = compact;
+        RefreshPaneButtons();
+    }
+
+    private void SetPaneOpen(bool isOpen)
+    {
+        IsPaneOpen = isOpen;
+        if (_isCompact == false) _widePaneOpen = IsPaneOpen;
+        RefreshPaneButtons();
+    }
+
+    private void RehostPaneContent()
+    {
+        if (_paneContent?.Parent == _paneHost) _paneHost.RemoveChild(_paneContent);
+        _paneScroller.Content = null;
+        _paneScroller.Visibility = _isPaneScrollEnabled ? Visibility.Visible : Visibility.Collapsed;
+        if (_paneContent == null) return;
+        if (_isPaneScrollEnabled) _paneScroller.Content = _paneContent;
+        else _paneHost.InsertChild(0, _paneContent);
+    }
+
+    private void ApplyButtonPlacement()
+    {
+        var paneOnLeft = PanePlacement == PanePlacement.Left;
+        _openPaneButton.HorizontalAlignment = paneOnLeft ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+        _closePaneButton.HorizontalAlignment = paneOnLeft ? HorizontalAlignment.Right : HorizontalAlignment.Left;
+        SetButtonGlyph(_closePaneButton, paneOnLeft ? "‹" : "›");
+    }
+
+    private void RefreshPaneButtons()
+    {
+        _openPaneButton.Visibility = IsPaneOpen ? Visibility.Collapsed : Visibility.Visible;
+        _closePaneButton.Visibility = IsPaneOpen ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private static Button CreatePaneButton(string glyph, string toolTip)
+    {
+        var button = new Button
+        {
+            Width = 34f,
+            Height = 34f,
+            Padding = new Thickness(0),
+            Margin = new Thickness(8f),
+            CornerRadius = 6f,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Background = new ThemeResourceBrush("ControlBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(1f),
+            ToolTip = toolTip
+        };
+        SetButtonGlyph(button, glyph);
+        return button;
+    }
+
+    private static void SetButtonGlyph(Button button, string glyph)
+    {
+        if (button.Content is RichTextBlock existing &&
+            existing.Inlines.Count > 0 &&
+            existing.Inlines[0] is Run run)
+        {
+            run.Text = glyph;
+            return;
+        }
+
+        var label = new RichTextBlock
+        {
+            Font = PopupService.DefaultFont,
+            FontSize = 18f,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        label.Inlines.Add(new Run(glyph));
+        button.Content = label;
+    }
+}

--- a/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
+++ b/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
@@ -81,7 +81,7 @@ public class ResponsiveSplitView : SplitView
 
     public float MinimumCompactOpenPaneLength { get; set; } = 340f;
 
-    public float CompactContentRevealLength { get; set; } = 48f;
+    public float CompactContentRevealLength { get; set; }
 
     public bool IsPaneScrollEnabled
     {

--- a/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
+++ b/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
@@ -79,8 +79,6 @@ public class ResponsiveSplitView : SplitView
 
     public float CompactModeThreshold { get; set; } = 760f;
 
-    public float MinimumCompactOpenPaneLength { get; set; } = 340f;
-
     public float CompactContentRevealLength { get; set; }
 
     public bool IsPaneScrollEnabled
@@ -120,9 +118,7 @@ public class ResponsiveSplitView : SplitView
             }
 
             var availablePaneWidth = Math.Max(0f, width - CompactContentRevealLength);
-            OpenPaneLength = Math.Min(
-                Math.Max(_wideOpenPaneLength, MinimumCompactOpenPaneLength),
-                availablePaneWidth);
+            OpenPaneLength = availablePaneWidth;
         }
         else
         {

--- a/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
+++ b/src/ProGPU.WinUI/Controls/ResponsiveSplitView.cs
@@ -26,6 +26,7 @@ public class ResponsiveSplitView : SplitView
     private bool? _isCompact;
     private bool _widePaneOpen = true;
     private bool _isPaneScrollEnabled = true;
+    private float _wideOpenPaneLength = 300f;
 
     public ResponsiveSplitView()
     {
@@ -78,6 +79,10 @@ public class ResponsiveSplitView : SplitView
 
     public float CompactModeThreshold { get; set; } = 760f;
 
+    public float MinimumCompactOpenPaneLength { get; set; } = 340f;
+
+    public float CompactContentRevealLength { get; set; } = 48f;
+
     public bool IsPaneScrollEnabled
     {
         get => _isPaneScrollEnabled;
@@ -104,18 +109,33 @@ public class ResponsiveSplitView : SplitView
     private void ApplyAdaptiveState(float width)
     {
         var compact = !float.IsPositiveInfinity(width) && width < CompactModeThreshold;
-        if (_isCompact == compact) return;
-
         if (compact)
         {
-            if (_isCompact == false) _widePaneOpen = IsPaneOpen;
-            DisplayMode = SplitViewDisplayMode.Overlay;
-            IsPaneOpen = false;
+            if (_isCompact != true)
+            {
+                _wideOpenPaneLength = OpenPaneLength;
+                if (_isCompact == false) _widePaneOpen = IsPaneOpen;
+                DisplayMode = SplitViewDisplayMode.Overlay;
+                IsPaneOpen = false;
+            }
+
+            var availablePaneWidth = Math.Max(0f, width - CompactContentRevealLength);
+            OpenPaneLength = Math.Min(
+                Math.Max(_wideOpenPaneLength, MinimumCompactOpenPaneLength),
+                availablePaneWidth);
         }
         else
         {
-            DisplayMode = SplitViewDisplayMode.Inline;
-            IsPaneOpen = _widePaneOpen;
+            if (_isCompact == true)
+            {
+                OpenPaneLength = _wideOpenPaneLength;
+                DisplayMode = SplitViewDisplayMode.Inline;
+                IsPaneOpen = _widePaneOpen;
+            }
+            else
+            {
+                _wideOpenPaneLength = OpenPaneLength;
+            }
         }
 
         _isCompact = compact;

--- a/src/ProGPU.WinUI/Controls/ScrollBarInteraction.cs
+++ b/src/ProGPU.WinUI/Controls/ScrollBarInteraction.cs
@@ -1,0 +1,108 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Windows.Devices.Input;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+internal readonly record struct ScrollBarMetrics(
+    float TrackStart,
+    float TrackLength,
+    float ThumbStart,
+    float ThumbLength,
+    float Maximum);
+
+internal static class ScrollBarInteraction
+{
+    public const float CollapsedThickness = 3f;
+    public const float ExpandedThickness = 8f;
+    public const float ExpandedPadding = 2f;
+    public const float CollapsedPadding = 4f;
+    public const float MinimumThumbLength = 24f;
+
+    public static float GetCrossAxisHitTarget(PointerDeviceType deviceType) => deviceType switch
+    {
+        PointerDeviceType.Touch => 32f,
+        PointerDeviceType.Pen => 20f,
+        _ => 12f
+    };
+
+    public static float GetAlongAxisHitTarget(PointerDeviceType deviceType) => deviceType switch
+    {
+        PointerDeviceType.Touch => 44f,
+        PointerDeviceType.Pen => 28f,
+        _ => MinimumThumbLength
+    };
+
+    public static bool CapturePointer(FrameworkElement owner, PointerRoutedEventArgs e)
+    {
+        if (e.Pointer.IsInContact) return owner.CapturePointer(e.Pointer);
+        InputSystem.CapturePointer(owner);
+        return true;
+    }
+
+    public static void ReleasePointer(FrameworkElement owner, PointerRoutedEventArgs e)
+    {
+        if (e.Pointer.IsInContact) owner.ReleasePointerCapture(e.Pointer);
+        else InputSystem.ReleasePointerCapture();
+    }
+
+    public static bool TryCreateMetrics(
+        float trackStart,
+        float viewportLength,
+        float extentLength,
+        float value,
+        out ScrollBarMetrics metrics)
+    {
+        metrics = default;
+        if (!float.IsFinite(trackStart) || !float.IsFinite(viewportLength) ||
+            !float.IsFinite(extentLength) || viewportLength <= 0f || extentLength <= viewportLength)
+        {
+            return false;
+        }
+
+        var maximum = extentLength - viewportLength;
+        var thumbLength = Math.Min(viewportLength,
+            Math.Max(MinimumThumbLength, (viewportLength / extentLength) * viewportLength));
+        var travel = Math.Max(0f, viewportLength - thumbLength);
+        var clampedValue = Math.Clamp(float.IsFinite(value) ? value : 0f, 0f, maximum);
+        var thumbStart = trackStart + (maximum > 0f ? (clampedValue / maximum) * travel : 0f);
+        metrics = new ScrollBarMetrics(trackStart, viewportLength, thumbStart, thumbLength, maximum);
+        return true;
+    }
+
+    public static bool IsVerticalTrackHit(float x, float width, PointerDeviceType deviceType) =>
+        x >= Math.Max(0f, width - GetCrossAxisHitTarget(deviceType)) && x <= width;
+
+    public static bool IsHorizontalTrackHit(float y, float height, PointerDeviceType deviceType) =>
+        y >= Math.Max(0f, height - GetCrossAxisHitTarget(deviceType)) && y <= height;
+
+    public static bool IsThumbHit(float position, ScrollBarMetrics metrics, PointerDeviceType deviceType)
+    {
+        var hitLength = Math.Max(metrics.ThumbLength, GetAlongAxisHitTarget(deviceType));
+        var expansion = (hitLength - metrics.ThumbLength) * 0.5f;
+        var hitStart = Math.Max(metrics.TrackStart, metrics.ThumbStart - expansion);
+        var hitEnd = Math.Min(metrics.TrackStart + metrics.TrackLength,
+            metrics.ThumbStart + metrics.ThumbLength + expansion);
+        return position >= hitStart && position <= hitEnd;
+    }
+
+    public static float ValueFromDrag(float startValue, float delta, ScrollBarMetrics metrics)
+    {
+        var travel = metrics.TrackLength - metrics.ThumbLength;
+        if (travel <= 0f || metrics.Maximum <= 0f) return 0f;
+        return Math.Clamp(startValue + (delta / travel) * metrics.Maximum, 0f, metrics.Maximum);
+    }
+
+    public static float ValueFromTrackPress(
+        float currentValue,
+        float position,
+        ScrollBarMetrics metrics,
+        float viewportLength)
+    {
+        var page = Math.Max(1f, viewportLength * 0.9f);
+        if (position < metrics.ThumbStart) return Math.Max(0f, currentValue - page);
+        if (position > metrics.ThumbStart + metrics.ThumbLength) return Math.Min(metrics.Maximum, currentValue + page);
+        return currentValue;
+    }
+}

--- a/src/ProGPU.WinUI/Controls/ScrollViewer.cs
+++ b/src/ProGPU.WinUI/Controls/ScrollViewer.cs
@@ -16,6 +16,32 @@ public interface IScrollViewportAware
     void OnScrollViewportChanged();
 }
 
+public enum ScrollMode
+{
+    Disabled,
+    Enabled,
+    Auto
+}
+
+public enum ZoomMode
+{
+    Disabled,
+    Enabled
+}
+
+public sealed class ScrollViewerViewChangingEventArgs : EventArgs
+{
+    public bool IsInertial { get; internal init; }
+    public float HorizontalOffset { get; internal init; }
+    public float VerticalOffset { get; internal init; }
+    public float ZoomFactor { get; internal init; }
+}
+
+public sealed class ScrollViewerViewChangedEventArgs : EventArgs
+{
+    public bool IsIntermediate { get; internal init; }
+}
+
 [ContentProperty(Name = "Content")]
 public class ScrollViewer : ContentControl
 {
@@ -26,6 +52,12 @@ public class ScrollViewer : ContentControl
     private float _dragStartOffset;
     private float _dragStartMouseY;
     private bool _isPointerOverScrollbar;
+    private float _zoomFactor = 1f;
+    private Vector2 _inertiaVelocity;
+    private Vector2 _contentBaseTranslation;
+    private Vector3 _contentBaseScale = Vector3.One;
+    private Vector2 _contentBaseTransformOrigin = new(0.5f, 0.5f);
+    private bool _hasContentTransformSnapshot;
 
     public new FrameworkElement? Content
     {
@@ -34,10 +66,20 @@ public class ScrollViewer : ContentControl
         {
             if (base.Content is FrameworkElement oldContent && !ReferenceEquals(oldContent, value))
             {
-                oldContent.LayoutTranslation = Vector2.Zero;
+                oldContent.LayoutTranslation = _contentBaseTranslation;
+                oldContent.Scale = _contentBaseScale;
+                oldContent.RenderTransformOrigin = _contentBaseTransformOrigin;
+                _hasContentTransformSnapshot = false;
             }
 
             base.Content = value;
+            if (value != null && !_hasContentTransformSnapshot)
+            {
+                _contentBaseTranslation = value.LayoutTranslation;
+                _contentBaseScale = value.Scale;
+                _contentBaseTransformOrigin = value.RenderTransformOrigin;
+                _hasContentTransformSnapshot = true;
+            }
             UpdateContentTranslation();
         }
     }
@@ -98,12 +140,37 @@ public class ScrollViewer : ContentControl
         }
     }
 
-    public float ContentHeight => Content?.DesiredSize.Y ?? Size.Y;
-    public float ContentWidth => Content?.DesiredSize.X ?? Size.X;
+    public float ContentHeight => (Content?.DesiredSize.Y ?? Size.Y) * ZoomFactor;
+    public float ContentWidth => (Content?.DesiredSize.X ?? Size.X) * ZoomFactor;
+    public ScrollMode HorizontalScrollMode { get; set; } = ScrollMode.Auto;
+    public ScrollMode VerticalScrollMode { get; set; } = ScrollMode.Auto;
+    public ZoomMode ZoomMode { get; set; } = ZoomMode.Disabled;
+    public float MinZoomFactor { get; set; } = 0.1f;
+    public float MaxZoomFactor { get; set; } = 10f;
+    public float ZoomFactor
+    {
+        get => _zoomFactor;
+        private set
+        {
+            var clamped = Math.Clamp(value, Math.Max(0.01f, MinZoomFactor), Math.Max(MinZoomFactor, MaxZoomFactor));
+            if (MathF.Abs(_zoomFactor - clamped) < 0.0001f) return;
+            _zoomFactor = clamped;
+            _horizontalOffset = Math.Clamp(_horizontalOffset, 0f, Math.Max(0f, ContentWidth - Size.X));
+            _verticalOffset = Math.Clamp(_verticalOffset, 0f, Math.Max(0f, ContentHeight - Size.Y));
+            UpdateContentTranslation();
+            Invalidate();
+        }
+    }
+
+    public event EventHandler<ScrollViewerViewChangingEventArgs>? ViewChanging;
+    public event EventHandler<ScrollViewerViewChangedEventArgs>? ViewChanged;
 
     public ScrollViewer()
     {
         Padding = new Thickness(0);
+        ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY |
+            ManipulationModes.TranslateRailsX | ManipulationModes.TranslateRailsY |
+            ManipulationModes.TranslateInertia | ManipulationModes.Scale | ManipulationModes.ScaleInertia;
         
         var defaultStyle = ThemeManager.GetDefaultStyle(GetType());
         if (defaultStyle != null)
@@ -111,6 +178,105 @@ public class ScrollViewer : ContentControl
             Style = defaultStyle;
         }
     }
+
+    public bool ChangeView(double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation = true)
+    {
+        var changed = false;
+        if (zoomFactor.HasValue && ZoomMode == ZoomMode.Enabled)
+        {
+            var old = ZoomFactor;
+            ZoomFactor = zoomFactor.Value;
+            changed |= old != ZoomFactor;
+        }
+        if (horizontalOffset.HasValue && HorizontalScrollMode != ScrollMode.Disabled)
+        {
+            var old = HorizontalOffset;
+            HorizontalOffset = (float)horizontalOffset.Value;
+            changed |= old != HorizontalOffset;
+        }
+        if (verticalOffset.HasValue && VerticalScrollMode != ScrollMode.Disabled)
+        {
+            var old = VerticalOffset;
+            VerticalOffset = (float)verticalOffset.Value;
+            changed |= old != VerticalOffset;
+        }
+        if (changed) RaiseViewChanged(isIntermediate: false);
+        return changed;
+    }
+
+    public override void OnManipulationStarted(ManipulationStartedRoutedEventArgs e)
+    {
+        _inertiaVelocity = Vector2.Zero;
+        base.OnManipulationStarted(e);
+    }
+
+    public override void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)
+    {
+        if (!IsEnabled)
+        {
+            base.OnManipulationDelta(e);
+            return;
+        }
+        var oldHorizontal = HorizontalOffset;
+        var oldVertical = VerticalOffset;
+        var oldZoom = ZoomFactor;
+        if (HorizontalScrollMode != ScrollMode.Disabled) HorizontalOffset -= e.Delta.Translation.X;
+        if (VerticalScrollMode != ScrollMode.Disabled) VerticalOffset -= e.Delta.Translation.Y;
+        if (ZoomMode == ZoomMode.Enabled && float.IsFinite(e.Delta.Scale)) ZoomFactor *= e.Delta.Scale;
+        if (oldHorizontal != HorizontalOffset || oldVertical != VerticalOffset || oldZoom != ZoomFactor)
+        {
+            ViewChanging?.Invoke(this, new ScrollViewerViewChangingEventArgs
+            {
+                IsInertial = e.IsInertial,
+                HorizontalOffset = HorizontalOffset,
+                VerticalOffset = VerticalOffset,
+                ZoomFactor = ZoomFactor
+            });
+            RaiseViewChanged(isIntermediate: true);
+            e.Handled = true;
+        }
+        base.OnManipulationDelta(e);
+    }
+
+    public override void OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e)
+    {
+        if (e.IsInertial) _inertiaVelocity = -e.Velocities.Linear;
+        RaiseViewChanged(isIntermediate: false);
+        base.OnManipulationCompleted(e);
+    }
+
+    protected override void OnUpdateAnimations(float elapsedSeconds)
+    {
+        base.OnUpdateAnimations(elapsedSeconds);
+        if (_inertiaVelocity.LengthSquared() < 4f || elapsedSeconds <= 0f)
+        {
+            _inertiaVelocity = Vector2.Zero;
+            return;
+        }
+        var oldHorizontal = HorizontalOffset;
+        var oldVertical = VerticalOffset;
+        if (HorizontalScrollMode != ScrollMode.Disabled) HorizontalOffset += _inertiaVelocity.X * elapsedSeconds;
+        if (VerticalScrollMode != ScrollMode.Disabled) VerticalOffset += _inertiaVelocity.Y * elapsedSeconds;
+        if (oldHorizontal == HorizontalOffset && oldVertical == VerticalOffset)
+        {
+            _inertiaVelocity = Vector2.Zero;
+            RaiseViewChanged(isIntermediate: false);
+            return;
+        }
+        var decay = MathF.Pow(0.002f, elapsedSeconds);
+        _inertiaVelocity *= decay;
+        ViewChanging?.Invoke(this, new ScrollViewerViewChangingEventArgs
+        {
+            IsInertial = true,
+            HorizontalOffset = HorizontalOffset,
+            VerticalOffset = VerticalOffset,
+            ZoomFactor = ZoomFactor
+        });
+        RaiseViewChanged(isIntermediate: true);
+    }
+
+    private void RaiseViewChanged(bool isIntermediate) =>
+        ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
 
     public override void OnPointerWheelChanged(PointerRoutedEventArgs e)
     {
@@ -271,7 +437,9 @@ public class ScrollViewer : ContentControl
     {
         if (Content != null)
         {
-            Content.LayoutTranslation = new Vector2(-_horizontalOffset, -_verticalOffset);
+            Content.RenderTransformOrigin = Vector2.Zero;
+            Content.Scale = new Vector3(_contentBaseScale.X * ZoomFactor, _contentBaseScale.Y * ZoomFactor, _contentBaseScale.Z);
+            Content.LayoutTranslation = _contentBaseTranslation + new Vector2(-_horizontalOffset, -_verticalOffset);
         }
     }
 

--- a/src/ProGPU.WinUI/Controls/ScrollViewer.cs
+++ b/src/ProGPU.WinUI/Controls/ScrollViewer.cs
@@ -48,10 +48,13 @@ public class ScrollViewer : ContentControl
     private float _verticalOffset;
     private float _horizontalOffset;
     
-    private bool _isDraggingVert;
+    private Orientation? _draggingScrollBar;
+    private Orientation? _activeScrollBar;
+    private uint _scrollbarPointerId;
     private float _dragStartOffset;
-    private float _dragStartMouseY;
-    private bool _isPointerOverScrollbar;
+    private float _dragStartPosition;
+    private bool _isPointerOverVerticalScrollbar;
+    private bool _isPointerOverHorizontalScrollbar;
     private float _zoomFactor = 1f;
     private Vector2 _inertiaVelocity;
     private Vector2 _contentBaseTranslation;
@@ -302,26 +305,58 @@ public class ScrollViewer : ContentControl
     {
         if (IsEnabled)
         {
-            var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
-            float scrollbarWidth = 8f;
-            float contentHeight = ContentHeight;
-            float viewportHeight = Size.Y;
-
-            if (contentHeight > viewportHeight && localPos.X >= Size.X - scrollbarWidth - 4f)
+            var localPos = e.GetCurrentPoint(this).Position;
+            var deviceType = e.Pointer.PointerDeviceType;
+            if (ScrollBarInteraction.TryCreateMetrics(0f, Size.Y, ContentHeight, VerticalOffset, out var verticalMetrics) &&
+                ScrollBarInteraction.IsVerticalTrackHit(localPos.X, Size.X, deviceType))
             {
-                float thumbHeight = Math.Max(20f, (viewportHeight / contentHeight) * viewportHeight);
-                float scrollableHeight = contentHeight - viewportHeight;
-                float thumbY = (VerticalOffset / scrollableHeight) * (viewportHeight - thumbHeight);
-
-                if (localPos.Y >= thumbY && localPos.Y <= thumbY + thumbHeight)
+                if (ScrollBarInteraction.CapturePointer(this, e))
                 {
-                    _isDraggingVert = true;
-                    _dragStartOffset = VerticalOffset;
-                    _dragStartMouseY = localPos.Y;
-                    InputSystem.CapturePointer(this);
+                    _scrollbarPointerId = e.Pointer.PointerId;
+                    _activeScrollBar = Orientation.Vertical;
+                    _inertiaVelocity = Vector2.Zero;
+                    if (ScrollBarInteraction.IsThumbHit(localPos.Y, verticalMetrics, deviceType))
+                    {
+                        _draggingScrollBar = Orientation.Vertical;
+                        _dragStartOffset = VerticalOffset;
+                        _dragStartPosition = localPos.Y;
+                    }
+                    else
+                    {
+                        _draggingScrollBar = null;
+                        VerticalOffset = ScrollBarInteraction.ValueFromTrackPress(
+                            VerticalOffset, localPos.Y, verticalMetrics, Size.Y);
+                        RaiseViewChanged(isIntermediate: false);
+                    }
                     e.Handled = true;
+                    Invalidate();
                     return;
                 }
+            }
+
+            if (ScrollBarInteraction.TryCreateMetrics(0f, Size.X, ContentWidth, HorizontalOffset, out var horizontalMetrics) &&
+                ScrollBarInteraction.IsHorizontalTrackHit(localPos.Y, Size.Y, deviceType) &&
+                ScrollBarInteraction.CapturePointer(this, e))
+            {
+                _scrollbarPointerId = e.Pointer.PointerId;
+                _activeScrollBar = Orientation.Horizontal;
+                _inertiaVelocity = Vector2.Zero;
+                if (ScrollBarInteraction.IsThumbHit(localPos.X, horizontalMetrics, deviceType))
+                {
+                    _draggingScrollBar = Orientation.Horizontal;
+                    _dragStartOffset = HorizontalOffset;
+                    _dragStartPosition = localPos.X;
+                }
+                else
+                {
+                    _draggingScrollBar = null;
+                    HorizontalOffset = ScrollBarInteraction.ValueFromTrackPress(
+                        HorizontalOffset, localPos.X, horizontalMetrics, Size.X);
+                    RaiseViewChanged(isIntermediate: false);
+                }
+                e.Handled = true;
+                Invalidate();
+                return;
             }
         }
         base.OnPointerPressed(e);
@@ -329,23 +364,39 @@ public class ScrollViewer : ContentControl
 
     public override void OnPointerReleased(PointerRoutedEventArgs e)
     {
-        if (_isDraggingVert)
+        if (_scrollbarPointerId == e.Pointer.PointerId)
         {
-            _isDraggingVert = false;
-            InputSystem.ReleasePointerCapture();
+            _scrollbarPointerId = 0;
+            _draggingScrollBar = null;
+            _activeScrollBar = null;
+            ScrollBarInteraction.ReleasePointer(this, e);
+            e.Handled = true;
+            Invalidate();
         }
         base.OnPointerReleased(e);
     }
 
     public override void OnPointerCanceled(PointerRoutedEventArgs e)
     {
-        _isDraggingVert = false;
+        if (_scrollbarPointerId == e.Pointer.PointerId)
+        {
+            _scrollbarPointerId = 0;
+            _draggingScrollBar = null;
+            _activeScrollBar = null;
+            Invalidate();
+        }
         base.OnPointerCanceled(e);
     }
 
     public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
     {
-        _isDraggingVert = false;
+        if (_scrollbarPointerId == e.Pointer.PointerId)
+        {
+            _scrollbarPointerId = 0;
+            _draggingScrollBar = null;
+            _activeScrollBar = null;
+            Invalidate();
+        }
         base.OnPointerCaptureLost(e);
     }
 
@@ -353,8 +404,7 @@ public class ScrollViewer : ContentControl
     {
         if (IsEnabled)
         {
-            var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
-            _isPointerOverScrollbar = localPos.X >= Size.X - 12f;
+            UpdateScrollbarPointerOver(e);
             Invalidate();
         }
         base.OnPointerEntered(e);
@@ -362,7 +412,8 @@ public class ScrollViewer : ContentControl
 
     public override void OnPointerExited(PointerRoutedEventArgs e)
     {
-        _isPointerOverScrollbar = false;
+        _isPointerOverVerticalScrollbar = false;
+        _isPointerOverHorizontalScrollbar = false;
         Invalidate();
         base.OnPointerExited(e);
     }
@@ -371,29 +422,39 @@ public class ScrollViewer : ContentControl
     {
         if (IsEnabled)
         {
-            var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
-            _isPointerOverScrollbar = localPos.X >= Size.X - 12f;
+            UpdateScrollbarPointerOver(e);
             Invalidate();
         }
 
-        if (_isDraggingVert && IsEnabled)
+        if (_scrollbarPointerId == e.Pointer.PointerId && _draggingScrollBar.HasValue && IsEnabled)
         {
-            var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
-            float contentHeight = ContentHeight;
-            float viewportHeight = Size.Y;
-            float thumbHeight = Math.Max(20f, (viewportHeight / contentHeight) * viewportHeight);
-            float scrollableHeight = contentHeight - viewportHeight;
-            float trackLength = viewportHeight - thumbHeight;
-
-            if (trackLength > 0f)
+            var localPos = e.GetCurrentPoint(this).Position;
+            if (_draggingScrollBar == Orientation.Vertical &&
+                ScrollBarInteraction.TryCreateMetrics(0f, Size.Y, ContentHeight, _dragStartOffset, out var verticalMetrics))
             {
-                float deltaY = localPos.Y - _dragStartMouseY;
-                VerticalOffset = _dragStartOffset + (deltaY / trackLength) * scrollableHeight;
+                VerticalOffset = ScrollBarInteraction.ValueFromDrag(
+                    _dragStartOffset, localPos.Y - _dragStartPosition, verticalMetrics);
+            }
+            else if (_draggingScrollBar == Orientation.Horizontal &&
+                ScrollBarInteraction.TryCreateMetrics(0f, Size.X, ContentWidth, _dragStartOffset, out var horizontalMetrics))
+            {
+                HorizontalOffset = ScrollBarInteraction.ValueFromDrag(
+                    _dragStartOffset, localPos.X - _dragStartPosition, horizontalMetrics);
             }
             e.Handled = true;
             return;
         }
         base.OnPointerMoved(e);
+    }
+
+    private void UpdateScrollbarPointerOver(PointerRoutedEventArgs e)
+    {
+        var localPos = e.GetCurrentPoint(this).Position;
+        var deviceType = e.Pointer.PointerDeviceType;
+        _isPointerOverVerticalScrollbar = ContentHeight > Size.Y &&
+            ScrollBarInteraction.IsVerticalTrackHit(localPos.X, Size.X, deviceType);
+        _isPointerOverHorizontalScrollbar = ContentWidth > Size.X &&
+            ScrollBarInteraction.IsHorizontalTrackHit(localPos.Y, Size.Y, deviceType);
     }
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)
@@ -478,34 +539,42 @@ public class ScrollViewer : ContentControl
         base.OnRender(context);
         context.PopClip();
 
-        // Draw vertical scrollbar if content overflows viewport height
-        float contentHeight = ContentHeight;
-        float viewportHeight = Size.Y;
-
-        if (contentHeight > viewportHeight)
+        if (ScrollBarInteraction.TryCreateMetrics(0f, Size.Y, ContentHeight, VerticalOffset, out var verticalMetrics))
         {
-            // Dynamic expanding scrollbar thickness based on hover state
-            float scrollbarWidth = (_isPointerOverScrollbar || _isDraggingVert) ? 8f : 3f;
-            float padding = (_isPointerOverScrollbar || _isDraggingVert) ? 2f : 4f;
-
-            float thumbHeight = Math.Max(24f, (viewportHeight / contentHeight) * viewportHeight);
-            float scrollableHeight = contentHeight - viewportHeight;
-            float thumbY = (VerticalOffset / scrollableHeight) * (viewportHeight - thumbHeight);
-
-            Rect trackRect = new Rect(Size.X - scrollbarWidth - padding, 0f, scrollbarWidth, viewportHeight);
-            Rect thumbRect = new Rect(Size.X - scrollbarWidth - padding, thumbY, scrollbarWidth, thumbHeight);
-
-            // Draw track (subtle translucent backdrop line)
-            Brush trackBg = (_isPointerOverScrollbar || _isDraggingVert) 
+            var active = _isPointerOverVerticalScrollbar ||
+                (_scrollbarPointerId != 0 && _activeScrollBar == Orientation.Vertical);
+            var scrollbarWidth = active ? ScrollBarInteraction.ExpandedThickness : ScrollBarInteraction.CollapsedThickness;
+            var padding = active ? ScrollBarInteraction.ExpandedPadding : ScrollBarInteraction.CollapsedPadding;
+            var trackRect = new Rect(Size.X - scrollbarWidth - padding, 0f, scrollbarWidth, Size.Y);
+            var thumbRect = new Rect(Size.X - scrollbarWidth - padding, verticalMetrics.ThumbStart,
+                scrollbarWidth, verticalMetrics.ThumbLength);
+            Brush trackBg = active
                 ? ThemeManager.GetBrush("ControlBackgroundHover") 
                 : ThemeManager.GetBrush("ControlBackground");
             context.DrawRectangle(trackBg, null, trackRect);
-
-            // Draw thumb (glassmorphic capsule)
-            Brush thumbBg = (_isPointerOverScrollbar || _isDraggingVert)
+            Brush thumbBg = active
                 ? ThemeManager.GetBrush("ScrollbarThumbHover")
                 : ThemeManager.GetBrush("ScrollbarThumb");
             context.DrawRoundedRectangle(thumbBg, null, thumbRect, scrollbarWidth / 2f);
+        }
+
+        if (ScrollBarInteraction.TryCreateMetrics(0f, Size.X, ContentWidth, HorizontalOffset, out var horizontalMetrics))
+        {
+            var active = _isPointerOverHorizontalScrollbar ||
+                (_scrollbarPointerId != 0 && _activeScrollBar == Orientation.Horizontal);
+            var scrollbarHeight = active ? ScrollBarInteraction.ExpandedThickness : ScrollBarInteraction.CollapsedThickness;
+            var padding = active ? ScrollBarInteraction.ExpandedPadding : ScrollBarInteraction.CollapsedPadding;
+            var trackRect = new Rect(0f, Size.Y - scrollbarHeight - padding, Size.X, scrollbarHeight);
+            var thumbRect = new Rect(horizontalMetrics.ThumbStart, Size.Y - scrollbarHeight - padding,
+                horizontalMetrics.ThumbLength, scrollbarHeight);
+            Brush trackBg = active
+                ? ThemeManager.GetBrush("ControlBackgroundHover")
+                : ThemeManager.GetBrush("ControlBackground");
+            context.DrawRectangle(trackBg, null, trackRect);
+            Brush thumbBg = active
+                ? ThemeManager.GetBrush("ScrollbarThumbHover")
+                : ThemeManager.GetBrush("ScrollbarThumb");
+            context.DrawRoundedRectangle(thumbBg, null, thumbRect, scrollbarHeight / 2f);
         }
     }
 }

--- a/src/ProGPU.WinUI/Controls/ScrollViewer.cs
+++ b/src/ProGPU.WinUI/Controls/ScrollViewer.cs
@@ -337,6 +337,18 @@ public class ScrollViewer : ContentControl
         base.OnPointerReleased(e);
     }
 
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        _isDraggingVert = false;
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        _isDraggingVert = false;
+        base.OnPointerCaptureLost(e);
+    }
+
     public override void OnPointerEntered(PointerRoutedEventArgs e)
     {
         if (IsEnabled)

--- a/src/ProGPU.WinUI/Controls/Slider.cs
+++ b/src/ProGPU.WinUI/Controls/Slider.cs
@@ -104,6 +104,18 @@ public class Slider : Control
         base.OnPointerReleased(e);
     }
 
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        _isDragging = false;
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        _isDragging = false;
+        base.OnPointerCaptureLost(e);
+    }
+
     public override void OnPointerMoved(PointerRoutedEventArgs e)
     {
         if (_isDragging && IsEnabled)

--- a/src/ProGPU.WinUI/Controls/SplitView.cs
+++ b/src/ProGPU.WinUI/Controls/SplitView.cs
@@ -24,6 +24,11 @@ public enum SplitViewDisplayMode
     CompactOverlay
 }
 
+public sealed class SplitViewPaneClosingEventArgs : EventArgs
+{
+    public bool Cancel { get; set; }
+}
+
 public class SplitView : FrameworkElement
 {
     private FrameworkElement? _pane;
@@ -33,6 +38,11 @@ public class SplitView : FrameworkElement
     private float _compactPaneLength = 60f;
     private PanePlacement _panePlacement = PanePlacement.Left;
     private SplitViewDisplayMode _displayMode = SplitViewDisplayMode.Inline;
+
+    public event EventHandler? PaneOpening;
+    public event EventHandler? PaneOpened;
+    public event EventHandler<SplitViewPaneClosingEventArgs>? PaneClosing;
+    public event EventHandler? PaneClosed;
 
     public FrameworkElement? Pane
     {
@@ -71,9 +81,32 @@ public class SplitView : FrameworkElement
         {
             if (_isPaneOpen != value)
             {
+                if (value)
+                {
+                    PaneOpening?.Invoke(this, EventArgs.Empty);
+                }
+                else
+                {
+                    var closingArgs = new SplitViewPaneClosingEventArgs();
+                    PaneClosing?.Invoke(this, closingArgs);
+                    if (closingArgs.Cancel)
+                    {
+                        return;
+                    }
+                }
+
                 _isPaneOpen = value;
                 Invalidate();
                 InvalidateMeasure();
+
+                if (value)
+                {
+                    PaneOpened?.Invoke(this, EventArgs.Empty);
+                }
+                else
+                {
+                    PaneClosed?.Invoke(this, EventArgs.Empty);
+                }
             }
         }
     }
@@ -90,6 +123,16 @@ public class SplitView : FrameworkElement
                 InvalidateMeasure();
             }
         }
+    }
+
+    /// <summary>
+    /// Gets or sets the width of the pane when it is open. This is the WinUI-compatible
+    /// name for the legacy <see cref="PaneWidth"/> property.
+    /// </summary>
+    public float OpenPaneLength
+    {
+        get => PaneWidth;
+        set => PaneWidth = value;
     }
 
     public float CompactPaneLength
@@ -136,8 +179,7 @@ public class SplitView : FrameworkElement
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
-        bool hasCompact = DisplayMode == SplitViewDisplayMode.CompactInline || DisplayMode == SplitViewDisplayMode.CompactOverlay;
-        float pW = IsPaneOpen ? PaneWidth : (hasCompact ? CompactPaneLength : 0f);
+        float pW = GetPaneLength(availableSize.X);
 
         if (Pane != null)
         {
@@ -159,8 +201,7 @@ public class SplitView : FrameworkElement
 
     protected override void ArrangeOverride(Rect arrangeRect)
     {
-        bool hasCompact = DisplayMode == SplitViewDisplayMode.CompactInline || DisplayMode == SplitViewDisplayMode.CompactOverlay;
-        float pW = IsPaneOpen ? PaneWidth : (hasCompact ? CompactPaneLength : 0f);
+        float pW = GetPaneLength(arrangeRect.Width);
 
         float paneX = arrangeRect.X;
         float contentX = arrangeRect.X;
@@ -201,5 +242,17 @@ public class SplitView : FrameworkElement
         {
             Pane.Arrange(new Rect(paneX, arrangeRect.Y, pW, arrangeRect.Height));
         }
+    }
+
+    private float GetPaneLength(float availableWidth)
+    {
+        bool hasCompact = DisplayMode == SplitViewDisplayMode.CompactInline || DisplayMode == SplitViewDisplayMode.CompactOverlay;
+        float paneLength = IsPaneOpen ? OpenPaneLength : (hasCompact ? CompactPaneLength : 0f);
+        if (!float.IsPositiveInfinity(availableWidth))
+        {
+            paneLength = Math.Min(paneLength, Math.Max(0f, availableWidth));
+        }
+
+        return Math.Max(0f, paneLength);
     }
 }

--- a/src/ProGPU.WinUI/Controls/StackPanel.cs
+++ b/src/ProGPU.WinUI/Controls/StackPanel.cs
@@ -29,6 +29,19 @@ public class StackPanel : Panel
         set => SetValue(OrientationProperty, value);
     }
 
+    public static readonly DependencyProperty SpacingProperty =
+        DependencyProperty.Register(
+            nameof(Spacing),
+            typeof(float),
+            typeof(StackPanel),
+            new PropertyMetadata(0f, (d, e) => ((StackPanel)d).InvalidateMeasure()));
+
+    public float Spacing
+    {
+        get => (float)(GetValue(SpacingProperty) ?? 0f);
+        set => SetValue(SpacingProperty, Math.Max(0f, value));
+    }
+
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
         float totalWidth = 0f;
@@ -36,11 +49,18 @@ public class StackPanel : Panel
 
         float paddingH = Padding.Horizontal;
         float paddingV = Padding.Vertical;
+        var hasPreviousVisibleChild = false;
 
         foreach (var child in Children)
         {
+            if (child is FrameworkElement { Visibility: Visibility.Collapsed }) continue;
             if (child is LayoutNode node)
             {
+                if (hasPreviousVisibleChild)
+                {
+                    if (Orientation == Orientation.Vertical) totalHeight += Spacing;
+                    else totalWidth += Spacing;
+                }
                 if (Orientation == Orientation.Vertical)
                 {
                     float availW = float.IsInfinity(availableSize.X) ? availableSize.X : Math.Max(0f, availableSize.X - paddingH);
@@ -57,6 +77,7 @@ public class StackPanel : Panel
                     totalWidth += desired.X;
                     totalHeight = Math.Max(totalHeight, desired.Y);
                 }
+                hasPreviousVisibleChild = true;
             }
         }
 
@@ -67,10 +88,13 @@ public class StackPanel : Panel
     {
         float offset = 0f;
 
+        var hasPreviousVisibleChild = false;
         foreach (var child in Children)
         {
+            if (child is FrameworkElement { Visibility: Visibility.Collapsed }) continue;
             if (child is LayoutNode node)
             {
+                if (hasPreviousVisibleChild) offset += Spacing;
                 var desired = node.DesiredSize;
                 
                 if (Orientation == Orientation.Vertical)
@@ -85,6 +109,7 @@ public class StackPanel : Panel
                     node.Arrange(new Rect(arrangeRect.X + offset, arrangeRect.Y, childWidth, arrangeRect.Height));
                     offset += childWidth;
                 }
+                hasPreviousVisibleChild = true;
             }
         }
     }

--- a/src/ProGPU.WinUI/Controls/StackPanel.cs
+++ b/src/ProGPU.WinUI/Controls/StackPanel.cs
@@ -91,7 +91,14 @@ public class StackPanel : Panel
         var hasPreviousVisibleChild = false;
         foreach (var child in Children)
         {
-            if (child is FrameworkElement { Visibility: Visibility.Collapsed }) continue;
+            if (child is FrameworkElement { Visibility: Visibility.Collapsed })
+            {
+                if (child is LayoutNode collapsedNode)
+                {
+                    collapsedNode.Arrange(new Rect(arrangeRect.X, arrangeRect.Y, 0f, 0f));
+                }
+                continue;
+            }
             if (child is LayoutNode node)
             {
                 if (hasPreviousVisibleChild) offset += Spacing;

--- a/src/ProGPU.WinUI/Controls/TextBox.cs
+++ b/src/ProGPU.WinUI/Controls/TextBox.cs
@@ -14,7 +14,7 @@ using ProGPU.Text;
 
 namespace Microsoft.UI.Xaml.Controls;
 
-public class TextBox : Control
+public class TextBox : Control, ITextInputClient
 {
     private string _text = string.Empty;
     private string _placeholderText = "Enter text...";
@@ -27,6 +27,15 @@ public class TextBox : Control
     private int _selectionAnchor = 0;
     private bool _isDraggingSelection = false;
     private readonly HashSet<Key> _pressedKeys = new();
+    private int _compositionStart = -1;
+    private int _compositionLength;
+    private string _compositionOriginalText = string.Empty;
+
+    public InputScope InputScope { get; set; } = new();
+    public string EnterKeyHint { get; set; } = "enter";
+    public string AutoCapitalization { get; set; } = "sentences";
+    public bool IsSpellCheckEnabled { get; set; } = true;
+    public bool AcceptsReturn { get; set; }
 
     // Premium multi-step undo/redo state
     private class UndoState
@@ -225,6 +234,121 @@ public class TextBox : Control
         CaretIndex += insert.Length;
         SelectionStart = CaretIndex;
         SelectionLength = 0;
+    }
+
+    TextInputOptions ITextInputClient.GetTextInputOptions()
+    {
+        var scope = InputScope.Names.Count == 0 ? InputScopeNameValue.Default : InputScope.Names[0].NameValue;
+        var matrix = GetGlobalTransformMatrix();
+        var origin = Vector2.Transform(Vector2.Zero, matrix);
+        var end = Vector2.Transform(Size, matrix);
+        return new TextInputOptions(
+            scope,
+            EnterKeyHint,
+            AutoCapitalization,
+            IsSpellCheckEnabled,
+            false,
+            AcceptsReturn,
+            Text,
+            SelectionStart,
+            SelectionLength,
+            new Rect(origin.X, origin.Y, Math.Max(1f, end.X - origin.X), Math.Max(1f, end.Y - origin.Y)));
+    }
+
+    void ITextInputClient.OnTextInput(TextInputRoutedEventArgs args)
+    {
+        if (!IsEnabled || !IsFocused) return;
+        switch (args.Kind)
+        {
+            case TextInputEventKind.InsertText:
+                if (string.IsNullOrEmpty(args.Text)) break;
+                SaveUndoState();
+                InsertText(args.Text);
+                break;
+            case TextInputEventKind.DeleteContentBackward:
+                DeleteFromSoftwareKeyboard(backward: true);
+                break;
+            case TextInputEventKind.DeleteContentForward:
+                DeleteFromSoftwareKeyboard(backward: false);
+                break;
+            case TextInputEventKind.InsertLineBreak:
+                if (AcceptsReturn)
+                {
+                    SaveUndoState();
+                    InsertText(Environment.NewLine);
+                }
+                break;
+            case TextInputEventKind.CompositionStarted:
+                _compositionStart = Math.Min(SelectionStart, SelectionStart + SelectionLength);
+                _compositionLength = Math.Abs(SelectionLength);
+                _compositionOriginalText = SelectedText;
+                SaveUndoState();
+                break;
+            case TextInputEventKind.CompositionUpdated:
+            case TextInputEventKind.CompositionCompleted:
+                UpdateComposition(args.Text, args.Kind == TextInputEventKind.CompositionCompleted);
+                break;
+            case TextInputEventKind.CompositionCanceled:
+                if (_compositionStart >= 0)
+                {
+                    SelectionStart = _compositionStart;
+                    SelectionLength = _compositionLength;
+                    DeleteSelection();
+                    CaretIndex = _compositionStart;
+                    if (!string.IsNullOrEmpty(_compositionOriginalText)) InsertText(_compositionOriginalText);
+                    _compositionStart = -1;
+                    _compositionLength = 0;
+                    _compositionOriginalText = string.Empty;
+                }
+                break;
+        }
+        args.Handled = true;
+    }
+
+    private void DeleteFromSoftwareKeyboard(bool backward)
+    {
+        if (SelectionLength != 0)
+        {
+            SaveUndoState();
+            DeleteSelection();
+            return;
+        }
+        if (backward && CaretIndex > 0)
+        {
+            SaveUndoState();
+            var length = CaretIndex >= 2 && char.IsLowSurrogate(Text[CaretIndex - 1]) && char.IsHighSurrogate(Text[CaretIndex - 2]) ? 2 : 1;
+            SelectionStart = CaretIndex - length;
+            SelectionLength = length;
+            DeleteSelection();
+        }
+        else if (!backward && CaretIndex < Text.Length)
+        {
+            SaveUndoState();
+            SelectionStart = CaretIndex;
+            SelectionLength = CaretIndex + 1 < Text.Length && char.IsHighSurrogate(Text[CaretIndex]) && char.IsLowSurrogate(Text[CaretIndex + 1]) ? 2 : 1;
+            DeleteSelection();
+        }
+    }
+
+    private void UpdateComposition(string text, bool completed)
+    {
+        if (_compositionStart < 0)
+        {
+            _compositionStart = Math.Min(SelectionStart, SelectionStart + SelectionLength);
+            _compositionLength = Math.Abs(SelectionLength);
+        }
+        SelectionStart = _compositionStart;
+        SelectionLength = _compositionLength;
+        DeleteSelection();
+        CaretIndex = _compositionStart;
+        InsertText(text);
+        _compositionLength = text.Length;
+        if (completed)
+        {
+            _compositionStart = -1;
+            _compositionLength = 0;
+            _compositionOriginalText = string.Empty;
+        }
     }
 
     public override void OnVisualStateChanged()
@@ -668,4 +792,3 @@ public class TextBox : Control
         base.OnRender(context);
     }
 }
-

--- a/src/ProGPU.WinUI/Controls/TextBox.cs
+++ b/src/ProGPU.WinUI/Controls/TextBox.cs
@@ -418,6 +418,18 @@ public class TextBox : Control, ITextInputClient
         }
     }
 
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        _isDraggingSelection = false;
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        _isDraggingSelection = false;
+        base.OnPointerCaptureLost(e);
+    }
+
     public override void OnPointerMoved(PointerRoutedEventArgs e)
     {
         if (IsEnabled)

--- a/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
+++ b/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
@@ -175,7 +175,8 @@ namespace Microsoft.UI.Xaml.Controls
             List<TableVisualDecoration> tableDecorations,
             FrameworkElement parent,
             Action<Visual> addChild,
-            Action<Visual> removeChild)
+            Action<Visual> removeChild,
+            TextWrapping textWrapping = TextWrapping.Wrap)
         {
             var blocks = new List<Block> { new Paragraph(inlines.ToArray()) { MarginBottom = 0f } };
             return LayoutSingleColumn(
@@ -191,7 +192,8 @@ namespace Microsoft.UI.Xaml.Controls
                 tableDecorations,
                 parent,
                 addChild,
-                removeChild);
+                removeChild,
+                textWrapping);
         }        private static int GetInlinesLength(IEnumerable<Inline> inlines)
         {
             int len = 0;
@@ -375,7 +377,8 @@ namespace Microsoft.UI.Xaml.Controls
             Action<Visual> addChild,
             HashSet<Visual> encounteredChildren,
             List<PositionedRichChar> blockChars,
-            List<TableVisualDecoration> blockDecorations)
+            List<TableVisualDecoration> blockDecorations,
+            TextWrapping textWrapping)
         {
             blockChars.Clear();
             blockDecorations.Clear();
@@ -580,7 +583,9 @@ namespace Microsoft.UI.Xaml.Controls
                     lastWordStartCursorX = cursorX;
                 }
 
-                if (cursorX + advance > maxWidth - padding.Right && cursorX > padding.Left + rc.LeftIndent)
+                if (textWrapping != TextWrapping.NoWrap &&
+                    cursorX + advance > maxWidth - padding.Right &&
+                    cursorX > padding.Left + rc.LeftIndent)
                 {
                     if (lastWordStart > 0)
                     {
@@ -679,7 +684,8 @@ namespace Microsoft.UI.Xaml.Controls
             List<TableVisualDecoration> tableDecorations,
             FrameworkElement parent,
             Action<Visual> addChild,
-            Action<Visual> removeChild)
+            Action<Visual> removeChild,
+            TextWrapping textWrapping = TextWrapping.Wrap)
         {
             positionedChars.Clear();
             tableDecorations.Clear();
@@ -790,7 +796,7 @@ namespace Microsoft.UI.Xaml.Controls
 
                         if (!isCacheValid)
                         {
-                            LayoutBlock(block, cursorY, maxWidth, padding, activeFont, baseFontSize, resolvedFg, alignment, theme, parent, addChild, encounteredChildren, block.CachedChars, block.CachedDecorations);
+                            LayoutBlock(block, cursorY, maxWidth, padding, activeFont, baseFontSize, resolvedFg, alignment, theme, parent, addChild, encounteredChildren, block.CachedChars, block.CachedDecorations, textWrapping);
                             block.IsLayoutValid = true;
                             block.CachedWidthConstraint = maxWidth;
                             block.CachedTheme = theme;
@@ -850,7 +856,7 @@ namespace Microsoft.UI.Xaml.Controls
                 {
                     if (!block.IsLayoutValid || Math.Abs(block.CachedWidthConstraint - maxWidth) > 0.01f || block.CachedTheme != theme)
                     {
-                        LayoutBlock(block, blockTop, maxWidth, padding, activeFont, baseFontSize, resolvedFg, alignment, theme, parent, addChild, encounteredChildren, block.CachedChars, block.CachedDecorations);
+                        LayoutBlock(block, blockTop, maxWidth, padding, activeFont, baseFontSize, resolvedFg, alignment, theme, parent, addChild, encounteredChildren, block.CachedChars, block.CachedDecorations, textWrapping);
                         block.IsLayoutValid = true;
                         block.CachedWidthConstraint = maxWidth;
                         block.CachedTheme = theme;

--- a/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
+++ b/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
@@ -638,7 +638,7 @@ namespace Microsoft.UI.Xaml.Controls
                         lastWordStartCursorX = padding.Left + rc.LeftIndent;
                         continue;
                     }
-                    else
+                    else if (textWrapping == TextWrapping.Wrap)
                     {
                         CommitLine(currentLine, false);
                         currentLine = new List<PositionedRichChar>();

--- a/src/ProGPU.WinUI/Controls/Thumb.cs
+++ b/src/ProGPU.WinUI/Controls/Thumb.cs
@@ -105,13 +105,22 @@ public class Thumb : Control
 
     public override void OnPointerCanceled(PointerRoutedEventArgs e)
     {
-        _isDragging = false;
+        if (_isDragging)
+        {
+            _isDragging = false;
+            InputSystem.ReleasePointerCapture();
+            DragCompleted?.Invoke(this, new DragCompletedEventArgs(e.ScreenPosition.X, e.ScreenPosition.Y, canceled: true));
+        }
         base.OnPointerCanceled(e);
     }
 
     public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
     {
-        _isDragging = false;
+        if (_isDragging)
+        {
+            _isDragging = false;
+            DragCompleted?.Invoke(this, new DragCompletedEventArgs(e.ScreenPosition.X, e.ScreenPosition.Y, canceled: true));
+        }
         base.OnPointerCaptureLost(e);
     }
 

--- a/src/ProGPU.WinUI/Controls/Thumb.cs
+++ b/src/ProGPU.WinUI/Controls/Thumb.cs
@@ -103,6 +103,18 @@ public class Thumb : Control
         base.OnPointerReleased(e);
      }
 
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        _isDragging = false;
+        base.OnPointerCanceled(e);
+    }
+
+    public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        _isDragging = false;
+        base.OnPointerCaptureLost(e);
+    }
+
     public override void OnRender(DrawingContext context)
     {
         var bg = GetCurrentBackground();
@@ -118,4 +130,3 @@ public class Thumb : Control
         base.OnRender(context);
     }
 }
-

--- a/src/ProGPU.WinUI/Controls/TreeView.cs
+++ b/src/ProGPU.WinUI/Controls/TreeView.cs
@@ -11,6 +11,7 @@ using ProGPU.Layout;
 using ProGPU.Scene;
 using ProGPU.Vector;
 using ProGPU.Text;
+using Windows.Devices.Input;
 using static System.FormattableString;
 
 namespace Microsoft.UI.Xaml.Controls;
@@ -22,6 +23,7 @@ public class TreeViewItem : Control
     private bool _isSelected;
     private int _level;
     private TreeView? _parentTreeView;
+    private uint _pendingTouchPointerId;
 
     public object? Header
     {
@@ -111,23 +113,51 @@ public class TreeViewItem : Control
 
     public override void OnPointerPressed(PointerRoutedEventArgs e)
     {
-        if (IsEnabled)
+        if (!IsEnabled) return;
+        if (e.Pointer.PointerDeviceType is PointerDeviceType.Touch or PointerDeviceType.Pen)
         {
+            _pendingTouchPointerId = e.Pointer.PointerId;
+            e.Handled = true;
             base.OnPointerPressed(e);
-            if (_parentTreeView != null)
+            return;
+        }
+
+        base.OnPointerPressed(e);
+        Activate(e.GetCurrentPoint(this).Position);
+        e.Handled = true;
+    }
+
+    public override void OnPointerReleased(PointerRoutedEventArgs e)
+    {
+        if (_pendingTouchPointerId == e.Pointer.PointerId)
+        {
+            if (IsEnabled && IsPointerPressed && IsPointerOver)
             {
-                float indent = 12f + (Level * 16f);
-                // Toggle expand/collapse arrow click if inside arrow bounds
-                if (Items.Count > 0 && e.Position.X >= indent - 14f && e.Position.X <= indent + 6f)
-                {
-                    IsExpanded = !IsExpanded;
-                }
-                else
-                {
-                    _parentTreeView.SelectedItem = this;
-                }
+                Activate(e.GetCurrentPoint(this).Position);
                 e.Handled = true;
             }
+            _pendingTouchPointerId = 0;
+        }
+        base.OnPointerReleased(e);
+    }
+
+    public override void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        if (_pendingTouchPointerId == e.Pointer.PointerId) _pendingTouchPointerId = 0;
+        base.OnPointerCanceled(e);
+    }
+
+    private void Activate(Vector2 position)
+    {
+        if (_parentTreeView == null) return;
+        var indent = 12f + (Level * 16f);
+        if (Items.Count > 0 && position.X >= indent - 14f && position.X <= indent + 6f)
+        {
+            IsExpanded = !IsExpanded;
+        }
+        else
+        {
+            _parentTreeView.SelectedItem = this;
         }
     }
 

--- a/src/ProGPU.WinUI/Controls/VirtualizingPanel.cs
+++ b/src/ProGPU.WinUI/Controls/VirtualizingPanel.cs
@@ -306,6 +306,20 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
             base.OnPointerReleased(e);
         }
 
+        public override void OnPointerCanceled(PointerRoutedEventArgs e)
+        {
+            _isDragging = false;
+            Invalidate();
+            base.OnPointerCanceled(e);
+        }
+
+        public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+        {
+            _isDragging = false;
+            Invalidate();
+            base.OnPointerCaptureLost(e);
+        }
+
         public override void OnPointerEntered(PointerRoutedEventArgs e)
         {
             if (IsEnabled)

--- a/src/ProGPU.WinUI/Controls/VirtualizingPanel.cs
+++ b/src/ProGPU.WinUI/Controls/VirtualizingPanel.cs
@@ -234,6 +234,7 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
         private readonly VirtualizingPanel _panel;
         private bool _isDragging = false;
         private bool _isHovered = false;
+        private uint _scrollbarPointerId;
         private float _dragStartOffset = 0f;
         private float _dragStartMouse = 0f;
 
@@ -246,49 +247,34 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
         {
             if (IsEnabled)
             {
-                var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
-                float scrollbarThickness = 8f;
+                var localPos = e.GetCurrentPoint(this).Position;
                 float contentSize = _panel.IsHorizontal ? _panel.TotalVirtualWidth : _panel.TotalVirtualHeight;
                 float viewportSize = _panel.IsHorizontal ? Size.X : Size.Y;
 
-                if (contentSize > viewportSize)
+                if (ScrollBarInteraction.TryCreateMetrics(0f, viewportSize, contentSize, _panel.ScrollOffset, out var metrics))
                 {
-                    float thumbSize = Math.Max(24f, (viewportSize / contentSize) * viewportSize);
-                    float scrollableSize = contentSize - viewportSize;
-
-                    if (_panel.IsHorizontal)
+                    var inTrack = _panel.IsHorizontal
+                        ? ScrollBarInteraction.IsHorizontalTrackHit(localPos.Y, Size.Y, e.Pointer.PointerDeviceType)
+                        : ScrollBarInteraction.IsVerticalTrackHit(localPos.X, Size.X, e.Pointer.PointerDeviceType);
+                    if (inTrack && ScrollBarInteraction.CapturePointer(this, e))
                     {
-                        if (localPos.Y >= Size.Y - scrollbarThickness - 4f)
+                        _scrollbarPointerId = e.Pointer.PointerId;
+                        var pointerPosition = _panel.IsHorizontal ? localPos.X : localPos.Y;
+                        if (ScrollBarInteraction.IsThumbHit(pointerPosition, metrics, e.Pointer.PointerDeviceType))
                         {
-                            float thumbX = (_panel.ScrollOffset / scrollableSize) * (viewportSize - thumbSize);
-                            if (localPos.X >= thumbX && localPos.X <= thumbX + thumbSize)
-                            {
-                                _isDragging = true;
-                                _dragStartOffset = _panel.ScrollOffset;
-                                _dragStartMouse = localPos.X;
-                                InputSystem.CapturePointer(this);
-                                e.Handled = true;
-                                Invalidate();
-                                return;
-                            }
+                            _isDragging = true;
+                            _dragStartOffset = _panel.ScrollOffset;
+                            _dragStartMouse = pointerPosition;
                         }
-                    }
-                    else
-                    {
-                        if (localPos.X >= Size.X - scrollbarThickness - 4f)
+                        else
                         {
-                            float thumbY = (_panel.ScrollOffset / scrollableSize) * (viewportSize - thumbSize);
-                            if (localPos.Y >= thumbY && localPos.Y <= thumbY + thumbSize)
-                            {
-                                _isDragging = true;
-                                _dragStartOffset = _panel.ScrollOffset;
-                                _dragStartMouse = localPos.Y;
-                                InputSystem.CapturePointer(this);
-                                e.Handled = true;
-                                Invalidate();
-                                return;
-                            }
+                            _isDragging = false;
+                            _panel.ScrollOffset = ScrollBarInteraction.ValueFromTrackPress(
+                                _panel.ScrollOffset, pointerPosition, metrics, viewportSize);
                         }
+                        e.Handled = true;
+                        Invalidate();
+                        return;
                     }
                 }
             }
@@ -297,10 +283,12 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
 
         public override void OnPointerReleased(PointerRoutedEventArgs e)
         {
-            if (_isDragging)
+            if (_scrollbarPointerId == e.Pointer.PointerId)
             {
+                _scrollbarPointerId = 0;
                 _isDragging = false;
-                InputSystem.ReleasePointerCapture();
+                ScrollBarInteraction.ReleasePointer(this, e);
+                e.Handled = true;
                 Invalidate();
             }
             base.OnPointerReleased(e);
@@ -308,15 +296,23 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
 
         public override void OnPointerCanceled(PointerRoutedEventArgs e)
         {
-            _isDragging = false;
-            Invalidate();
+            if (_scrollbarPointerId == e.Pointer.PointerId)
+            {
+                _scrollbarPointerId = 0;
+                _isDragging = false;
+                Invalidate();
+            }
             base.OnPointerCanceled(e);
         }
 
         public override void OnPointerCaptureLost(PointerRoutedEventArgs e)
         {
-            _isDragging = false;
-            Invalidate();
+            if (_scrollbarPointerId == e.Pointer.PointerId)
+            {
+                _scrollbarPointerId = 0;
+                _isDragging = false;
+                Invalidate();
+            }
             base.OnPointerCaptureLost(e);
         }
 
@@ -343,8 +339,8 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
             {
                 var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
                 bool over = _panel.IsHorizontal 
-                    ? localPos.Y >= Size.Y - 12f
-                    : localPos.X >= Size.X - 12f;
+                    ? ScrollBarInteraction.IsHorizontalTrackHit(localPos.Y, Size.Y, e.Pointer.PointerDeviceType)
+                    : ScrollBarInteraction.IsVerticalTrackHit(localPos.X, Size.X, e.Pointer.PointerDeviceType);
                 if (_isHovered != over)
                 {
                     _isHovered = over;
@@ -352,20 +348,16 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
                 }
             }
 
-            if (_isDragging && IsEnabled)
+            if (_isDragging && _scrollbarPointerId == e.Pointer.PointerId && IsEnabled)
             {
                 var localPos = InputSystem.GetLocalPosition(this, e.ScreenPosition);
                 float contentSize = _panel.IsHorizontal ? _panel.TotalVirtualWidth : _panel.TotalVirtualHeight;
                 float viewportSize = _panel.IsHorizontal ? Size.X : Size.Y;
-                float thumbSize = Math.Max(24f, (viewportSize / contentSize) * viewportSize);
-                float scrollableSize = contentSize - viewportSize;
-                float trackLength = viewportSize - thumbSize;
-
-                if (trackLength > 0f)
+                if (ScrollBarInteraction.TryCreateMetrics(0f, viewportSize, contentSize, _dragStartOffset, out var metrics))
                 {
                     float mousePos = _panel.IsHorizontal ? localPos.X : localPos.Y;
-                    float delta = mousePos - _dragStartMouse;
-                    _panel.ScrollOffset = _dragStartOffset + (delta / trackLength) * scrollableSize;
+                    _panel.ScrollOffset = ScrollBarInteraction.ValueFromDrag(
+                        _dragStartOffset, mousePos - _dragStartMouse, metrics);
                 }
                 e.Handled = true;
                 return;
@@ -378,35 +370,35 @@ public class VirtualizingPanel : Panel, IScrollViewportAware
             float contentSize = _panel.IsHorizontal ? _panel.TotalVirtualWidth : _panel.TotalVirtualHeight;
             float viewportSize = _panel.IsHorizontal ? Size.X : Size.Y;
 
-            if (contentSize > viewportSize)
+            if (ScrollBarInteraction.TryCreateMetrics(0f, viewportSize, contentSize, _panel.ScrollOffset, out var metrics))
             {
-                float scrollbarThickness = (_isHovered || _isDragging) ? 8f : 3f;
-                float padding = (_isHovered || _isDragging) ? 2f : 4f;
-
-                float thumbSize = Math.Max(24f, (viewportSize / contentSize) * viewportSize);
-                float scrollableSize = contentSize - viewportSize;
-                float thumbPos = (_panel.ScrollOffset / scrollableSize) * (viewportSize - thumbSize);
+                float scrollbarThickness = (_isHovered || _scrollbarPointerId != 0)
+                    ? ScrollBarInteraction.ExpandedThickness
+                    : ScrollBarInteraction.CollapsedThickness;
+                float padding = (_isHovered || _scrollbarPointerId != 0)
+                    ? ScrollBarInteraction.ExpandedPadding
+                    : ScrollBarInteraction.CollapsedPadding;
 
                 Rect trackRect, thumbRect;
                 if (_panel.IsHorizontal)
                 {
                     trackRect = new Rect(0f, Size.Y - scrollbarThickness - padding, viewportSize, scrollbarThickness);
-                    thumbRect = new Rect(thumbPos, Size.Y - scrollbarThickness - padding, thumbSize, scrollbarThickness);
+                    thumbRect = new Rect(metrics.ThumbStart, Size.Y - scrollbarThickness - padding, metrics.ThumbLength, scrollbarThickness);
                 }
                 else
                 {
                     trackRect = new Rect(Size.X - scrollbarThickness - padding, 0f, scrollbarThickness, viewportSize);
-                    thumbRect = new Rect(Size.X - scrollbarThickness - padding, thumbPos, scrollbarThickness, thumbSize);
+                    thumbRect = new Rect(Size.X - scrollbarThickness - padding, metrics.ThumbStart, scrollbarThickness, metrics.ThumbLength);
                 }
 
                 // Draw track (subtle translucent backdrop line)
-                Brush trackBg = (_isHovered || _isDragging) 
+                Brush trackBg = (_isHovered || _scrollbarPointerId != 0)
                     ? ThemeManager.GetBrush("ControlBackgroundHover") 
                     : ThemeManager.GetBrush("ControlBackground");
                 context.DrawRectangle(trackBg, null, trackRect);
 
                 // Draw thumb (glassmorphic capsule)
-                Brush thumbBg = (_isHovered || _isDragging)
+                Brush thumbBg = (_isHovered || _scrollbarPointerId != 0)
                     ? ThemeManager.GetBrush("ScrollbarThumbHover")
                     : ThemeManager.GetBrush("ScrollbarThumb");
                 context.DrawRoundedRectangle(thumbBg, null, thumbRect, scrollbarThickness / 2f);

--- a/src/ProGPU.WinUI/Core/FrameworkElement.cs
+++ b/src/ProGPU.WinUI/Core/FrameworkElement.cs
@@ -11,6 +11,8 @@ using System.Runtime.CompilerServices;
 using Silk.NET.Input;
 using ProGPU.Layout;
 using ProGPU.Scene;
+using Microsoft.UI.Input;
+using Windows.Devices.Input;
 
 namespace Microsoft.UI.Xaml;
 
@@ -38,6 +40,62 @@ public class PointerRoutedEventArgs : RoutedEventArgs
     public bool IsMiddleButtonPressed { get; set; }
     public bool IsRightButtonPressed { get; set; }
     public float WheelDelta { get; set; }
+    public Pointer Pointer { get; set; } = new(1, PointerDeviceType.Mouse, false);
+    public ulong Timestamp { get; set; }
+    public bool IsPrimary { get; set; } = true;
+    public float Pressure { get; set; }
+    public Rect ContactRect { get; set; }
+    public VirtualKeyModifiers KeyModifiers { get; set; }
+    public bool IsCanceled { get; set; }
+    internal IReadOnlyList<PointerPoint>? IntermediatePoints { get; set; }
+
+    public PointerPoint GetCurrentPoint(FrameworkElement? relativeTo)
+    {
+        var position = InputSystem.GetLocalPosition(relativeTo, ScreenPosition);
+        return CreatePoint(position);
+    }
+
+    public IReadOnlyList<PointerPoint> GetIntermediatePoints(FrameworkElement? relativeTo)
+    {
+        if (IntermediatePoints == null || IntermediatePoints.Count == 0)
+        {
+            return new[] { GetCurrentPoint(relativeTo) };
+        }
+
+        var result = new PointerPoint[IntermediatePoints.Count];
+        for (var index = 0; index < result.Length; index++)
+        {
+            var point = IntermediatePoints[index];
+            result[index] = new PointerPoint(
+                point.PointerId,
+                point.Timestamp,
+                InputSystem.GetLocalPosition(relativeTo, point.RawPosition),
+                point.RawPosition,
+                point.PointerDevice.PointerDeviceType,
+                point.IsInContact,
+                point.Properties);
+        }
+        return result;
+    }
+
+    private PointerPoint CreatePoint(Vector2 position) => new(
+        Pointer.PointerId,
+        Timestamp,
+        position,
+        ScreenPosition,
+        Pointer.PointerDeviceType,
+        Pointer.IsInContact,
+        new PointerPointProperties
+        {
+            IsLeftButtonPressed = IsLeftButtonPressed,
+            IsMiddleButtonPressed = IsMiddleButtonPressed,
+            IsRightButtonPressed = IsRightButtonPressed,
+            IsPrimary = IsPrimary,
+            IsCanceled = IsCanceled,
+            Pressure = Pressure,
+            ContactRect = ContactRect,
+            MouseWheelDelta = (int)WheelDelta
+        });
 }
 
 public partial class FrameworkElement
@@ -643,10 +701,45 @@ public partial class FrameworkElement
     public event EventHandler<PointerRoutedEventArgs>? PointerEntered;
     public event EventHandler<PointerRoutedEventArgs>? PointerExited;
     public event EventHandler<PointerRoutedEventArgs>? PointerWheelChanged;
+    public event EventHandler<PointerRoutedEventArgs>? PointerCanceled;
+    public event EventHandler<PointerRoutedEventArgs>? PointerCaptureLost;
+
+    public event EventHandler<TappedRoutedEventArgs>? Tapped;
+    public event EventHandler<DoubleTappedRoutedEventArgs>? DoubleTapped;
+    public event EventHandler<RightTappedRoutedEventArgs>? RightTapped;
+    public event EventHandler<HoldingRoutedEventArgs>? Holding;
+    public event EventHandler<ManipulationStartingRoutedEventArgs>? ManipulationStarting;
+    public event EventHandler<ManipulationStartedRoutedEventArgs>? ManipulationStarted;
+    public event EventHandler<ManipulationDeltaRoutedEventArgs>? ManipulationDelta;
+    public event EventHandler<ManipulationInertiaStartingRoutedEventArgs>? ManipulationInertiaStarting;
+    public event EventHandler<ManipulationCompletedRoutedEventArgs>? ManipulationCompleted;
 
     public event EventHandler<KeyRoutedEventArgs>? KeyDown;
     public event EventHandler<KeyRoutedEventArgs>? KeyUp;
     public event EventHandler<CharacterReceivedRoutedEventArgs>? CharacterReceived;
+    public event EventHandler<TextInputRoutedEventArgs>? TextInput;
+
+    public static readonly DependencyProperty ManipulationModeProperty =
+        DependencyProperty.Register(
+            nameof(ManipulationMode),
+            typeof(ManipulationModes),
+            typeof(FrameworkElement),
+            new PropertyMetadata(ManipulationModes.System));
+
+    public ManipulationModes ManipulationMode
+    {
+        get => (ManipulationModes)(GetValue(ManipulationModeProperty) ?? ManipulationModes.System);
+        set => SetValue(ManipulationModeProperty, value);
+    }
+
+    public bool IsTapEnabled { get; set; } = true;
+    public bool IsDoubleTapEnabled { get; set; } = true;
+    public bool IsRightTapEnabled { get; set; } = true;
+    public bool IsHoldingEnabled { get; set; } = true;
+
+    public bool CapturePointer(Pointer pointer) => InputSystem.CapturePointer(this, pointer);
+    public void ReleasePointerCapture(Pointer pointer) => InputSystem.ReleasePointerCapture(this, pointer);
+    public void ReleasePointerCaptures() => InputSystem.ReleasePointerCaptures(this);
 
     // Drag & Drop Events
     public event EventHandler<DragEventArgs>? DragEnter;
@@ -722,6 +815,49 @@ public partial class FrameworkElement
         {
             parentFe.OnPointerWheelChanged(e);
         }
+    }
+
+    public virtual void OnPointerCanceled(PointerRoutedEventArgs e)
+    {
+        e.OriginalSource ??= this;
+        IsPointerPressed = false;
+        PointerCanceled?.Invoke(this, e);
+        if (!e.Handled && Parent is FrameworkElement parentFe) parentFe.OnPointerCanceled(e);
+    }
+
+    public virtual void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        e.OriginalSource ??= this;
+        IsPointerPressed = false;
+        PointerCaptureLost?.Invoke(this, e);
+        if (!e.Handled && Parent is FrameworkElement parentFe) parentFe.OnPointerCaptureLost(e);
+    }
+
+    public virtual void OnTapped(TappedRoutedEventArgs e) => RaiseGesture(e, Tapped, static (p, a) => p.OnTapped(a));
+    public virtual void OnDoubleTapped(DoubleTappedRoutedEventArgs e) => RaiseGesture(e, DoubleTapped, static (p, a) => p.OnDoubleTapped(a));
+    public virtual void OnRightTapped(RightTappedRoutedEventArgs e) => RaiseGesture(e, RightTapped, static (p, a) => p.OnRightTapped(a));
+    public virtual void OnHolding(HoldingRoutedEventArgs e) => RaiseGesture(e, Holding, static (p, a) => p.OnHolding(a));
+
+    public virtual void OnManipulationStarting(ManipulationStartingRoutedEventArgs e) => RaiseGesture(e, ManipulationStarting, static (p, a) => p.OnManipulationStarting(a));
+    public virtual void OnManipulationStarted(ManipulationStartedRoutedEventArgs e) => RaiseGesture(e, ManipulationStarted, static (p, a) => p.OnManipulationStarted(a));
+    public virtual void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e) => RaiseGesture(e, ManipulationDelta, static (p, a) => p.OnManipulationDelta(a));
+    public virtual void OnManipulationInertiaStarting(ManipulationInertiaStartingRoutedEventArgs e) => RaiseGesture(e, ManipulationInertiaStarting, static (p, a) => p.OnManipulationInertiaStarting(a));
+    public virtual void OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e) => RaiseGesture(e, ManipulationCompleted, static (p, a) => p.OnManipulationCompleted(a));
+
+    public virtual void OnTextInput(TextInputRoutedEventArgs e)
+    {
+        e.OriginalSource ??= this;
+        TextInput?.Invoke(this, e);
+        if (this is ITextInputClient client && !e.Handled) client.OnTextInput(e);
+        if (!e.Handled && Parent is FrameworkElement parentFe) parentFe.OnTextInput(e);
+    }
+
+    private void RaiseGesture<T>(T e, EventHandler<T>? handler, Action<FrameworkElement, T> bubble)
+        where T : RoutedEventArgs
+    {
+        e.OriginalSource ??= this;
+        handler?.Invoke(this, e);
+        if (!e.Handled && Parent is FrameworkElement parentFe) bubble(parentFe, e);
     }
 
     public virtual void OnKeyDown(KeyRoutedEventArgs e)

--- a/src/ProGPU.WinUI/Core/ThemeManager.cs
+++ b/src/ProGPU.WinUI/Core/ThemeManager.cs
@@ -886,6 +886,7 @@ public static class ThemeManager
             new Setter(nameof(Control.BorderThickness), new Thickness(1f)),
             new Setter(nameof(Control.CornerRadius), 9f),
             new Setter(nameof(Control.Padding), new Thickness(8f, 4f)),
+            new Setter(nameof(Control.HorizontalContentAlignment), HorizontalAlignment.Left),
             new Setter(nameof(Control.Template), new ControlTemplate(typeof(RadioButton), (parent) =>
             {
                 var grid = new Grid();
@@ -1245,7 +1246,7 @@ public class CheckboxChrome : FrameworkElement
             context.DrawPath(null, checkPen, checkGeometry);
         }
 
-        if (IsEnabled && IsFocused)
+        if (IsEnabled && IsFocused && InputSystem.IsKeyboardFocusActive)
         {
             var accentColor = ThemeManager.GetBrush("SystemAccentColor", activeTheme, activeFamily);
             if (activeFamily == VisualThemeFamily.macOS)
@@ -1390,7 +1391,7 @@ public class RadioButtonChrome : FrameworkElement
             context.DrawRoundedRectangle(dotBrush, null, dotRect, 3f);
         }
 
-        if (IsEnabled && IsFocused)
+        if (IsEnabled && IsFocused && InputSystem.IsKeyboardFocusActive)
         {
             var accentColor = ThemeManager.GetBrush("SystemAccentColor", activeTheme, activeFamily);
             if (activeFamily == VisualThemeFamily.macOS)
@@ -1540,7 +1541,7 @@ public class ToggleSwitchChrome : FrameworkElement
 
         context.DrawRoundedRectangle(thumbBg, thumbBorder, thumbRect, thumbRadius);
 
-        if (IsEnabled && IsFocused)
+        if (IsEnabled && IsFocused && InputSystem.IsKeyboardFocusActive)
         {
             var accentColor = ThemeManager.GetBrush("SystemAccentColor", activeTheme, activeFamily);
             if (activeFamily == VisualThemeFamily.macOS)
@@ -1837,7 +1838,7 @@ public class SliderChrome : FrameworkElement
             context.DrawRoundedRectangle(thumbBg, thumbBorder, thumbRect, drawThumbRadius);
 
             // 4. Focus visual if focused
-            if (IsEnabled && IsFocused)
+            if (IsEnabled && IsFocused && InputSystem.IsKeyboardFocusActive)
             {
                 var accentColor = ThemeManager.GetBrush("SystemAccentColor", activeTheme, activeFamily);
                 var focusPen = new Pen(accentColor, 1.5f);
@@ -1887,7 +1888,7 @@ public class SliderChrome : FrameworkElement
 
             context.DrawRoundedRectangle(thumbBg, thumbBorder, thumbRect, drawThumbRadius);
 
-            if (IsEnabled && IsFocused)
+            if (IsEnabled && IsFocused && InputSystem.IsKeyboardFocusActive)
             {
                 var accentColor = ThemeManager.GetBrush("SystemAccentColor", activeTheme, activeFamily);
                 var focusPen = new Pen(accentColor, 1.5f);

--- a/src/ProGPU.WinUI/Core/VisualStateManager.cs
+++ b/src/ProGPU.WinUI/Core/VisualStateManager.cs
@@ -1,0 +1,179 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using Microsoft.UI.Xaml.Controls;
+using ProGPU.Scene;
+
+namespace Microsoft.UI.Xaml;
+
+public abstract class StateTriggerBase : DependencyObject
+{
+    internal abstract bool IsActive(float windowWidth, float windowHeight);
+}
+
+public sealed class AdaptiveTrigger : StateTriggerBase
+{
+    public double MinWindowWidth { get; set; }
+    public double MinWindowHeight { get; set; }
+
+    internal override bool IsActive(float windowWidth, float windowHeight) =>
+        windowWidth >= MinWindowWidth && windowHeight >= MinWindowHeight;
+}
+
+public sealed class VisualState
+{
+    public string Name { get; set; } = string.Empty;
+    public Collection<Setter> Setters { get; } = new();
+    public Collection<StateTriggerBase> StateTriggers { get; } = new();
+}
+
+public sealed class VisualStateChangedEventArgs : EventArgs
+{
+    internal VisualStateChangedEventArgs(VisualState? oldState, VisualState? newState)
+    {
+        OldState = oldState;
+        NewState = newState;
+    }
+
+    public VisualState? OldState { get; }
+    public VisualState? NewState { get; }
+}
+
+public sealed class VisualStateGroup
+{
+    public string Name { get; set; } = string.Empty;
+    public Collection<VisualState> States { get; } = new();
+    public VisualState? CurrentState { get; internal set; }
+    public event EventHandler<VisualStateChangedEventArgs>? CurrentStateChanged;
+
+    internal List<SetterSnapshot> Snapshots { get; } = new();
+
+    internal void RaiseCurrentStateChanged(VisualState? oldState, VisualState? newState) =>
+        CurrentStateChanged?.Invoke(this, new VisualStateChangedEventArgs(oldState, newState));
+}
+
+internal readonly record struct SetterSnapshot(DependencyObject Target, DependencyProperty Property, bool HadLocalValue, object? Value);
+
+public static class VisualStateManager
+{
+    private static readonly ConditionalWeakTable<FrameworkElement, Collection<VisualStateGroup>> Groups = new();
+
+    public static IList<VisualStateGroup> GetVisualStateGroups(FrameworkElement element)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+        return Groups.GetOrCreateValue(element);
+    }
+
+    public static bool GoToState(Control control, string stateName, bool useTransitions)
+    {
+        ArgumentNullException.ThrowIfNull(control);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stateName);
+        foreach (var group in GetVisualStateGroups(control))
+        {
+            var state = group.States.FirstOrDefault(item => string.Equals(item.Name, stateName, StringComparison.Ordinal));
+            if (state != null)
+            {
+                ApplyState(control, group, state);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal static void UpdateAdaptiveStates(FrameworkElement root, Vector2 windowSize)
+    {
+        UpdateElement(root, windowSize.X, windowSize.Y);
+    }
+
+    private static void UpdateElement(FrameworkElement element, float width, float height)
+    {
+        if (Groups.TryGetValue(element, out var groups))
+        {
+            foreach (var group in groups)
+            {
+                VisualState? fallback = null;
+                VisualState? active = null;
+                foreach (var state in group.States)
+                {
+                    if (state.StateTriggers.Count == 0)
+                    {
+                        fallback ??= state;
+                        continue;
+                    }
+                    if (state.StateTriggers.All(trigger => trigger.IsActive(width, height))) active = state;
+                }
+                ApplyState(element, group, active ?? fallback);
+            }
+        }
+
+        if (element is ContainerVisual container)
+        {
+            foreach (var child in container.Children)
+                if (child is FrameworkElement childElement) UpdateElement(childElement, width, height);
+        }
+    }
+
+    private static void ApplyState(FrameworkElement root, VisualStateGroup group, VisualState? state)
+    {
+        if (ReferenceEquals(group.CurrentState, state)) return;
+        foreach (var snapshot in group.Snapshots)
+        {
+            if (snapshot.HadLocalValue) snapshot.Target.SetValue(snapshot.Property, snapshot.Value);
+            else snapshot.Target.ClearValue(snapshot.Property);
+        }
+        group.Snapshots.Clear();
+
+        var oldState = group.CurrentState;
+        group.CurrentState = state;
+        if (state != null)
+        {
+            foreach (var setter in state.Setters)
+            {
+                if (!TryResolveSetter(root, setter, out var target, out var property)) continue;
+                group.Snapshots.Add(new SetterSnapshot(target, property, target.IsPropertySetLocally(property), target.GetValue(property)));
+                target.SetValue(property, ConvertValue(property.PropertyType, setter.Value));
+            }
+        }
+        group.RaiseCurrentStateChanged(oldState, state);
+    }
+
+    private static bool TryResolveSetter(FrameworkElement root, Setter setter, out DependencyObject target, out DependencyProperty property)
+    {
+        target = root;
+        property = null!;
+        if (string.IsNullOrWhiteSpace(setter.Property)) return false;
+        var separator = setter.Property.LastIndexOf('.');
+        var propertyName = separator < 0 ? setter.Property : setter.Property[(separator + 1)..];
+        if (separator > 0)
+        {
+            var targetName = setter.Property[..separator];
+            var named = FindName(root, targetName);
+            if (named == null) return false;
+            target = named;
+        }
+        property = DependencyProperty.Lookup(target.GetType(), propertyName)!;
+        return property != null;
+    }
+
+    private static FrameworkElement? FindName(FrameworkElement root, string name)
+    {
+        if (string.Equals(root.Name, name, StringComparison.Ordinal)) return root;
+        if (root is not ContainerVisual container) return null;
+        foreach (var child in container.Children)
+        {
+            if (child is not FrameworkElement element) continue;
+            var found = FindName(element, name);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static object? ConvertValue(Type targetType, object? value)
+    {
+        if (value == null || targetType.IsInstanceOfType(value)) return value;
+        if (targetType.IsEnum && value is string enumValue) return Enum.Parse(targetType, enumValue, ignoreCase: true);
+        if (targetType == typeof(Thickness) && value is string thickness) return Thickness.Parse(thickness);
+        return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/ProGPU.WinUI/Core/VisualStateManager.cs
+++ b/src/ProGPU.WinUI/Core/VisualStateManager.cs
@@ -101,7 +101,7 @@ public static class VisualStateManager
                         fallback ??= state;
                         continue;
                     }
-                    if (state.StateTriggers.All(trigger => trigger.IsActive(width, height))) active = state;
+                    if (state.StateTriggers.Any(trigger => trigger.IsActive(width, height))) active = state;
                 }
                 ApplyState(element, group, active ?? fallback);
             }

--- a/src/ProGPU.WinUI/Core/WinUI.Xaml.cs
+++ b/src/ProGPU.WinUI/Core/WinUI.Xaml.cs
@@ -8,6 +8,13 @@ namespace Microsoft.UI.Xaml
         Collapsed = 1
     }
 
+    public enum TextWrapping
+    {
+        NoWrap = 1,
+        Wrap = 2,
+        WrapWholeWords = 3
+    }
+
     public class UIElement : DependencyObject
     {
         public static readonly DependencyProperty VisibilityProperty =

--- a/src/ProGPU.WinUI/Core/Window.cs
+++ b/src/ProGPU.WinUI/Core/Window.cs
@@ -542,6 +542,7 @@ public class Window
         double animationTimeMs = System.Diagnostics.Stopwatch.GetElapsedTime(phaseStart).TotalMilliseconds;
 
         phaseStart = System.Diagnostics.Stopwatch.GetTimestamp();
+        VisualStateManager.UpdateAdaptiveStates(content, logicalSize);
         content.Measure(logicalSize);
         content.Arrange(new Rect(0, 0, logicalSize.X, logicalSize.Y));
         double layoutTimeMs = System.Diagnostics.Stopwatch.GetElapsedTime(phaseStart).TotalMilliseconds;

--- a/src/ProGPU.WinUI/Documents/RichText.cs
+++ b/src/ProGPU.WinUI/Documents/RichText.cs
@@ -257,6 +257,7 @@ public class RichTextBlock : FrameworkElement
 
     private float _fontSize = 14f;
     private TextAlignment _textAlignment = TextAlignment.Left;
+    private TextWrapping _textWrapping = TextWrapping.Wrap;
     private readonly List<PositionedRichChar> _positionedChars = new();
     private readonly List<TableVisualDecoration> _tableDecorations = new();
     private readonly DrawingContext _renderCommandCache = new();
@@ -359,6 +360,18 @@ public class RichTextBlock : FrameworkElement
         }
     }
 
+    public TextWrapping TextWrapping
+    {
+        get => _textWrapping;
+        set
+        {
+            if (_textWrapping == value) return;
+            _textWrapping = value;
+            _isLayoutDirty = true;
+            Invalidate();
+        }
+    }
+
     public List<PositionedRichChar> PositionedChars => _positionedChars;
 
     public override Rect? LocalRenderBounds
@@ -431,6 +444,8 @@ public class RichTextBlock : FrameworkElement
 
         float measuredH = 0f;
         float measuredW = 0f;
+        float? firstLineY = null;
+        bool hasMultipleLines = false;
         foreach (var pc in _positionedChars)
         {
             float adv = 0f;
@@ -446,6 +461,13 @@ public class RichTextBlock : FrameworkElement
             }
             measuredW = Math.Max(measuredW, pc.Position.X + adv);
             measuredH = Math.Max(measuredH, pc.Position.Y + pc.Info.FontSize);
+            firstLineY ??= pc.Position.Y;
+            hasMultipleLines |= Math.Abs(pc.Position.Y - firstLineY.Value) > 0.01f;
+        }
+
+        if (TextWrapping != TextWrapping.NoWrap && hasMultipleLines && !float.IsInfinity(maxW))
+        {
+            measuredW = Math.Max(measuredW, maxW);
         }
 
         return new Vector2(measuredW, measuredH + 4f);
@@ -532,12 +554,13 @@ public class RichTextBlock : FrameworkElement
             FontSize, 
             Foreground, 
             TextAlignment, 
-            this.ActualTheme, 
-            _positionedChars, 
-            _tableDecorations, 
-            this, 
-            AddChild, 
-            RemoveChild);
+            this.ActualTheme,
+            _positionedChars,
+            _tableDecorations,
+            this,
+            AddChild,
+            RemoveChild,
+            TextWrapping);
         _isRenderCommandCacheDirty = true;
     }
 

--- a/src/ProGPU.WinUI/Input/DragDropManager.cs
+++ b/src/ProGPU.WinUI/Input/DragDropManager.cs
@@ -14,6 +14,7 @@ public static class DragDropManager
     public static DragDropEffects AllowedOperations { get; set; }
     public static FrameworkElement? CurrentTarget { get; set; }
     public static FrameworkElement? DragVisual { get; set; }
+    public static uint ActivePointerId { get; private set; }
 
     public static void StartDrag(FrameworkElement source, DataPackage data, DragDropEffects allowedOperations, FrameworkElement? dragVisual = null)
     {
@@ -23,6 +24,7 @@ public static class DragDropManager
         AllowedOperations = allowedOperations;
         DragVisual = dragVisual;
         CurrentTarget = null;
+        ActivePointerId = InputSystem.Current.CurrentDispatchPointerId;
 
         // Force a layout pass and invalidation to arrange the initial state
         InputSystem.Root?.Invalidate();
@@ -55,9 +57,13 @@ public static class DragDropManager
         AllowedOperations = DragDropEffects.None;
         DragVisual = null;
         CurrentTarget = null;
+        ActivePointerId = 0;
 
         InputSystem.Root?.Invalidate();
     }
+
+    internal static bool IsPointerOwner(uint pointerId) =>
+        ActivePointerId == 0 ? pointerId == 1 : ActivePointerId == pointerId;
 
     public static void UpdateDrag(Vector2 screenPos)
     {

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -6,9 +6,11 @@ using Microsoft.UI.Xaml.Documents;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Diagnostics;
 using Silk.NET.Input;
 using ProGPU.Scene;
 using ProGPU.Vector;
+using Windows.Devices.Input;
 
 namespace Microsoft.UI.Xaml.Input;
 
@@ -32,6 +34,46 @@ public class WindowInputState
     public bool IsMiddleButtonPressed;
     public bool IsRightButtonPressed;
     public Action<StandardCursor>? CursorChanged;
+    internal Dictionary<uint, PointerContactState> PointerContacts { get; } = new();
+    internal Dictionary<uint, FrameworkElement> CapturedElements { get; } = new();
+    internal Dictionary<FrameworkElement, ManipulationSession> Manipulations { get; } = new();
+    internal uint CurrentDispatchPointerId;
+    internal FrameworkElement? LastTappedElement;
+    internal Vector2 LastTapPosition;
+    internal ulong LastTapTimestamp;
+    public Action<FrameworkElement?>? FocusChanged;
+}
+
+internal sealed class PointerContactState
+{
+    public required Pointer Pointer { get; init; }
+    public required FrameworkElement? Target { get; init; }
+    public required PointerInputEvent LastEvent { get; set; }
+    public Vector2 DownPosition { get; init; }
+    public ulong DownTimestamp { get; init; }
+    public Vector2 Velocity { get; set; }
+    public bool ExceededTapThreshold { get; set; }
+    public bool HoldingStarted { get; set; }
+    public CancellationTokenSource? HoldingCancellation { get; set; }
+    public FrameworkElement? ManipulationTarget { get; set; }
+    public bool StartedWithRightButton { get; init; }
+}
+
+internal sealed class ManipulationSession
+{
+    public required FrameworkElement Target { get; init; }
+    public required ManipulationModes Mode { get; set; }
+    public HashSet<uint> PointerIds { get; } = new();
+    public Vector2 PreviousCentroid { get; set; }
+    public float PreviousDistance { get; set; }
+    public float PreviousAngle { get; set; }
+    public Vector2 CumulativeTranslation { get; set; }
+    public float CumulativeScale { get; set; } = 1f;
+    public float CumulativeRotation { get; set; }
+    public float CumulativeExpansion { get; set; }
+    public ManipulationVelocities Velocities { get; set; }
+    public ulong PreviousTimestamp { get; set; }
+    public bool Started { get; set; }
 }
 
 public static class InputSystem
@@ -47,13 +89,30 @@ public static class InputSystem
 
     // Public event injection entry points for external host containers (e.g. Avalonia)
     public static void InjectMouseMove(Vector2 screenPos) => OnMouseMove(screenPos);
-    public static void InjectMouseDown(MouseButton button) => OnMouseDown(button);
-    public static void InjectMouseUp(MouseButton button) => OnMouseUp(button);
-    public static void InjectMouseScroll(Vector2 scroll) => OnMouseScroll(scroll);
+    public static void InjectMouseDown(MouseButton button) => InjectPointer(CreateMouseButtonEvent(PointerInputKind.Pressed, button));
+    public static void InjectMouseUp(MouseButton button)
+    {
+        InjectPointer(CreateMouseButtonEvent(PointerInputKind.Released, button));
+        // Designer/toolbox drags can begin without a preceding press in this input state.
+        // Preserve the legacy release-to-drop contract even when no pointer contact exists.
+        if (button == MouseButton.Left && DragDropManager.IsDragging) DragDropManager.CompleteDrop(_lastMousePos);
+    }
+    public static void InjectMouseScroll(Vector2 scroll) => InjectPointer(CreateMouseEvent(PointerInputKind.Wheel, _lastMousePos) with { WheelDeltaX = scroll.X, WheelDeltaY = scroll.Y });
     public static void InjectKeyDown(Key key) => OnKeyDown(key);
     public static void InjectKeyUp(Key key) => OnKeyUp(key);
     public static void InjectKeyChar(char c) => OnKeyChar(c);
     public static void InjectFocusLost() => OnFocusLost();
+    public static void InjectPointer(PointerInputEvent pointerEvent) => OnPointer(pointerEvent);
+    public static void InjectTextInput(TextInputEventKind kind, string? text = null, bool isComposing = false)
+    {
+        if (_focusedElement == null) return;
+        _focusedElement.OnTextInput(new TextInputRoutedEventArgs
+        {
+            Kind = kind,
+            Text = text ?? string.Empty,
+            IsComposing = isComposing
+        });
+    }
 
     public static Action<Action>? DispatcherQueue { get; set; }
 
@@ -171,13 +230,57 @@ public static class InputSystem
             DevToolsInputSystem.CapturePointer(element);
             return;
         }
+        var pointerId = Current.CurrentDispatchPointerId;
+        if (pointerId != 0 && Current.PointerContacts.TryGetValue(pointerId, out var contact))
+        {
+            CapturePointer(element!, contact.Pointer);
+            return;
+        }
         _capturedElement = element;
+    }
+
+    public static bool CapturePointer(FrameworkElement element, Pointer pointer)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+        ArgumentNullException.ThrowIfNull(pointer);
+        if (!pointer.IsInContact || !Current.PointerContacts.ContainsKey(pointer.PointerId)) return false;
+        if (Current.CapturedElements.ContainsKey(pointer.PointerId)) return false;
+        Current.CapturedElements[pointer.PointerId] = element;
+        if (pointer.PointerId == 1) _capturedElement = element;
+        return true;
     }
 
     public static void ReleasePointerCapture()
     {
+        var pointerId = Current.CurrentDispatchPointerId;
+        if (pointerId != 0 && Current.CapturedElements.TryGetValue(pointerId, out var element) &&
+            Current.PointerContacts.TryGetValue(pointerId, out var contact))
+        {
+            ReleasePointerCapture(element, contact.Pointer);
+            return;
+        }
         _capturedElement = null;
         DevToolsInputSystem.ReleasePointerCapture();
+    }
+
+    public static void ReleasePointerCapture(FrameworkElement element, Pointer pointer)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+        ArgumentNullException.ThrowIfNull(pointer);
+        if (!Current.CapturedElements.TryGetValue(pointer.PointerId, out var captured) || !ReferenceEquals(captured, element)) return;
+        Current.CapturedElements.Remove(pointer.PointerId);
+        if (pointer.PointerId == 1) _capturedElement = null;
+        RaiseCaptureLost(element, Current.PointerContacts.TryGetValue(pointer.PointerId, out var contact) ? contact.LastEvent : default, pointer);
+    }
+
+    public static void ReleasePointerCaptures(FrameworkElement element)
+    {
+        var ids = Current.CapturedElements.Where(pair => ReferenceEquals(pair.Value, element)).Select(pair => pair.Key).ToArray();
+        foreach (var pointerId in ids)
+        {
+            if (Current.PointerContacts.TryGetValue(pointerId, out var contact)) ReleasePointerCapture(element, contact.Pointer);
+            else Current.CapturedElements.Remove(pointerId);
+        }
     }
 
     public static void SetMouseCursor(StandardCursor cursor)
@@ -235,15 +338,15 @@ public static class InputSystem
             };
             mouse.MouseDown += (m, btn) => {
                 _currentState = state;
-                OnMouseDown(btn);
+                InjectMouseDown(btn);
             };
             mouse.MouseUp += (m, btn) => {
                 _currentState = state;
-                OnMouseUp(btn);
+                InjectMouseUp(btn);
             };
             mouse.Scroll += (m, scroll) => {
                 _currentState = state;
-                OnMouseScroll(new Vector2(scroll.X, scroll.Y));
+                InjectMouseScroll(new Vector2(scroll.X, scroll.Y));
             };
         }
 
@@ -277,6 +380,575 @@ public static class InputSystem
         return state.PointerPositionTransform?.Invoke(pointerPosition) ?? pointerPosition;
     }
 
+    private static ulong GetTimestamp() => (ulong)(Stopwatch.GetTimestamp() * 1_000_000L / Stopwatch.Frequency);
+
+    private static PointerInputEvent CreateMouseEvent(PointerInputKind kind, Vector2 position) => new(
+        kind,
+        1,
+        PointerDeviceType.Mouse,
+        position,
+        GetTimestamp(),
+        IsPrimary: true,
+        IsInContact: Current.IsLeftButtonPressed || Current.IsMiddleButtonPressed || Current.IsRightButtonPressed,
+        IsLeftButtonPressed: Current.IsLeftButtonPressed,
+        IsMiddleButtonPressed: Current.IsMiddleButtonPressed,
+        IsRightButtonPressed: Current.IsRightButtonPressed,
+        Pressure: Current.IsLeftButtonPressed ? 0.5f : 0f,
+        Modifiers: GetCurrentModifiers());
+
+    private static PointerInputEvent CreateMouseButtonEvent(PointerInputKind kind, MouseButton button)
+    {
+        var left = Current.IsLeftButtonPressed;
+        var middle = Current.IsMiddleButtonPressed;
+        var right = Current.IsRightButtonPressed;
+        var pressed = kind == PointerInputKind.Pressed;
+        if (button == MouseButton.Left) left = pressed;
+        else if (button == MouseButton.Middle) middle = pressed;
+        else if (button == MouseButton.Right) right = pressed;
+        return CreateMouseEvent(kind, _lastMousePos) with
+        {
+            IsInContact = left || middle || right,
+            IsLeftButtonPressed = left,
+            IsMiddleButtonPressed = middle,
+            IsRightButtonPressed = right,
+            Pressure = left ? 0.5f : 0f
+        };
+    }
+
+    private static VirtualKeyModifiers GetCurrentModifiers()
+    {
+        var modifiers = VirtualKeyModifiers.None;
+        if (IsShiftPressedDynamic()) modifiers |= VirtualKeyModifiers.Shift;
+        if (IsControlPressedDynamic()) modifiers |= VirtualKeyModifiers.Control;
+        if (IsAltPressedDynamic()) modifiers |= VirtualKeyModifiers.Menu;
+        return modifiers;
+    }
+
+    private static void OnPointer(PointerInputEvent input)
+    {
+        _lastMousePos = input.Position;
+        Current.IsShiftPressed = input.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
+        Current.IsControlPressed = input.Modifiers.HasFlag(VirtualKeyModifiers.Control);
+        Current.IsAltPressed = input.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
+        Current.IsLeftButtonPressed = input.IsLeftButtonPressed;
+        Current.IsMiddleButtonPressed = input.IsMiddleButtonPressed;
+        Current.IsRightButtonPressed = input.IsRightButtonPressed;
+        Current.CurrentDispatchPointerId = input.PointerId;
+
+        try
+        {
+            switch (input.Kind)
+            {
+                case PointerInputKind.Pressed:
+                    OnPointerPressedCore(input);
+                    break;
+                case PointerInputKind.Moved:
+                    OnPointerMovedCore(input);
+                    break;
+                case PointerInputKind.Released:
+                    OnPointerReleasedCore(input, canceled: false);
+                    break;
+                case PointerInputKind.Canceled:
+                    OnPointerReleasedCore(input, canceled: true);
+                    break;
+                case PointerInputKind.Wheel:
+                    OnPointerWheelCore(input);
+                    break;
+            }
+        }
+        finally
+        {
+            Current.CurrentDispatchPointerId = 0;
+        }
+    }
+
+    private static void OnPointerPressedCore(PointerInputEvent input)
+    {
+        if (Current.PointerContacts.TryGetValue(input.PointerId, out var previousContact))
+        {
+            OnPointerReleasedCore(previousContact.LastEvent with
+            {
+                Kind = PointerInputKind.Canceled,
+                IsInContact = false,
+                Timestamp = input.Timestamp
+            }, canceled: true);
+        }
+        IsKeyboardFocusActive = false;
+        DismissToolTip();
+        var target = HitTest(input.Position);
+        ProGpuWinUiDiagnostics.WriteLine($"[InputSystem] PointerDown {input.PointerId} ({input.DeviceType}) at {input.Position}. Hit: {target?.GetType().Name} (Name: {target?.Name})");
+
+        if (DevToolsService.IsInspectModeActive || (IsControlPressedDynamic() && IsShiftPressedDynamic()))
+        {
+            if (!IsDescendantOf(target, "DevToolsPanel"))
+            {
+                if (target != null)
+                {
+                    if (!DevToolsService.IsDevToolsActive) DevToolsService.IsDevToolsActive = true;
+                    DevToolsService.InspectedElement = target;
+                    DevToolsService.IsInspectModeActive = false;
+                }
+                return;
+            }
+        }
+
+        if (PopupService.ActivePopups.Count > 0)
+        {
+            var topmostPopup = PopupService.ActivePopups[^1];
+            if (!IsDescendantOf(target, topmostPopup) && topmostPopup is not ContentDialog)
+            {
+                var owner = PopupService.GetOwner(topmostPopup);
+                PopupService.HidePopup(topmostPopup);
+                target = HitTest(input.Position);
+                if (target != null && owner != null && IsDescendantOf(target, owner))
+                {
+                    SetFocus(target);
+                    return;
+                }
+            }
+        }
+        var pointer = new Pointer(input.PointerId, input.DeviceType, true);
+        var contact = new PointerContactState
+        {
+            Pointer = pointer,
+            Target = target,
+            LastEvent = input,
+            DownPosition = input.Position,
+            DownTimestamp = input.Timestamp,
+            StartedWithRightButton = input.IsRightButtonPressed
+        };
+        Current.PointerContacts[input.PointerId] = contact;
+
+        if (target != null)
+        {
+            if (input.DeviceType == PointerDeviceType.Touch)
+            {
+                target.OnPointerEntered(CreatePointerArgs(target, input, pointer));
+            }
+            target.OnPointerPressed(CreatePointerArgs(target, input, pointer));
+            BeginHolding(contact);
+            BeginManipulation(contact);
+        }
+        else
+        {
+            SetFocus(null);
+        }
+    }
+
+    private static void OnPointerMovedCore(PointerInputEvent input)
+    {
+        if (input.DeviceType == PointerDeviceType.Mouse && DragDropManager.IsDragging)
+        {
+            if (Current.PointerContacts.TryGetValue(input.PointerId, out var dragContact)) dragContact.LastEvent = input;
+            DragDropManager.UpdateDrag(input.Position);
+            return;
+        }
+
+        if (input.DeviceType == PointerDeviceType.Mouse &&
+            (DevToolsService.IsInspectModeActive || (IsControlPressedDynamic() && IsShiftPressedDynamic())))
+        {
+            var inspectHit = HitTest(input.Position);
+            var insideDevTools = IsDescendantOf(inspectHit, "DevToolsPanel");
+            DevToolsService.HoveredElement = insideDevTools ? null : inspectHit;
+            if (!insideDevTools) return;
+        }
+
+        if (!Current.PointerContacts.TryGetValue(input.PointerId, out var contact))
+        {
+            if (input.DeviceType is PointerDeviceType.Mouse or PointerDeviceType.Pen) UpdateHover(input);
+            var hoverTarget = HitTest(input.Position);
+            hoverTarget?.OnPointerMoved(CreatePointerArgs(hoverTarget, input, new Pointer(input.PointerId, input.DeviceType, input.IsInContact)));
+            return;
+        }
+
+        var elapsedMicros = input.Timestamp > contact.LastEvent.Timestamp
+            ? input.Timestamp - contact.LastEvent.Timestamp
+            : 1UL;
+        contact.Velocity = (input.Position - contact.LastEvent.Position) * (1_000_000f / elapsedMicros);
+        contact.LastEvent = input;
+        var threshold = input.DeviceType == PointerDeviceType.Touch ? 12f : 4f;
+        if (Vector2.DistanceSquared(contact.DownPosition, input.Position) > threshold * threshold)
+        {
+            contact.ExceededTapThreshold = true;
+            CancelHolding(contact, raiseCanceled: true);
+        }
+
+        var target = Current.CapturedElements.GetValueOrDefault(input.PointerId) ?? contact.Target ?? HitTest(input.Position);
+        target?.OnPointerMoved(CreatePointerArgs(target, input, contact.Pointer));
+        UpdateManipulation(contact);
+    }
+
+    private static void OnPointerReleasedCore(PointerInputEvent input, bool canceled)
+    {
+        if (!Current.PointerContacts.TryGetValue(input.PointerId, out var contact))
+        {
+            return;
+        }
+
+        var completesDrag = input.DeviceType == PointerDeviceType.Mouse &&
+            DragDropManager.IsDragging && contact.LastEvent.IsLeftButtonPressed && !input.IsLeftButtonPressed;
+        contact.LastEvent = input;
+        contact.Pointer.IsInContact = false;
+        var target = Current.CapturedElements.GetValueOrDefault(input.PointerId) ?? contact.Target ?? HitTest(input.Position);
+        var args = CreatePointerArgs(target, input, contact.Pointer, canceled);
+        if (completesDrag)
+        {
+            DragDropManager.CompleteDrop(input.Position);
+            target?.OnPointerCanceled(args);
+        }
+        else if (canceled) target?.OnPointerCanceled(args);
+        else target?.OnPointerReleased(args);
+
+        EndManipulation(contact, canceled || completesDrag);
+        if (!canceled && !completesDrag) CompleteGesture(contact, input);
+        else CancelHolding(contact, raiseCanceled: true);
+
+        if (Current.CapturedElements.Remove(input.PointerId, out var captured)) RaiseCaptureLost(captured, input, contact.Pointer);
+        if (input.PointerId == 1) _capturedElement = null;
+        contact.HoldingCancellation?.Cancel();
+        Current.PointerContacts.Remove(input.PointerId);
+
+        if (input.DeviceType is PointerDeviceType.Mouse or PointerDeviceType.Pen) UpdateHover(input);
+        else target?.OnPointerExited(CreatePointerArgs(target, input, contact.Pointer, canceled));
+    }
+
+    private static void OnPointerWheelCore(PointerInputEvent input)
+    {
+        DismissToolTip();
+        var target = HitTest(input.Position);
+        if (target == null) return;
+        var pointer = new Pointer(input.PointerId, input.DeviceType, false);
+        target.OnPointerWheelChanged(CreatePointerArgs(target, input, pointer));
+    }
+
+    private static PointerRoutedEventArgs CreatePointerArgs(
+        FrameworkElement? target,
+        PointerInputEvent input,
+        Pointer pointer,
+        bool canceled = false) => new()
+    {
+        Position = GetLocalPosition(target, input.Position),
+        ScreenPosition = input.Position,
+        Pointer = pointer,
+        Timestamp = input.Timestamp,
+        IsPrimary = input.IsPrimary,
+        IsLeftButtonPressed = input.IsLeftButtonPressed,
+        IsMiddleButtonPressed = input.IsMiddleButtonPressed,
+        IsRightButtonPressed = input.IsRightButtonPressed,
+        Pressure = input.Pressure,
+        ContactRect = input.ContactRect,
+        WheelDelta = input.WheelDeltaY,
+        KeyModifiers = input.Modifiers,
+        IsCanceled = canceled
+    };
+
+    private static void RaiseCaptureLost(FrameworkElement element, PointerInputEvent input, Pointer pointer)
+    {
+        element.OnPointerCaptureLost(CreatePointerArgs(element, input, pointer, input.Kind == PointerInputKind.Canceled));
+    }
+
+    private static void UpdateHover(PointerInputEvent input)
+    {
+        var hit = HitTest(input.Position);
+        if (ReferenceEquals(hit, _hoveredElement)) return;
+        var oldPath = GetVisualPath(_hoveredElement);
+        var newPath = GetVisualPath(hit);
+        var common = -1;
+        for (var index = 0; index < Math.Min(oldPath.Count, newPath.Count) && ReferenceEquals(oldPath[index], newPath[index]); index++) common = index;
+        var pointer = new Pointer(input.PointerId, input.DeviceType, input.IsInContact);
+        for (var index = oldPath.Count - 1; index > common; index--) oldPath[index].OnPointerExited(CreatePointerArgs(oldPath[index], input, pointer));
+        for (var index = common + 1; index < newPath.Count; index++) newPath[index].OnPointerEntered(CreatePointerArgs(newPath[index], input, pointer));
+        _hoveredElement = hit;
+        ResetHoverTimer(hit);
+    }
+
+    private static bool IsDescendantOf(FrameworkElement? element, FrameworkElement ancestor)
+    {
+        for (var current = element; current != null; current = current.Parent as FrameworkElement)
+            if (ReferenceEquals(current, ancestor)) return true;
+        return false;
+    }
+
+    private static bool IsDescendantOf(FrameworkElement? element, string ancestorName)
+    {
+        for (var current = element; current != null; current = current.Parent as FrameworkElement)
+            if (string.Equals(current.Name, ancestorName, StringComparison.Ordinal)) return true;
+        return false;
+    }
+
+    private static void BeginHolding(PointerContactState contact)
+    {
+        if (contact.Target == null || !contact.Target.IsHoldingEnabled || contact.Pointer.PointerDeviceType == PointerDeviceType.Mouse) return;
+        var cancellation = new CancellationTokenSource();
+        contact.HoldingCancellation = cancellation;
+        var state = Current;
+        Task.Delay(TimeSpan.FromMilliseconds(800), cancellation.Token).ContinueWith(task =>
+        {
+            if (!task.IsCompletedSuccessfully || cancellation.IsCancellationRequested) return;
+            void Raise()
+            {
+                InputSystem.Current = state;
+                if (!state.PointerContacts.TryGetValue(contact.Pointer.PointerId, out var active) || active.ExceededTapThreshold) return;
+                active.HoldingStarted = true;
+                active.Target?.OnHolding(new HoldingRoutedEventArgs
+                {
+                    PointerDeviceType = active.Pointer.PointerDeviceType,
+                    ScreenPosition = active.LastEvent.Position,
+                    HoldingState = HoldingState.Started
+                });
+            }
+            if (DispatcherQueue != null) DispatcherQueue(Raise); else Raise();
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+    }
+
+    private static void CancelHolding(PointerContactState contact, bool raiseCanceled)
+    {
+        contact.HoldingCancellation?.Cancel();
+        if (!contact.HoldingStarted || !raiseCanceled || contact.Target == null) return;
+        contact.HoldingStarted = false;
+        contact.Target.OnHolding(new HoldingRoutedEventArgs
+        {
+            PointerDeviceType = contact.Pointer.PointerDeviceType,
+            ScreenPosition = contact.LastEvent.Position,
+            HoldingState = HoldingState.Canceled
+        });
+    }
+
+    private static void CompleteGesture(PointerContactState contact, PointerInputEvent input)
+    {
+        contact.HoldingCancellation?.Cancel();
+        if (contact.Target == null) return;
+        if (contact.HoldingStarted)
+        {
+            contact.Target.OnHolding(new HoldingRoutedEventArgs
+            {
+                PointerDeviceType = contact.Pointer.PointerDeviceType,
+                ScreenPosition = input.Position,
+                HoldingState = HoldingState.Completed
+            });
+            return;
+        }
+
+        var contactDuration = input.Timestamp >= contact.DownTimestamp
+            ? input.Timestamp - contact.DownTimestamp
+            : ulong.MaxValue;
+        if (contact.ExceededTapThreshold || contactDuration > 800_000UL) return;
+        if (input.DeviceType == PointerDeviceType.Mouse && contact.StartedWithRightButton)
+        {
+            if (contact.Target.IsRightTapEnabled)
+            {
+                contact.Target.OnRightTapped(new RightTappedRoutedEventArgs
+                {
+                    PointerId = input.PointerId,
+                    PointerDeviceType = input.DeviceType,
+                    ScreenPosition = input.Position
+                });
+            }
+            return;
+        }
+
+        if (!contact.Target.IsTapEnabled) return;
+        var tapped = new TappedRoutedEventArgs
+        {
+            PointerId = input.PointerId,
+            PointerDeviceType = input.DeviceType,
+            ScreenPosition = input.Position
+        };
+        contact.Target.OnTapped(tapped);
+
+        var isDouble = contact.Target.IsDoubleTapEnabled &&
+            ReferenceEquals(Current.LastTappedElement, contact.Target) &&
+            input.Timestamp >= Current.LastTapTimestamp &&
+            input.Timestamp - Current.LastTapTimestamp <= 500_000UL &&
+            Vector2.DistanceSquared(Current.LastTapPosition, input.Position) <= 24f * 24f;
+        if (isDouble)
+        {
+            contact.Target.OnDoubleTapped(new DoubleTappedRoutedEventArgs
+            {
+                PointerId = input.PointerId,
+                PointerDeviceType = input.DeviceType,
+                ScreenPosition = input.Position
+            });
+            Current.LastTappedElement = null;
+            Current.LastTapTimestamp = 0;
+        }
+        else
+        {
+            Current.LastTappedElement = contact.Target;
+            Current.LastTapPosition = input.Position;
+            Current.LastTapTimestamp = input.Timestamp;
+        }
+    }
+
+    private static FrameworkElement? FindManipulationTarget(FrameworkElement? element)
+    {
+        var current = element;
+        while (current != null)
+        {
+            if (current.ManipulationMode is not (ManipulationModes.None or ManipulationModes.System)) return current;
+            current = current.Parent as FrameworkElement;
+        }
+        return null;
+    }
+
+    private static void BeginManipulation(PointerContactState contact)
+    {
+        var target = FindManipulationTarget(contact.Target);
+        if (target == null) return;
+        contact.ManipulationTarget = target;
+        if (!Current.Manipulations.TryGetValue(target, out var session))
+        {
+            var starting = new ManipulationStartingRoutedEventArgs
+            {
+                OriginalSource = target,
+                Mode = target.ManipulationMode,
+                Container = target,
+                PivotCenter = contact.LastEvent.Position
+            };
+            target.OnManipulationStarting(starting);
+            if (starting.Mode == ManipulationModes.None) return;
+            session = new ManipulationSession
+            {
+                Target = target,
+                Mode = starting.Mode,
+                PreviousTimestamp = contact.LastEvent.Timestamp
+            };
+            Current.Manipulations[target] = session;
+        }
+        session.PointerIds.Add(contact.Pointer.PointerId);
+        ResetManipulationBaseline(session);
+    }
+
+    private static void ResetManipulationBaseline(ManipulationSession session)
+    {
+        var points = session.PointerIds
+            .Select(id => Current.PointerContacts.TryGetValue(id, out var state) ? state.LastEvent.Position : (Vector2?)null)
+            .Where(point => point.HasValue)
+            .Select(point => point!.Value)
+            .ToArray();
+        if (points.Length == 0) return;
+        session.PreviousCentroid = points.Aggregate(Vector2.Zero, static (sum, point) => sum + point) / points.Length;
+        if (points.Length >= 2)
+        {
+            var vector = points[1] - points[0];
+            session.PreviousDistance = Math.Max(0.0001f, vector.Length());
+            session.PreviousAngle = MathF.Atan2(vector.Y, vector.X);
+        }
+    }
+
+    private static void UpdateManipulation(PointerContactState contact)
+    {
+        if (contact.ManipulationTarget == null || !Current.Manipulations.TryGetValue(contact.ManipulationTarget, out var session)) return;
+        var points = session.PointerIds
+            .Select(id => Current.PointerContacts.TryGetValue(id, out var state) ? state.LastEvent.Position : (Vector2?)null)
+            .Where(point => point.HasValue)
+            .Select(point => point!.Value)
+            .ToArray();
+        if (points.Length == 0) return;
+
+        var centroid = points.Aggregate(Vector2.Zero, static (sum, point) => sum + point) / points.Length;
+        var translation = centroid - session.PreviousCentroid;
+        if (!session.Mode.HasFlag(ManipulationModes.TranslateX) && !session.Mode.HasFlag(ManipulationModes.TranslateRailsX)) translation.X = 0;
+        if (!session.Mode.HasFlag(ManipulationModes.TranslateY) && !session.Mode.HasFlag(ManipulationModes.TranslateRailsY)) translation.Y = 0;
+
+        var scale = 1f;
+        var rotation = 0f;
+        var expansion = 0f;
+        if (points.Length >= 2)
+        {
+            var vector = points[1] - points[0];
+            var distance = Math.Max(0.0001f, vector.Length());
+            var angle = MathF.Atan2(vector.Y, vector.X);
+            if (session.Mode.HasFlag(ManipulationModes.Scale))
+            {
+                scale = distance / Math.Max(0.0001f, session.PreviousDistance);
+                expansion = distance - session.PreviousDistance;
+            }
+            if (session.Mode.HasFlag(ManipulationModes.Rotate)) rotation = (angle - session.PreviousAngle) * (180f / MathF.PI);
+            session.PreviousDistance = distance;
+            session.PreviousAngle = angle;
+        }
+
+        var meaningful = translation.LengthSquared() > 0.01f || MathF.Abs(scale - 1f) > 0.001f || MathF.Abs(rotation) > 0.01f;
+        if (!session.Started && !meaningful) return;
+        if (!session.Started)
+        {
+            session.Started = true;
+            foreach (var id in session.PointerIds)
+            {
+                if (!Current.PointerContacts.TryGetValue(id, out var state)) continue;
+                state.ExceededTapThreshold = true;
+                state.Target?.OnPointerCanceled(CreatePointerArgs(state.Target, state.LastEvent, state.Pointer, canceled: true));
+            }
+            session.Target.OnManipulationStarted(new ManipulationStartedRoutedEventArgs
+            {
+                OriginalSource = session.Target,
+                Position = centroid
+            });
+        }
+
+        session.CumulativeTranslation += translation;
+        session.CumulativeScale *= scale;
+        session.CumulativeRotation += rotation;
+        session.CumulativeExpansion += expansion;
+        var elapsedMicros = contact.LastEvent.Timestamp > session.PreviousTimestamp
+            ? contact.LastEvent.Timestamp - session.PreviousTimestamp
+            : 1UL;
+        var seconds = elapsedMicros / 1_000_000f;
+        session.Velocities = new ManipulationVelocities(translation / seconds, rotation / seconds, expansion / seconds);
+        session.PreviousTimestamp = contact.LastEvent.Timestamp;
+        session.PreviousCentroid = centroid;
+        var delta = new ManipulationDelta(translation, scale, rotation, expansion);
+        var cumulative = new ManipulationDelta(session.CumulativeTranslation, session.CumulativeScale, session.CumulativeRotation, session.CumulativeExpansion);
+        var args = new ManipulationDeltaRoutedEventArgs
+        {
+            OriginalSource = session.Target,
+            Delta = delta,
+            Cumulative = cumulative,
+            Velocities = session.Velocities
+        };
+        session.Target.OnManipulationDelta(args);
+        if (args.Complete) CompleteManipulation(session, inertial: false);
+    }
+
+    private static void EndManipulation(PointerContactState contact, bool canceled)
+    {
+        if (contact.ManipulationTarget == null || !Current.Manipulations.TryGetValue(contact.ManipulationTarget, out var session)) return;
+        session.PointerIds.Remove(contact.Pointer.PointerId);
+        if (session.PointerIds.Count != 0)
+        {
+            ResetManipulationBaseline(session);
+            return;
+        }
+        CompleteManipulation(session, inertial: !canceled &&
+            (session.Mode.HasFlag(ManipulationModes.TranslateInertia) || session.Mode.HasFlag(ManipulationModes.RotateInertia) || session.Mode.HasFlag(ManipulationModes.ScaleInertia)));
+    }
+
+    private static void CompleteManipulation(ManipulationSession session, bool inertial)
+    {
+        var cumulative = new ManipulationDelta(session.CumulativeTranslation, session.CumulativeScale, session.CumulativeRotation, session.CumulativeExpansion);
+        if (session.Started && inertial)
+        {
+            session.Target.OnManipulationInertiaStarting(new ManipulationInertiaStartingRoutedEventArgs
+            {
+                OriginalSource = session.Target,
+                Cumulative = cumulative,
+                Velocities = session.Velocities
+            });
+        }
+        if (session.Started)
+        {
+            session.Target.OnManipulationCompleted(new ManipulationCompletedRoutedEventArgs
+            {
+                OriginalSource = session.Target,
+                Cumulative = cumulative,
+                Velocities = session.Velocities,
+                IsInertial = inertial
+            });
+        }
+        Current.Manipulations.Remove(session.Target);
+    }
+
     public static void SetFocus(FrameworkElement? element)
     {
         if (element != null && IsInsideDevTools(element))
@@ -299,6 +971,7 @@ public static class InputSystem
         {
             newControl.IsFocused = true;
         }
+        Current.FocusChanged?.Invoke(_focusedElement);
     }
 
     public static FrameworkElement? HitTest(Vector2 screenPoint)
@@ -415,7 +1088,10 @@ public static class InputSystem
         return path;
     }
 
-    private static void OnMouseMove(Vector2 screenPos)
+    private static void OnMouseMove(Vector2 screenPos) =>
+        InjectPointer(CreateMouseEvent(PointerInputKind.Moved, screenPos));
+
+    private static void OnMouseMoveLegacy(Vector2 screenPos)
     {
         _lastMousePos = screenPos;
 
@@ -857,6 +1533,18 @@ public static class InputSystem
 
     private static void OnFocusLost()
     {
+        foreach (var contact in Current.PointerContacts.Values.ToArray())
+        {
+            InjectPointer(contact.LastEvent with
+            {
+                Kind = PointerInputKind.Canceled,
+                IsInContact = false,
+                IsLeftButtonPressed = false,
+                IsMiddleButtonPressed = false,
+                IsRightButtonPressed = false,
+                Timestamp = GetTimestamp()
+            });
+        }
         if (Current.IsLeftButtonPressed) OnMouseUp(MouseButton.Left);
         if (Current.IsMiddleButtonPressed) OnMouseUp(MouseButton.Middle);
         if (Current.IsRightButtonPressed) OnMouseUp(MouseButton.Right);

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -581,7 +581,7 @@ public static class InputSystem
             : 1UL;
         contact.Velocity = (input.Position - contact.LastEvent.Position) * (1_000_000f / elapsedMicros);
         contact.LastEvent = input;
-        var threshold = input.DeviceType == PointerDeviceType.Touch ? 12f : 4f;
+        var threshold = GetTapThreshold(input.DeviceType);
         if (Vector2.DistanceSquared(contact.DownPosition, input.Position) > threshold * threshold)
         {
             contact.ExceededTapThreshold = true;
@@ -783,7 +783,10 @@ public static class InputSystem
         var contactDuration = input.Timestamp >= contact.DownTimestamp
             ? input.Timestamp - contact.DownTimestamp
             : ulong.MaxValue;
-        if (contact.ExceededTapThreshold || contactDuration > 800_000UL) return;
+        var tapThreshold = GetTapThreshold(input.DeviceType);
+        var releaseExceededTapThreshold =
+            Vector2.DistanceSquared(contact.DownPosition, input.Position) > tapThreshold * tapThreshold;
+        if (contact.ExceededTapThreshold || releaseExceededTapThreshold || contactDuration > 800_000UL) return;
         if (input.DeviceType == PointerDeviceType.Mouse && contact.StartedWithRightButton)
         {
             if (contact.Target.IsRightTapEnabled)
@@ -830,6 +833,9 @@ public static class InputSystem
             Current.LastTapTimestamp = input.Timestamp;
         }
     }
+
+    private static float GetTapThreshold(PointerDeviceType deviceType) =>
+        deviceType == PointerDeviceType.Touch ? 12f : 4f;
 
     private static FrameworkElement? FindManipulationTarget(FrameworkElement? element)
     {

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -80,6 +80,8 @@ internal sealed class ManipulationSession
 
 public static class InputSystem
 {
+    private static readonly long s_timestampOrigin = Stopwatch.GetTimestamp();
+
     [ThreadStatic]
     private static WindowInputState? _currentState;
 
@@ -382,7 +384,14 @@ public static class InputSystem
         return state.PointerPositionTransform?.Invoke(pointerPosition) ?? pointerPosition;
     }
 
-    private static ulong GetTimestamp() => (ulong)(Stopwatch.GetTimestamp() * 1_000_000L / Stopwatch.Frequency);
+    private static ulong GetTimestamp()
+    {
+        long elapsedTicks = Stopwatch.GetTimestamp() - s_timestampOrigin;
+        long wholeSeconds = elapsedTicks / Stopwatch.Frequency;
+        long remainingTicks = elapsedTicks % Stopwatch.Frequency;
+        var fractionalMicros = (ulong)((UInt128)(ulong)remainingTicks * 1_000_000UL / (ulong)Stopwatch.Frequency);
+        return (ulong)wholeSeconds * 1_000_000UL + fractionalMicros;
+    }
 
     private static PointerInputEvent CreateMouseEvent(PointerInputKind kind, Vector2 position) => new(
         kind,
@@ -861,7 +870,19 @@ public static class InputSystem
             Current.Manipulations[target] = session;
         }
         session.PointerIds.Add(contact.Pointer.PointerId);
+        if (session.Started)
+        {
+            CancelContactForManipulation(contact);
+        }
         ResetManipulationBaseline(session);
+    }
+
+    private static void CancelContactForManipulation(PointerContactState contact)
+    {
+        if (contact.CanceledByManipulation) return;
+        contact.ExceededTapThreshold = true;
+        contact.CanceledByManipulation = true;
+        contact.Target?.OnPointerCanceled(CreatePointerArgs(contact.Target, contact.LastEvent, contact.Pointer, canceled: true));
     }
 
     private static void ResetManipulationBaseline(ManipulationSession session)
@@ -923,9 +944,7 @@ public static class InputSystem
             foreach (var id in session.PointerIds)
             {
                 if (!Current.PointerContacts.TryGetValue(id, out var state)) continue;
-                state.ExceededTapThreshold = true;
-                state.CanceledByManipulation = true;
-                state.Target?.OnPointerCanceled(CreatePointerArgs(state.Target, state.LastEvent, state.Pointer, canceled: true));
+                CancelContactForManipulation(state);
             }
             session.Target.OnManipulationStarted(new ManipulationStartedRoutedEventArgs
             {

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -56,6 +56,8 @@ internal sealed class PointerContactState
     public bool HoldingStarted { get; set; }
     public CancellationTokenSource? HoldingCancellation { get; set; }
     public FrameworkElement? ManipulationTarget { get; set; }
+    public FrameworkElement? OverTarget { get; set; }
+    public bool CanceledByManipulation { get; set; }
     public bool StartedWithRightButton { get; init; }
 }
 
@@ -523,7 +525,11 @@ public static class InputSystem
         {
             if (input.DeviceType == PointerDeviceType.Touch)
             {
-                target.OnPointerEntered(CreatePointerArgs(target, input, pointer));
+                UpdateContactOver(contact, target, input);
+            }
+            else
+            {
+                UpdateHover(input);
             }
             target.OnPointerPressed(CreatePointerArgs(target, input, pointer));
             BeginHolding(contact);
@@ -573,7 +579,10 @@ public static class InputSystem
             CancelHolding(contact, raiseCanceled: true);
         }
 
-        var target = Current.CapturedElements.GetValueOrDefault(input.PointerId) ?? contact.Target ?? HitTest(input.Position);
+        var hit = HitTest(input.Position);
+        if (input.DeviceType == PointerDeviceType.Touch) UpdateContactOver(contact, hit, input);
+        else UpdateHover(input);
+        var target = Current.CapturedElements.GetValueOrDefault(input.PointerId) ?? hit;
         target?.OnPointerMoved(CreatePointerArgs(target, input, contact.Pointer));
         UpdateManipulation(contact);
     }
@@ -589,18 +598,24 @@ public static class InputSystem
             DragDropManager.IsDragging && contact.LastEvent.IsLeftButtonPressed && !input.IsLeftButtonPressed;
         contact.LastEvent = input;
         contact.Pointer.IsInContact = false;
-        var target = Current.CapturedElements.GetValueOrDefault(input.PointerId) ?? contact.Target ?? HitTest(input.Position);
+        var hit = HitTest(input.Position);
+        if (!canceled)
+        {
+            if (input.DeviceType == PointerDeviceType.Touch) UpdateContactOver(contact, hit, input);
+            else UpdateHover(input);
+        }
+        var target = Current.CapturedElements.GetValueOrDefault(input.PointerId) ?? (canceled ? contact.Target : hit);
         var args = CreatePointerArgs(target, input, contact.Pointer, canceled);
         if (completesDrag)
         {
             DragDropManager.CompleteDrop(input.Position);
             target?.OnPointerCanceled(args);
         }
-        else if (canceled) target?.OnPointerCanceled(args);
-        else target?.OnPointerReleased(args);
+        else if (canceled && !contact.CanceledByManipulation) target?.OnPointerCanceled(args);
+        else if (!canceled && !contact.CanceledByManipulation) target?.OnPointerReleased(args);
 
         EndManipulation(contact, canceled || completesDrag);
-        if (!canceled && !completesDrag) CompleteGesture(contact, input);
+        if (!canceled && !completesDrag && !contact.CanceledByManipulation) CompleteGesture(contact, input);
         else CancelHolding(contact, raiseCanceled: true);
 
         if (Current.CapturedElements.Remove(input.PointerId, out var captured)) RaiseCaptureLost(captured, input, contact.Pointer);
@@ -609,7 +624,7 @@ public static class InputSystem
         Current.PointerContacts.Remove(input.PointerId);
 
         if (input.DeviceType is PointerDeviceType.Mouse or PointerDeviceType.Pen) UpdateHover(input);
-        else target?.OnPointerExited(CreatePointerArgs(target, input, contact.Pointer, canceled));
+        else UpdateContactOver(contact, null, input, canceled);
     }
 
     private static void OnPointerWheelCore(PointerInputEvent input)
@@ -660,6 +675,28 @@ public static class InputSystem
         for (var index = common + 1; index < newPath.Count; index++) newPath[index].OnPointerEntered(CreatePointerArgs(newPath[index], input, pointer));
         _hoveredElement = hit;
         ResetHoverTimer(hit);
+    }
+
+    private static void UpdateContactOver(
+        PointerContactState contact,
+        FrameworkElement? hit,
+        PointerInputEvent input,
+        bool canceled = false)
+    {
+        if (ReferenceEquals(hit, contact.OverTarget)) return;
+        var oldPath = GetVisualPath(contact.OverTarget);
+        var newPath = GetVisualPath(hit);
+        var common = -1;
+        for (var index = 0; index < Math.Min(oldPath.Count, newPath.Count) && ReferenceEquals(oldPath[index], newPath[index]); index++) common = index;
+        for (var index = oldPath.Count - 1; index > common; index--)
+        {
+            oldPath[index].OnPointerExited(CreatePointerArgs(oldPath[index], input, contact.Pointer, canceled));
+        }
+        for (var index = common + 1; index < newPath.Count; index++)
+        {
+            newPath[index].OnPointerEntered(CreatePointerArgs(newPath[index], input, contact.Pointer, canceled));
+        }
+        contact.OverTarget = hit;
     }
 
     private static bool IsDescendantOf(FrameworkElement? element, FrameworkElement ancestor)
@@ -793,8 +830,10 @@ public static class InputSystem
 
     private static void BeginManipulation(PointerContactState contact)
     {
+        if (contact.Pointer.PointerDeviceType == PointerDeviceType.Mouse) return;
         var target = FindManipulationTarget(contact.Target);
         if (target == null) return;
+        if (Current.CapturedElements.ContainsKey(contact.Pointer.PointerId)) return;
         contact.ManipulationTarget = target;
         if (!Current.Manipulations.TryGetValue(target, out var session))
         {
@@ -869,7 +908,8 @@ public static class InputSystem
             session.PreviousAngle = angle;
         }
 
-        var meaningful = translation.LengthSquared() > 0.01f || MathF.Abs(scale - 1f) > 0.001f || MathF.Abs(rotation) > 0.01f;
+        var meaningful = session.PointerIds.Any(id =>
+            Current.PointerContacts.TryGetValue(id, out var state) && state.ExceededTapThreshold);
         if (!session.Started && !meaningful) return;
         if (!session.Started)
         {
@@ -878,6 +918,7 @@ public static class InputSystem
             {
                 if (!Current.PointerContacts.TryGetValue(id, out var state)) continue;
                 state.ExceededTapThreshold = true;
+                state.CanceledByManipulation = true;
                 state.Target?.OnPointerCanceled(CreatePointerArgs(state.Target, state.LastEvent, state.Pointer, canceled: true));
             }
             session.Target.OnManipulationStarted(new ManipulationStartedRoutedEventArgs

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -543,7 +543,7 @@ public static class InputSystem
 
     private static void OnPointerMovedCore(PointerInputEvent input)
     {
-        if (input.DeviceType == PointerDeviceType.Mouse && DragDropManager.IsDragging)
+        if (DragDropManager.IsDragging && DragDropManager.IsPointerOwner(input.PointerId))
         {
             if (Current.PointerContacts.TryGetValue(input.PointerId, out var dragContact)) dragContact.LastEvent = input;
             DragDropManager.UpdateDrag(input.Position);
@@ -594,8 +594,8 @@ public static class InputSystem
             return;
         }
 
-        var completesDrag = input.DeviceType == PointerDeviceType.Mouse &&
-            DragDropManager.IsDragging && contact.LastEvent.IsLeftButtonPressed && !input.IsLeftButtonPressed;
+        var completesDrag = !canceled && DragDropManager.IsDragging && DragDropManager.IsPointerOwner(input.PointerId);
+        var cancelsDrag = canceled && DragDropManager.IsDragging && DragDropManager.IsPointerOwner(input.PointerId);
         contact.LastEvent = input;
         contact.Pointer.IsInContact = false;
         var hit = HitTest(input.Position);
@@ -609,13 +609,18 @@ public static class InputSystem
         if (completesDrag)
         {
             DragDropManager.CompleteDrop(input.Position);
-            target?.OnPointerCanceled(args);
+            contact.Target?.OnPointerCanceled(CreatePointerArgs(contact.Target, input, contact.Pointer, canceled: true));
+        }
+        else if (cancelsDrag)
+        {
+            DragDropManager.CancelDrag();
+            contact.Target?.OnPointerCanceled(CreatePointerArgs(contact.Target, input, contact.Pointer, canceled: true));
         }
         else if (canceled && !contact.CanceledByManipulation) target?.OnPointerCanceled(args);
         else if (!canceled && !contact.CanceledByManipulation) target?.OnPointerReleased(args);
 
-        EndManipulation(contact, canceled || completesDrag);
-        if (!canceled && !completesDrag && !contact.CanceledByManipulation) CompleteGesture(contact, input);
+        EndManipulation(contact, canceled || completesDrag || cancelsDrag);
+        if (!canceled && !completesDrag && !cancelsDrag && !contact.CanceledByManipulation) CompleteGesture(contact, input);
         else CancelHolding(contact, raiseCanceled: true);
 
         if (Current.CapturedElements.Remove(input.PointerId, out var captured)) RaiseCaptureLost(captured, input, contact.Pointer);
@@ -831,6 +836,7 @@ public static class InputSystem
     private static void BeginManipulation(PointerContactState contact)
     {
         if (contact.Pointer.PointerDeviceType == PointerDeviceType.Mouse) return;
+        if (DragDropManager.IsDragging && DragDropManager.IsPointerOwner(contact.Pointer.PointerId)) return;
         var target = FindManipulationTarget(contact.Target);
         if (target == null) return;
         if (Current.CapturedElements.ContainsKey(contact.Pointer.PointerId)) return;

--- a/src/ProGPU.WinUI/Input/PointerGestureTypes.cs
+++ b/src/ProGPU.WinUI/Input/PointerGestureTypes.cs
@@ -1,0 +1,285 @@
+using System.Numerics;
+using ProGPU.Scene;
+
+namespace Windows.Devices.Input
+{
+    public enum PointerDeviceType
+    {
+        Touch = 0,
+        Pen = 1,
+        Mouse = 2
+    }
+
+    public sealed class PointerDevice
+    {
+        internal PointerDevice(PointerDeviceType pointerDeviceType)
+        {
+            PointerDeviceType = pointerDeviceType;
+        }
+
+        public PointerDeviceType PointerDeviceType { get; }
+
+        public static PointerDevice GetPointerDevice(PointerDeviceType pointerDeviceType) => new(pointerDeviceType);
+    }
+}
+
+namespace Microsoft.UI.Input
+{
+using Windows.Devices.Input;
+
+public sealed class PointerPointProperties
+{
+    public bool IsLeftButtonPressed { get; internal set; }
+    public bool IsMiddleButtonPressed { get; internal set; }
+    public bool IsRightButtonPressed { get; internal set; }
+    public bool IsPrimary { get; internal set; }
+    public bool IsCanceled { get; internal set; }
+    public bool IsEraser { get; internal set; }
+    public float Pressure { get; internal set; }
+    public Rect ContactRect { get; internal set; }
+    public int MouseWheelDelta { get; internal set; }
+}
+
+public sealed class PointerPoint
+{
+    internal PointerPoint(
+        uint pointerId,
+        ulong timestamp,
+        Vector2 position,
+        Vector2 rawPosition,
+        PointerDeviceType deviceType,
+        bool isInContact,
+        PointerPointProperties properties)
+    {
+        PointerId = pointerId;
+        Timestamp = timestamp;
+        Position = position;
+        RawPosition = rawPosition;
+        PointerDevice = PointerDevice.GetPointerDevice(deviceType);
+        IsInContact = isInContact;
+        Properties = properties;
+    }
+
+    public uint PointerId { get; }
+    public ulong Timestamp { get; }
+    public Vector2 Position { get; }
+    public Vector2 RawPosition { get; }
+    public PointerDevice PointerDevice { get; }
+    public bool IsInContact { get; }
+    public PointerPointProperties Properties { get; }
+}
+}
+
+namespace Microsoft.UI.Xaml.Input
+{
+using Windows.Devices.Input;
+
+public sealed class Pointer
+{
+    internal Pointer(uint pointerId, PointerDeviceType pointerDeviceType, bool isInContact, bool isInRange = true)
+    {
+        PointerId = pointerId;
+        PointerDeviceType = pointerDeviceType;
+        IsInContact = isInContact;
+        IsInRange = isInRange;
+    }
+
+    public uint PointerId { get; }
+    public PointerDeviceType PointerDeviceType { get; }
+    public bool IsInContact { get; internal set; }
+    public bool IsInRange { get; internal set; }
+}
+
+[Flags]
+public enum ManipulationModes : uint
+{
+    None = 0,
+    TranslateX = 1,
+    TranslateY = 2,
+    TranslateRailsX = 4,
+    TranslateRailsY = 8,
+    Rotate = 16,
+    Scale = 32,
+    TranslateInertia = 64,
+    RotateInertia = 128,
+    ScaleInertia = 256,
+    All = 65535,
+    System = 65536
+}
+
+public enum HoldingState
+{
+    Started = 0,
+    Completed = 1,
+    Canceled = 2
+}
+
+public readonly record struct ManipulationDelta(
+    Vector2 Translation,
+    float Scale,
+    float Rotation,
+    float Expansion)
+{
+    public static ManipulationDelta Identity => new(Vector2.Zero, 1f, 0f, 0f);
+}
+
+public readonly record struct ManipulationVelocities(
+    Vector2 Linear,
+    float Angular,
+    float Expansion);
+
+public abstract class GestureRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    internal Vector2 ScreenPosition { get; init; }
+    public PointerDeviceType PointerDeviceType { get; internal init; }
+
+    public Vector2 GetPosition(Microsoft.UI.Xaml.FrameworkElement? relativeTo) =>
+        InputSystem.GetLocalPosition(relativeTo, ScreenPosition);
+}
+
+public sealed class TappedRoutedEventArgs : GestureRoutedEventArgs
+{
+    public uint PointerId { get; internal init; }
+}
+
+public sealed class DoubleTappedRoutedEventArgs : GestureRoutedEventArgs
+{
+    public uint PointerId { get; internal init; }
+}
+
+public sealed class RightTappedRoutedEventArgs : GestureRoutedEventArgs
+{
+    public uint PointerId { get; internal init; }
+}
+
+public sealed class HoldingRoutedEventArgs : GestureRoutedEventArgs
+{
+    public HoldingState HoldingState { get; internal init; }
+}
+
+public sealed class ManipulationStartingRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    public ManipulationModes Mode { get; set; }
+    public Microsoft.UI.Xaml.FrameworkElement? Container { get; set; }
+    public Vector2 PivotCenter { get; set; }
+    public float PivotRadius { get; set; }
+}
+
+public sealed class ManipulationStartedRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    public Vector2 Position { get; internal init; }
+    public ManipulationDelta Cumulative { get; internal init; } = ManipulationDelta.Identity;
+}
+
+public sealed class ManipulationDeltaRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    public ManipulationDelta Delta { get; internal init; } = ManipulationDelta.Identity;
+    public ManipulationDelta Cumulative { get; internal init; } = ManipulationDelta.Identity;
+    public ManipulationVelocities Velocities { get; internal init; }
+    public bool IsInertial { get; internal init; }
+    public bool Complete { get; set; }
+}
+
+public sealed class ManipulationInertiaStartingRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    public ManipulationDelta Cumulative { get; internal init; } = ManipulationDelta.Identity;
+    public ManipulationVelocities Velocities { get; internal init; }
+    public float TranslationDeceleration { get; set; } = 0.001f;
+    public float RotationDeceleration { get; set; } = 0.0001f;
+    public float ExpansionDeceleration { get; set; } = 0.001f;
+}
+
+public sealed class ManipulationCompletedRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    public ManipulationDelta Cumulative { get; internal init; } = ManipulationDelta.Identity;
+    public ManipulationVelocities Velocities { get; internal init; }
+    public bool IsInertial { get; internal init; }
+}
+
+public enum InputScopeNameValue
+{
+    Default = 0,
+    Url,
+    EmailSmtpAddress,
+    Number,
+    TelephoneNumber,
+    Search,
+    Chat,
+    NameOrPhoneNumber,
+    Password,
+    NumericPin
+}
+
+public sealed class InputScopeName
+{
+    public InputScopeNameValue NameValue { get; set; }
+}
+
+public sealed class InputScope
+{
+    public IList<InputScopeName> Names { get; } = new List<InputScopeName>();
+}
+
+public enum TextInputEventKind
+{
+    InsertText,
+    DeleteContentBackward,
+    DeleteContentForward,
+    InsertLineBreak,
+    CompositionStarted,
+    CompositionUpdated,
+    CompositionCompleted,
+    CompositionCanceled
+}
+
+public sealed class TextInputRoutedEventArgs : Microsoft.UI.Xaml.RoutedEventArgs
+{
+    public TextInputEventKind Kind { get; internal init; }
+    public string Text { get; internal init; } = string.Empty;
+    public bool IsComposing { get; internal init; }
+}
+
+public readonly record struct TextInputOptions(
+    InputScopeNameValue InputScope,
+    string EnterKeyHint,
+    string AutoCapitalize,
+    bool IsSpellCheckEnabled,
+    bool IsPassword,
+    bool AcceptsReturn,
+    string Text,
+    int SelectionStart,
+    int SelectionLength,
+    Rect Bounds);
+
+public interface ITextInputClient
+{
+    TextInputOptions GetTextInputOptions();
+    void OnTextInput(TextInputRoutedEventArgs args);
+}
+
+public enum PointerInputKind
+{
+    Moved,
+    Pressed,
+    Released,
+    Canceled,
+    Wheel
+}
+
+public readonly record struct PointerInputEvent(
+    PointerInputKind Kind,
+    uint PointerId,
+    PointerDeviceType DeviceType,
+    Vector2 Position,
+    ulong Timestamp,
+    bool IsPrimary = true,
+    bool IsInContact = false,
+    bool IsLeftButtonPressed = false,
+    bool IsMiddleButtonPressed = false,
+    bool IsRightButtonPressed = false,
+    float Pressure = 0f,
+    Rect ContactRect = default,
+    float WheelDeltaX = 0f,
+    float WheelDeltaY = 0f,
+    VirtualKeyModifiers Modifiers = VirtualKeyModifiers.None);
+}

--- a/src/ProGPU.WinUI/Properties/AssemblyInfo.cs
+++ b/src/ProGPU.WinUI/Properties/AssemblyInfo.cs
@@ -1,3 +1,11 @@
 using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
 
 [assembly: MetadataUpdateHandler(typeof(Microsoft.UI.Xaml.HotReload.HotReloadManager))]
+[assembly: InternalsVisibleTo(
+    "ProGPU.Avalonia, PublicKey=" +
+    "002400000480000094000000060200000024000052534131000400000100010045aa5f537c126e" +
+    "38b67a4e22a49d30ad6424dc66d3e82890c03de2caa8f421736dbe5170b054610320e4a436e808" +
+    "a38b05e02998b776d1ae9133d2bf7197e5eb39e9ba6bee9ed837236a90c151c6d6e154dc8debd4" +
+    "fef44d6597f795ee9e33bf0b2a959915729166099862717525ec4bab3002d4d8f8a81d656b5c25" +
+    "c891cb91")]


### PR DESCRIPTION
# Summary

This PR adds a WinUI-aligned, device-neutral input and responsive-layout layer for
ProGPU across desktop hosts and browser/mobile. It replaces the mouse-only interaction
assumptions with stable mouse, touch, and pen identities; routed gestures and
manipulations; per-pointer capture; mobile text/IME delivery; touch-aware controls; and
effective-pixel adaptive layouts.

The existing mouse APIs and control overrides remain source compatible. Platform hosts
translate native events into neutral pointer and text-edit records, while the retained
WinUI layer continues to own hit testing, routing, focus, recognition, control behavior,
and invalidation.

## Why

ProGPU previously routed a single mouse position and capture target. That model could
not represent simultaneous touch contacts, touch cancellation, pen metadata, pinch or
rotation gestures, or mobile software-keyboard text editing. The Samples shell also
assumed desktop widths, and the browser canvas did not account for safe areas, visual
viewport changes, or keyboard occlusion.

This work establishes one typed input contract for all hosts and makes responsive
behavior part of the WinUI control layer rather than a browser-only workaround.

## Core pointer and gesture pipeline

- Adds WinUI-shaped `Pointer`, `PointerPoint`, `PointerPointProperties`,
  `PointerDeviceType`, and `PointerInputEvent` types.
- Preserves pointer ID, device kind, primary/contact state, buttons, pressure, contact
  rectangle, modifiers, cancellation state, and monotonic timestamps.
- Replaces global single-pointer capture with per-window, per-pointer contact and
  capture maps while retaining the existing single-pointer helper methods.
- Adds routed `PointerCanceled` and `PointerCaptureLost` events.
- Adds `Tapped`, `DoubleTapped`, `RightTapped`, and `Holding` recognition.
- Adds WinUI-style manipulation starting/started/delta/inertia-starting/completed
  events with translation, scale, rotation, expansion, cumulative values, and velocity.
- Cancels child press state after the manipulation threshold so touch scrolling does
  not accidentally activate buttons.
- Preserves popup dismissal, drag/drop completion, DevTools inspection, hover, and DPI
  normalization behavior from the existing mouse path.
- Adds a retained animation callback used by control-owned inertia without scheduling
  frames or mutating geometry from `OnRender`.

## Desktop and browser platform integration

- The Avalonia host now forwards native mouse, touch, and pen IDs and device metadata,
  including cancellation when capture is lost.
- Browser input records expand to 64 bytes to carry pointer identity, device type,
  pressure, contact dimensions, timestamp, buttons, and modifiers.
- Pointer down/up/cancel remain synchronous for browser user-activation semantics;
  coalesced motion is drained in bounded per-frame batches without merging different
  pointer IDs.
- Before a synchronous terminal event, queued moves for that pointer are replayed
  synchronously in order. If replay cannot complete, the terminal event stays queued
  behind the moves, preventing both stale post-release motion and lost fast swipes.
- Browser `pointercancel`, pointer capture, `touch-action`, and focus-loss behavior map
  into the same managed pointer lifecycle.
- Physical keyboard events remain separate from text edits.

## Mobile keyboard, text, and IME support

- Adds `InputScope`, enter-key hint, capitalization, spellcheck, password, and multiline
  metadata for editable controls.
- Focused `TextBox` and `PasswordBox` controls configure a DOM text-input seam during
  the initiating user gesture so mobile browsers can display the software keyboard.
- DOM `beforeinput`, `input`, paste, and composition events become explicit insert,
  delete, line-break, composition-start/update/complete/cancel operations.
- Text insertion and deletion preserve surrogate pairs.
- IME previews replace the active composition range transactionally; cancellation
  restores the original selected text.
- Backspace, Delete, and Enter are not applied twice through both physical key and DOM
  text-edit paths.
- `VisualViewport`, the optional VirtualKeyboard geometry API, orientation changes, and
  CSS safe-area insets keep the canvas and hidden text seam usable while a keyboard is
  visible.
- The focused text seam retains its WinUI field bounds and recomputes its fixed DOM
  position whenever the visual viewport, canvas origin, orientation, or virtual-keyboard
  geometry changes; this does not reset focus or IME composition.

## WinUI controls and responsive layout

- Adds `VisualStateManager`, `VisualStateGroup`, `VisualState`, state setters,
  `StateTriggerBase`, and effective-pixel `AdaptiveTrigger` evaluation before layout.
- Evaluates adaptive states before measure in both the native WinUI window path and the
  Avalonia host path, so the same responsive setters apply regardless of desktop host.
- Matches WinUI trigger selection semantics: multiple triggers attached to one visual
  state are alternatives, so any active trigger can select that state.
- Adds WinUI `StackPanel.Spacing` without introducing per-layout scratch allocations;
  collapsed children do not contribute gaps.
- Adds `NavigationViewPaneDisplayMode`, `NavigationViewDisplayMode`, pane lengths,
  display-mode events, and the standard 641/1008 effective-pixel thresholds.
- Extends `ScrollViewer` with horizontal/vertical scroll modes, zoom mode, touch pan,
  pinch zoom, inertia, view-changing/view-changed events, and `ChangeView`.
- Scroll offsets and zoom are clamped transactionally, and original content transforms
  are restored when content is replaced.

## Touch interaction regression fixes

- Routes uncaptured move and release events through the current hit target while
  retaining the original press target only for gesture recognition. Touch over-state
  now follows the full visual path, so child visuals no longer prevent their owning
  `Button`, `CheckBox`, toggle, or dropdown control from activating on release.
- Excludes mouse contacts from default scroll manipulation recognition, waits for the
  touch/pen movement threshold, and lets explicit pointer capture own direct-control
  drags. Small desktop mouse jitter therefore cannot cancel a click.
- Defers touch/pen activation in `NavigationViewItem`, `TreeViewItem`, `ComboBox`, and
  `DataGrid` until a clean release. Starting a scroll cancels the pending action before
  it can select, expand, sort, edit, or open anything.
- Adds direct vertical touch manipulation and inertia to `DataGrid`, preserving tap row
  selection after scrolling finishes.
- Gives chart plot and zoom-slider interactions explicit pointer capture and adds
  cancellation cleanup across sliders, thumbs, scrollbars, text selection, color
  controls, and repeat buttons.
- Makes drag/drop pointer-owned instead of mouse-owned, so touch and pen contacts can
  carry toolbox items into the visual designer and cancellation cannot complete a drop
  from the wrong pointer.
- Normalizes Avalonia platform timestamps to microseconds, leaves browser paste
  insertion exclusively to the DOM text path, and adds the WinUI
  `IsPaneToggleButtonVisible` affordance so standalone minimal NavigationViews always
  retain a touch-accessible opener.
- Arranges a hidden NavigationView pane-toggle button to zero bounds, clearing stale
  hit-test geometry when the property changes after an earlier visible layout pass.
- Validates tap displacement again from the original press coordinate to the terminal
  release coordinate. A browser sequence that omits its final move therefore cannot
  activate a control after the finger has already crossed the touch threshold.

## Samples

- Makes the gallery header adaptive so secondary selectors and subtitle content collapse
  progressively on narrow windows.
- Keeps the NavigationView pane usable as a touch-scrollable overlay in minimal mode.
- Adds a reusable WinUI-aligned `ResponsiveSplitView` with an in-pane close button,
  compact-width overlay behavior, preserved wide-screen inline layout, and automatic
  viewport-bounded pane sizing.
- Moves the control/tool panes in the 3D mesh viewer, font glyph browser, text and
  documents, Markdown playground, framework effects, image effects, GDI shim, glyph
  runs, WPF shim, Compute FX, LOL/s, DXF viewer, picture caching, and ShaderToy samples
  into adaptive split panes. MotionMark and typography/script pages receive the same
  responsive presenter behavior where they use the shared sample page shell.
- Places Font Glyph Browser selected-glyph information in its collapsible left pane.
- Makes both Visual Designer tool/property panes independently collapsible and converts
  them to overlay panes at compact widths.
- Reflows the default 3D mesh viewer viewports below 720 effective pixels, keeps toolbar
  captions and mesh statistics on one line, and gives statistic values an adaptive
  star/auto grid rather than fixed columns that can stack characters on mobile.
- Adds a **Touch & Gestures** page demonstrating routed tap/double-tap/hold events,
  per-pointer capture, direct manipulation, pinch/rotation, touch scrolling, and mobile
  keyboard input scopes.
- Uses dynamic theme resources and retained drawing objects for the new sample visuals.

## WinUI text layout and iPhone text quality

- Adds WinUI `TextWrapping.WrapWholeWords` and makes `ContentPresenter` apply the
  control's wrapping/alignment contract to implicit text content, while preserving the
  explicit properties of supplied text elements.
- Makes rich-text measurement honor `NoWrap`, `Wrap`, and `WrapWholeWords` consistently,
  preventing buttons, labels, and data values from collapsing into one-character columns
  in compact panes.
- Keeps an unspaced token intact under `WrapWholeWords` (allowing it to overflow like
  WinUI) while ordinary `Wrap` retains character-level hard breaking when required.
- Fixes high-DPI text softness observed on iPhone. The previous large-glyph bucket
  rounded physical raster sizes to two-pixel increments: 11 DIP at DPR 3 requested
  33 px, was rasterized at 32 px, and was then magnified by 3.125%. UI glyphs now use
  their exact clamped physical size (for example 33, 34.5, and 36.75 px), so the atlas
  coverage is sampled 1:1 instead of being rescaled.
- Fixes the remaining Inter specimen blur at DPR 3. The 26-DIP weight samples request
  78 physical pixels and previously crossed the 64-pixel glyph-atlas ceiling. Their
  vector-path coverage was rasterized at the 26-pixel logical scale and magnified 3x.
  Vector glyph and color-layer path keys now include the effective DPI/static-zoom
  raster scale, and their quarter-pixel device phase is calculated in physical pixels.
- Keeps common mobile display text in the bounded glyph atlas through 128 physical
  pixels, so 26 DIP at DPR 3 receives exact 78-pixel coverage and viewport culling runs
  before residency. Exceptionally large, forced-vector, transformed, and CFF text still
  uses the device-scaled vector fallback.
- Culls offscreen vector glyphs and color layers before requesting path-atlas coverage.
  The fixed atlas dimensions, LRU/generation behavior, shaped glyph reuse, 128-phase
  local-position lattice, four device phases per axis, ten-bit scale quantization,
  retained-scene reuse, and demand-driven upload remain intact.
- Adds a DPR-3 GPU render regression for both regular and bold 11-DIP rich text, plus
  exact-size unit coverage for odd/fractional physical sizes, forced-vector thin-stem
  opacity coverage, and offscreen vector-glyph culling.

## Compatibility and performance

- Existing `InjectMouse*`, pointer positions, control overrides, drag/drop, popup, and
  keyboard behavior remain supported.
- Contact and recognition storage is per window and `O(P)` for `P` active pointers.
- Adaptive states do no property work when the selected state is unchanged.
- Browser event draining remains bounded at 256 records per batch and four batches per
  frame.
- Manipulations invalidate only the affected control; no unconditional root-per-frame
  invalidation was introduced.
- Exact physical glyph raster sizes increase key precision without changing the atlas's
  fixed memory bound or LRU eviction policy. Layout/shaping results and retained draw
  commands remain reusable across stable frames.
- DPI-scaled vector coverage changes only the bounded path-atlas key and raster work;
  final logical quad placement remains unsnapped and unchanged.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-restore`
  - 2,042 passed, 0 failed.
- `dotnet test src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj -c Release --no-restore`
  - 185 passed, 0 failed.
- `dotnet build src/ProGPU.Samples/ProGPU.Samples.csproj -c Release --no-restore`
  completed with 0 warnings and 0 errors.
- Release builds also completed for the Avalonia and browser hosts during the feature
  validation passes.
- A trimmed default WebAssembly AOT publish completed with 68 AOT-compiled assemblies
  and the documented mixed-mode `netDxf.netstandard` assembly. Existing
  dependency-property and third-party trim-analysis warnings remain unchanged.
- The final refreshed AOT artifact contains 69 managed/mixed-mode WebAssembly resources
  and a 23,692,169-byte native runtime/AOT module
  (`dotnet.native.2npetmw61x.wasm`, SHA-256
  `4e4e68beb2719bd5247957136c614fbecf4445ab0b6ebe12e66d62e7213de409`).
- A Chromium smoke run at 390 x 844 effective pixels verified:
  - stacked responsive layout and scrollable navigation/content;
  - DOM focus bridging into a ProGPU `TextBox`;
  - Unicode software-keyboard text delivery;
  - a touch Pointer Events sequence with stable ID, pressure, and contact dimensions;
  - no browser console errors.
- A second Chromium run against the refreshed Release AOT output at 1180 x 820 used
  trusted DevTools touch input to verify:
  - hamburger pane open/close;
  - pane gesture scrolling without navigation selection;
  - DataGrid touch/inertial scrolling without row selection, followed by tap selection;
  - chart-tab activation and chart direct-touch ownership;
  - button, checkbox, toggle-switch, and ComboBox dropdown activation;
  - visual-designer toolbox touch drag/drop creating and selecting a new control;
  - zero console errors.
- An iPhone 15-sized Chromium run at DPR 3 verified a 393 x 659 CSS-pixel viewport backed
  by a 1179 x 1977 physical-pixel canvas, sharper regular/bold text after the exact-size
  fix, single-line compact controls/statistics, and zero console errors or warnings.
- A second final-AOT Chromium run at DPR 3 verified an 1180 x 820 CSS-pixel viewport
  backed by a 3540 x 2460 physical-pixel canvas. Device-resolution inspection of the
  Inter 100/200 weight and italic rows showed crisp single-pixel stems with zero console
  errors or warnings.
- The refreshed final AOT also verified the two last review fixes: an email-scope field
  focused the DOM sink with `inputmode=email`; after shifting the canvas origin by 40
  pixels and dispatching a visual-viewport resize, the focused sink moved by exactly 40
  pixels and preserved its 448.65625-pixel canvas-relative position. A trusted fast
  touch start/move/end sequence retained `ScrollViewer` ownership, and the browser
  reported zero errors or warnings.
- The post-review Release AOT rebuild at 1180 x 820 initialized WebGPU successfully,
  exposed the canvas keyboard-input seam, rendered to an exactly matching physical
  canvas at DPR 1, and reported zero console errors or warnings.
- A 300-frame uncapped DPR-3 scrolling Inter Typeface benchmark improved from 337.53 to
  644.33 wall FPS. Average compilation fell from 2.0887 to 0.9170 ms, compositor time
  from 2.2817 to 0.9983 ms, render time from 0.1307 to 0.0573 ms, and the maximum compile
  remained below budget (10.0 ms, 0 over-budget frames). Visible work shifted from
  1,548 vector / 469 text vertices to 460 vector / 788 text vertices as exact device-size
  specimens stayed in the glyph atlas.
- The isolated no-scroll AOT comparison preserved steady-state behavior: 965.87 versus
  953.59 wall FPS, 27,832 versus 27,975 allocated bytes/frame, and 299/300 compiled-scene
  cache hits in both final and baseline runs. The scrolling pass performs bounded
  first-visibility glyph rasterization for higher-quality physical coverage; stable
  replay remains allocation-neutral relative to baseline.
- `node --check src/ProGPU.Browser/BrowserAssets/progpu-browser.js`
- `git diff --check`

## Rendering and text architecture research

The text-quality change was gated against primary documentation/source from current
production and research engines:

- **Skia / SkParagraph**: strike specifications key glyph caches by concrete device
  font/scaler state, while the text stack keeps shaping/layout separate from raster
  caching and retained drawing. `SkScalerContext` distinguishes logical text size from
  the real device size represented by its total device matrix. Sources:
  [SkStrikeSpec](https://skia.googlesource.com/skia/+/main/src/core/SkStrikeSpec.cpp),
  [`SkScalerContext`](https://skia.googlesource.com/skia/+/c6e63919c318/src/core/SkScalerContext.h),
  [Skia text design](https://skia.org/docs/dev/design/text_c2d/), and
  [rendering tips](https://skia.org/docs/user/tips/).
- **DirectWrite / Direct2D / Win2D**: layout and glyph-run analysis remain reusable CPU
  results, while rasterization receives pixels-per-DIP and the current transform so
  coverage is generated for actual device pixels. Sources:
  [Direct2D and DirectWrite](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-and-directwrite),
  [Direct2D high DPI](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-and-high-dpi),
  [`GetPixelsPerDip`](https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritepixelsnapping-getpixelsperdip),
  [`CreateGlyphRunAnalysis`](https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritefactory-createglyphrunanalysis),
  [`IDWriteGlyphRunAnalysis`](https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nn-dwrite-idwriteglyphrunanalysis),
  [Win2D `CanvasTextLayout`](https://microsoft.github.io/Win2D/WinUI2/html/T_Microsoft_Graphics_Canvas_Text_CanvasTextLayout.htm), and
  [Win2D antialiasing](https://microsoft.github.io/Win2D/WinUI2/html/T_Microsoft_Graphics_Canvas_Text_CanvasTextAntialiasing.htm).
- **WebRender**: retained display lists feed a resource cache and glyph rasterizer;
  visibility and uploads are demand driven and texture-cache generations validate GPU
  resources. Its rendering overview explicitly maps world coordinates through a
  DPI-aware world-to-device transform and rasterizes text at final scale for simple
  transforms. Sources:
  [WebRender rendering overview](https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst),
  [WebRender architecture](https://doc.servo.org/webrender/),
  [glyph rasterizer](https://doc.servo.org/wr_glyph_rasterizer/index.html), and
  [resource cache source](https://docs.rs/webrender/latest/src/webrender/resource_cache.rs.html).
- **Vello / Glifo / Parley**: cache keys include font identity, size, variations, and
  transform-related state; Parley owns shaping/layout while Vello performs retained GPU
  rendering. Sources: [Glifo atlas key](https://skia.googlesource.com/external/github.com/linebender/vello/+/refs/heads/gh-readonly-queue/main/pr-1628-da3f40e73685e9fdf12f0307d8e6d3f8c93dbbd1/glifo/src/atlas/key.rs),
  [Vello](https://github.com/linebender/vello),
  [Vello glyph rendering plan](https://github.com/linebender/vello/issues/204), and
  [Parley](https://github.com/linebender/parley).
- **HarfBuzz**: Unicode/OpenType shaping produces reusable glyph IDs, advances,
  positions, clusters, fallback/variation-sensitive results, and intentionally does not
  own device rasterization. Source: [HarfBuzz](https://github.com/harfbuzz/harfbuzz).

ProGPU adopts the shared separation: lazy font discovery; reusable HarfBuzz/OpenType
shaping and line layout; retained scene/display-list reuse; viewport culling;
font/style/size/subpixel/transform-sensitive bounded atlas keys; demand-driven upload;
GPU batching/rasterization; and atlas-generation invalidation after reset or device
loss. Font fallback and variable-font state continue to be resolved before raster-cache
lookup. Worker preparation and full GPU shaping were rejected for this fix because they
would expand scope without addressing the measured scaling defect. The adopted changes
preserve exact physical size for ordinary glyph coverage, pass effective DPI into the
bounded vector-coverage cache, retain device-space phase quantization, and cull before
residency. This matches the device-space coverage and visibility-first models used by
the compared engines without moving shaping or layout onto the GPU.

## Input, responsive-layout, and browser design references

The implementation follows the current primary guidance for:

- WinUI pointer input and touch interactions:
  https://learn.microsoft.com/en-us/windows/apps/develop/input/handle-pointer-input
  and https://learn.microsoft.com/en-us/windows/apps/develop/input/touch-interactions
- WinUI routed gestures and manipulation concepts:
  https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.tapped
  and https://learn.microsoft.com/en-us/uwp/api/windows.ui.input.gesturerecognizer
- WinUI responsive layouts and NavigationView:
  https://learn.microsoft.com/en-us/windows/apps/develop/ui/layouts-with-xaml
  and https://learn.microsoft.com/en-us/windows/apps/develop/ui/controls/navigationview
- W3C Pointer Events, Input Events, and VirtualKeyboard APIs:
  https://www.w3.org/TR/pointerevents3/,
  https://www.w3.org/TR/input-events-2/, and
  https://w3c.github.io/editing/docs/virtualkeyboard/

The detailed implementation plan and adopted/rejected architecture decisions are in
`docs/TOUCH_GESTURES_RESPONSIVE_PLAN.md`.
