### PR TITLE
Run OpenType GPU shaping CI on macOS 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           - os: ubuntu-latest
             rid: linux-x64
             native_output: src/ProGPU.Tests/bin/Release/net10.0/linux-x64
-          - os: macos-15
+          - os: macos-26
             rid: osx-arm64
             native_output: src/ProGPU.Tests/bin/Release/net10.0/osx-arm64
           - os: windows-latest

--- a/.github/workflows/svg-skia-parity.yml
+++ b/.github/workflows/svg-skia-parity.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   image-parity:
     name: Native and ProGPU image parity
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 45
 
     steps:

--- a/eng/progpu-verify-svg-skia-results.ps1
+++ b/eng/progpu-verify-svg-skia-results.ps1
@@ -71,6 +71,6 @@ if ($difference.Count -ne 0) {
 }
 
 Assert-Counts $native 533 530 0 3 'Native W3C'
-Assert-Counts $progpu 533 484 46 3 'ProGPU W3C'
+Assert-Counts $progpu 533 485 45 3 'ProGPU W3C'
 
-Write-Host "Svg.Skia W3C parity inventory verified: native 530/533 with 3 skips; ProGPU 484/533 with 46 reviewed differences and 3 skips."
+Write-Host "Svg.Skia W3C parity inventory verified: native 530/533 with 3 skips; ProGPU 485/533 with 45 reviewed differences and 3 skips."

--- a/eng/svg-skia-w3c-known-differences.txt
+++ b/eng/svg-skia-w3c-known-differences.txt
@@ -36,7 +36,6 @@ text-fonts-03-t
 text-fonts-04-t
 text-fonts-05-f
 text-intro-01-t
-text-intro-04-t
 text-intro-11-t
 text-text-01-b
 text-text-10-t

--- a/src/ProGPU.Tests/ShapingContractsTests.cs
+++ b/src/ProGPU.Tests/ShapingContractsTests.cs
@@ -9,8 +9,15 @@ using Xunit;
 
 namespace ProGPU.Tests;
 
