### PR TITLE
feat: add playable voxel engine and Minecraft-style game

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,8 @@
     <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.Android'">true</IsPackable>
     <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.iOS'">true</IsPackable>
     <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.Scene'">true</IsPackable>
+    <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.Voxel'">true</IsPackable>
+    <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.Voxel.WinUI'">true</IsPackable>
     <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.Layout'">true</IsPackable>
     <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.Virtualization'">true</IsPackable>
     <IsPackable Condition="'$(MSBuildProjectName)' == 'ProGPU.WinUI'">true</IsPackable>

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ intentionally not packed.
 | `ProGPU.Fonts.Inter` | Official Inter font assets and typed accessors for deterministic UI typography. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Fonts.Inter.svg)](https://www.nuget.org/packages/ProGPU.Fonts.Inter/) |
 | `ProGPU.Fonts.Noto` | Official Noto fallback assets and typed accessors for CJK and symbol coverage. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Fonts.Noto.svg)](https://www.nuget.org/packages/ProGPU.Fonts.Noto/) |
 | `ProGPU.Scene` | Scene graph, compositor commands, retained visuals, effects, and presentation primitives. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Scene.svg)](https://www.nuget.org/packages/ProGPU.Scene/) |
+| `ProGPU.Voxel` | Chunked voxel worlds, greedy meshing, collision, terrain generation, and grid ray casting. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Voxel.svg)](https://www.nuget.org/packages/ProGPU.Voxel/) |
 | `ProGPU.Layout` | Measure/arrange layout substrate shared by higher-level UI adapters. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Layout.svg)](https://www.nuget.org/packages/ProGPU.Layout/) |
 | `ProGPU.Virtualization` | Virtualization helpers for large retained visual and item surfaces. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Virtualization.svg)](https://www.nuget.org/packages/ProGPU.Virtualization/) |
 | `ProGPU.WinUI` | WinUI-shaped controls and app model implemented on ProGPU. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.WinUI.svg)](https://www.nuget.org/packages/ProGPU.WinUI/) |
+| `ProGPU.Voxel.WinUI` | Playable WinUI voxel control with first-person input and retained ProGPU rendering. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.Voxel.WinUI.svg)](https://www.nuget.org/packages/ProGPU.Voxel.WinUI/) |
 | `ProGPU.WinUI.Themes.Fluent` | Source-generated unchanged WinUI Fluent theme resources and inspectable XAML content. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.WinUI.Themes.Fluent.svg)](https://www.nuget.org/packages/ProGPU.WinUI.Themes.Fluent/) |
 | `ProGPU.WinUI.Charts` | Chart controls and chart rendering primitives for the WinUI-shaped layer. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.WinUI.Charts.svg)](https://www.nuget.org/packages/ProGPU.WinUI.Charts/) |
 | `ProGPU.WinUI.Designer` | Designer/editor controls and diagnostics for ProGPU WinUI surfaces. | [![NuGet](https://img.shields.io/nuget/vpre/ProGPU.WinUI.Designer.svg)](https://www.nuget.org/packages/ProGPU.WinUI.Designer/) |
@@ -71,7 +73,7 @@ contracts. Until native binaries are distributed independently, applications set
 `ProGpuWgpuNativeAndroidRoot` or `ProGpuWgpuNativeXCFramework` to outputs from the
 repository's pinned wgpu-native build scripts before deployment.
 Packing the complete set requires macOS with the Android and iOS workloads;
-`PROGPU_PACKAGE_GROUP=portable` packs the 29 cross-platform packages on Linux.
+`PROGPU_PACKAGE_GROUP=portable` packs the 31 cross-platform packages on Linux.
 
 ## Native iPhone WebGPU sample
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,9 +19,11 @@ from `scripts/progpu-package-list.sh`.
 - `ProGPU.Fonts.Inter`
 - `ProGPU.Fonts.Noto`
 - `ProGPU.Scene`
+- `ProGPU.Voxel`
 - `ProGPU.Layout`
 - `ProGPU.Virtualization`
 - `ProGPU.WinUI`
+- `ProGPU.Voxel.WinUI`
 - `ProGPU.WinUI.Themes.Fluent`
 - `ProGPU.WinUI.Charts`
 - `ProGPU.WinUI.Designer`

--- a/docs/voxel-engine-architecture.md
+++ b/docs/voxel-engine-architecture.md
@@ -1,0 +1,223 @@
+# ProGPU voxel engine architecture
+
+Status: first playable vertical slice, 25 July 2026.
+
+## Decision
+
+ProGPU's existing `Viewport3D`, `MeshGeometry3D`, OBJ reader, camera matrices, and
+`Mesh3DExtensionPipeline` remain the right API for arbitrary imported and modeled
+objects. The voxel engine reuses the lower-level ProGPU infrastructure:
+
+- compositor extension lifecycle and offscreen texture composition;
+- physical-pixel render targets, depth/MSAA policy, `GpuBuffer`, `GpuTexture`,
+  `RenderPipelineCache`, and `ShaderResource`;
+- the same `RenderCommand`/compiled-scene integration and matrix conventions;
+- the normal visual animation update phase and typed WinUI input events.
+
+The generic mesh pipeline is deliberately not the voxel hot path. It de-indexes every
+mesh, uploads generic per-model material records during compilation, uses an OBJ-shaped
+object model, and submits orbit-camera interactions. A block world needs editable dense
+chunk storage, neighbor-aware surface extraction, indexed packed vertices, versioned
+chunk uploads, first-person collision, grid ray queries, and visibility-driven chunk
+submission. Adding those concerns to `MeshGeometry3D` would make both APIs less clear.
+
+The resulting package boundary is:
+
+```text
+ProGPU.Voxel
+  block data -> sparse world -> dirty chunks -> greedy indexed meshes
+       |              |               |              |
+       +---------- player/collision and grid DDA -----+
+
+ProGPU.Voxel.WinUI
+  background generation -> frame simulation -> frustum-visible render payload
+
+ProGPU.Scene
+  VoxelTerrainExtensionPipeline -> versioned visible-geometry arena -> pure WGSL shading
+```
+
+`ProGPU.Voxel` has no UI or GPU dependency. A server, editor, test runner, or another
+frontend can use the same world, mesh, collision, and ray APIs.
+
+## Clean-room research record
+
+No foreign implementation source was copied, ported, translated, or used as a file or
+control-flow template. The implementation was written against public contracts,
+algorithm descriptions, and independently designed ProGPU types.
+
+Primary sources examined:
+
+- The [WebGPU specification](https://gpuweb.github.io/gpuweb/) and
+  [WGSL specification](https://www.w3.org/TR/WGSL/) define vertex/index/storage buffer
+  usage, render passes, resource binding, shader layout, and direct indexed draws.
+- The [W3C Pointer Lock 2.0 specification](https://www.w3.org/TR/pointerlock-2/)
+  defines the user-activated browser capture lifecycle, `movementX`/`movementY`,
+  and `pointerlockchange` used by the first-person input host. Desktop follows
+  Silk.NET's typed `CursorMode.Raw` capability contract and falls back to
+  `CursorMode.Disabled`; browser uses the broadly supported baseline lock request
+  because unadjusted motion is an optional capability.
+- Mozilla's [WebRender rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html)
+  describes display-list to scene to culled-frame separation and demand preparation of
+  GPU resources.
+- Skia's [canvas creation documentation](https://skia.org/docs/user/api/skcanvas_creation/)
+  describes backend-owned surfaces and GPU-context resource caches; the
+  [SkCanvas overview](https://skia.org/docs/user/api/skcanvas_overview/) keeps draw
+  state explicit at call sites.
+- Microsoft's [retained versus immediate mode](https://learn.microsoft.com/en-us/windows/win32/learnwin32/retained-mode-versus-immediate-mode)
+  guidance informed the retained world plus explicit frame-payload boundary.
+  [Direct2D and DirectWrite](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-and-directwrite)
+  explicitly recommend reusing prepared glyph positions instead of recomputing layout;
+  ProGPU applies the same prepare-on-change rule to chunk meshes.
+- [Vello](https://github.com/linebender/vello) separates scene encoding from WebGPU
+  context setup and moves bounded parallel work to GPU shaders.
+- [Parley](https://github.com/linebender/parley) and the
+  [HarfBuzz shaping model](https://harfbuzz.github.io/shaping-concepts.html) preserve
+  reusable semantic CPU results. They informed the decision to keep HUD text in
+  ProGPU's existing shaping stack rather than creating text in the voxel shader.
+- Mikola Lysenko's algorithm analysis,
+  [Meshing in a Minecraft Game](https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/)
+  and [part 2](https://0fps.net/2012/07/07/meshing-minecraft-part-2/), defines the
+  observable greedy rectangle-merging problem and its linear voxel-volume cost.
+- Amanatides and Woo's
+  [A Fast Voxel Traversal Algorithm](https://physique.cmaisonneuve.qc.ca/svezina/projet/ray_tracer/download/A_Fast_Voxel_Traversal_Algorythm_For_Ray_Tracing.pdf)
+  defines incremental uniform-grid traversal used by block targeting.
+- Godot's [MultiMesh optimization guidance](https://docs.godotengine.org/en/stable/tutorials/performance/using_multimesh.html)
+  documents the batching-versus-culling tradeoff. ProGPU batches geometry per chunk so
+  a chunk remains the visibility and update unit.
+- Unreal Engine's
+  [Nanite virtualized geometry overview](https://dev.epicgames.com/documentation/en-us/unreal-engine/nanite-virtualized-geometry-in-unreal-engine)
+  motivates visible-detail work, compressed internal geometry, fine-grained streaming,
+  and avoiding object-count-scaled CPU work. Nanite's mesh-cluster format itself was
+  rejected because cubic editable terrain and baseline WebGPU have different constraints.
+
+## Cross-engine comparison
+
+| Concern | Production/research pattern | ProGPU decision |
+|---|---|---|
+| Startup and lazy initialization | Skia/Vello separate GPU context setup from scene description; WebRender prepares a frame from a larger scene. | World generation and initial meshing run on a worker. Shaders, pipelines, bind groups, textures, and GPU chunk buffers are created on first visible use. |
+| Reusable layout/scene results | DirectWrite caches glyph positions; HarfBuzz/Parley preserve shaped/layout results; WebRender retains a scene. | Block data is authoritative, each chunk owns a mesh generation, and unchanged mesh arrays/GPU buffers are reused. |
+| Visibility culling | WebRender culls scene to frame; Nanite limits work to visible detail; Godot notes whole-batch culling limits. | CPU homogeneous-clip frustum and distance tests select chunks. Individual blocks are not scene objects. |
+| Cache keys and eviction | Skia keys GPU resources; WebRender uses resource caches; Nanite streams fine-grained data. | Stable transfer-geometry identity, mesh generation, origin, and visible ordering key a packed vertex/index arena. Current demo residency is bounded by generated chunks; streaming worlds will add explicitly budgeted arena pages. |
+| Demand-driven upload | WebRender prepares only resources needed by a frame. | Only visible chunks enter the payload; only new or changed generations upload. |
+| Worker preparation | WebRender scene building and production engines move reusable preparation away from presentation. | Terrain generation and initial greedy meshing are worker-owned. Interactive single-chunk remesh is synchronous today because a 16³ chunk is bounded; a scheduler seam is planned for streaming. |
+| GPU organization | Vello uses GPU compute where parallelism wins; WebGPU exposes explicit render resources; Godot batches instances. | WGSL handles transforms, procedural texels, lighting, selection, water motion, and fog. CPU meshing remains cheaper and simpler for small editable chunks. Chunk origins and indices are baked into a visible-geometry arena for one indexed terrain draw. |
+| DPI/subpixel/hinting | Skia, DirectWrite, HarfBuzz, and Parley keep text-specific DPI and shaping behavior. | The 3D framebuffer uses physical pixels. HUD text remains in ProGPU.Text; voxel geometry does not invent a text or snapping path. |
+| Fallback fonts and variable fonts | HarfBuzz/Parley/DirectWrite treat fallback and variation state as shaping inputs. | Unchanged and deliberately outside the voxel renderer. The sample uses the existing application font stack. |
+| Device loss and invalidation | GPU engines recreate device-owned caches while preserving CPU scene data. | The world and chunk meshes are CPU-owned. The compositor extension owns and disposes GPU buffers; texture recreation is size/sample aware. Full device-loss replay can rebuild every GPU resource from retained mesh arrays. |
+
+## Implemented API and cost model
+
+- `VoxelWorld`: sparse `Dictionary<VoxelChunkPosition, VoxelChunk>` storage. Average
+  block get/set is O(1). Boundary edits invalidate both participating chunks.
+- `VoxelChunk`: fixed 16³ `ushort` storage, O(1) mutation, explicit content and mesh
+  generations.
+- `VoxelGreedyMesher`: three-axis, slice-mask rectangle merging. Work is
+  O(3 × 17 × 16²), temporary storage is O(16²), and output is O(Q) for Q merged quads.
+- `VoxelRaycaster`: uniform-grid DDA, O(K) for K crossed cells, O(1) storage.
+- `VoxelPlayerController`: axis-separated AABB collision, fixed small overlap query per
+  movement axis.
+- `RelativePointerCapture`: ProGPU-specific first-person input extension outside the
+  `Microsoft.UI.Xaml` namespace. Desktop uses Silk raw mouse mode with a disabled-cursor
+  fallback; browser uses the Pointer Lock API and summed coalesced motion. Capture ends
+  on Escape, host focus loss, unload, or a platform-initiated lock loss without adding
+  non-WinUI members to `PointerRoutedEventArgs`.
+- `VoxelFrustum`: conservative eight-corner homogeneous clip test, fixed O(1) work.
+- `VoxelTerrainExtensionPipeline`: two power-of-two GPU arenas for visible indexed
+  geometry, generation/origin/order-sensitive repacking, no per-chunk storage buffer,
+  exact uniform change detection, and one indexed terrain draw. Stable frames perform
+  no geometry or uniform upload. Repacking is O(V + I) when an edit or visibility
+  change alters the arena, for V vertices and I indices.
+- `VoxelGameView`: background deterministic terrain generation, first-person movement,
+  click-to-capture continuous mouse look, immediate left-button mining/right-button
+  placement, wheel and number-key hotbar selection, Escape release, seven block
+  materials, selection highlighting, physical-pixel depth/MSAA targets, procedural WGSL
+  surface detail, directional light, and fog.
+
+The WGSL module is embedded and loaded through `ShaderResource`. Its header documents
+algorithm, time, and space complexity. It performs no texture fetches: the first slice
+uses deterministic procedural block texels so the sample has no copied or licensed game
+assets.
+
+## Validation and next engine tiers
+
+The focused tests cover negative chunk coordinates, indexed greedy output, full-chunk
+surface collapse, material merge boundaries, cross-chunk invalidation, DDA targeting,
+player collision, frustum rejection, and deterministic generation.
+
+Release measurements on 25 July 2026 used arm64 macOS binaries, seed 1337, and a
+radius-three world. Desktop measurements used a fresh process, 180 warmup frames and
+600 measured frames with VSync disabled unless noted:
+
+| Measurement | Result |
+|---|---|
+| Generated world | 72 chunks, 191,696 solid blocks |
+| CPU generation | 2.283 ms median over five iterations |
+| Initial greedy meshing | 12.954 ms median over five iterations |
+| Surface reduction | 30,776 visible block faces to 4,545 merged quads, an 85.23% reduction |
+| Retained mesh payload | 18,180 vertices, 27,270 indices, 545,400 bytes |
+| Final desktop Release | 2.073 ms average total frame, 12.167 ms maximum, zero frames over 16.67 ms |
+| Final desktop steady allocation | 1,307 managed bytes per complete gallery frame; no measured GC collections or pause |
+| Browser Release AOT publish | 83 assemblies processed; both voxel assemblies compiled to WebAssembly AOT |
+| Real Chromium WebGPU smoke | 72 chunks rendered; selection, movement, relative pointer-lock look, targeting, and block clicks exercised; zero console errors or warnings |
+
+The final input build was republished and rerun after correcting the right-handed
+`CreateLookAt` horizontal convention. A 60-frame warmup plus 300-frame desktop
+NativeAOT run measured 5.6202 ms average total frame time, 17.7037 ms maximum,
+0.3841 ms average compilation, 1,117 managed bytes per frame, and zero GC
+collections. The focused input suite passed 39 relative-pointer/touch tests and all
+11 voxel tests, including explicit screen-right strafe and mouse-yaw sign
+regressions. The browser AOT artifact was then loaded in Chromium with zero console
+errors or warnings; a physical click acquired Pointer Lock and Escape released it.
+
+### Xcode Instruments profile and optimization
+
+The desktop profile used Xcode 16 `xctrace` Time Profiler and Game Memory against the
+same Release executable and benchmark window. The retained trace artifacts are ignored
+build outputs under `artifacts/voxel-instruments`; `tools/profile-voxel-instruments.sh`
+reproduces the captures.
+
+Game Memory exposed two costs that the managed allocation counter could not show:
+28 separately rounded 128 KiB vertex buffers plus 28 separately rounded 128 KiB index
+buffers for the visible chunks, and a per-frame WebGPU staging stream caused by
+rewriting unchanged records/uniforms. The first optimization packed chunk geometry into
+two arenas, changed the depth target from `Depth32Float_Stencil8` to `Depth24Plus`,
+and stopped stable uniform updates when the world has no animated water.
+
+| Instruments measurement | Before | Shared arenas | Change |
+|---|---:|---:|---:|
+| Voxel vertex buffers | 3,473,408 B / 28 resources | 278,528 B / 1 resource | -92.0% |
+| Voxel index buffers | 3,670,016 B / 28 resources | 65,536 B / 1 resource | -98.2% |
+| Depth target at 2028×1180 | 12,845,056 B | 10,092,544 B | -21.4% |
+| Labelled voxel render resources | 30.34 MB | 20.79 MB | -31.5% |
+| WebGPU staging activity over the trace | 7,093 writes / 865.44 MB | 5,516 / 658.98 MB | -22.2% writes, -23.8% bytes |
+| `MTLDevice.currentAllocatedSize` peak | 89,751,552 B | 87,179,264 B | -2,572,288 B |
+
+The second optimization removed the remaining 128 KiB chunk-record storage buffer,
+baked chunk origins and base indices into the arena, removed the shader storage lookup,
+and collapsed 28 visible-chunk calls to one indexed terrain draw. The final Time
+Profiler run reported 0.246 ms compilation, 0.438 ms compositor time, 1.981 ms total
+frame time, 11.0 ms maximum, 1,172 managed bytes/frame, and zero missed frame budgets.
+An independent final run reported 0.212 ms compilation and 0.371 ms compositor time;
+the spread is expected from macOS surface acquisition and profiler overhead, so both
+runs are retained rather than selecting only the fastest result.
+
+The browser run also exposed a deferred Fluent-theme module-constructor edge in the
+trimmed AOT startup path. `FluentThemeResources` now explicitly runs its generated,
+idempotent module registration before URI resolution; the republished artifact passed
+the same real-browser smoke.
+
+This slice is a playable engine foundation, not a claim that every large-world system is
+finished. The public boundaries intentionally leave room for these measured follow-ups:
+
+1. camera-centered chunk streaming with cancellable generation and a byte-budgeted CPU/GPU LRU;
+2. worker remesh queues with generation-stamped publish and stale-result rejection;
+3. texture-array material packs, mipmaps, alpha-tested foliage, and a separate transparent pass;
+4. GPU Hi-Z occlusion and indirect submission where target WebGPU capabilities make it a win;
+5. sunlight/block-light propagation, persistence, entities/ECS, networking, and deterministic simulation;
+6. cold-start, first-interaction, sustained frame-time percentile, upload-byte, residency,
+   browser AOT, and image-regression dashboards on release binaries.
+
+GPU-driven occlusion, meshlets, or a Nanite-like hierarchy are not enabled blindly:
+greedy chunks already make large flat voxel surfaces extremely compact, and every added
+stage must beat the current final-binary frame-time and memory measurements without
+reducing quality or edit latency.

--- a/eng/progpu-package-list.sh
+++ b/eng/progpu-package-list.sh
@@ -15,9 +15,11 @@ progpu_portable_package_ids=(
   ProGPU.Fonts.Inter
   ProGPU.Fonts.Noto
   ProGPU.Scene
+  ProGPU.Voxel
   ProGPU.Layout
   ProGPU.Virtualization
   ProGPU.WinUI
+  ProGPU.Voxel.WinUI
   ProGPU.WinUI.Themes.Fluent
   ProGPU.WinUI.Charts
   ProGPU.WinUI.Designer
@@ -47,9 +49,11 @@ progpu_portable_package_projects=(
   src/ProGPU.Fonts.Inter/ProGPU.Fonts.Inter.csproj
   src/ProGPU.Fonts.Noto/ProGPU.Fonts.Noto.csproj
   src/ProGPU.Scene/ProGPU.Scene.csproj
+  src/ProGPU.Voxel/ProGPU.Voxel.csproj
   src/ProGPU.Layout/ProGPU.Layout.csproj
   src/ProGPU.Virtualization/ProGPU.Virtualization.csproj
   src/ProGPU.WinUI/ProGPU.WinUI.csproj
+  src/ProGPU.Voxel.WinUI/ProGPU.Voxel.WinUI.csproj
   src/ProGPU.WinUI.Themes.Fluent/ProGPU.WinUI.Themes.Fluent.csproj
   src/ProGPU.WinUI.Charts/ProGPU.WinUI.Charts.csproj
   src/ProGPU.WinUI.Designer/ProGPU.WinUI.Designer.csproj
@@ -79,9 +83,11 @@ progpu_portable_package_purposes=(
   "Official Inter font assets and typed accessors for deterministic UI typography."
   "Official Noto fallback assets and typed accessors for CJK and symbol coverage."
   "Scene graph, compositor commands, retained visuals, effects, and presentation primitives."
+  "Chunked voxel worlds, greedy meshing, collision, terrain generation, and grid ray casting."
   "Measure/arrange layout substrate shared by higher-level UI adapters."
   "Virtualization helpers for large retained visual and item surfaces."
   "WinUI-shaped controls and app model implemented on ProGPU."
+  "Playable WinUI voxel control with first-person input and retained ProGPU rendering."
   "Source-generated unchanged WinUI Fluent theme resources and inspectable XAML content."
   "Chart controls and chart rendering primitives for the WinUI-shaped layer."
   "Designer/editor controls and diagnostics for ProGPU WinUI surfaces."
@@ -171,6 +177,7 @@ progpu_nonshipping_projects=(
   src/ProGPU.Samples/ProGPU.Samples.csproj
   src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj
   src/ProGPU.Tests/ProGPU.Tests.csproj
+  src/ProGPU.Voxel.Tests/ProGPU.Voxel.Tests.csproj
   src/ProGPU.Xaml.Tests/ProGPU.Xaml.Tests.csproj
   src/WindowsBase/WindowsBase.csproj
 )
@@ -187,6 +194,7 @@ progpu_nonshipping_reasons=(
   "Shared sample gallery."
   "Headless test project."
   "Test project."
+  "Voxel engine test project."
   "XAML compiler and source-generator test project."
   "Framework implementation shim; shipped through consuming compatibility packages."
 )

--- a/eng/progpu-verify-package-list.sh
+++ b/eng/progpu-verify-package-list.sh
@@ -108,8 +108,8 @@ while IFS= read -r project; do
   fi
 done < <(find "${repo_root}/src" -type f -name '*.csproj' -not -path '*/bin/*' -not -path '*/obj/*' | sort)
 
-if [[ "${#classified_projects[@]}" -ne 48 ]]; then
-  echo "Expected 48 classified projects, found ${#classified_projects[@]}. Update the manifest and this audit count together." >&2
+if [[ "${#classified_projects[@]}" -ne 51 ]]; then
+  echo "Expected 51 classified projects, found ${#classified_projects[@]}. Update the manifest and this audit count together." >&2
   exit 1
 fi
 

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -18,6 +18,8 @@ const state = {
   uploads: null,
   inputEvents: [],
   inputInstalled: false,
+  pointerLockActive: false,
+  pointerLockRequestPending: false,
   dispatchImmediatePointer: null,
   dispatchTextInput: null,
   textSink: null,
@@ -390,6 +392,11 @@ function queueInputEvent(kind, x = 0, y = 0, a = 0, b = 0, data = 0, modifiers =
     state.inputEvents[state.inputEvents.length - 1] = event;
     return;
   }
+  if (kind === 10 && last?.kind === 10) {
+    last.a += a; last.b += b;
+    last.timestamp = timestamp;
+    return;
+  }
   if (kind === 4 && last?.kind === 4) {
     last.x = x; last.y = y; last.a += a; last.b += b;
     return;
@@ -417,6 +424,50 @@ function queuePointerEvent(kind, event, point) {
   queueInputEvent(kind, point.x, point.y, 0, 0, event.pointerId, eventModifiers(event), flags,
     event.timeStamp, event.pressure || 0, event.width || 0, event.height || 0,
     pointerTypeValue(event.pointerType), event.button);
+}
+
+function queueRelativePointerEvent(event) {
+  queueInputEvent(10, 0, 0, event.movementX || 0, event.movementY || 0,
+    event.pointerId, eventModifiers(event), event.buttons,
+    event.timeStamp, 0, 0, 0, 0, -1);
+}
+
+function notifyPointerLockLost() {
+  if (!state.pointerLockActive && !state.pointerLockRequestPending) return;
+  state.pointerLockActive = false;
+  state.pointerLockRequestPending = false;
+  queueInputEvent(11);
+}
+
+function requestCanvasPointerLock() {
+  if (!state.canvas || typeof state.canvas.requestPointerLock !== 'function') return false;
+  if (document.pointerLockElement === state.canvas) {
+    state.pointerLockActive = true;
+    state.pointerLockRequestPending = false;
+    return true;
+  }
+
+  try {
+    state.pointerLockRequestPending = true;
+    // The baseline request is supported more broadly than unadjustedMovement and
+    // still supplies unbounded relative movementX/Y required by first-person look.
+    const request = state.canvas.requestPointerLock();
+    if (request && typeof request.catch === 'function') {
+      request.catch(() => notifyPointerLockLost());
+    }
+    return true;
+  } catch {
+    state.pointerLockRequestPending = false;
+    return false;
+  }
+}
+
+function exitCanvasPointerLock() {
+  state.pointerLockRequestPending = false;
+  if (document.pointerLockElement === state.canvas && typeof document.exitPointerLock === 'function') {
+    document.exitPointerLock();
+  }
+  state.pointerLockActive = false;
 }
 
 function dispatchPointerEvent(kind, event, point) {
@@ -483,6 +534,15 @@ function installBrowserInput() {
   state.textSink = textSink;
 
   state.canvas.addEventListener('pointermove', event => {
+    if (document.pointerLockElement === state.canvas) {
+      const coalesced = typeof event.getCoalescedEvents === 'function' ? event.getCoalescedEvents() : [];
+      if (coalesced.length > 1) {
+        for (const sample of coalesced) queueRelativePointerEvent(sample);
+      } else {
+        queueRelativePointerEvent(event);
+      }
+      return;
+    }
     const point = pointerPosition(event);
     const coalesced = typeof event.getCoalescedEvents === 'function' ? event.getCoalescedEvents() : [];
     if (coalesced.length > 1) {
@@ -494,7 +554,9 @@ function installBrowserInput() {
   state.canvas.addEventListener('pointerdown', event => {
     const point = pointerPosition(event);
     dispatchPointerEvent(2, event, point);
-    try { state.canvas.setPointerCapture(event.pointerId); } catch { }
+    if (!state.pointerLockActive && !state.pointerLockRequestPending) {
+      try { state.canvas.setPointerCapture(event.pointerId); } catch { }
+    }
     event.preventDefault();
   });
   state.canvas.addEventListener('pointerup', event => {
@@ -579,6 +641,15 @@ function installBrowserInput() {
     event.preventDefault();
   });
   globalThis.addEventListener('blur', () => queueInputEvent(8));
+  document.addEventListener('pointerlockchange', () => {
+    if (document.pointerLockElement === state.canvas) {
+      state.pointerLockActive = true;
+      state.pointerLockRequestPending = false;
+    } else {
+      notifyPointerLockLost();
+    }
+  });
+  document.addEventListener('pointerlockerror', () => notifyPointerLockLost());
 }
 
 function drainInputEvents(destination, capacity) {
@@ -1717,7 +1788,7 @@ if (isDispatcherWorker) {
 } else {
   initializeDiagnosticsVisibility();
   runtime = await dotnet.withEnvironmentVariables(readBenchmarkEnvironment()).create();
-  runtime.setModuleImports('progpu-browser', { initialize, dispatch, dispatchUpload, mapBuffer, copyMappedBuffer, writeMappedBuffer, releaseMappedBuffer, nextAnimationFrame, writeCanvasMetrics, drainInputEvents, setCanvasCursor, configureTextInput, hideTextInput, setClipboardText, getClipboardText, setClipboardRichText, getClipboardRtf, getClipboardHtml, pickStorage, getPickedStorageLength, copyPickedStorage, clearPickedStorage, writePickedStorageText, writePickedStorageBytes, downloadText, downloadBytes, getDiagnosticsVisible, setDiagnosticsVisible, setStatus, updateCounters });
+  runtime.setModuleImports('progpu-browser', { initialize, dispatch, dispatchUpload, mapBuffer, copyMappedBuffer, writeMappedBuffer, releaseMappedBuffer, nextAnimationFrame, writeCanvasMetrics, drainInputEvents, setCanvasCursor, requestCanvasPointerLock, exitCanvasPointerLock, configureTextInput, hideTextInput, setClipboardText, getClipboardText, setClipboardRichText, getClipboardRtf, getClipboardHtml, pickStorage, getPickedStorageLength, copyPickedStorage, clearPickedStorage, writePickedStorageText, writePickedStorageBytes, downloadText, downloadBytes, getDiagnosticsVisible, setDiagnosticsVisible, setStatus, updateCounters });
   const browserExports = await runtime.getAssemblyExports('ProGPU.Browser.dll');
   state.dispatchImmediatePointer = browserExports.ProGPU.Browser.BrowserInputDispatcher.DispatchImmediatePointer;
   state.dispatchTextInput = browserExports.ProGPU.Browser.BrowserInputDispatcher.DispatchTextInput;

--- a/src/ProGPU.Browser/BrowserInputDispatcher.cs
+++ b/src/ProGPU.Browser/BrowserInputDispatcher.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Silk.NET.Input;
 using Windows.Devices.Input;
 using ProGPU.Scene;
+using ProGPU.WinUI.Input;
 
 namespace ProGPU.Browser;
 
@@ -28,12 +29,14 @@ public static partial class BrowserInputDispatcher
         s_attachedState = state;
         state.CursorChanged = cursor => SetCanvasCursor(ToCssCursor(cursor));
         state.FocusChanged = OnFocusChanged;
+        RelativePointerCapture.ConfigureHost(state, RequestCanvasPointerLock, ExitCanvasPointerLock);
     }
 
     public static void Detach(WindowInputState state)
     {
         ArgumentNullException.ThrowIfNull(state);
         if (!ReferenceEquals(s_attachedState, state)) return;
+        RelativePointerCapture.ClearHost(state);
         state.CursorChanged = null;
         state.FocusChanged = null;
         HideTextInput();
@@ -160,6 +163,14 @@ public static partial class BrowserInputDispatcher
                 break;
             case BrowserInputKind.FocusLost:
                 InputSystem.InjectFocusLost();
+                break;
+            case BrowserInputKind.RelativePointerMove:
+                RelativePointerCapture.InjectHostMovement(new Vector2(
+                    ReadSingle(record, 12),
+                    ReadSingle(record, 16)));
+                break;
+            case BrowserInputKind.PointerLockLost:
+                RelativePointerCapture.NotifyHostCaptureLost();
                 break;
         }
     }
@@ -354,6 +365,12 @@ public static partial class BrowserInputDispatcher
     [JSImport("setCanvasCursor", "progpu-browser")]
     private static partial void SetCanvasCursor(string cursor);
 
+    [JSImport("requestCanvasPointerLock", "progpu-browser")]
+    private static partial bool RequestCanvasPointerLock();
+
+    [JSImport("exitCanvasPointerLock", "progpu-browser")]
+    private static partial void ExitCanvasPointerLock();
+
     [JSImport("configureTextInput", "progpu-browser")]
     private static partial void ConfigureTextInput(
         string inputMode,
@@ -380,7 +397,9 @@ public static partial class BrowserInputDispatcher
         KeyUp = 6,
         Text = 7,
         FocusLost = 8,
-        PointerCancel = 9
+        PointerCancel = 9,
+        RelativePointerMove = 10,
+        PointerLockLost = 11
     }
 
     private enum BrowserKey : uint

--- a/src/ProGPU.Samples.Desktop/ProGPU.Samples.Desktop.csproj
+++ b/src/ProGPU.Samples.Desktop/ProGPU.Samples.Desktop.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ProGpuUseWindowsBaseShim>true</ProGpuUseWindowsBaseShim>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProGPU.Samples\ProGPU.Samples.csproj" />

--- a/src/ProGPU.Samples.Desktop/Program.cs
+++ b/src/ProGPU.Samples.Desktop/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.UI.Xaml;
 using ProGPU.Samples;
+using Silk.NET.Input.Glfw;
+using Silk.NET.Windowing.Glfw;
 
 namespace ProGPU.Samples.Desktop;
 
@@ -7,6 +9,8 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        GlfwWindowing.Use();
+        GlfwInput.RegisterPlatform();
         AppBuilder<App>.Configure()
             .WithTitle("ProGPU Substrate - High-Performance WinUI Gallery Dashboard")
             .WithSize(1280, 800)

--- a/src/ProGPU.Samples/Pages/MinecraftGamePage.cs
+++ b/src/ProGPU.Samples/Pages/MinecraftGamePage.cs
@@ -1,0 +1,89 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using ProGPU.Vector;
+using ProGPU.Voxel;
+using ProGPU.Voxel.WinUI;
+
+namespace ProGPU.Samples;
+
+public static class MinecraftGamePage
+{
+    public static FrameworkElement Create()
+    {
+        var root = new Grid { Margin = new Thickness(12f) };
+        root.RowDefinitions.Add(new GridLength(82f, GridUnitType.Absolute));
+        root.RowDefinitions.Add(new GridLength(1f, GridUnitType.Star));
+
+        var header = new Border
+        {
+            Background = new ThemeResourceBrush("CardBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(1f),
+            CornerRadius = 8f,
+            Padding = new Thickness(14f, 10f),
+            Margin = new Thickness(0, 0, 0, 10f)
+        };
+        var headerLayout = new StackPanel { Orientation = Orientation.Vertical };
+        var title = new RichTextBlock
+        {
+            Font = AppState.GetFont(),
+            FontSize = 16f
+        };
+        title.Inlines.Add(new Bold(new Run("ProGPU Voxel Game")));
+        title.Inlines.Add(new Run("  •  pure WGSL chunk rendering"));
+        headerLayout.AddChild(title);
+
+        var statusRun = new Run("Generating deterministic terrain and greedy chunk meshes…");
+        var status = new RichTextBlock
+        {
+            Font = AppState.GetFont(),
+            FontSize = 11.5f,
+            Foreground = new ThemeResourceBrush("TextSecondary"),
+            Margin = new Thickness(0, 4f, 0, 0)
+        };
+        status.Inlines.Add(statusRun);
+        headerLayout.AddChild(status);
+        header.Child = headerLayout;
+        root.AddChild(header);
+        Grid.SetRow(header, 0);
+
+        var game = new VoxelGameView
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            RenderDistanceInChunks = 6
+        };
+
+        void UpdateStatus()
+        {
+            var capture = game.IsMouseLookActive
+                ? "Mouse captured — Esc release"
+                : "Click game to capture mouse";
+            var name = VoxelBlockCatalog.Get(game.SelectedBlock).Name;
+            statusRun.Text =
+                $"{capture} • WASD move, Shift sprint, Space jump, F fly • " +
+                $"Left mine, right place, wheel/1–7 select • Selected: {name}";
+        }
+
+        game.WorldReady += (_, _) =>
+        {
+            UpdateStatus();
+        };
+        game.SelectedBlockChanged += (_, _) => UpdateStatus();
+        game.MouseLookActiveChanged += (_, _) => UpdateStatus();
+
+        var gameFrame = new Border
+        {
+            Background = new ThemeResourceBrush("ControlBackground"),
+            BorderBrush = new ThemeResourceBrush("ControlBorder"),
+            BorderThickness = new Thickness(1f),
+            CornerRadius = 8f,
+            Child = game
+        };
+        root.AddChild(gameFrame);
+        Grid.SetRow(gameFrame, 1);
+        game.StartNewWorld(seed: 1337, chunkRadius: 3);
+        return root;
+    }
+}

--- a/src/ProGPU.Samples/ProGPU.Samples.csproj
+++ b/src/ProGPU.Samples/ProGPU.Samples.csproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="..\ProGPU.WinUI.Themes.Fluent\ProGPU.WinUI.Themes.Fluent.csproj" />
     <ProjectReference Include="..\ProGPU.WinUI.Charts\ProGPU.WinUI.Charts.csproj" />
     <ProjectReference Include="..\ProGPU.WinUI.Designer\ProGPU.WinUI.Designer.csproj" />
+    <ProjectReference Include="..\ProGPU.Voxel\ProGPU.Voxel.csproj" />
+    <ProjectReference Include="..\ProGPU.Voxel.WinUI\ProGPU.Voxel.WinUI.csproj" />
     <ProjectReference Include="..\ProGPU.Xaml\ProGPU.Xaml.csproj" />
     <ProjectReference Include="..\ProGPU.Xaml.Roslyn\ProGPU.Xaml.Roslyn.csproj" />
     <ProjectReference Include="..\ProGPU.Xaml.SourceGenerator\ProGPU.Xaml.SourceGenerator.csproj"

--- a/src/ProGPU.Samples/Windows/MainWindowController.cs
+++ b/src/ProGPU.Samples/Windows/MainWindowController.cs
@@ -328,6 +328,7 @@ public static unsafe class MainWindowController
         var pictureCachingItem = PageItem("Picture Caching", "🖼️", PictureShowcasePage.Create);
         var fontGlyphBrowserItem = PageItem("Font Glyph Browser", "🔤", FontGlyphBrowserPage.Create);
         var mesh3DViewerItem = PageItem("3D Mesh Viewer", "🧊", Mesh3DViewerPage.Create);
+        var voxelGameItem = PageItem("Voxel Game", "⛏️", MinecraftGamePage.Create);
         var shaderToyPlaygroundItem = PageItem("ShaderToy Playground", "🔮", ShaderToyPlaygroundPage.Create);
         var xamlWelcomeItem = PageItem("Compiled XAML", "✦", XamlCompilerWelcomePage.Create);
         var xamlBindingsItem = PageItem("XAML Bindings", "⇄", XamlCompilerBindingsPage.Create);
@@ -391,6 +392,7 @@ public static unsafe class MainWindowController
         AppState._navigationView.MenuItems.Add(visualDesignerItem);
         AppState._navigationView.MenuItems.Add(pictureCachingItem);
         AppState._navigationView.MenuItems.Add(mesh3DViewerItem);
+        AppState._navigationView.MenuItems.Add(voxelGameItem);
         AppState._navigationView.MenuItems.Add(shaderToyPlaygroundItem);
         AppState._navigationView.MenuItems.Add(xamlWelcomeItem);
         AppState._navigationView.MenuItems.Add(xamlBindingsItem);

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1611,6 +1611,7 @@ public unsafe partial class Compositor : IDisposable
         RegisterExtension(CompositorBuiltInExtensions.ShaderToy, new ShaderToyExtensionPipeline());
         RegisterExtension(CompositorBuiltInExtensions.WpfShaderEffect, new WpfShaderEffectExtensionPipeline());
         RegisterExtension(CompositorBuiltInExtensions.BackdropMaterial, new BackdropMaterialExtensionPipeline());
+        RegisterExtension(CompositorBuiltInExtensions.VoxelTerrain, new VoxelTerrainExtensionPipeline());
 
         InitializePipelinesAndBindGroups();
         GpuTexture.OnDisposedWithId += HandleTextureDisposed;

--- a/src/ProGPU.Scene/Extensions/VoxelTerrainExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/VoxelTerrainExtensionPipeline.cs
@@ -1,0 +1,546 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using ProGPU.Backend;
+using ProGPU.Vector;
+using Silk.NET.Core.Native;
+using Silk.NET.WebGPU;
+
+namespace ProGPU.Scene.Extensions;
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public struct GpuVoxelVertex
+{
+    public Vector3 Position;
+    public Vector2 TextureCoordinate;
+    public uint Material;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 16)]
+internal struct GpuVoxelUniforms
+{
+    public Matrix4x4 Projection;
+    public Matrix4x4 View;
+    public Vector4 CameraAndTime;
+    public Vector4 SunDirectionAndIntensity;
+    public Vector4 SkyColorAndFogStart;
+    public Vector4 FogEndAndAmbient;
+    public Vector4 SelectedBlock;
+}
+
+public sealed class VoxelTerrainCompilationPayload
+{
+    public List<VoxelChunkRenderEntry> Chunks { get; } = new();
+    public GpuTexture? ColorTexture { get; set; }
+    public GpuTexture? MsaaColorTexture { get; set; }
+    public GpuTexture? DepthTexture { get; set; }
+    public uint SampleCount { get; set; } = 1;
+    public Vector3 CameraPosition { get; set; }
+    public Vector3 SunDirection { get; set; } = Vector3.Normalize(new Vector3(0.45f, 0.8f, -0.3f));
+    public float SunIntensity { get; set; } = 0.85f;
+    public Vector3 SkyColor { get; set; } = new(0.48f, 0.72f, 0.92f);
+    public float FogStart { get; set; } = 48f;
+    public float FogEnd { get; set; } = 92f;
+    public float SkyAmbient { get; set; } = 0.62f;
+    public float GroundAmbient { get; set; } = 0.38f;
+    public float Time { get; set; }
+    public Vector3 SelectedBlock { get; set; }
+    public bool HasSelectedBlock { get; set; }
+}
+
+public sealed class VoxelChunkRenderEntry
+{
+    public object? Geometry { get; set; }
+    public int GeometryVersion { get; set; }
+    public GpuVoxelVertex[] Vertices { get; set; } = Array.Empty<GpuVoxelVertex>();
+    public uint[] Indices { get; set; } = Array.Empty<uint>();
+    public Vector3 Origin { get; set; }
+}
+
+/// <summary>
+/// Indexed, versioned chunk renderer. Visible chunk geometry is packed into a shared arena
+/// and submitted with one draw. Stable layouts reuse the arena without geometry uploads.
+/// </summary>
+public sealed unsafe class VoxelTerrainExtensionPipeline : ICompositorExtension, IDisposable
+{
+    private static readonly string ShaderCode =
+        ShaderResource.Load(typeof(VoxelTerrainExtensionPipeline), "VoxelTerrain.wgsl");
+
+    private readonly record struct ArenaSlice(
+        object? Geometry,
+        int Version,
+        Vector3 Origin,
+        int VertexCount,
+        int IndexCount);
+
+    private sealed class ViewportResource
+    {
+        public readonly GpuBuffer UniformsBuffer;
+        public GpuBuffer? VertexArena;
+        public GpuBuffer? IndexArena;
+        public BindGroup* BindGroup;
+        public nint BindGroupPipeline;
+        public GpuVoxelVertex[] CpuVertices = Array.Empty<GpuVoxelVertex>();
+        public uint[] CpuIndices = Array.Empty<uint>();
+        public readonly List<ArenaSlice> ArenaSlices = new();
+        public uint ArenaIndexCount;
+        public GpuVoxelUniforms LastUniforms;
+        public bool HasUniforms;
+
+        public ViewportResource(WgpuContext context)
+        {
+            UniformsBuffer = new GpuBuffer(
+                context,
+                (uint)Marshal.SizeOf<GpuVoxelUniforms>(),
+                BufferUsage.Uniform | BufferUsage.CopyDst,
+                "Voxel uniforms");
+        }
+
+        public void EnsureGeometryCpuCapacity(int vertexCount, int indexCount)
+        {
+            if (CpuVertices.Length < vertexCount)
+            {
+                CpuVertices = new GpuVoxelVertex[NextArrayCapacity(vertexCount)];
+            }
+            if (CpuIndices.Length < indexCount)
+            {
+                CpuIndices = new uint[NextArrayCapacity(indexCount)];
+            }
+        }
+
+        public void Dispose(WgpuContext context)
+        {
+            UniformsBuffer.Dispose();
+            VertexArena?.Dispose();
+            IndexArena?.Dispose();
+            if (BindGroup != null)
+            {
+                context.Api.BindGroupRelease(BindGroup);
+                BindGroup = null;
+            }
+        }
+
+        private static int NextArrayCapacity(int required)
+        {
+            var capacity = 256;
+            while (capacity < required)
+            {
+                capacity = checked(capacity * 2);
+            }
+            return capacity;
+        }
+    }
+
+    private readonly List<ViewportResource> _viewportResources = new();
+    private readonly List<nint> _pendingCommandBuffers = new();
+    private WgpuContext? _context;
+    private int _compileIndex;
+    private RenderPipeline* _pipelineSingle;
+    private RenderPipeline* _pipelineMsaa;
+
+    public void BeginFrame(Compositor compositor)
+    {
+        _compileIndex = 0;
+        ReleasePendingCommandBuffers(compositor.Context);
+    }
+
+    public void Compile(
+        Compositor compositor,
+        IRenderDataProvider? provider,
+        Matrix4x4 transform,
+        ref RenderCommand cmd)
+    {
+        if (cmd.DataParam is not VoxelTerrainCompilationPayload payload ||
+            payload.Chunks.Count == 0 ||
+            payload.ColorTexture is null ||
+            payload.DepthTexture is null)
+        {
+            return;
+        }
+
+        _context = compositor.Context;
+        var context = compositor.Context;
+        var wgpu = context.Api;
+        var sampleCount = payload.SampleCount is 1 or 4 ? payload.SampleCount : 1u;
+        while (_viewportResources.Count <= _compileIndex)
+        {
+            _viewportResources.Add(new ViewportResource(context));
+        }
+        var resource = _viewportResources[_compileIndex];
+
+        EnsureGeometryArena(context, resource, payload);
+
+        var uniforms = new GpuVoxelUniforms
+        {
+            Projection = cmd.Transform,
+            View = cmd.CameraView,
+            CameraAndTime = new Vector4(payload.CameraPosition, payload.Time),
+            SunDirectionAndIntensity = new Vector4(payload.SunDirection, payload.SunIntensity),
+            SkyColorAndFogStart = new Vector4(payload.SkyColor, payload.FogStart),
+            FogEndAndAmbient = new Vector4(payload.FogEnd, payload.SkyAmbient, payload.GroundAmbient, 0f),
+            SelectedBlock = new Vector4(payload.SelectedBlock, payload.HasSelectedBlock ? 1f : 0f)
+        };
+        if (!resource.HasUniforms || !UniformsEqual(resource.LastUniforms, uniforms))
+        {
+            resource.UniformsBuffer.WriteSingle(uniforms);
+            resource.LastUniforms = uniforms;
+            resource.HasUniforms = true;
+        }
+
+        var pipeline = GetOrCreatePipeline(compositor, sampleCount);
+        EnsureBindGroup(context, resource, pipeline);
+        EncodeOffscreenPass(context, resource, pipeline, payload);
+
+        _compileIndex++;
+        cmd.PointBufferOffset = 0;
+        cmd.PointBufferCount = 0;
+    }
+
+    public void EndFrame(Compositor compositor)
+    {
+        if (_pendingCommandBuffers.Count == 0)
+        {
+            return;
+        }
+
+        var buffers = stackalloc CommandBuffer*[_pendingCommandBuffers.Count];
+        for (var index = 0; index < _pendingCommandBuffers.Count; index++)
+        {
+            buffers[index] = (CommandBuffer*)_pendingCommandBuffers[index];
+        }
+
+        compositor.Context.Api.QueueSubmit(
+            compositor.Context.Queue,
+            (uint)_pendingCommandBuffers.Count,
+            buffers);
+        ReleasePendingCommandBuffers(compositor.Context);
+    }
+
+    public void Render(
+        Compositor compositor,
+        void* renderPassEncoder,
+        bool isOffscreen,
+        in Compositor.CompositorDrawCall dc)
+    {
+    }
+
+    public void Dispose()
+    {
+        if (_context is not null)
+        {
+            foreach (var viewport in _viewportResources)
+            {
+                viewport.Dispose(_context);
+            }
+            ReleasePendingCommandBuffers(_context);
+        }
+        _viewportResources.Clear();
+    }
+
+    private RenderPipeline* GetOrCreatePipeline(Compositor compositor, uint sampleCount)
+    {
+        var cached = sampleCount == 1 ? _pipelineSingle : _pipelineMsaa;
+        if (cached != null)
+        {
+            return cached;
+        }
+
+        var shader = compositor.PipelineCache.GetOrCreateShader(
+            "VoxelTerrainShader_v2",
+            ShaderCode,
+            "Voxel terrain shader");
+        Span<VertexAttribute> attributes = stackalloc VertexAttribute[3];
+        attributes[0] = new VertexAttribute
+        {
+            Format = VertexFormat.Float32x3,
+            Offset = 0,
+            ShaderLocation = 0
+        };
+        attributes[1] = new VertexAttribute
+        {
+            Format = VertexFormat.Float32x2,
+            Offset = 12,
+            ShaderLocation = 1
+        };
+        attributes[2] = new VertexAttribute
+        {
+            Format = VertexFormat.Uint32,
+            Offset = 20,
+            ShaderLocation = 2
+        };
+        Span<VertexBufferLayout> layouts = stackalloc VertexBufferLayout[1];
+        fixed (VertexAttribute* attributesPointer = attributes)
+        {
+            layouts[0] = new VertexBufferLayout
+            {
+                ArrayStride = (uint)Unsafe.SizeOf<GpuVoxelVertex>(),
+                StepMode = VertexStepMode.Vertex,
+                AttributeCount = 3,
+                Attributes = attributesPointer
+            };
+            cached = compositor.PipelineCache.GetOrCreateRenderPipeline(
+                $"VoxelTerrainPipeline_v2_{sampleCount}",
+                shader,
+                layouts,
+                topology: PrimitiveTopology.TriangleList,
+                targetFormat: TextureFormat.Rgba8Unorm,
+                enableBlend: false,
+                enableDepthStencil: true,
+                depthFormat: TextureFormat.Depth24Plus,
+                sampleCount: sampleCount,
+                depthWriteEnabled: true,
+                depthCompare: CompareFunction.LessEqual,
+                cullMode: CullMode.Back);
+        }
+
+        if (sampleCount == 1) _pipelineSingle = cached;
+        else _pipelineMsaa = cached;
+        return cached;
+    }
+
+    private static void EnsureBindGroup(
+        WgpuContext context,
+        ViewportResource resource,
+        RenderPipeline* pipeline)
+    {
+        if (resource.BindGroup != null && resource.BindGroupPipeline == (nint)pipeline)
+        {
+            return;
+        }
+
+        resource.BindGroupPipeline = (nint)pipeline;
+        if (resource.BindGroup != null)
+        {
+            context.Api.BindGroupRelease(resource.BindGroup);
+        }
+
+        var entries = stackalloc BindGroupEntry[1];
+        entries[0] = new BindGroupEntry
+        {
+            Binding = 0,
+            Buffer = resource.UniformsBuffer.BufferPtr,
+            Offset = 0,
+            Size = resource.UniformsBuffer.Size
+        };
+        var layout = context.Api.RenderPipelineGetBindGroupLayout(pipeline, 0);
+        var label = SilkMarshal.StringToPtr("Voxel terrain bind group");
+        var descriptor = new BindGroupDescriptor
+        {
+            Layout = layout,
+            EntryCount = 1,
+            Entries = entries,
+            Label = (byte*)label
+        };
+        resource.BindGroup = context.Api.DeviceCreateBindGroup(context.Device, &descriptor);
+        SilkMarshal.Free(label);
+    }
+
+    private static bool EnsureGeometryArena(
+        WgpuContext context,
+        ViewportResource resource,
+        VoxelTerrainCompilationPayload payload)
+    {
+        var layoutMatches = resource.ArenaSlices.Count == payload.Chunks.Count;
+        if (layoutMatches)
+        {
+            for (var index = 0; index < payload.Chunks.Count; index++)
+            {
+                var entry = payload.Chunks[index];
+                var slice = resource.ArenaSlices[index];
+                if (!ReferenceEquals(entry.Geometry, slice.Geometry) ||
+                    entry.GeometryVersion != slice.Version ||
+                    entry.Origin != slice.Origin ||
+                    entry.Vertices.Length != slice.VertexCount ||
+                    entry.Indices.Length != slice.IndexCount)
+                {
+                    layoutMatches = false;
+                    break;
+                }
+            }
+        }
+
+        if (layoutMatches)
+        {
+            return false;
+        }
+
+        var totalVertices = 0;
+        var totalIndices = 0;
+        foreach (var entry in payload.Chunks)
+        {
+            totalVertices = checked(totalVertices + entry.Vertices.Length);
+            totalIndices = checked(totalIndices + entry.Indices.Length);
+        }
+        resource.EnsureGeometryCpuCapacity(totalVertices, totalIndices);
+        resource.ArenaSlices.Clear();
+
+        var vertexOffset = 0;
+        var indexOffset = 0;
+        foreach (var entry in payload.Chunks)
+        {
+            resource.ArenaSlices.Add(new ArenaSlice(
+                entry.Geometry,
+                entry.GeometryVersion,
+                entry.Origin,
+                entry.Vertices.Length,
+                entry.Indices.Length));
+            if (entry.Geometry is null || entry.Vertices.Length == 0 || entry.Indices.Length == 0)
+            {
+                continue;
+            }
+
+            for (var index = 0; index < entry.Vertices.Length; index++)
+            {
+                var vertex = entry.Vertices[index];
+                vertex.Position += entry.Origin;
+                resource.CpuVertices[vertexOffset + index] = vertex;
+            }
+            for (var index = 0; index < entry.Indices.Length; index++)
+            {
+                resource.CpuIndices[indexOffset + index] =
+                    checked(entry.Indices[index] + (uint)vertexOffset);
+            }
+            vertexOffset += entry.Vertices.Length;
+            indexOffset += entry.Indices.Length;
+        }
+        resource.ArenaIndexCount = (uint)indexOffset;
+
+        var vertexBytes = checked((uint)vertexOffset * (uint)Unsafe.SizeOf<GpuVoxelVertex>());
+        var indexBytes = checked((uint)indexOffset * sizeof(uint));
+        if (resource.VertexArena is null || resource.VertexArena.Size < vertexBytes)
+        {
+            resource.VertexArena?.Dispose();
+            resource.VertexArena = new GpuBuffer(
+                context,
+                Math.Max(256u, NextPowerOfTwo(vertexBytes)),
+                BufferUsage.Vertex | BufferUsage.CopyDst,
+                "Voxel vertex arena");
+        }
+        if (resource.IndexArena is null || resource.IndexArena.Size < indexBytes)
+        {
+            resource.IndexArena?.Dispose();
+            resource.IndexArena = new GpuBuffer(
+                context,
+                Math.Max(256u, NextPowerOfTwo(indexBytes)),
+                BufferUsage.Index | BufferUsage.CopyDst,
+                "Voxel index arena");
+        }
+
+        resource.VertexArena.Write(resource.CpuVertices.AsSpan(0, vertexOffset));
+        resource.IndexArena.Write(resource.CpuIndices.AsSpan(0, indexOffset));
+        return true;
+    }
+
+    private void EncodeOffscreenPass(
+        WgpuContext context,
+        ViewportResource resource,
+        RenderPipeline* pipeline,
+        VoxelTerrainCompilationPayload payload)
+    {
+        var label = SilkMarshal.StringToPtr("Voxel offscreen encoder");
+        var encoderDescriptor = new CommandEncoderDescriptor { Label = (byte*)label };
+        var encoder = context.Api.DeviceCreateCommandEncoder(context.Device, &encoderDescriptor);
+        SilkMarshal.Free(label);
+
+        var colorAttachment = new RenderPassColorAttachment
+        {
+            View = payload.MsaaColorTexture is not null
+                ? payload.MsaaColorTexture.ViewPtr
+                : payload.ColorTexture!.ViewPtr,
+            ResolveTarget = payload.MsaaColorTexture is not null
+                ? payload.ColorTexture!.ViewPtr
+                : null,
+            LoadOp = LoadOp.Clear,
+            StoreOp = payload.MsaaColorTexture is not null ? StoreOp.Discard : StoreOp.Store,
+            ClearValue = new Silk.NET.WebGPU.Color
+            {
+                R = payload.SkyColor.X,
+                G = payload.SkyColor.Y,
+                B = payload.SkyColor.Z,
+                A = 1.0
+            }
+        };
+        var depthAttachment = new RenderPassDepthStencilAttachment
+        {
+            View = payload.DepthTexture!.ViewPtr,
+            DepthLoadOp = LoadOp.Clear,
+            DepthStoreOp = StoreOp.Store,
+            DepthClearValue = 1.0f,
+            DepthReadOnly = false,
+            StencilLoadOp = LoadOp.Undefined,
+            StencilStoreOp = StoreOp.Undefined,
+            StencilClearValue = 0,
+            StencilReadOnly = false
+        };
+        var passDescriptor = new RenderPassDescriptor
+        {
+            ColorAttachmentCount = 1,
+            ColorAttachments = &colorAttachment,
+            DepthStencilAttachment = &depthAttachment
+        };
+        var pass = context.Api.CommandEncoderBeginRenderPass(encoder, &passDescriptor);
+        context.Api.RenderPassEncoderSetPipeline(pass, pipeline);
+        context.Api.RenderPassEncoderSetBindGroup(pass, 0, resource.BindGroup, 0, null);
+        context.Api.RenderPassEncoderSetVertexBuffer(
+            pass,
+            0,
+            resource.VertexArena!.BufferPtr,
+            0,
+            resource.VertexArena.Size);
+        context.Api.RenderPassEncoderSetIndexBuffer(
+            pass,
+            resource.IndexArena!.BufferPtr,
+            IndexFormat.Uint32,
+            0,
+            resource.IndexArena.Size);
+
+        if (resource.ArenaIndexCount > 0)
+        {
+            context.Api.RenderPassEncoderDrawIndexed(
+                pass,
+                resource.ArenaIndexCount,
+                1,
+                0,
+                0,
+                0);
+        }
+
+        context.Api.RenderPassEncoderEnd(pass);
+        context.Api.RenderPassEncoderRelease(pass);
+        var commandLabel = SilkMarshal.StringToPtr("Voxel command buffer");
+        var commandDescriptor = new CommandBufferDescriptor { Label = (byte*)commandLabel };
+        var commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
+        SilkMarshal.Free(commandLabel);
+        context.Api.CommandEncoderRelease(encoder);
+        _pendingCommandBuffers.Add((nint)commandBuffer);
+    }
+
+    private void ReleasePendingCommandBuffers(WgpuContext context)
+    {
+        foreach (var handle in _pendingCommandBuffers)
+        {
+            context.Api.CommandBufferRelease((CommandBuffer*)handle);
+        }
+        _pendingCommandBuffers.Clear();
+    }
+
+    private static uint NextPowerOfTwo(uint value)
+    {
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        return value + 1;
+    }
+
+    private static bool UniformsEqual(in GpuVoxelUniforms left, in GpuVoxelUniforms right) =>
+        left.Projection == right.Projection &&
+        left.View == right.View &&
+        left.CameraAndTime == right.CameraAndTime &&
+        left.SunDirectionAndIntensity == right.SunDirectionAndIntensity &&
+        left.SkyColorAndFogStart == right.SkyColorAndFogStart &&
+        left.FogEndAndAmbient == right.FogEndAndAmbient &&
+        left.SelectedBlock == right.SelectedBlock;
+}

--- a/src/ProGPU.Scene/IDrawingExtension.cs
+++ b/src/ProGPU.Scene/IDrawingExtension.cs
@@ -28,5 +28,6 @@ namespace ProGPU.Scene
         public const int ShaderToy = 11;
         public const int WpfShaderEffect = 12;
         public const int BackdropMaterial = 13;
+        public const int VoxelTerrain = 14;
     }
 }

--- a/src/ProGPU.Scene/Shaders/VoxelTerrain.wgsl
+++ b/src/ProGPU.Scene/Shaders/VoxelTerrain.wgsl
@@ -1,0 +1,135 @@
+// Algorithm: Transform indexed greedy-chunk vertices and shade procedural voxel materials with directional light, target highlighting, and distance fog.
+// Time complexity: O(1) per vertex and fragment; each fragment performs a fixed material branch, bounded hash work, and one directional-light evaluation.
+// Space complexity: O(1) private storage per invocation with one uniform read per vertex; no storage-buffer or texture samples.
+struct VoxelUniforms {
+    projection: mat4x4<f32>,
+    view: mat4x4<f32>,
+    cameraAndTime: vec4<f32>,
+    sunDirectionAndIntensity: vec4<f32>,
+    skyColorAndFogStart: vec4<f32>,
+    fogEndAndAmbient: vec4<f32>,
+    selectedBlock: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: VoxelUniforms;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) textureCoordinate: vec2<f32>,
+    @location(2) material: u32,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) worldPosition: vec3<f32>,
+    @location(1) textureCoordinate: vec2<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) faceLight: f32,
+    @location(4) @interpolate(flat) material: u32,
+    @location(5) @interpolate(flat) face: u32,
+};
+
+fn face_normal(face: u32) -> vec3<f32> {
+    switch face {
+        case 0u: { return vec3<f32>(1.0, 0.0, 0.0); }
+        case 1u: { return vec3<f32>(-1.0, 0.0, 0.0); }
+        case 2u: { return vec3<f32>(0.0, 1.0, 0.0); }
+        case 3u: { return vec3<f32>(0.0, -1.0, 0.0); }
+        case 4u: { return vec3<f32>(0.0, 0.0, 1.0); }
+        default: { return vec3<f32>(0.0, 0.0, -1.0); }
+    }
+}
+
+fn hash21(value: vec2<f32>) -> f32 {
+    let p = fract(value * vec2<f32>(123.34, 456.21));
+    let q = p + dot(p, p + 45.32);
+    return fract(q.x * q.y);
+}
+
+fn texel_noise(uv: vec2<f32>, worldPosition: vec3<f32>) -> f32 {
+    let texel = floor(fract(uv) * 16.0);
+    let seed = texel + floor(worldPosition.xz) * vec2<f32>(7.0, 13.0);
+    return hash21(seed);
+}
+
+fn material_color(material: u32, face: u32, uv: vec2<f32>, worldPosition: vec3<f32>) -> vec3<f32> {
+    let noise = texel_noise(uv, worldPosition);
+    if (material == 1u) {
+        if (face == 2u) {
+            return mix(vec3<f32>(0.16, 0.46, 0.10), vec3<f32>(0.30, 0.66, 0.16), noise);
+        }
+        let grassBand = step(0.76, fract(uv.y + 0.02 * noise));
+        let dirt = mix(vec3<f32>(0.34, 0.20, 0.09), vec3<f32>(0.48, 0.30, 0.13), noise);
+        let grass = mix(vec3<f32>(0.13, 0.39, 0.08), vec3<f32>(0.25, 0.58, 0.12), noise);
+        return mix(dirt, grass, grassBand);
+    }
+    if (material == 2u) {
+        return mix(vec3<f32>(0.31, 0.18, 0.08), vec3<f32>(0.50, 0.31, 0.14), noise);
+    }
+    if (material == 3u) {
+        let vein = step(0.86, hash21(floor(fract(uv) * 8.0) + vec2<f32>(19.0, 3.0)));
+        return mix(
+            mix(vec3<f32>(0.34, 0.35, 0.36), vec3<f32>(0.55, 0.56, 0.57), noise),
+            vec3<f32>(0.68, 0.69, 0.70),
+            vein * 0.45);
+    }
+    if (material == 4u) {
+        return mix(vec3<f32>(0.72, 0.61, 0.34), vec3<f32>(0.91, 0.82, 0.52), noise);
+    }
+    if (material == 5u) {
+        if (face == 2u || face == 3u) {
+            let ring = 0.5 + 0.5 * sin(length(fract(uv) - vec2<f32>(0.5)) * 42.0 + noise * 3.0);
+            return mix(vec3<f32>(0.28, 0.13, 0.045), vec3<f32>(0.58, 0.32, 0.10), ring);
+        }
+        let bark = 0.5 + 0.5 * sin(fract(uv.x) * 36.0 + noise * 2.0);
+        return mix(vec3<f32>(0.24, 0.11, 0.035), vec3<f32>(0.47, 0.25, 0.075), bark);
+    }
+    if (material == 6u) {
+        let leaf = step(0.19, noise);
+        return mix(vec3<f32>(0.08, 0.21, 0.045), mix(vec3<f32>(0.11, 0.36, 0.07), vec3<f32>(0.24, 0.55, 0.12), noise), leaf);
+    }
+    if (material == 7u) {
+        let wave = 0.5 + 0.5 * sin((worldPosition.x + worldPosition.z) * 2.8 + uniforms.cameraAndTime.w * 1.4);
+        return mix(vec3<f32>(0.035, 0.24, 0.42), vec3<f32>(0.08, 0.48, 0.69), wave * 0.45 + noise * 0.15);
+    }
+    return vec3<f32>(1.0, 0.0, 1.0);
+}
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    let worldPosition = input.position;
+    let face = (input.material >> 8u) & 7u;
+    var output: VertexOutput;
+    output.position = uniforms.projection * uniforms.view * vec4<f32>(worldPosition, 1.0);
+    output.worldPosition = worldPosition;
+    output.textureCoordinate = input.textureCoordinate;
+    output.normal = face_normal(face);
+    output.faceLight = f32((input.material >> 16u) & 255u) / 255.0;
+    output.material = input.material & 255u;
+    output.face = face;
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    var color = material_color(input.material, input.face, input.textureCoordinate, input.worldPosition);
+    let sun = normalize(uniforms.sunDirectionAndIntensity.xyz);
+    let direct = max(dot(input.normal, sun), 0.0) * uniforms.sunDirectionAndIntensity.w;
+    let skyAmbient = mix(uniforms.fogEndAndAmbient.z, uniforms.fogEndAndAmbient.y, input.normal.y * 0.5 + 0.5);
+    color *= (skyAmbient + direct) * mix(0.72, 1.0, input.faceLight);
+
+    if (uniforms.selectedBlock.w > 0.5) {
+        let ownerBlock = floor(input.worldPosition - input.normal * 0.001);
+        if (all(ownerBlock == uniforms.selectedBlock.xyz)) {
+            let localUv = fract(input.textureCoordinate);
+            let edgeDistance = min(min(localUv.x, 1.0 - localUv.x), min(localUv.y, 1.0 - localUv.y));
+            let outline = 1.0 - smoothstep(0.025, 0.065, edgeDistance);
+            color = mix(color, vec3<f32>(1.0, 0.92, 0.28), 0.72 * outline + 0.12);
+        }
+    }
+
+    let distanceToCamera = distance(input.worldPosition, uniforms.cameraAndTime.xyz);
+    let fog = smoothstep(uniforms.skyColorAndFogStart.w, uniforms.fogEndAndAmbient.x, distanceToCamera);
+    color = mix(color, uniforms.skyColorAndFogStart.rgb, fog);
+    return vec4<f32>(color, 1.0);
+}

--- a/src/ProGPU.Tests/ProGPU.Tests.csproj
+++ b/src/ProGPU.Tests/ProGPU.Tests.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\ProGPU.WinUI\ProGPU.WinUI.csproj" />
     <ProjectReference Include="..\ProGPU.WinUI.Designer\ProGPU.WinUI.Designer.csproj" />
     <ProjectReference Include="..\ProGPU.WinUI.Themes.Fluent\ProGPU.WinUI.Themes.Fluent.csproj" />
+    <ProjectReference Include="..\ProGPU.Voxel.WinUI\ProGPU.Voxel.WinUI.csproj" />
     <ProjectReference Include="..\ProGPU.Xaml.Workspaces\ProGPU.Xaml.Workspaces.csproj" />
     <ProjectReference Include="..\ProGPU.Xaml.Roslyn\ProGPU.Xaml.Roslyn.csproj" />
   </ItemGroup>

--- a/src/ProGPU.Tests/RelativePointerCaptureTests.cs
+++ b/src/ProGPU.Tests/RelativePointerCaptureTests.cs
@@ -1,0 +1,123 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using ProGPU.Voxel;
+using ProGPU.Voxel.WinUI;
+using ProGPU.WinUI.Input;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class RelativePointerCaptureTests
+{
+    [Fact]
+    public void VoxelGameUsesRelativeMouseUntilEscapeReleasesCapture()
+    {
+        var previousState = InputSystem.Current;
+        var game = new VoxelGameView();
+        var state = InputSystem.CreateExternalState(game);
+        var acquireCount = 0;
+        var releaseCount = 0;
+        var stateChangeCount = 0;
+        try
+        {
+            InputSystem.Current = state;
+            RelativePointerCapture.ConfigureHost(
+                state,
+                () =>
+                {
+                    acquireCount++;
+                    return true;
+                },
+                () => releaseCount++);
+            game.MouseLookActiveChanged += (_, _) => stateChangeCount++;
+
+            game.OnPointerPressed(new PointerRoutedEventArgs
+            {
+                IsLeftButtonPressed = true
+            });
+
+            Assert.True(game.IsMouseLookActive);
+            Assert.True(game.IsFocused);
+            Assert.Equal(1, acquireCount);
+            Assert.Equal(1, stateChangeCount);
+
+            var initialYaw = game.Player.Yaw;
+            var initialPitch = game.Player.Pitch;
+            RelativePointerCapture.InjectHostMovement(new Vector2(20f, -10f));
+            Assert.Equal(initialYaw - 20f * game.MouseSensitivity, game.Player.Yaw, 5);
+            Assert.Equal(initialPitch + 10f * game.MouseSensitivity, game.Player.Pitch, 5);
+
+            game.OnPointerWheelChanged(new PointerRoutedEventArgs { WheelDelta = 1f });
+            Assert.Equal(VoxelBlock.Water, game.SelectedBlock);
+            game.OnPointerWheelChanged(new PointerRoutedEventArgs { WheelDelta = -1f });
+            Assert.Equal(VoxelBlock.Grass, game.SelectedBlock);
+
+            game.OnKeyDown(new KeyRoutedEventArgs { Key = Silk.NET.Input.Key.Escape });
+            Assert.False(game.IsMouseLookActive);
+            Assert.Equal(1, releaseCount);
+            Assert.Equal(2, stateChangeCount);
+        }
+        finally
+        {
+            RelativePointerCapture.ClearHost(state);
+            InputSystem.Current = previousState;
+        }
+    }
+
+    [Fact]
+    public void FocusLossReleasesRelativePointerAndStopsMovement()
+    {
+        var previousState = InputSystem.Current;
+        var owner = new Microsoft.UI.Xaml.Controls.Border();
+        var state = InputSystem.CreateExternalState(owner);
+        var movement = Vector2.Zero;
+        var releaseCount = 0;
+        try
+        {
+            InputSystem.Current = state;
+            RelativePointerCapture.ConfigureHost(state, () => true, () => releaseCount++);
+            Assert.True(RelativePointerCapture.TryAcquire(owner, delta => movement += delta));
+
+            RelativePointerCapture.InjectHostMovement(new Vector2(3f, 4f));
+            Assert.Equal(new Vector2(3f, 4f), movement);
+
+            InputSystem.InjectFocusLost();
+            Assert.False(RelativePointerCapture.IsCaptured(owner));
+            Assert.Equal(1, releaseCount);
+
+            RelativePointerCapture.InjectHostMovement(new Vector2(10f, 10f));
+            Assert.Equal(new Vector2(3f, 4f), movement);
+        }
+        finally
+        {
+            RelativePointerCapture.ClearHost(state);
+            InputSystem.Current = previousState;
+        }
+    }
+
+    [Fact]
+    public void HostInitiatedLossDoesNotRequestSecondPlatformRelease()
+    {
+        var previousState = InputSystem.Current;
+        var owner = new Microsoft.UI.Xaml.Controls.Border();
+        var state = InputSystem.CreateExternalState(owner);
+        var releaseCount = 0;
+        try
+        {
+            InputSystem.Current = state;
+            RelativePointerCapture.ConfigureHost(state, () => true, () => releaseCount++);
+            Assert.True(RelativePointerCapture.TryAcquire(owner, _ => { }));
+
+            RelativePointerCapture.NotifyHostCaptureLost();
+
+            Assert.False(RelativePointerCapture.IsCaptured(owner));
+            Assert.Equal(0, releaseCount);
+        }
+        finally
+        {
+            RelativePointerCapture.ClearHost(state);
+            InputSystem.Current = previousState;
+        }
+    }
+}

--- a/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
+++ b/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
@@ -107,7 +107,9 @@ public sealed class WindowsDpiAwarenessTests
         string devTools = File.ReadAllText(FindRepoFile("src", "ProGPU.Samples", "Windows", "DevToolsWindowController.cs"));
 
         Assert.Contains("PointerPositionTransform", inputSystem, StringComparison.Ordinal);
-        Assert.Contains("OnMouseMove(NormalizeInputPosition(state, new Vector2(pos.X, pos.Y)))", inputSystem, StringComparison.Ordinal);
+        Assert.Contains("var platformPosition = new Vector2(pos.X, pos.Y);", inputSystem, StringComparison.Ordinal);
+        Assert.Contains("RelativePointerCapture.ProcessPlatformMouseMove(state, platformPosition)", inputSystem, StringComparison.Ordinal);
+        Assert.Contains("OnMouseMove(NormalizeInputPosition(state, platformPosition));", inputSystem, StringComparison.Ordinal);
         Assert.Contains("InputSystem.Initialize(inputContext, _renderRoot, NormalizePointerPosition)", window, StringComparison.Ordinal);
         Assert.Contains("OperatingSystem.IsWindows()", window, StringComparison.Ordinal);
         Assert.Contains("InputSystem.NormalizePointerPositionForDpi", window, StringComparison.Ordinal);

--- a/src/ProGPU.Voxel.Tests/ProGPU.Voxel.Tests.csproj
+++ b/src/ProGPU.Voxel.Tests/ProGPU.Voxel.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProGPU.Backend\ProGPU.Backend.csproj" />
+    <ProjectReference Include="..\ProGPU.Scene\ProGPU.Scene.csproj" />
+    <ProjectReference Include="..\ProGPU.Voxel\ProGPU.Voxel.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ProGPU.Voxel.Tests/VoxelEngineTests.cs
+++ b/src/ProGPU.Voxel.Tests/VoxelEngineTests.cs
@@ -1,0 +1,211 @@
+using System.Numerics;
+using ProGPU.Backend;
+using ProGPU.Scene.Extensions;
+using ProGPU.Voxel;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class VoxelEngineTests
+{
+    [Fact]
+    public void WorldCoordinatesRoundTripAcrossNegativeChunkBoundaries()
+    {
+        var world = new VoxelWorld();
+
+        Assert.True(world.SetBlock(-1, -1, -1, VoxelBlock.Stone));
+        Assert.True(world.SetBlock(-16, 0, -17, VoxelBlock.Dirt));
+
+        Assert.Equal(VoxelBlock.Stone, world.GetBlock(-1, -1, -1));
+        Assert.Equal(VoxelBlock.Dirt, world.GetBlock(-16, 0, -17));
+        Assert.Equal(new VoxelChunkPosition(-1, -1, -1), VoxelWorld.ToChunkPosition(-1, -1, -1));
+        Assert.Equal(new VoxelChunkPosition(-1, 0, -2), VoxelWorld.ToChunkPosition(-16, 0, -17));
+        Assert.Equal(15, VoxelWorld.ToLocal(-1));
+        Assert.Equal(0, VoxelWorld.ToLocal(-16));
+    }
+
+    [Fact]
+    public void SingleBlockProducesSixIndexedQuads()
+    {
+        var world = new VoxelWorld();
+        world.SetBlock(2, 3, 4, VoxelBlock.Grass);
+        var chunk = Assert.Single(world.Chunks);
+
+        var mesh = world.GetOrBuildMesh(chunk);
+
+        Assert.Equal(6, mesh.VisibleFaceCount);
+        Assert.Equal(6, mesh.MergedQuadCount);
+        Assert.Equal(24, mesh.Vertices.Length);
+        Assert.Equal(36, mesh.Indices.Length);
+        Assert.Equal(12, mesh.TriangleCount);
+    }
+
+    [Fact]
+    public void GreedyMeshingCollapsesAFullChunkToSixQuads()
+    {
+        var world = new VoxelWorld();
+        var chunk = world.GetOrCreateChunk(new VoxelChunkPosition(0, 0, 0));
+        for (var y = 0; y < VoxelChunk.Size; y++)
+        {
+            for (var z = 0; z < VoxelChunk.Size; z++)
+            {
+                for (var x = 0; x < VoxelChunk.Size; x++)
+                {
+                    chunk.SetLocal(x, y, z, VoxelBlock.Stone);
+                }
+            }
+        }
+
+        var mesh = world.GetOrBuildMesh(chunk);
+
+        Assert.Equal(6 * VoxelChunk.Size * VoxelChunk.Size, mesh.VisibleFaceCount);
+        Assert.Equal(6, mesh.MergedQuadCount);
+        Assert.Equal(24, mesh.Vertices.Length);
+        Assert.Equal(36, mesh.Indices.Length);
+    }
+
+    [Fact]
+    public void DifferentMaterialsDoNotMergeAcrossAVisiblePlane()
+    {
+        var world = new VoxelWorld();
+        world.SetBlock(0, 0, 0, VoxelBlock.Grass);
+        world.SetBlock(1, 0, 0, VoxelBlock.Stone);
+        var mesh = world.GetOrBuildMesh(Assert.Single(world.Chunks));
+
+        Assert.Equal(10, mesh.VisibleFaceCount);
+        Assert.True(mesh.MergedQuadCount > 6);
+    }
+
+    [Fact]
+    public void BoundaryMutationInvalidatesBothParticipatingChunks()
+    {
+        var world = new VoxelWorld();
+        world.SetBlock(15, 1, 1, VoxelBlock.Stone);
+        world.SetBlock(16, 1, 1, VoxelBlock.Stone);
+        Assert.True(world.TryGetChunk(new VoxelChunkPosition(0, 0, 0), out var left));
+        Assert.True(world.TryGetChunk(new VoxelChunkPosition(1, 0, 0), out var right));
+        world.GetOrBuildMesh(left);
+        world.GetOrBuildMesh(right);
+        Assert.False(left.IsMeshDirty);
+        Assert.False(right.IsMeshDirty);
+
+        world.SetBlock(15, 1, 1, VoxelBlock.Air);
+
+        Assert.True(left.IsMeshDirty);
+        Assert.True(right.IsMeshDirty);
+        Assert.True(left.MeshVersion > 0);
+        Assert.True(right.MeshVersion > 0);
+    }
+
+    [Fact]
+    public void GridDdaReturnsHitAndPlacementCell()
+    {
+        var world = new VoxelWorld();
+        world.SetBlock(3, 1, 0, VoxelBlock.Wood);
+
+        var found = VoxelRaycaster.TryCast(
+            world,
+            new Vector3(0.5f, 1.5f, 0.5f),
+            Vector3.UnitX,
+            8f,
+            out var hit);
+
+        Assert.True(found);
+        Assert.Equal((3, 1, 0), hit.Block);
+        Assert.Equal((2, 1, 0), hit.Previous);
+        Assert.Equal((-1, 0, 0), hit.Normal);
+        Assert.Equal(VoxelBlock.Wood, hit.BlockType);
+        Assert.InRange(hit.Distance, 2.49f, 2.51f);
+    }
+
+    [Fact]
+    public void PlayerFallsOntoSolidTerrain()
+    {
+        var world = new VoxelWorld();
+        for (var z = -2; z <= 2; z++)
+        {
+            for (var x = -2; x <= 2; x++)
+            {
+                world.SetBlock(x, 0, z, VoxelBlock.Stone);
+            }
+        }
+        var player = new VoxelPlayerController();
+        player.Teleport(new Vector3(0.5f, 4f, 0.5f));
+        var input = default(VoxelPlayerInput);
+
+        for (var frame = 0; frame < 180; frame++)
+        {
+            player.Update(world, input, 1f / 60f);
+        }
+
+        Assert.True(player.IsGrounded);
+        Assert.InRange(player.Position.Y, 0.999f, 1.01f);
+    }
+
+    [Fact]
+    public void PositiveStrafeMovesTowardCameraRight()
+    {
+        var world = new VoxelWorld();
+        var player = new VoxelPlayerController();
+        player.Teleport(Vector3.Zero, yaw: 0f, pitch: 0f);
+        player.ToggleFlying();
+
+        player.Update(
+            world,
+            new VoxelPlayerInput(
+                Forward: 0f,
+                Strafe: 1f,
+                Vertical: 0f,
+                Jump: false,
+                Sprint: false),
+            0.05f);
+
+        Assert.True(player.Position.X < 0f);
+        Assert.Equal(0f, player.Position.Z, 5);
+    }
+
+    [Fact]
+    public void HomogeneousFrustumTestRejectsBoxOutsideIdentityClipVolume()
+    {
+        Assert.True(VoxelFrustum.Intersects(
+            Matrix4x4.Identity,
+            new Vector3(-0.5f, -0.5f, 0.1f),
+            new Vector3(0.5f, 0.5f, 0.9f)));
+        Assert.False(VoxelFrustum.Intersects(
+            Matrix4x4.Identity,
+            new Vector3(2f, -0.5f, 0.1f),
+            new Vector3(3f, 0.5f, 0.9f)));
+    }
+
+    [Fact]
+    public void TerrainGenerationIsDeterministic()
+    {
+        var settings = new VoxelTerrainSettings(42, ChunkRadius: 1, BuildMeshes: false);
+        var first = VoxelTerrainGenerator.Generate(settings);
+        var second = VoxelTerrainGenerator.Generate(settings);
+
+        Assert.Equal(first.ChunkCount, second.ChunkCount);
+        for (var z = -12; z <= 12; z += 3)
+        {
+            for (var x = -12; x <= 12; x += 3)
+            {
+                Assert.Equal(first.FindSurfaceY(x, z), second.FindSurfaceY(x, z));
+            }
+        }
+    }
+
+    [Fact]
+    public void VoxelShaderIsEmbeddedAndDocumentsItsCostModel()
+    {
+        var source = ShaderResource.Load(
+            typeof(VoxelTerrainCompilationPayload),
+            "VoxelTerrain.wgsl");
+
+        Assert.Contains("// Algorithm:", source, StringComparison.Ordinal);
+        Assert.Contains("// Time complexity:", source, StringComparison.Ordinal);
+        Assert.Contains("// Space complexity:", source, StringComparison.Ordinal);
+        Assert.Contains("@" + "vertex", source, StringComparison.Ordinal);
+        Assert.Contains("@" + "fragment", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("var<storage", source, StringComparison.Ordinal);
+    }
+}

--- a/src/ProGPU.Voxel.WinUI/ProGPU.Voxel.WinUI.csproj
+++ b/src/ProGPU.Voxel.WinUI/ProGPU.Voxel.WinUI.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Silk.NET.Input.Common" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProGPU.Backend\ProGPU.Backend.csproj" />
+    <ProjectReference Include="..\ProGPU.Vector\ProGPU.Vector.csproj" />
+    <ProjectReference Include="..\ProGPU.Scene\ProGPU.Scene.csproj" />
+    <ProjectReference Include="..\ProGPU.WinUI\ProGPU.WinUI.csproj" />
+    <ProjectReference Include="..\ProGPU.Voxel\ProGPU.Voxel.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ProGPU.Voxel.WinUI/VoxelGameView.cs
+++ b/src/ProGPU.Voxel.WinUI/VoxelGameView.cs
@@ -1,0 +1,629 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Scene.Extensions;
+using ProGPU.Vector;
+using ProGPU.WinUI.Input;
+using Silk.NET.Input;
+using Silk.NET.WebGPU;
+
+namespace ProGPU.Voxel.WinUI;
+
+/// <summary>
+/// A self-contained first-person voxel game surface. World generation and initial meshing
+/// run off the UI thread; frame simulation is owned by the normal visual update phase.
+/// </summary>
+public sealed class VoxelGameView : Control
+{
+    private sealed class TransferGeometry
+    {
+        public int Version = -1;
+        public GpuVoxelVertex[] Vertices = Array.Empty<GpuVoxelVertex>();
+        public uint[] Indices = Array.Empty<uint>();
+    }
+
+    private readonly HashSet<Key> _pressedKeys = new();
+    private readonly Dictionary<VoxelChunk, TransferGeometry> _transferGeometry = new();
+    private readonly List<VoxelChunkRenderEntry> _renderEntryPool = new();
+    private readonly VoxelPlayerController _player = new();
+    private readonly VoxelTerrainCompilationPayload _payload = new();
+    private readonly Brush _hudBrush = new ThemeResourceBrush("TextPrimary");
+    private readonly Brush _accentBrush = new ThemeResourceBrush("SystemAccentColor");
+    private readonly Pen _crosshairPen;
+    private readonly Pen _focusPen;
+    private Task<VoxelWorld>? _worldTask;
+    private GpuTexture? _colorTexture;
+    private GpuTexture? _msaaColorTexture;
+    private GpuTexture? _depthTexture;
+    private uint _textureSampleCount;
+    private bool _jumpRequested;
+    private bool _animateMaterials;
+    private float _time;
+    private VoxelRaycastHit? _target;
+    private Exception? _loadError;
+
+    public VoxelGameView()
+    {
+        _crosshairPen = new Pen(_hudBrush, 2f);
+        _focusPen = new Pen(_accentBrush, 2f);
+        HorizontalAlignment = HorizontalAlignment.Stretch;
+        VerticalAlignment = VerticalAlignment.Stretch;
+        IsTabStop = true;
+        Unloaded += (_, _) =>
+        {
+            DisposeTextures();
+            _pressedKeys.Clear();
+            RelativePointerCapture.Release(this);
+        };
+    }
+
+    public VoxelWorld? World { get; private set; }
+
+    public VoxelPlayerController Player => _player;
+
+    public VoxelBlock SelectedBlock { get; private set; } = VoxelBlock.Grass;
+
+    public int RenderDistanceInChunks { get; set; } = 6;
+
+    public float MouseSensitivity { get; set; } = 0.0025f;
+
+    public bool IsMouseLookActive => RelativePointerCapture.IsCaptured(this);
+
+    public bool IsLoading => _worldTask is not null;
+
+    public Exception? LoadError => _loadError;
+
+    public event EventHandler? WorldReady;
+
+    public event EventHandler? SelectedBlockChanged;
+
+    public event EventHandler? MouseLookActiveChanged;
+
+    public void StartNewWorld(int seed = 1337, int chunkRadius = 3)
+    {
+        if (_worldTask is not null)
+        {
+            return;
+        }
+
+        World = null;
+        _loadError = null;
+        _transferGeometry.Clear();
+        _worldTask = Task.Run(() =>
+            VoxelTerrainGenerator.Generate(
+                new VoxelTerrainSettings(seed, chunkRadius, BuildMeshes: true)));
+        Invalidate();
+    }
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        var width = float.IsInfinity(availableSize.X) ? 960f : availableSize.X;
+        var height = float.IsInfinity(availableSize.Y) ? 640f : availableSize.Y;
+        return new Vector2(width, height);
+    }
+
+    protected override void OnUpdateAnimations(float elapsedSeconds)
+    {
+        base.OnUpdateAnimations(elapsedSeconds);
+        CompleteWorldLoadIfReady();
+        if (World is null)
+        {
+            if (_worldTask is not null)
+            {
+                Invalidate();
+            }
+            return;
+        }
+
+        var input = new VoxelPlayerInput(
+            Axis(Key.W, Key.Up, Key.S, Key.Down),
+            Axis(Key.D, Key.Right, Key.A, Key.Left),
+            Axis(Key.Space, Key.E, Key.ControlLeft, Key.Q),
+            _jumpRequested,
+            IsPressed(Key.ShiftLeft) || IsPressed(Key.ShiftRight));
+        _jumpRequested = false;
+        _player.Update(World, input, elapsedSeconds);
+        if (_player.Position.Y < -24f)
+        {
+            SpawnPlayer(World);
+        }
+
+        if (_animateMaterials)
+        {
+            _time += Math.Clamp(elapsedSeconds, 0f, 0.1f);
+        }
+        UpdateTarget();
+        Invalidate();
+    }
+
+    public override void OnRender(DrawingContext context)
+    {
+        if (Size.X <= 0 || Size.Y <= 0)
+        {
+            return;
+        }
+
+        var wgpuContext = GetActiveWgpuContext();
+        if (wgpuContext is null || World is null)
+        {
+            DrawLoadingSurface(context);
+            base.OnRender(context);
+            return;
+        }
+
+        var dpiScale = (float)DisplayScaleResolver.ResolveWindowDisplayScale(wgpuContext.Window);
+        var width = (uint)Math.Max(1, Size.X * dpiScale);
+        var height = (uint)Math.Max(1, Size.Y * dpiScale);
+        var sampleCount = dpiScale >= 1.5f ? 1u : 4u;
+        EnsureTextures(wgpuContext, width, height, sampleCount);
+
+        var aspect = Size.X / Math.Max(1f, Size.Y);
+        var farPlane = Math.Max(48f, RenderDistanceInChunks * VoxelChunk.Size * 1.45f);
+        var projection = Matrix4x4.CreatePerspectiveFieldOfView(
+            70f * MathF.PI / 180f,
+            aspect,
+            0.08f,
+            farPlane);
+        var view = Matrix4x4.CreateLookAt(
+            _player.EyePosition,
+            _player.EyePosition + _player.LookDirection,
+            Vector3.UnitY);
+        var viewProjection = view * projection;
+
+        PreparePayload(viewProjection, farPlane);
+        if (_payload.Chunks.Count > 0)
+        {
+            context.Commands.Add(new RenderCommand
+            {
+                Type = RenderCommandType.DrawExtension,
+                ExtensionId = CompositorBuiltInExtensions.VoxelTerrain,
+                UseGpuTransforms = true,
+                CameraView = view,
+                Transform = projection,
+                DataParam = _payload
+            });
+            context.Commands.Add(new RenderCommand
+            {
+                Type = RenderCommandType.DrawTexture,
+                Rect = new Rect(Vector2.Zero, Size),
+                Texture = _colorTexture
+            });
+        }
+
+        DrawHud(context);
+        base.OnRender(context);
+    }
+
+    public override void OnKeyDown(KeyRoutedEventArgs e)
+    {
+        if (IsEnabled && IsFocused)
+        {
+            if (e.Key == Key.Escape)
+            {
+                RelativePointerCapture.Release(this);
+                _pressedKeys.Clear();
+                e.Handled = true;
+                base.OnKeyDown(e);
+                return;
+            }
+
+            var wasPressed = !_pressedKeys.Add(e.Key);
+            if (!wasPressed && e.Key == Key.Space)
+            {
+                _jumpRequested = true;
+            }
+            else if (!wasPressed && e.Key == Key.F)
+            {
+                _player.ToggleFlying();
+            }
+            else if (!wasPressed && TrySelectBlock(e.Key, out var selected))
+            {
+                SelectedBlock = selected;
+                SelectedBlockChanged?.Invoke(this, EventArgs.Empty);
+            }
+
+            if (IsGameKey(e.Key))
+            {
+                e.Handled = true;
+            }
+        }
+        base.OnKeyDown(e);
+    }
+
+    public override void OnKeyUp(KeyRoutedEventArgs e)
+    {
+        _pressedKeys.Remove(e.Key);
+        if (IsGameKey(e.Key))
+        {
+            e.Handled = true;
+        }
+        base.OnKeyUp(e);
+    }
+
+    public override void OnPointerPressed(PointerRoutedEventArgs e)
+    {
+        if (IsEnabled)
+        {
+            InputSystem.SetFocus(this);
+            if (!IsMouseLookActive)
+            {
+                RelativePointerCapture.TryAcquire(
+                    this,
+                    OnRelativePointerMoved,
+                    OnMouseLookActiveChanged);
+            }
+            else if (e.IsLeftButtonPressed)
+            {
+                RemoveTargetedBlock();
+            }
+            else if (e.IsRightButtonPressed)
+            {
+                PlaceSelectedBlock();
+            }
+            e.Handled = true;
+        }
+        base.OnPointerPressed(e);
+    }
+
+    public override void OnPointerReleased(PointerRoutedEventArgs e)
+    {
+        if (IsMouseLookActive)
+        {
+            e.Handled = true;
+        }
+        base.OnPointerReleased(e);
+    }
+
+    public override void OnPointerWheelChanged(PointerRoutedEventArgs e)
+    {
+        if (IsMouseLookActive && e.WheelDelta != 0f)
+        {
+            CycleSelectedBlock(e.WheelDelta < 0f ? 1 : -1);
+            e.Handled = true;
+        }
+        base.OnPointerWheelChanged(e);
+    }
+
+    private void OnRelativePointerMoved(Vector2 delta)
+    {
+        if (!IsEnabled || !IsMouseLookActive) return;
+        _player.AddLook(-delta.X * MouseSensitivity, -delta.Y * MouseSensitivity);
+        UpdateTarget();
+        Invalidate();
+    }
+
+    private void OnMouseLookActiveChanged(bool active)
+    {
+        if (!active)
+        {
+            _pressedKeys.Clear();
+            _jumpRequested = false;
+        }
+        MouseLookActiveChanged?.Invoke(this, EventArgs.Empty);
+        Invalidate();
+    }
+
+    private void CompleteWorldLoadIfReady()
+    {
+        if (_worldTask is null || !_worldTask.IsCompleted)
+        {
+            return;
+        }
+
+        if (_worldTask.IsCompletedSuccessfully)
+        {
+            World = _worldTask.Result;
+            _animateMaterials = World.ContainsBlock(VoxelBlock.Water);
+            SpawnPlayer(World);
+            WorldReady?.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            _loadError = _worldTask.Exception?.GetBaseException() ??
+                new InvalidOperationException("Voxel world generation was canceled.");
+        }
+        _worldTask = null;
+        Invalidate();
+    }
+
+    private void SpawnPlayer(VoxelWorld world)
+    {
+        var surface = world.FindSurfaceY(0, 0);
+        _player.Teleport(new Vector3(0.5f, surface + 1.05f, 0.5f), yaw: 0.65f);
+        UpdateTarget();
+    }
+
+    private void PreparePayload(Matrix4x4 viewProjection, float farPlane)
+    {
+        _payload.Chunks.Clear();
+        _payload.ColorTexture = _colorTexture;
+        _payload.MsaaColorTexture = _msaaColorTexture;
+        _payload.DepthTexture = _depthTexture;
+        _payload.SampleCount = _textureSampleCount;
+        _payload.CameraPosition = _player.EyePosition;
+        _payload.Time = _time;
+        _payload.FogStart = farPlane * 0.55f;
+        _payload.FogEnd = farPlane * 0.92f;
+        _payload.HasSelectedBlock = _target.HasValue;
+        if (_target is { } target)
+        {
+            _payload.SelectedBlock = new Vector3(target.Block.X, target.Block.Y, target.Block.Z);
+        }
+
+        var maxDistanceSquared = MathF.Pow(RenderDistanceInChunks * VoxelChunk.Size, 2f);
+        var renderEntryIndex = 0;
+        foreach (var chunk in World!.Chunks)
+        {
+            if (chunk.IsEmpty)
+            {
+                continue;
+            }
+
+            var origin = chunk.Position.WorldOrigin;
+            var center = origin + new Vector3(VoxelChunk.Size * 0.5f);
+            if (Vector3.DistanceSquared(center, _player.EyePosition) > maxDistanceSquared)
+            {
+                continue;
+            }
+
+            var maximum = origin + new Vector3(VoxelChunk.Size);
+            if (!VoxelFrustum.Intersects(viewProjection, origin, maximum))
+            {
+                continue;
+            }
+
+            var mesh = World.GetOrBuildMesh(chunk);
+            if (mesh.Indices.Length == 0)
+            {
+                continue;
+            }
+
+            var transfer = GetTransferGeometry(chunk, mesh);
+            VoxelChunkRenderEntry entry;
+            if (renderEntryIndex < _renderEntryPool.Count)
+            {
+                entry = _renderEntryPool[renderEntryIndex];
+            }
+            else
+            {
+                entry = new VoxelChunkRenderEntry();
+                _renderEntryPool.Add(entry);
+            }
+            entry.Geometry = transfer;
+            entry.GeometryVersion = transfer.Version;
+            entry.Vertices = transfer.Vertices;
+            entry.Indices = transfer.Indices;
+            entry.Origin = origin;
+            _payload.Chunks.Add(entry);
+            renderEntryIndex++;
+        }
+    }
+
+    private TransferGeometry GetTransferGeometry(VoxelChunk chunk, VoxelMesh mesh)
+    {
+        if (!_transferGeometry.TryGetValue(chunk, out var transfer))
+        {
+            transfer = new TransferGeometry();
+            _transferGeometry.Add(chunk, transfer);
+        }
+
+        if (transfer.Version == mesh.Version)
+        {
+            return transfer;
+        }
+
+        var vertices = new GpuVoxelVertex[mesh.Vertices.Length];
+        for (var index = 0; index < vertices.Length; index++)
+        {
+            var source = mesh.Vertices[index];
+            vertices[index] = new GpuVoxelVertex
+            {
+                Position = source.Position,
+                TextureCoordinate = source.TextureCoordinate,
+                Material = source.Material
+            };
+        }
+        transfer.Vertices = vertices;
+        transfer.Indices = mesh.Indices;
+        transfer.Version = mesh.Version;
+        return transfer;
+    }
+
+    private void UpdateTarget()
+    {
+        _target = World is not null &&
+            VoxelRaycaster.TryCast(
+                World,
+                _player.EyePosition,
+                _player.LookDirection,
+                7f,
+                out var hit)
+            ? hit
+            : null;
+    }
+
+    private void RemoveTargetedBlock()
+    {
+        if (World is null || _target is not { } target || target.Block.Y <= 0)
+        {
+            return;
+        }
+        World.SetBlock(target.Block.X, target.Block.Y, target.Block.Z, VoxelBlock.Air);
+        UpdateTarget();
+        Invalidate();
+    }
+
+    private void PlaceSelectedBlock()
+    {
+        if (World is null || _target is not { } target)
+        {
+            return;
+        }
+
+        var position = target.Previous;
+        if (_player.IntersectsBlock(position.X, position.Y, position.Z))
+        {
+            return;
+        }
+
+        World.SetBlock(position.X, position.Y, position.Z, SelectedBlock);
+        _animateMaterials |= SelectedBlock == VoxelBlock.Water;
+        UpdateTarget();
+        Invalidate();
+    }
+
+    private void DrawLoadingSurface(DrawingContext context)
+    {
+        context.DrawRectangle(
+            new ThemeResourceBrush("CardBackground"),
+            null,
+            new Rect(Vector2.Zero, Size));
+        var center = Size * 0.5f;
+        context.DrawLine(_focusPen, center - new Vector2(16, 0), center + new Vector2(16, 0));
+    }
+
+    private void DrawHud(DrawingContext context)
+    {
+        var center = Size * 0.5f;
+        const float gap = 4f;
+        const float length = 10f;
+        context.DrawLine(_crosshairPen, center - new Vector2(gap + length, 0), center - new Vector2(gap, 0));
+        context.DrawLine(_crosshairPen, center + new Vector2(gap, 0), center + new Vector2(gap + length, 0));
+        context.DrawLine(_crosshairPen, center - new Vector2(0, gap + length), center - new Vector2(0, gap));
+        context.DrawLine(_crosshairPen, center + new Vector2(0, gap), center + new Vector2(0, gap + length));
+
+        if (IsFocused)
+        {
+            context.DrawRectangle(
+                null,
+                _focusPen,
+                new Rect(1, 1, Math.Max(0, Size.X - 2), Math.Max(0, Size.Y - 2)));
+        }
+    }
+
+    private void EnsureTextures(WgpuContext context, uint width, uint height, uint sampleCount)
+    {
+        if (_colorTexture is not null &&
+            _colorTexture.Width == width &&
+            _colorTexture.Height == height &&
+            _textureSampleCount == sampleCount)
+        {
+            return;
+        }
+
+        DisposeTextures();
+        _colorTexture = new GpuTexture(
+            context,
+            width,
+            height,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.RenderAttachment | TextureUsage.TextureBinding,
+            "Voxel color",
+            alphaMode: GpuTextureAlphaMode.Premultiplied);
+        _msaaColorTexture = sampleCount > 1
+            ? new GpuTexture(
+                context,
+                width,
+                height,
+                TextureFormat.Rgba8Unorm,
+                TextureUsage.RenderAttachment,
+                "Voxel MSAA color",
+                sampleCount: sampleCount,
+                alphaMode: GpuTextureAlphaMode.Premultiplied)
+            : null;
+        _depthTexture = new GpuTexture(
+            context,
+            width,
+            height,
+            TextureFormat.Depth24Plus,
+            TextureUsage.RenderAttachment,
+            "Voxel depth",
+            sampleCount: sampleCount);
+        _textureSampleCount = sampleCount;
+    }
+
+    private void DisposeTextures()
+    {
+        _colorTexture?.Dispose();
+        _colorTexture = null;
+        _msaaColorTexture?.Dispose();
+        _msaaColorTexture = null;
+        _depthTexture?.Dispose();
+        _depthTexture = null;
+        _textureSampleCount = 0;
+    }
+
+    private WgpuContext? GetActiveWgpuContext()
+    {
+        var windows = WindowManager.ActiveWindows;
+        if (windows.Count == 0) return WgpuContext.Current;
+        if (windows.Count == 1) return windows[0].WgpuContext;
+
+        Visual? current = this;
+        while (current is not null)
+        {
+            for (var index = 0; index < windows.Count; index++)
+            {
+                if (windows[index].Content == current)
+                {
+                    return windows[index].WgpuContext;
+                }
+            }
+            current = current.Parent;
+        }
+        return windows[0].WgpuContext;
+    }
+
+    private bool IsPressed(Key primary, Key alternate = Key.Unknown) =>
+        _pressedKeys.Contains(primary) ||
+        (alternate != Key.Unknown && _pressedKeys.Contains(alternate));
+
+    private float Axis(Key positive, Key positiveAlternate, Key negative, Key negativeAlternate) =>
+        (IsPressed(positive, positiveAlternate) ? 1f : 0f) -
+        (IsPressed(negative, negativeAlternate) ? 1f : 0f);
+
+    private static bool TrySelectBlock(Key key, out VoxelBlock block)
+    {
+        var slot = key switch
+        {
+            Key.Number1 or Key.Keypad1 => 1,
+            Key.Number2 or Key.Keypad2 => 2,
+            Key.Number3 or Key.Keypad3 => 3,
+            Key.Number4 or Key.Keypad4 => 4,
+            Key.Number5 or Key.Keypad5 => 5,
+            Key.Number6 or Key.Keypad6 => 6,
+            Key.Number7 or Key.Keypad7 => 7,
+            _ => 0
+        };
+        block = VoxelBlockCatalog.FromHotbarSlot(slot);
+        return slot != 0;
+    }
+
+    private void CycleSelectedBlock(int direction)
+    {
+        var slot = 1;
+        for (; slot <= VoxelBlockCatalog.PlaceableCount; slot++)
+        {
+            if (VoxelBlockCatalog.FromHotbarSlot(slot) == SelectedBlock) break;
+        }
+        slot = 1 + (slot - 1 + direction + VoxelBlockCatalog.PlaceableCount) %
+            VoxelBlockCatalog.PlaceableCount;
+        SelectedBlock = VoxelBlockCatalog.FromHotbarSlot(slot);
+        SelectedBlockChanged?.Invoke(this, EventArgs.Empty);
+        Invalidate();
+    }
+
+    private static bool IsGameKey(Key key) => key is
+        Key.W or Key.A or Key.S or Key.D or
+        Key.Up or Key.Down or Key.Left or Key.Right or
+        Key.Space or Key.Q or Key.E or Key.F or Key.Escape or
+        Key.ControlLeft or Key.ControlRight or
+        Key.ShiftLeft or Key.ShiftRight or
+        Key.Number1 or Key.Number2 or Key.Number3 or Key.Number4 or
+        Key.Number5 or Key.Number6 or Key.Number7 or
+        Key.Keypad1 or Key.Keypad2 or Key.Keypad3 or Key.Keypad4 or
+        Key.Keypad5 or Key.Keypad6 or Key.Keypad7;
+}

--- a/src/ProGPU.Voxel/ProGPU.Voxel.csproj
+++ b/src/ProGPU.Voxel/ProGPU.Voxel.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/ProGPU.Voxel/VoxelBlock.cs
+++ b/src/ProGPU.Voxel/VoxelBlock.cs
@@ -1,0 +1,58 @@
+namespace ProGPU.Voxel;
+
+public enum VoxelBlock : ushort
+{
+    Air = 0,
+    Grass = 1,
+    Dirt = 2,
+    Stone = 3,
+    Sand = 4,
+    Wood = 5,
+    Leaves = 6,
+    Water = 7
+}
+
+public readonly record struct VoxelBlockDefinition(
+    VoxelBlock Id,
+    string Name,
+    bool IsSolid,
+    bool IsOpaque);
+
+public static class VoxelBlockCatalog
+{
+    public const int PlaceableCount = 7;
+
+    public static VoxelBlockDefinition Get(VoxelBlock block) => block switch
+    {
+        VoxelBlock.Grass => new(block, "Grass", true, true),
+        VoxelBlock.Dirt => new(block, "Dirt", true, true),
+        VoxelBlock.Stone => new(block, "Stone", true, true),
+        VoxelBlock.Sand => new(block, "Sand", true, true),
+        VoxelBlock.Wood => new(block, "Wood", true, true),
+        VoxelBlock.Leaves => new(block, "Leaves", true, true),
+        VoxelBlock.Water => new(block, "Water", false, true),
+        _ => new(VoxelBlock.Air, "Air", false, false)
+    };
+
+    public static bool IsSolid(VoxelBlock block) => block is
+        VoxelBlock.Grass or
+        VoxelBlock.Dirt or
+        VoxelBlock.Stone or
+        VoxelBlock.Sand or
+        VoxelBlock.Wood or
+        VoxelBlock.Leaves;
+
+    public static bool IsOpaque(VoxelBlock block) => block != VoxelBlock.Air;
+
+    public static VoxelBlock FromHotbarSlot(int slot) => slot switch
+    {
+        1 => VoxelBlock.Grass,
+        2 => VoxelBlock.Dirt,
+        3 => VoxelBlock.Stone,
+        4 => VoxelBlock.Sand,
+        5 => VoxelBlock.Wood,
+        6 => VoxelBlock.Leaves,
+        7 => VoxelBlock.Water,
+        _ => VoxelBlock.Grass
+    };
+}

--- a/src/ProGPU.Voxel/VoxelChunk.cs
+++ b/src/ProGPU.Voxel/VoxelChunk.cs
@@ -1,0 +1,92 @@
+namespace ProGPU.Voxel;
+
+/// <summary>
+/// A fixed-size, densely packed chunk. Mutations are O(1); enumeration is O(ChunkVolume).
+/// Instances are intentionally thread-confined so gameplay can update without locks.
+/// </summary>
+public sealed class VoxelChunk
+{
+    public const int Size = 16;
+    public const int Volume = Size * Size * Size;
+
+    private readonly ushort[] _blocks = new ushort[Volume];
+    private int _nonAirCount;
+
+    public VoxelChunk(VoxelChunkPosition position)
+    {
+        Position = position;
+    }
+
+    public VoxelChunkPosition Position { get; }
+
+    public int ContentVersion { get; private set; }
+
+    public int MeshVersion { get; private set; }
+
+    public int NonAirCount => _nonAirCount;
+
+    public bool IsEmpty => _nonAirCount == 0;
+
+    public bool IsMeshDirty { get; private set; } = true;
+
+    public VoxelMesh? Mesh { get; private set; }
+
+    public VoxelBlock GetLocal(int x, int y, int z)
+    {
+        if ((uint)x >= Size || (uint)y >= Size || (uint)z >= Size)
+        {
+            return VoxelBlock.Air;
+        }
+
+        return (VoxelBlock)_blocks[ToIndex(x, y, z)];
+    }
+
+    public bool SetLocal(int x, int y, int z, VoxelBlock block)
+    {
+        if ((uint)x >= Size || (uint)y >= Size || (uint)z >= Size)
+        {
+            throw new ArgumentOutOfRangeException(nameof(x), "Chunk-local coordinates must be in [0, 16).");
+        }
+
+        var index = ToIndex(x, y, z);
+        var previous = (VoxelBlock)_blocks[index];
+        if (previous == block)
+        {
+            return false;
+        }
+
+        if (previous == VoxelBlock.Air)
+        {
+            _nonAirCount++;
+        }
+        else if (block == VoxelBlock.Air)
+        {
+            _nonAirCount--;
+        }
+
+        _blocks[index] = (ushort)block;
+        ContentVersion++;
+        MarkMeshDirty();
+        return true;
+    }
+
+    public bool Contains(VoxelBlock block) =>
+        Array.IndexOf(_blocks, (ushort)block) >= 0;
+
+    public void MarkMeshDirty()
+    {
+        if (!IsMeshDirty)
+        {
+            IsMeshDirty = true;
+            MeshVersion++;
+        }
+    }
+
+    internal void AcceptMesh(VoxelMesh mesh)
+    {
+        Mesh = mesh;
+        IsMeshDirty = false;
+    }
+
+    private static int ToIndex(int x, int y, int z) => x + Size * (z + Size * y);
+}

--- a/src/ProGPU.Voxel/VoxelChunkPosition.cs
+++ b/src/ProGPU.Voxel/VoxelChunkPosition.cs
@@ -1,0 +1,11 @@
+using System.Numerics;
+
+namespace ProGPU.Voxel;
+
+public readonly record struct VoxelChunkPosition(int X, int Y, int Z)
+{
+    public Vector3 WorldOrigin => new(
+        X * VoxelChunk.Size,
+        Y * VoxelChunk.Size,
+        Z * VoxelChunk.Size);
+}

--- a/src/ProGPU.Voxel/VoxelFrustum.cs
+++ b/src/ProGPU.Voxel/VoxelFrustum.cs
@@ -1,0 +1,56 @@
+using System.Numerics;
+
+namespace ProGPU.Voxel;
+
+/// <summary>
+/// Conservative homogeneous-clip AABB test. It performs fixed O(1) work with no allocation.
+/// </summary>
+public static class VoxelFrustum
+{
+    public static bool Intersects(Matrix4x4 viewProjection, Vector3 minimum, Vector3 maximum)
+    {
+        Span<Vector4> corners = stackalloc Vector4[8];
+        corners[0] = Transform(minimum.X, minimum.Y, minimum.Z, viewProjection);
+        corners[1] = Transform(maximum.X, minimum.Y, minimum.Z, viewProjection);
+        corners[2] = Transform(minimum.X, maximum.Y, minimum.Z, viewProjection);
+        corners[3] = Transform(maximum.X, maximum.Y, minimum.Z, viewProjection);
+        corners[4] = Transform(minimum.X, minimum.Y, maximum.Z, viewProjection);
+        corners[5] = Transform(maximum.X, minimum.Y, maximum.Z, viewProjection);
+        corners[6] = Transform(minimum.X, maximum.Y, maximum.Z, viewProjection);
+        corners[7] = Transform(maximum.X, maximum.Y, maximum.Z, viewProjection);
+
+        for (var plane = 0; plane < 6; plane++)
+        {
+            var allOutside = true;
+            for (var i = 0; i < corners.Length; i++)
+            {
+                var point = corners[i];
+                var outside = plane switch
+                {
+                    0 => point.X < -point.W,
+                    1 => point.X > point.W,
+                    2 => point.Y < -point.W,
+                    3 => point.Y > point.W,
+                    4 => point.Z < 0f,
+                    _ => point.Z > point.W
+                };
+                if (!outside)
+                {
+                    allOutside = false;
+                    break;
+                }
+            }
+
+            if (allOutside)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static Vector4 Transform(float x, float y, float z, Matrix4x4 matrix) =>
+        Vector4.Transform(new Vector4(x, y, z, 1f), matrix);
+
+}

--- a/src/ProGPU.Voxel/VoxelGreedyMesher.cs
+++ b/src/ProGPU.Voxel/VoxelGreedyMesher.cs
@@ -1,0 +1,226 @@
+using System.Numerics;
+
+namespace ProGPU.Voxel;
+
+/// <summary>
+/// Builds exposed chunk surfaces by greedily merging equal coplanar faces.
+/// Time is O(3 * (S + 1) * S²), or O(S³), and temporary storage is O(S²).
+/// </summary>
+public static class VoxelGreedyMesher
+{
+    private readonly record struct FaceKey(VoxelBlock Block, sbyte Direction)
+    {
+        public bool IsEmpty => Block == VoxelBlock.Air;
+    }
+
+    public static VoxelMesh Build(VoxelWorld world, VoxelChunk chunk)
+    {
+        ArgumentNullException.ThrowIfNull(world);
+        ArgumentNullException.ThrowIfNull(chunk);
+
+        var vertices = new List<VoxelVertex>(1024);
+        var indices = new List<uint>(1536);
+        var mask = new FaceKey[VoxelChunk.Size * VoxelChunk.Size];
+        var origin = chunk.Position.WorldOrigin;
+        var originX = (int)origin.X;
+        var originY = (int)origin.Y;
+        var originZ = (int)origin.Z;
+        var visibleFaces = 0;
+        var mergedQuads = 0;
+
+        Span<int> coordinate = stackalloc int[3];
+
+        for (var axis = 0; axis < 3; axis++)
+        {
+            var uAxis = (axis + 1) % 3;
+            var vAxis = (axis + 2) % 3;
+
+            for (var slice = 0; slice <= VoxelChunk.Size; slice++)
+            {
+                var maskIndex = 0;
+                for (var v = 0; v < VoxelChunk.Size; v++)
+                {
+                    for (var u = 0; u < VoxelChunk.Size; u++)
+                    {
+                        coordinate[axis] = slice - 1;
+                        coordinate[uAxis] = u;
+                        coordinate[vAxis] = v;
+                        var negative = GetWorldBlock(world, originX, originY, originZ, coordinate);
+
+                        coordinate[axis] = slice;
+                        var positive = GetWorldBlock(world, originX, originY, originZ, coordinate);
+
+                        var negativeOpaque = VoxelBlockCatalog.IsOpaque(negative);
+                        var positiveOpaque = VoxelBlockCatalog.IsOpaque(positive);
+                        if (negativeOpaque == positiveOpaque)
+                        {
+                            mask[maskIndex++] = default;
+                        }
+                        else if (negativeOpaque)
+                        {
+                            mask[maskIndex++] = new FaceKey(negative, 1);
+                            visibleFaces++;
+                        }
+                        else
+                        {
+                            mask[maskIndex++] = new FaceKey(positive, -1);
+                            visibleFaces++;
+                        }
+                    }
+                }
+
+                for (var v = 0; v < VoxelChunk.Size; v++)
+                {
+                    for (var u = 0; u < VoxelChunk.Size;)
+                    {
+                        var start = u + v * VoxelChunk.Size;
+                        var face = mask[start];
+                        if (face.IsEmpty)
+                        {
+                            u++;
+                            continue;
+                        }
+
+                        var width = 1;
+                        while (u + width < VoxelChunk.Size && mask[start + width] == face)
+                        {
+                            width++;
+                        }
+
+                        var height = 1;
+                        var canGrow = true;
+                        while (v + height < VoxelChunk.Size && canGrow)
+                        {
+                            var rowStart = start + height * VoxelChunk.Size;
+                            for (var x = 0; x < width; x++)
+                            {
+                                if (mask[rowStart + x] != face)
+                                {
+                                    canGrow = false;
+                                    break;
+                                }
+                            }
+
+                            if (canGrow)
+                            {
+                                height++;
+                            }
+                        }
+
+                        EmitQuad(vertices, indices, axis, uAxis, vAxis, slice, u, v, width, height, face);
+                        mergedQuads++;
+
+                        for (var clearV = 0; clearV < height; clearV++)
+                        {
+                            var rowStart = start + clearV * VoxelChunk.Size;
+                            for (var clearU = 0; clearU < width; clearU++)
+                            {
+                                mask[rowStart + clearU] = default;
+                            }
+                        }
+
+                        u += width;
+                    }
+                }
+            }
+        }
+
+        return new VoxelMesh(
+            vertices.ToArray(),
+            indices.ToArray(),
+            chunk.MeshVersion,
+            visibleFaces,
+            mergedQuads);
+    }
+
+    private static VoxelBlock GetWorldBlock(
+        VoxelWorld world,
+        int originX,
+        int originY,
+        int originZ,
+        ReadOnlySpan<int> coordinate) =>
+        world.GetBlock(
+            originX + coordinate[0],
+            originY + coordinate[1],
+            originZ + coordinate[2]);
+
+    private static void EmitQuad(
+        List<VoxelVertex> vertices,
+        List<uint> indices,
+        int axis,
+        int uAxis,
+        int vAxis,
+        int slice,
+        int u,
+        int v,
+        int width,
+        int height,
+        FaceKey face)
+    {
+        Span<float> p = stackalloc float[3];
+        Span<float> du = stackalloc float[3];
+        Span<float> dv = stackalloc float[3];
+        p[axis] = slice;
+        p[uAxis] = u;
+        p[vAxis] = v;
+        du[uAxis] = width;
+        dv[vAxis] = height;
+
+        var p0 = new Vector3(p[0], p[1], p[2]);
+        var uVector = new Vector3(du[0], du[1], du[2]);
+        var vVector = new Vector3(dv[0], dv[1], dv[2]);
+        var p1 = p0 + uVector;
+        var p2 = p1 + vVector;
+        var p3 = p0 + vVector;
+        var faceIndex = GetFaceIndex(axis, face.Direction);
+        var packed = PackMaterial(face.Block, faceIndex, GetFaceLight(faceIndex));
+        var baseIndex = (uint)vertices.Count;
+
+        vertices.Add(new VoxelVertex(p0, Vector2.Zero, packed));
+        vertices.Add(new VoxelVertex(p1, new Vector2(width, 0), packed));
+        vertices.Add(new VoxelVertex(p2, new Vector2(width, height), packed));
+        vertices.Add(new VoxelVertex(p3, new Vector2(0, height), packed));
+
+        if (face.Direction > 0)
+        {
+            indices.Add(baseIndex);
+            indices.Add(baseIndex + 1);
+            indices.Add(baseIndex + 2);
+            indices.Add(baseIndex);
+            indices.Add(baseIndex + 2);
+            indices.Add(baseIndex + 3);
+        }
+        else
+        {
+            indices.Add(baseIndex);
+            indices.Add(baseIndex + 2);
+            indices.Add(baseIndex + 1);
+            indices.Add(baseIndex);
+            indices.Add(baseIndex + 3);
+            indices.Add(baseIndex + 2);
+        }
+    }
+
+    private static uint PackMaterial(VoxelBlock block, uint face, uint light) =>
+        (uint)block | (face << 8) | (light << 16);
+
+    private static uint GetFaceIndex(int axis, sbyte direction) => (axis, direction) switch
+    {
+        (0, > 0) => 0,
+        (0, < 0) => 1,
+        (1, > 0) => 2,
+        (1, < 0) => 3,
+        (2, > 0) => 4,
+        _ => 5
+    };
+
+    private static uint GetFaceLight(uint face) => face switch
+    {
+        2 => 255,
+        3 => 105,
+        0 => 218,
+        1 => 175,
+        4 => 202,
+        _ => 158
+    };
+}

--- a/src/ProGPU.Voxel/VoxelMesh.cs
+++ b/src/ProGPU.Voxel/VoxelMesh.cs
@@ -1,0 +1,53 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace ProGPU.Voxel;
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public readonly struct VoxelVertex
+{
+    public VoxelVertex(Vector3 position, Vector2 textureCoordinate, uint material)
+    {
+        Position = position;
+        TextureCoordinate = textureCoordinate;
+        Material = material;
+    }
+
+    public Vector3 Position { get; }
+
+    public Vector2 TextureCoordinate { get; }
+
+    /// <summary>
+    /// Packed as material[0..7], face[8..10], light[16..23].
+    /// </summary>
+    public uint Material { get; }
+}
+
+public sealed class VoxelMesh
+{
+    public VoxelMesh(
+        VoxelVertex[] vertices,
+        uint[] indices,
+        int version,
+        int visibleFaceCount,
+        int mergedQuadCount)
+    {
+        Vertices = vertices;
+        Indices = indices;
+        Version = version;
+        VisibleFaceCount = visibleFaceCount;
+        MergedQuadCount = mergedQuadCount;
+    }
+
+    public VoxelVertex[] Vertices { get; }
+
+    public uint[] Indices { get; }
+
+    public int Version { get; }
+
+    public int VisibleFaceCount { get; }
+
+    public int MergedQuadCount { get; }
+
+    public int TriangleCount => Indices.Length / 3;
+}

--- a/src/ProGPU.Voxel/VoxelPlayerController.cs
+++ b/src/ProGPU.Voxel/VoxelPlayerController.cs
@@ -1,0 +1,186 @@
+using System.Numerics;
+
+namespace ProGPU.Voxel;
+
+public readonly record struct VoxelPlayerInput(
+    float Forward,
+    float Strafe,
+    float Vertical,
+    bool Jump,
+    bool Sprint);
+
+/// <summary>
+/// First-person kinematic controller with axis-separated voxel collision.
+/// Update is O(B), where B is the small number of blocks overlapping the player AABB.
+/// </summary>
+public sealed class VoxelPlayerController
+{
+    private const float Radius = 0.3f;
+    private const float Height = 1.8f;
+    private const float EyeHeight = 1.62f;
+    private const float Gravity = 24f;
+    private const float JumpSpeed = 8.2f;
+
+    public Vector3 Position { get; private set; }
+
+    public Vector3 Velocity { get; private set; }
+
+    public float Yaw { get; private set; }
+
+    public float Pitch { get; private set; } = -0.15f;
+
+    public bool IsGrounded { get; private set; }
+
+    public bool IsFlying { get; private set; }
+
+    public Vector3 EyePosition => Position + new Vector3(0, EyeHeight, 0);
+
+    public Vector3 LookDirection
+    {
+        get
+        {
+            var cosPitch = MathF.Cos(Pitch);
+            return Vector3.Normalize(new Vector3(
+                MathF.Sin(Yaw) * cosPitch,
+                MathF.Sin(Pitch),
+                MathF.Cos(Yaw) * cosPitch));
+        }
+    }
+
+    public void Teleport(Vector3 position, float yaw = 0f, float pitch = -0.15f)
+    {
+        Position = position;
+        Velocity = Vector3.Zero;
+        Yaw = yaw;
+        Pitch = Math.Clamp(pitch, -1.52f, 1.52f);
+        IsGrounded = false;
+    }
+
+    public void AddLook(float yawDelta, float pitchDelta)
+    {
+        Yaw += yawDelta;
+        Pitch = Math.Clamp(Pitch + pitchDelta, -1.52f, 1.52f);
+    }
+
+    public void ToggleFlying()
+    {
+        IsFlying = !IsFlying;
+        Velocity = Vector3.Zero;
+    }
+
+    public void Update(VoxelWorld world, in VoxelPlayerInput input, float elapsedSeconds)
+    {
+        ArgumentNullException.ThrowIfNull(world);
+        var delta = Math.Clamp(elapsedSeconds, 0f, 0.05f);
+        if (delta <= 0f)
+        {
+            return;
+        }
+
+        var forward = new Vector3(MathF.Sin(Yaw), 0, MathF.Cos(Yaw));
+        // Matrix4x4.CreateLookAt uses a right-handed view. With this controller's
+        // +Z forward convention, screen-right is the negative horizontal
+        // perpendicular of forward.
+        var right = new Vector3(-forward.Z, 0, forward.X);
+        var movement = forward * input.Forward + right * input.Strafe;
+        if (movement.LengthSquared() > 1f)
+        {
+            movement = Vector3.Normalize(movement);
+        }
+
+        var speed = input.Sprint ? 9.5f : 5.5f;
+        Velocity = new Vector3(movement.X * speed, Velocity.Y, movement.Z * speed);
+
+        if (IsFlying)
+        {
+            Velocity = new Vector3(Velocity.X, input.Vertical * speed, Velocity.Z);
+            Position += Velocity * delta;
+            IsGrounded = false;
+            return;
+        }
+
+        if (input.Jump && IsGrounded)
+        {
+            Velocity = new Vector3(Velocity.X, JumpSpeed, Velocity.Z);
+            IsGrounded = false;
+        }
+
+        Velocity = new Vector3(Velocity.X, Velocity.Y - Gravity * delta, Velocity.Z);
+        MoveAxis(world, 0, Velocity.X * delta);
+        MoveAxis(world, 2, Velocity.Z * delta);
+        IsGrounded = false;
+        MoveAxis(world, 1, Velocity.Y * delta);
+    }
+
+    public bool IntersectsBlock(int x, int y, int z)
+    {
+        var playerMin = new Vector3(Position.X - Radius, Position.Y, Position.Z - Radius);
+        var playerMax = new Vector3(Position.X + Radius, Position.Y + Height, Position.Z + Radius);
+        return playerMin.X < x + 1 && playerMax.X > x &&
+               playerMin.Y < y + 1 && playerMax.Y > y &&
+               playerMin.Z < z + 1 && playerMax.Z > z;
+    }
+
+    private void MoveAxis(VoxelWorld world, int axis, float amount)
+    {
+        if (MathF.Abs(amount) < 1e-7f)
+        {
+            return;
+        }
+
+        var candidate = Position;
+        if (axis == 0) candidate.X += amount;
+        else if (axis == 1) candidate.Y += amount;
+        else candidate.Z += amount;
+
+        if (!Collides(world, candidate))
+        {
+            Position = candidate;
+            return;
+        }
+
+        if (axis == 0)
+        {
+            Velocity = new Vector3(0, Velocity.Y, Velocity.Z);
+        }
+        else if (axis == 1)
+        {
+            if (amount < 0f)
+            {
+                IsGrounded = true;
+            }
+            Velocity = new Vector3(Velocity.X, 0, Velocity.Z);
+        }
+        else
+        {
+            Velocity = new Vector3(Velocity.X, Velocity.Y, 0);
+        }
+    }
+
+    private static bool Collides(VoxelWorld world, Vector3 position)
+    {
+        const float epsilon = 0.0001f;
+        var minX = (int)MathF.Floor(position.X - Radius);
+        var maxX = (int)MathF.Floor(position.X + Radius - epsilon);
+        var minY = (int)MathF.Floor(position.Y);
+        var maxY = (int)MathF.Floor(position.Y + Height - epsilon);
+        var minZ = (int)MathF.Floor(position.Z - Radius);
+        var maxZ = (int)MathF.Floor(position.Z + Radius - epsilon);
+
+        for (var y = minY; y <= maxY; y++)
+        {
+            for (var z = minZ; z <= maxZ; z++)
+            {
+                for (var x = minX; x <= maxX; x++)
+                {
+                    if (VoxelBlockCatalog.IsSolid(world.GetBlock(x, y, z)))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ProGPU.Voxel/VoxelRaycaster.cs
+++ b/src/ProGPU.Voxel/VoxelRaycaster.cs
@@ -1,0 +1,94 @@
+using System.Numerics;
+
+namespace ProGPU.Voxel;
+
+public readonly record struct VoxelRaycastHit(
+    (int X, int Y, int Z) Block,
+    (int X, int Y, int Z) Previous,
+    (int X, int Y, int Z) Normal,
+    float Distance,
+    VoxelBlock BlockType);
+
+/// <summary>
+/// Grid DDA traversal. Time is O(number of crossed voxel boundaries), storage is O(1).
+/// </summary>
+public static class VoxelRaycaster
+{
+    public static bool TryCast(
+        VoxelWorld world,
+        Vector3 origin,
+        Vector3 direction,
+        float maxDistance,
+        out VoxelRaycastHit hit)
+    {
+        ArgumentNullException.ThrowIfNull(world);
+        hit = default;
+        if (maxDistance <= 0f || direction.LengthSquared() < 1e-12f)
+        {
+            return false;
+        }
+
+        direction = Vector3.Normalize(direction);
+        var x = (int)MathF.Floor(origin.X);
+        var y = (int)MathF.Floor(origin.Y);
+        var z = (int)MathF.Floor(origin.Z);
+        var previous = (X: x, Y: y, Z: z);
+        var stepX = Math.Sign(direction.X);
+        var stepY = Math.Sign(direction.Y);
+        var stepZ = Math.Sign(direction.Z);
+        var deltaX = direction.X == 0f ? float.PositiveInfinity : MathF.Abs(1f / direction.X);
+        var deltaY = direction.Y == 0f ? float.PositiveInfinity : MathF.Abs(1f / direction.Y);
+        var deltaZ = direction.Z == 0f ? float.PositiveInfinity : MathF.Abs(1f / direction.Z);
+        var maxX = InitialBoundaryDistance(origin.X, direction.X, x, stepX);
+        var maxY = InitialBoundaryDistance(origin.Y, direction.Y, y, stepY);
+        var maxZ = InitialBoundaryDistance(origin.Z, direction.Z, z, stepZ);
+        var normal = (X: 0, Y: 0, Z: 0);
+        var distance = 0f;
+
+        while (distance <= maxDistance)
+        {
+            var block = world.GetBlock(x, y, z);
+            if (block != VoxelBlock.Air && block != VoxelBlock.Water)
+            {
+                hit = new VoxelRaycastHit((x, y, z), previous, normal, distance, block);
+                return true;
+            }
+
+            previous = (x, y, z);
+            if (maxX <= maxY && maxX <= maxZ)
+            {
+                x += stepX;
+                distance = maxX;
+                maxX += deltaX;
+                normal = (-stepX, 0, 0);
+            }
+            else if (maxY <= maxZ)
+            {
+                y += stepY;
+                distance = maxY;
+                maxY += deltaY;
+                normal = (0, -stepY, 0);
+            }
+            else
+            {
+                z += stepZ;
+                distance = maxZ;
+                maxZ += deltaZ;
+                normal = (0, 0, -stepZ);
+            }
+        }
+
+        return false;
+    }
+
+    private static float InitialBoundaryDistance(float origin, float direction, int cell, int step)
+    {
+        if (step == 0)
+        {
+            return float.PositiveInfinity;
+        }
+
+        var boundary = step > 0 ? cell + 1f : cell;
+        return (boundary - origin) / direction;
+    }
+}

--- a/src/ProGPU.Voxel/VoxelTerrainGenerator.cs
+++ b/src/ProGPU.Voxel/VoxelTerrainGenerator.cs
@@ -1,0 +1,154 @@
+namespace ProGPU.Voxel;
+
+public readonly record struct VoxelTerrainSettings(
+    int Seed,
+    int ChunkRadius = 3,
+    int BaseHeight = 20,
+    int HeightVariation = 14,
+    bool BuildMeshes = true);
+
+/// <summary>
+/// Deterministic fractal value-noise terrain generation.
+/// Time is O(W² * H); world storage is O(number of non-air chunks).
+/// </summary>
+public static class VoxelTerrainGenerator
+{
+    public static VoxelWorld Generate(VoxelTerrainSettings settings)
+    {
+        if (settings.ChunkRadius < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(settings), "Chunk radius must be positive.");
+        }
+
+        var world = new VoxelWorld();
+        var radius = settings.ChunkRadius * VoxelChunk.Size;
+
+        for (var z = -radius; z < radius; z++)
+        {
+            for (var x = -radius; x < radius; x++)
+            {
+                var continental = FractalNoise(x * 0.018f, z * 0.018f, settings.Seed, 4);
+                var detail = FractalNoise(x * 0.065f, z * 0.065f, settings.Seed + 7919, 3);
+                var height = settings.BaseHeight +
+                    (int)MathF.Round((continental * 0.75f + detail * 0.25f) * settings.HeightVariation);
+                height = Math.Max(4, height);
+                var sandy = height <= settings.BaseHeight - 2;
+
+                for (var y = 0; y <= height; y++)
+                {
+                    var depth = height - y;
+                    var block = depth switch
+                    {
+                        0 when sandy => VoxelBlock.Sand,
+                        0 => VoxelBlock.Grass,
+                        <= 3 when sandy => VoxelBlock.Sand,
+                        <= 3 => VoxelBlock.Dirt,
+                        _ => VoxelBlock.Stone
+                    };
+                    world.SetBlock(x, y, z, block);
+                }
+
+                var treeHash = Hash(x, 0, z, settings.Seed + 104729);
+                if (!sandy &&
+                    height > settings.BaseHeight - 1 &&
+                    (treeHash & 0x1ffu) == 0u &&
+                    x > -radius + 3 && x < radius - 3 &&
+                    z > -radius + 3 && z < radius - 3)
+                {
+                    AddTree(world, x, height + 1, z, treeHash);
+                }
+            }
+        }
+
+        if (settings.BuildMeshes)
+        {
+            world.BuildAllMeshes();
+        }
+
+        return world;
+    }
+
+    private static void AddTree(VoxelWorld world, int x, int y, int z, uint hash)
+    {
+        var trunkHeight = 4 + (int)((hash >> 12) & 1u);
+        for (var trunkY = 0; trunkY < trunkHeight; trunkY++)
+        {
+            world.SetBlock(x, y + trunkY, z, VoxelBlock.Wood);
+        }
+
+        var crownY = y + trunkHeight - 2;
+        for (var dy = 0; dy <= 3; dy++)
+        {
+            var radius = dy is 0 or 3 ? 1 : 2;
+            for (var dz = -radius; dz <= radius; dz++)
+            {
+                for (var dx = -radius; dx <= radius; dx++)
+                {
+                    if (Math.Abs(dx) == radius && Math.Abs(dz) == radius && ((hash + (uint)(dx * 7 + dz * 13 + dy * 17)) & 1u) == 0u)
+                    {
+                        continue;
+                    }
+
+                    if (world.GetBlock(x + dx, crownY + dy, z + dz) == VoxelBlock.Air)
+                    {
+                        world.SetBlock(x + dx, crownY + dy, z + dz, VoxelBlock.Leaves);
+                    }
+                }
+            }
+        }
+    }
+
+    private static float FractalNoise(float x, float z, int seed, int octaves)
+    {
+        var sum = 0f;
+        var amplitude = 1f;
+        var frequency = 1f;
+        var normalization = 0f;
+
+        for (var octave = 0; octave < octaves; octave++)
+        {
+            sum += SmoothValueNoise(x * frequency, z * frequency, seed + octave * 1013) * amplitude;
+            normalization += amplitude;
+            amplitude *= 0.5f;
+            frequency *= 2.03f;
+        }
+
+        return sum / normalization;
+    }
+
+    private static float SmoothValueNoise(float x, float z, int seed)
+    {
+        var x0 = (int)MathF.Floor(x);
+        var z0 = (int)MathF.Floor(z);
+        var tx = Smooth(x - x0);
+        var tz = Smooth(z - z0);
+
+        var a = HashToSignedUnit(Hash(x0, 0, z0, seed));
+        var b = HashToSignedUnit(Hash(x0 + 1, 0, z0, seed));
+        var c = HashToSignedUnit(Hash(x0, 0, z0 + 1, seed));
+        var d = HashToSignedUnit(Hash(x0 + 1, 0, z0 + 1, seed));
+        return Lerp(Lerp(a, b, tx), Lerp(c, d, tx), tz);
+    }
+
+    private static float Smooth(float value) => value * value * (3f - 2f * value);
+
+    private static float Lerp(float a, float b, float amount) => a + (b - a) * amount;
+
+    private static float HashToSignedUnit(uint value) =>
+        (value & 0x00ffffffu) / 8388607.5f - 1f;
+
+    private static uint Hash(int x, int y, int z, int seed)
+    {
+        var value = unchecked((uint)seed);
+        value ^= unchecked((uint)x) * 0x9e3779b1u;
+        value = (value << 13) | (value >> 19);
+        value ^= unchecked((uint)y) * 0x85ebca77u;
+        value = (value << 11) | (value >> 21);
+        value ^= unchecked((uint)z) * 0xc2b2ae3du;
+        value ^= value >> 16;
+        value *= 0x7feb352du;
+        value ^= value >> 15;
+        value *= 0x846ca68bu;
+        return value ^ (value >> 16);
+    }
+}

--- a/src/ProGPU.Voxel/VoxelWorld.cs
+++ b/src/ProGPU.Voxel/VoxelWorld.cs
@@ -1,0 +1,137 @@
+namespace ProGPU.Voxel;
+
+/// <summary>
+/// Sparse chunked voxel storage. Reads and writes are O(1) average; remeshing is explicit.
+/// </summary>
+public sealed class VoxelWorld
+{
+    private readonly Dictionary<VoxelChunkPosition, VoxelChunk> _chunks = new();
+
+    public IReadOnlyCollection<VoxelChunk> Chunks => _chunks.Values;
+
+    public int ChunkCount => _chunks.Count;
+
+    public VoxelBlock GetBlock(int x, int y, int z)
+    {
+        var chunkPosition = ToChunkPosition(x, y, z);
+        return _chunks.TryGetValue(chunkPosition, out var chunk)
+            ? chunk.GetLocal(ToLocal(x), ToLocal(y), ToLocal(z))
+            : VoxelBlock.Air;
+    }
+
+    public bool SetBlock(int x, int y, int z, VoxelBlock block)
+    {
+        var chunkPosition = ToChunkPosition(x, y, z);
+        if (!_chunks.TryGetValue(chunkPosition, out var chunk))
+        {
+            if (block == VoxelBlock.Air)
+            {
+                return false;
+            }
+
+            chunk = new VoxelChunk(chunkPosition);
+            _chunks.Add(chunkPosition, chunk);
+        }
+
+        var localX = ToLocal(x);
+        var localY = ToLocal(y);
+        var localZ = ToLocal(z);
+        if (!chunk.SetLocal(localX, localY, localZ, block))
+        {
+            return false;
+        }
+
+        if (localX == 0) MarkChunkMeshDirty(new(chunkPosition.X - 1, chunkPosition.Y, chunkPosition.Z));
+        if (localX == VoxelChunk.Size - 1) MarkChunkMeshDirty(new(chunkPosition.X + 1, chunkPosition.Y, chunkPosition.Z));
+        if (localY == 0) MarkChunkMeshDirty(new(chunkPosition.X, chunkPosition.Y - 1, chunkPosition.Z));
+        if (localY == VoxelChunk.Size - 1) MarkChunkMeshDirty(new(chunkPosition.X, chunkPosition.Y + 1, chunkPosition.Z));
+        if (localZ == 0) MarkChunkMeshDirty(new(chunkPosition.X, chunkPosition.Y, chunkPosition.Z - 1));
+        if (localZ == VoxelChunk.Size - 1) MarkChunkMeshDirty(new(chunkPosition.X, chunkPosition.Y, chunkPosition.Z + 1));
+
+        return true;
+    }
+
+    public VoxelChunk GetOrCreateChunk(VoxelChunkPosition position)
+    {
+        if (!_chunks.TryGetValue(position, out var chunk))
+        {
+            chunk = new VoxelChunk(position);
+            _chunks.Add(position, chunk);
+        }
+
+        return chunk;
+    }
+
+    public bool TryGetChunk(VoxelChunkPosition position, out VoxelChunk chunk) =>
+        _chunks.TryGetValue(position, out chunk!);
+
+    public VoxelMesh GetOrBuildMesh(VoxelChunk chunk)
+    {
+        if (!chunk.IsMeshDirty && chunk.Mesh is not null)
+        {
+            return chunk.Mesh;
+        }
+
+        var mesh = VoxelGreedyMesher.Build(this, chunk);
+        chunk.AcceptMesh(mesh);
+        return mesh;
+    }
+
+    public void BuildAllMeshes()
+    {
+        foreach (var chunk in _chunks.Values)
+        {
+            GetOrBuildMesh(chunk);
+        }
+    }
+
+    public bool ContainsBlock(VoxelBlock block)
+    {
+        foreach (var chunk in _chunks.Values)
+        {
+            if (chunk.Contains(block))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public int FindSurfaceY(int x, int z, int startY = 127)
+    {
+        for (var y = startY; y >= -64; y--)
+        {
+            if (VoxelBlockCatalog.IsSolid(GetBlock(x, y, z)))
+            {
+                return y;
+            }
+        }
+
+        return 0;
+    }
+
+    public static VoxelChunkPosition ToChunkPosition(int x, int y, int z) =>
+        new(FloorDiv(x, VoxelChunk.Size), FloorDiv(y, VoxelChunk.Size), FloorDiv(z, VoxelChunk.Size));
+
+    public static int ToLocal(int coordinate)
+    {
+        var result = coordinate % VoxelChunk.Size;
+        return result < 0 ? result + VoxelChunk.Size : result;
+    }
+
+    private void MarkChunkMeshDirty(VoxelChunkPosition position)
+    {
+        if (_chunks.TryGetValue(position, out var neighbor))
+        {
+            neighbor.MarkMeshDirty();
+        }
+    }
+
+    private static int FloorDiv(int value, int divisor)
+    {
+        var quotient = value / divisor;
+        var remainder = value % divisor;
+        return remainder < 0 ? quotient - 1 : quotient;
+    }
+}

--- a/src/ProGPU.WinUI.Themes.Fluent/FluentThemeResources.cs
+++ b/src/ProGPU.WinUI.Themes.Fluent/FluentThemeResources.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using System.Runtime.CompilerServices;
 
 namespace ProGPU.WinUI.Themes.Fluent;
 
@@ -11,9 +12,15 @@ public static class FluentThemeResources
     public const string ResourcePath =
         "ProGPU.WinUI.Themes.Fluent/Themes/Generic.xaml";
 
-    public static ResourceDictionary CreateDictionary() =>
-        XamlResourceProviderRegistry.Create(
+    public static ResourceDictionary CreateDictionary()
+    {
+        // Browser WebAssembly AOT can defer a referenced assembly's module constructor
+        // until after this public entry point is reached. Root and run the generated,
+        // idempotent provider registration before resolving the resource URI.
+        RuntimeHelpers.RunModuleConstructor(typeof(FluentThemeResources).Module.ModuleHandle);
+        return XamlResourceProviderRegistry.Create(
             new Uri(ResourcePath, UriKind.Relative));
+    }
 
     public static ResourceDictionary Apply(Application application)
     {

--- a/src/ProGPU.WinUI/Core/Window.cs
+++ b/src/ProGPU.WinUI/Core/Window.cs
@@ -422,6 +422,7 @@ public class Window : DependencyObject
         _silkWindow.Render += OnRender;
         _silkWindow.Resize += OnResize;
         _silkWindow.FramebufferResize += OnFramebufferResize;
+        _silkWindow.FocusChanged += OnFocusChanged;
         _silkWindow.Closing += OnClosing;
 
         _silkWindow.Initialize();
@@ -1098,6 +1099,11 @@ public class Window : DependencyObject
 
     private void OnClosing()
     {
+        if (_inputState != null)
+        {
+            InputSystem.Current = _inputState;
+            InputSystem.InjectFocusLost();
+        }
         NotifyHostVisibilityChanged(false);
         NotifyHostActivationChanged(WindowActivationState.Deactivated);
         RaiseClosed();
@@ -1109,6 +1115,20 @@ public class Window : DependencyObject
         _windowController = null;
         DetachWindowServices();
         _silkWindow = null;
+    }
+
+    private void OnFocusChanged(bool focused)
+    {
+        if (_inputState != null)
+        {
+            InputSystem.Current = _inputState;
+            if (!focused)
+            {
+                InputSystem.InjectFocusLost();
+            }
+        }
+        NotifyHostActivationChanged(
+            focused ? WindowActivationState.CodeActivated : WindowActivationState.Deactivated);
     }
 
     private void UpdateBounds(double width, double height)

--- a/src/ProGPU.WinUI/Input/InputSystem.cs
+++ b/src/ProGPU.WinUI/Input/InputSystem.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using Silk.NET.Input;
 using ProGPU.Scene;
 using ProGPU.Vector;
+using ProGPU.WinUI.Input;
 using Windows.Devices.Input;
 
 namespace Microsoft.UI.Xaml.Input;
@@ -35,6 +36,7 @@ public class WindowInputState
     public bool IsRightButtonPressed;
     public Action<StandardCursor>? CursorChanged;
     internal FrameworkElement? ComposingElement;
+    internal RelativePointerCaptureState RelativePointerCapture { get; } = new();
     internal Dictionary<uint, PointerContactState> PointerContacts { get; } = new();
     internal Dictionary<uint, FrameworkElement> CapturedElements { get; } = new();
     internal Dictionary<FrameworkElement, ManipulationSession> Manipulations { get; } = new();
@@ -384,7 +386,11 @@ public static class InputSystem
         {
             mouse.MouseMove += (m, pos) => {
                 _currentState = state;
-                OnMouseMove(NormalizeInputPosition(state, new Vector2(pos.X, pos.Y)));
+                var platformPosition = new Vector2(pos.X, pos.Y);
+                if (!RelativePointerCapture.ProcessPlatformMouseMove(state, platformPosition))
+                {
+                    OnMouseMove(NormalizeInputPosition(state, platformPosition));
+                }
             };
             mouse.MouseDown += (m, btn) => {
                 _currentState = state;
@@ -1845,6 +1851,7 @@ public static class InputSystem
 
     private static void OnFocusLost()
     {
+        RelativePointerCapture.ReleaseCurrent();
         foreach (var contact in Current.PointerContacts.Values.ToArray())
         {
             InjectPointer(contact.LastEvent with

--- a/src/ProGPU.WinUI/Input/RelativePointerCapture.cs
+++ b/src/ProGPU.WinUI/Input/RelativePointerCapture.cs
@@ -1,0 +1,204 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Silk.NET.Input;
+
+namespace ProGPU.WinUI.Input;
+
+/// <summary>
+/// ProGPU host extension for first-person relative mouse input. This deliberately
+/// lives outside Microsoft.UI.Xaml so the projected WinUI API surface stays compatible.
+/// </summary>
+public static class RelativePointerCapture
+{
+    public static bool TryAcquire(
+        FrameworkElement owner,
+        Action<Vector2> movement,
+        Action<bool>? captureChanged = null)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(movement);
+        var windowState = InputSystem.Current;
+        var state = windowState.RelativePointerCapture;
+        if (ReferenceEquals(state.Owner, owner))
+        {
+            state.Movement = movement;
+            state.CaptureChanged = captureChanged;
+            return true;
+        }
+        if (state.Owner != null) ReleaseCurrent();
+
+        var acquired = false;
+        if (state.HostAcquire != null)
+        {
+            try
+            {
+                acquired = state.HostAcquire();
+            }
+            catch
+            {
+                acquired = false;
+            }
+        }
+        else if (windowState.InputContext != null)
+        {
+            foreach (var mouse in windowState.InputContext.Mice)
+            {
+                try
+                {
+                    var cursor = mouse.Cursor;
+                    var mode = cursor.IsSupported(CursorMode.Raw)
+                        ? CursorMode.Raw
+                        : cursor.IsSupported(CursorMode.Disabled)
+                            ? CursorMode.Disabled
+                            : (CursorMode?)null;
+                    if (!mode.HasValue) continue;
+                    state.CursorModes[mouse] = cursor.CursorMode;
+                    cursor.CursorMode = mode.Value;
+                    acquired = true;
+                }
+                catch
+                {
+                    state.CursorModes.Remove(mouse);
+                }
+            }
+        }
+
+        if (!acquired) return false;
+        state.Owner = owner;
+        state.Movement = movement;
+        state.CaptureChanged = captureChanged;
+        state.HasLastPlatformPosition = false;
+        captureChanged?.Invoke(true);
+        owner.Invalidate();
+        return true;
+    }
+
+    public static bool IsCaptured(FrameworkElement owner) =>
+        ReferenceEquals(InputSystem.Current.RelativePointerCapture.Owner, owner);
+
+    public static void Release(FrameworkElement owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        if (IsCaptured(owner)) ReleaseCurrent();
+    }
+
+    public static void ConfigureHost(
+        WindowInputState windowState,
+        Func<bool> acquire,
+        Action release)
+    {
+        ArgumentNullException.ThrowIfNull(windowState);
+        ArgumentNullException.ThrowIfNull(acquire);
+        ArgumentNullException.ThrowIfNull(release);
+        windowState.RelativePointerCapture.HostAcquire = acquire;
+        windowState.RelativePointerCapture.HostRelease = release;
+    }
+
+    public static void ClearHost(WindowInputState windowState)
+    {
+        ArgumentNullException.ThrowIfNull(windowState);
+        var previous = InputSystem.Current;
+        try
+        {
+            InputSystem.Current = windowState;
+            ReleaseCurrent();
+        }
+        finally
+        {
+            InputSystem.Current = previous;
+        }
+        windowState.RelativePointerCapture.HostAcquire = null;
+        windowState.RelativePointerCapture.HostRelease = null;
+    }
+
+    public static void InjectHostMovement(Vector2 movement)
+    {
+        if (!float.IsFinite(movement.X) || !float.IsFinite(movement.Y)) return;
+        InputSystem.Current.RelativePointerCapture.Movement?.Invoke(movement);
+    }
+
+    public static void NotifyHostCaptureLost()
+    {
+        var state = InputSystem.Current.RelativePointerCapture;
+        var owner = state.Owner;
+        if (owner == null) return;
+        var captureChanged = state.CaptureChanged;
+        ClearLogicalCapture(state);
+        RestoreCursorModes(state);
+        captureChanged?.Invoke(false);
+        owner.Invalidate();
+    }
+
+    internal static bool ProcessPlatformMouseMove(WindowInputState windowState, Vector2 position)
+    {
+        var state = windowState.RelativePointerCapture;
+        if (state.Owner == null) return false;
+        if (state.HasLastPlatformPosition)
+        {
+            state.Movement?.Invoke(position - state.LastPlatformPosition);
+        }
+        state.LastPlatformPosition = position;
+        state.HasLastPlatformPosition = true;
+        return true;
+    }
+
+    internal static void ReleaseCurrent()
+    {
+        var state = InputSystem.Current.RelativePointerCapture;
+        var owner = state.Owner;
+        if (owner == null) return;
+        var captureChanged = state.CaptureChanged;
+        ClearLogicalCapture(state);
+        if (state.HostRelease != null)
+        {
+            try
+            {
+                state.HostRelease();
+            }
+            catch
+            {
+                // The host may already have released the capture.
+            }
+        }
+        RestoreCursorModes(state);
+        captureChanged?.Invoke(false);
+        owner.Invalidate();
+    }
+
+    private static void ClearLogicalCapture(RelativePointerCaptureState state)
+    {
+        state.Owner = null;
+        state.Movement = null;
+        state.CaptureChanged = null;
+        state.HasLastPlatformPosition = false;
+    }
+
+    private static void RestoreCursorModes(RelativePointerCaptureState state)
+    {
+        foreach (var pair in state.CursorModes)
+        {
+            try
+            {
+                pair.Key.Cursor.CursorMode = pair.Value;
+            }
+            catch
+            {
+                // The mouse may have been disconnected with the window unfocused.
+            }
+        }
+        state.CursorModes.Clear();
+    }
+}
+
+internal sealed class RelativePointerCaptureState
+{
+    public FrameworkElement? Owner;
+    public Action<Vector2>? Movement;
+    public Action<bool>? CaptureChanged;
+    public Func<bool>? HostAcquire;
+    public Action? HostRelease;
+    public Dictionary<IMouse, CursorMode> CursorModes { get; } = new();
+    public Vector2 LastPlatformPosition;
+    public bool HasLastPlatformPosition;
+}

--- a/src/ProGPU.slnx
+++ b/src/ProGPU.slnx
@@ -13,6 +13,9 @@
   <Project Path="ProGPU.Fonts.Noto/ProGPU.Fonts.Noto.csproj" />
   <Project Path="ProGPU.Compute/ProGPU.Compute.csproj" />
   <Project Path="ProGPU.Scene/ProGPU.Scene.csproj" />
+  <Project Path="ProGPU.Voxel/ProGPU.Voxel.csproj" />
+  <Project Path="ProGPU.Voxel.WinUI/ProGPU.Voxel.WinUI.csproj" />
+  <Project Path="ProGPU.Voxel.Tests/ProGPU.Voxel.Tests.csproj" />
   <Project Path="ProGPU.Wpf.Interop/ProGPU.Wpf.Interop.csproj" />
   <Project Path="System.Drawing.Common/System.Drawing.Common.csproj" />
   <Project Path="PresentationCore/PresentationCore.csproj" />
@@ -51,5 +54,6 @@
   <Project Path="../tools/TtfDiag/TtfDiag.csproj" />
   <Project Path="../tools/DxfDiag/DxfDiag.csproj" />
   <Project Path="../tools/HarfBuzzParity/HarfBuzzParity.csproj" />
+  <Project Path="../tools/ProGPU.Voxel.Benchmarks/ProGPU.Voxel.Benchmarks.csproj" />
   <Project Path="../tools/ProGPU.Xaml.Cli/ProGPU.Xaml.Cli.csproj" />
 </Solution>

--- a/tools/ProGPU.Voxel.Benchmarks/ProGPU.Voxel.Benchmarks.csproj
+++ b/tools/ProGPU.Voxel.Benchmarks/ProGPU.Voxel.Benchmarks.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ProGPU.Voxel\ProGPU.Voxel.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ProGPU.Voxel.Benchmarks/Program.cs
+++ b/tools/ProGPU.Voxel.Benchmarks/Program.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using System.Globalization;
+using ProGPU.Voxel;
+
+CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+const int seed = 1337;
+const int radius = 3;
+const int iterations = 5;
+
+_ = VoxelTerrainGenerator.Generate(
+    new VoxelTerrainSettings(seed, ChunkRadius: 1, BuildMeshes: true));
+
+var generationTimes = new double[iterations];
+var meshingTimes = new double[iterations];
+long generatedBytes = 0;
+long meshingBytes = 0;
+VoxelWorld? finalWorld = null;
+
+for (var iteration = 0; iteration < iterations; iteration++)
+{
+    var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+    var timer = Stopwatch.StartNew();
+    var world = VoxelTerrainGenerator.Generate(
+        new VoxelTerrainSettings(seed, radius, BuildMeshes: false));
+    timer.Stop();
+    generationTimes[iteration] = timer.Elapsed.TotalMilliseconds;
+    generatedBytes += GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+    allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+    timer.Restart();
+    world.BuildAllMeshes();
+    timer.Stop();
+    meshingTimes[iteration] = timer.Elapsed.TotalMilliseconds;
+    meshingBytes += GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+    finalWorld = world;
+}
+
+Array.Sort(generationTimes);
+Array.Sort(meshingTimes);
+
+var chunks = finalWorld!.Chunks.Count;
+var nonAirBlocks = finalWorld.Chunks.Sum(static chunk => chunk.NonAirCount);
+var vertices = finalWorld.Chunks.Sum(static chunk => chunk.Mesh?.Vertices.Length ?? 0);
+var indices = finalWorld.Chunks.Sum(static chunk => chunk.Mesh?.Indices.Length ?? 0);
+var visibleFaces = finalWorld.Chunks.Sum(static chunk => chunk.Mesh?.VisibleFaceCount ?? 0);
+var mergedQuads = finalWorld.Chunks.Sum(static chunk => chunk.Mesh?.MergedQuadCount ?? 0);
+var vertexBytes = vertices * 24L;
+var indexBytes = indices * sizeof(uint);
+
+Console.WriteLine(
+    $"Voxel benchmark seed={seed} radius={radius} iterations={iterations} " +
+    $"chunks={chunks} blocks={nonAirBlocks}");
+Console.WriteLine(
+    $"generation medianMs={generationTimes[iterations / 2]:F3} " +
+    $"minMs={generationTimes[0]:F3} " +
+    $"allocatedBytes={generatedBytes / iterations}");
+Console.WriteLine(
+    $"meshing medianMs={meshingTimes[iterations / 2]:F3} " +
+    $"minMs={meshingTimes[0]:F3} " +
+    $"allocatedBytes={meshingBytes / iterations}");
+Console.WriteLine(
+    $"surface visibleFaces={visibleFaces} mergedQuads={mergedQuads} " +
+    $"reduction={(visibleFaces == 0 ? 0d : 1d - mergedQuads / (double)visibleFaces):P2} " +
+    $"vertices={vertices} indices={indices} meshBytes={vertexBytes + indexBytes}");

--- a/tools/profile-voxel-instruments.sh
+++ b/tools/profile-voxel-instruments.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+output_root="${1:-$repo_root/artifacts/voxel-instruments/$(date +%Y%m%d-%H%M%S)}"
+desktop_project="$repo_root/src/ProGPU.Samples.Desktop/ProGPU.Samples.Desktop.csproj"
+desktop_app="$repo_root/src/ProGPU.Samples.Desktop/bin/Release/net10.0/ProGPU.Samples.Desktop"
+warmup_frames="${PROGPU_VOXEL_INSTRUMENTS_WARMUP_FRAMES:-180}"
+measure_frames="${PROGPU_VOXEL_INSTRUMENTS_MEASURE_FRAMES:-600}"
+game_memory_limit="${PROGPU_VOXEL_INSTRUMENTS_GAME_MEMORY_LIMIT:-8s}"
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "Xcode command-line tools are required." >&2
+  exit 2
+fi
+if [[ -e "$output_root" ]]; then
+  echo "Output path already exists: $output_root" >&2
+  exit 3
+fi
+
+if [[ "${PROGPU_VOXEL_INSTRUMENTS_SKIP_BUILD:-0}" != "1" ]]; then
+  dotnet restore "$desktop_project"
+  dotnet build "$desktop_project" -c Release --no-restore
+fi
+
+mkdir -p "$output_root"
+
+record() {
+  local template="$1"
+  local slug="$2"
+  shift 2
+  xcrun xctrace record \
+    --template "$template" \
+    --output "$output_root/$slug.trace" \
+    --no-prompt \
+    "$@" \
+    --env PROGPU_SAMPLE_BENCHMARK_PAGE="Voxel Game" \
+    --env PROGPU_SAMPLE_BENCHMARK_WARMUP_FRAMES="$warmup_frames" \
+    --env PROGPU_SAMPLE_BENCHMARK_MEASURE_FRAMES="$measure_frames" \
+    --env PROGPU_SAMPLE_BENCHMARK_VSYNC=false \
+    --target-stdout "$output_root/$slug.log" \
+    --launch -- "$desktop_app"
+}
+
+record "Time Profiler" "time-profiler"
+record "Game Memory" "game-memory" --time-limit "$game_memory_limit"
+
+echo "[VoxelInstruments] traces=$output_root"


### PR DESCRIPTION
# Summary

This PR adds a clean-room, playable Minecraft-style voxel engine to ProGPU while
preserving the existing generic `Viewport3D`, `MeshGeometry3D`, and OBJ APIs for
arbitrary modeled geometry.

The later experimental reusable WGSL effects, shader ray-tracing, voxel deformation,
rain, and motion-blur work was reverted after evaluation because it did not meet the
required visual and runtime quality. This PR is scoped to the original voxel-engine
implementation through commit `08593430`.

The new implementation reuses ProGPU's lower-level rendering infrastructure—compiled
scene extensions, physical-pixel render targets, cached WebGPU pipelines, retained
commands, typed input, and text/UI composition—but introduces voxel-specific APIs for
editable chunk storage, greedy meshing, collision, block ray casting, first-person
controls, visibility culling, and efficient indexed GPU submission.

## What changed

### Voxel simulation and meshing

- Adds the UI- and GPU-independent `ProGPU.Voxel` package.
- Stores blocks in sparse 16×16×16 chunks with explicit content and mesh generations.
- Invalidates both participating chunks when a block changes on a chunk boundary.
- Generates deterministic terrain on a background worker.
- Builds indexed chunk geometry with three-axis greedy rectangle merging.
- Adds conservative homogeneous frustum testing.
- Adds axis-separated player AABB collision, gravity, jumping, sprinting, and flying.
- Adds Amanatides–Woo uniform-grid DDA ray casting for mining and placement targets.

### WGSL terrain renderer

- Adds the embedded `VoxelTerrain.wgsl` production shader with the required algorithm,
  time-complexity, and space-complexity contract.
- Adds `VoxelTerrainExtensionPipeline` as a typed compositor extension.
- Packs all visible chunk vertices and indices into two power-of-two GPU arenas.
- Bakes chunk origins and base indices into transfer geometry, eliminating per-chunk
  storage buffers and shader storage lookups.
- Detects unchanged uniforms and mesh generations to avoid redundant uploads.
- Draws the visible terrain with one indexed call.
- Produces procedural block texels, directional lighting, selection highlighting,
  animated water, and distance fog without copied game assets or texture dependencies.

### Playable WinUI game control

- Adds `ProGPU.Voxel.WinUI` and the `VoxelGameView` control.
- Adds a **Voxel Game** gallery page with an in-app HUD and controls.
- Supports:
  - WASD/arrow movement;
  - sprint, jump, and flying;
  - click-to-capture continuous mouse look;
  - left-click mining and right-click placement;
  - wheel and number-key hotbar selection;
  - Escape-to-release;
  - seven block materials;
  - targeting and selection feedback.
- Corrects horizontal input for ProGPU's right-handed `Matrix4x4.CreateLookAt`
  convention: D/Right moves screen-right and positive mouse-X turns screen-right.

### Cross-platform relative pointer input

- Adds `ProGPU.WinUI.Input.RelativePointerCapture`.
- Keeps game-only relative input outside the `Microsoft.UI.Xaml` namespace.
- Does not add non-WinUI fields or behavior to `PointerRoutedEventArgs`.
- Uses Silk.NET `CursorMode.Raw` on desktop with `CursorMode.Disabled` fallback.
- Uses the W3C Pointer Lock lifecycle in the browser.
- Sums coalesced `movementX`/`movementY` events and batches them through the existing
  browser input queue.
- Releases capture on Escape, focus loss, unload, window close, or host lock loss.
- Restores prior desktop cursor modes after release.

### AOT and project integration

- Enables desktop NativeAOT publishing.
- Explicitly registers Silk GLFW windowing/input so trimmed NativeAOT builds do not
  depend on runtime discovery.
- Roots generated Fluent theme registration before browser AOT resource lookup.
- Registers the voxel projects, tests, packages, benchmarks, and sample in the build.

### Benchmarking, profiling, and documentation

- Adds a deterministic voxel benchmark executable.
- Adds `tools/profile-voxel-instruments.sh` for repeatable Xcode Instruments Time
  Profiler and Game Memory captures.
- Adds `docs/voxel-engine-architecture.md` with:
  - API and package-boundary rationale;
  - clean-room research record;
  - cross-engine architectural comparison;
  - algorithmic cost model;
  - browser and NativeAOT validation;
  - Xcode Instruments measurements;
  - follow-up streaming and rendering tiers.

## API design

The existing 3D/OBJ API remains unchanged and remains the preferred API for arbitrary
imported or modeled meshes.

The voxel API is separate because the hot path requires different ownership and update
semantics:

```text
ProGPU.Voxel
  blocks -> sparse chunks -> dirty generations -> greedy indexed meshes
       +---- player collision and grid DDA block targeting ----+

ProGPU.Voxel.WinUI
  background generation -> simulation -> visible render payload

ProGPU.Scene
  VoxelTerrainExtensionPipeline -> packed GPU arenas -> WGSL terrain draw
```

This keeps `ProGPU.Voxel` usable by servers, editors, tests, and non-WinUI frontends
without introducing a GPU or UI dependency.

## Performance results

The implementation was profiled with Release binaries on arm64 macOS using Xcode
Instruments.

| Measurement | Before optimization | Final architecture |
|---|---:|---:|
| Voxel vertex buffers | 3,473,408 B / 28 resources | 278,528 B / 1 resource |
| Voxel index buffers | 3,670,016 B / 28 resources | 65,536 B / 1 resource |
| Depth target at 2028×1180 | 12,845,056 B | 10,092,544 B |
| Labelled voxel render resources | 30.34 MB | 20.79 MB |
| Terrain draw calls | 28 | 1 |
| Surface reduction | 30,776 visible faces | 4,545 merged quads |

The final post-input desktop NativeAOT validation used 60 warmup frames and 300
measured frames:

- 5.6202 ms average total frame time;
- 17.7037 ms maximum frame time;
- 0.3841 ms average compilation;
- 1,117 managed bytes allocated per frame;
- zero Gen0, Gen1, or Gen2 collections;
- zero GC pause time.

The detailed Instruments record also captures the reduction in WebGPU staging writes,
Metal allocation, physical footprint, and per-frame compositor cost.

## Validation

### Automated

- `dotnet test src/ProGPU.Voxel.Tests/ProGPU.Voxel.Tests.csproj -c Release --no-restore`
  - 14 passed, 0 failed.
- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~RelativePointerCaptureTests|FullyQualifiedName~TouchGestureResponsiveTests'`
  - 39 passed, 0 failed.
- Focused coverage includes:
  - negative chunk coordinates;
  - full-chunk greedy surface collapse;
  - material merge boundaries;
  - cross-chunk invalidation;
  - DDA targeting and placement;
  - player collision;
  - camera-relative strafe direction;
  - mouse-yaw direction;
  - capture acquisition/release;
  - focus-loss cleanup;
  - embedded shader complexity metadata.

### Desktop Release NativeAOT

- Published for `osx-arm64`.
- Verified as a native Mach-O arm64 executable without a CoreCLR dependency.
- Ran the playable **Voxel Game** and the 300-frame benchmark successfully.

### Browser Release AOT

- AOT-processed 83 assemblies, including `ProGPU.Voxel`,
  `ProGPU.Voxel.WinUI`, `ProGPU.WinUI`, and `ProGPU.Browser`.
- Loaded the final artifact in Chromium with WebGPU enabled.
- Verified the rendered game, physical click-to-capture Pointer Lock, continuous
  first-person input, and Escape release.
- Observed zero browser console errors and zero warnings.

## Compatibility and risk

- No existing public 3D/OBJ API is replaced.
- No non-WinUI members are added to WinUI event argument types.
- Generic mesh rendering is not routed through the voxel pipeline.
- The terrain renderer is isolated behind a new compositor extension ID.
- CPU world and mesh data remain authoritative, so GPU resources can be rebuilt.
- The sample uses procedural visual assets and contains no copied Minecraft source or
  game assets.

## Clean-room research

The implementation was designed from public specifications and algorithm descriptions,
without copying or translating another engine's source:

- [WebGPU specification](https://gpuweb.github.io/gpuweb/)
- [WGSL specification](https://www.w3.org/TR/WGSL/)
- [Pointer Lock 2.0](https://www.w3.org/TR/pointerlock-2/)
- [Mozilla WebRender rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html)
- [Skia canvas creation](https://skia.org/docs/user/api/skcanvas_creation/)
- [Vello](https://github.com/linebender/vello)
- [HarfBuzz shaping concepts](https://harfbuzz.github.io/shaping-concepts.html)
- [Meshing in a Minecraft Game](https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/)
- [A Fast Voxel Traversal Algorithm](https://physique.cmaisonneuve.qc.ca/svezina/projet/ray_tracer/download/A_Fast_Voxel_Traversal_Algorythm_For_Ray_Tracing.pdf)
- [Godot MultiMesh optimization](https://docs.godotengine.org/en/stable/tutorials/performance/using_multimesh.html)
- [Unreal Engine Nanite overview](https://dev.epicgames.com/documentation/en-us/unreal-engine/nanite-virtualized-geometry-in-unreal-engine)

## Follow-up work

This PR intentionally establishes the first playable vertical slice. Future measured
tiers can add:

- camera-centered chunk streaming with cancellable generation;
- byte-budgeted CPU/GPU LRU residency;
- generation-stamped worker remesh queues;
- texture arrays, mipmaps, alpha-tested foliage, and transparent passes;
- sunlight and block-light propagation;
- persistence, entities/ECS, networking, and deterministic simulation;
- GPU Hi-Z/indirect submission where target WebGPU capabilities demonstrate a win.