-public sealed class ShapingContractsTests
+public sealed class ShapingContractsTests : IClassFixture<ShapingGpuFixture>
 {
+    private readonly ShapingGpuFixture _gpu;
+
+    public ShapingContractsTests(ShapingGpuFixture gpu)
+    {
+        _gpu = gpu;
+    }
+
     [Fact]
     public void OpenTypeTagRoundTripsFontByteOrder()
     {
@@ -391,10 +398,9 @@ public sealed class ShapingContractsTests
     {
         var face = new TtfShapingFontFace(InterFontFamily.Regular);
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.InitializeRun(
@@ -464,10 +470,9 @@ public sealed class ShapingContractsTests
     {
         var face = new TtfShapingFontFace(InterFontFamily.Regular);
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -490,10 +495,9 @@ public sealed class ShapingContractsTests
     {
         var face = new TtfShapingFontFace(InterFontFamily.Regular);
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -513,10 +517,9 @@ public sealed class ShapingContractsTests
     {
         var face = new KhmerShapingFontFace();
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var consonant = new ShapingBuffer();
         using var broken = new ShapingBuffer();
         using var splitMatra = new ShapingBuffer();
@@ -561,10 +564,9 @@ public sealed class ShapingContractsTests
             new(1, table + 48, 1, 0, new OpenTypeTag("fina").Value, 1),
             new(1, table + 70, 1, 0, new OpenTypeTag("isol").Value, 1)
         ];
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var joined = new ShapingBuffer();
         using var transparent = new ShapingBuffer();
 
@@ -600,10 +602,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(mirroredText, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var mirrored = new ShapingBuffer();
         using var reordered = new ShapingBuffer();
 
@@ -649,10 +650,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] interCommands = GpuOpenTypeLookupPlanCompiler.Compile(interPlan, request);
         using var expectedComposed = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape("e\u0301", interFace, request, expectedComposed);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var interData = new GpuOpenTypeFontData(context, interPlan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actualComposed = new ShapingBuffer();
         pipeline.ExecuteRun(
             [new GpuShapingScalar('e', 0), new GpuShapingScalar(0x0301, 0)],
@@ -689,11 +689,10 @@ public sealed class ShapingContractsTests
             new(1, table + 4, 1, 0, new OpenTypeTag("ljmo").Value, 1),
             new(1, table + 26, 1, 0, new OpenTypeTag("vjmo").Value, 1)
         ];
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var composedData = new GpuOpenTypeFontData(context, composedPlan);
         using var jamoData = new GpuOpenTypeFontData(context, jamoPlan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var composed = new ShapingBuffer();
         using var jamo = new ShapingBuffer();
         using var decomposed = new ShapingBuffer();
@@ -743,10 +742,9 @@ public sealed class ShapingContractsTests
         var face = new ThaiShapingFontFace();
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
         var request = new ShapingRequest(ShapingDirection.LeftToRight, new OpenTypeTag("thai"), language: "th");
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -767,10 +765,9 @@ public sealed class ShapingContractsTests
     {
         var face = new TtfShapingFontFace(InterFontFamily.Regular);
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -790,10 +787,9 @@ public sealed class ShapingContractsTests
     {
         var face = new UseDiacriticFontFace();
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -814,10 +810,9 @@ public sealed class ShapingContractsTests
     {
         var face = new TtfShapingFontFace(InterFontFamily.Regular);
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -855,10 +850,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand command = Assert.Single(
             GpuOpenTypeLookupPlanCompiler.Compile(plan, request),
             static value => value.FeatureTag == new OpenTypeTag("ltrm").Value);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -874,10 +868,9 @@ public sealed class ShapingContractsTests
     {
         var face = new TtfShapingFontFace(InterFontFamily.Regular);
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -904,10 +897,9 @@ public sealed class ShapingContractsTests
         var face = new IndicShapingFontFace();
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
         var request = new ShapingRequest(ShapingDirection.LeftToRight, new OpenTypeTag("deva"));
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
 
         foreach ((string Text, uint[] Expected) item in new[]
                  {
@@ -944,10 +936,9 @@ public sealed class ShapingContractsTests
             static value => value.FeatureTag == new OpenTypeTag("locl").Value);
         Assert.Equal(2u, command.CommandFlags & 0x0eu);
 
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         GpuShapingScalar[] input =
         [
             new GpuShapingScalar(0x0915, 0),
@@ -1061,10 +1052,9 @@ public sealed class ShapingContractsTests
 
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
         pipeline.ExecuteRun(
             text.Select((character, index) => new GpuShapingScalar(character, index)).ToArray(),
@@ -1091,10 +1081,9 @@ public sealed class ShapingContractsTests
         commands = commands.Where(command => command.FeatureTag == new OpenTypeTag("ss01").Value).ToArray();
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape("33", face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1117,10 +1106,9 @@ public sealed class ShapingContractsTests
         (uint lookupOffset, uint inputGlyph, uint expectedGlyph) = FindSingleSubstitution(plan);
         uint codePoint = FindCodePoint(plan, inputGlyph);
         Assert.NotEqual(uint.MaxValue, codePoint);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var output = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1148,10 +1136,9 @@ public sealed class ShapingContractsTests
             new GpuShapingScalar(character, index)).ToArray();
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(input, fontData, request.Direction, commands, actual);
@@ -1174,10 +1161,9 @@ public sealed class ShapingContractsTests
             new GpuShapingScalar(character, index)).ToArray();
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(input, fontData, request.Direction, commands, actual);
@@ -1195,10 +1181,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1216,10 +1201,9 @@ public sealed class ShapingContractsTests
     {
         var face = new FallbackMarkFontFace();
         GpuOpenTypeShapingPlan plan = GpuOpenTypeShapingPlanCompiler.Compile(face);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1244,10 +1228,9 @@ public sealed class ShapingContractsTests
         var request = new ShapingRequest(ShapingDirection.RightToLeft, new OpenTypeTag("arab"));
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         Assert.Contains(commands, static command => command.FeatureTag == new OpenTypeTag("stch").Value);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1273,10 +1256,9 @@ public sealed class ShapingContractsTests
         var request = new ShapingRequest(ShapingDirection.RightToLeft, new OpenTypeTag("arab"));
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         Assert.Contains(commands, static command => command.TableKind == 4);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1310,10 +1292,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1341,10 +1322,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1374,10 +1354,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1414,10 +1393,9 @@ public sealed class ShapingContractsTests
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         using var expected = new ShapingBuffer();
         CpuOpenTypeShaper.Instance.Shape(text, face, request, expected);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun([new GpuShapingScalar(0x200d, 0)], fontData, request, commands, actual);
@@ -1437,10 +1415,9 @@ public sealed class ShapingContractsTests
             ShapingDirection.LeftToRight,
             OpenTypeTag.DefaultScript,
             flags: ShapingBufferFlags.PreserveDefaultIgnorables);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -1464,10 +1441,9 @@ public sealed class ShapingContractsTests
         var request = new ShapingRequest(ShapingDirection.LeftToRight, OpenTypeTag.DefaultScript);
         GpuOpenTypeLookupCommand[] commands = GpuOpenTypeLookupPlanCompiler.Compile(plan, request);
         Assert.Contains(commands, command => command.TableKind == 3);
-        using var context = new WgpuContext();
-        context.Initialize(null);
+        WgpuContext context = _gpu.Context;
         using var fontData = new GpuOpenTypeFontData(context, plan);
-        using var pipeline = new GpuOpenTypeRunPipeline(context);
+        GpuOpenTypeRunPipeline pipeline = _gpu.Pipeline;
         using var actual = new ShapingBuffer();
 
         pipeline.ExecuteRun(
@@ -2252,4 +2228,41 @@ public sealed class ShapingContractsTests
         (ushort)(data[offset] << 8 | data[offset + 1]);
 
     private static ShapingGlyph Glyph(uint glyphId) => new() { GlyphId = glyphId };
+}
+
+public sealed class ShapingGpuFixture : IDisposable
+{
+    private readonly Lazy<Resources> _resources = new(CreateResources);
+
+    public WgpuContext Context => _resources.Value.Context;
+
+    public GpuOpenTypeRunPipeline Pipeline => _resources.Value.Pipeline;
+
+    public void Dispose()
+    {
+        if (_resources.IsValueCreated)
+            _resources.Value.Dispose();
+    }
+
+    private static Resources CreateResources()
+    {
+        var context = new WgpuContext();
+        context.Initialize(null);
+        return new Resources(context, new GpuOpenTypeRunPipeline(context));
+    }
+
+    private sealed class Resources(
+        WgpuContext context,
+        GpuOpenTypeRunPipeline pipeline) : IDisposable
+    {
+        public WgpuContext Context { get; } = context;
+
+        public GpuOpenTypeRunPipeline Pipeline { get; } = pipeline;
+
+        public void Dispose()
+        {
+            Pipeline.Dispose();
+            Context.Dispose();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Run the primary macOS build and test lane on the current macOS 26 ARM64 image.
- Run Svg.Skia parity on macOS 26 and refresh its audited inventory for one newly passing fixture.
- Reuse one lazily initialized WebGPU context and OpenType run pipeline across the shaping contract test class while retaining per-test font buffers and outputs.

## Root cause

The expanded OpenType contextual-substitution compute pipeline fails to compile with the Metal compiler on the pinned macOS 15 runner. The same shader passes on macOS 26 ARM64. Pinning the workflows to the current image removes the obsolete compiler constraint, while sharing the test pipeline avoids unnecessary recompilation and more closely models its production lifetime.

The runner update also makes `text-intro-04-t` pass in the Svg.Skia W3C comparison, reducing the reviewed difference inventory from 46 to 45.

## Validation

- GitHub-hosted macOS 26 build and test: passed
- Shaping contract suite: 66 passed locally on macOS 26 ARM64
- macOS ARM64 core suite: 2,181 passed locally
- macOS ARM64 headless suite: 192 passed locally
- Svg.Skia inventory verifier passes against the macOS 26 artifacts: native 530/533, ProGPU 485/533, 45 reviewed differences, 3 skips
- actionlint passes for both changed workflows