### PR TITLE
Fix cross-platform Avalonia native CI lane

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Unix entry points are invoked directly by CI on every host.
+*.sh text eol=lf
+
+# Reviewed Avalonia source patches must remain byte-stable when Git for Windows
+# enables core.autocrlf, otherwise git apply sees CRLF patch context.
+eng/avalonia/**/*.patch text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,11 +114,11 @@ jobs:
             -p:ProGpuAvaloniaSourceRoot="${{ github.workspace }}/.worktrees/avalonia-12.0.5" \
             -p:ProGpuSourceRoot="${{ github.workspace }}" \
             -p:UseSkiaSharpShim=true
-          dotnet restore tests/Avalonia.ProGpu.UnitTests/Avalonia.ProGpu.UnitTests.csproj
-          dotnet test tests/Avalonia.ProGpu.UnitTests/Avalonia.ProGpu.UnitTests.csproj \
+          dotnet restore tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
+          dotnet test tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj \
             --configuration Release \
             --no-restore \
-            --filter "FullyQualifiedName~DawnNativeWindowSourceTests|FullyQualifiedName~SourceControlCatalogHasStrictNonSilkDawnPresentationGate"
+            --filter "FullyQualifiedName~DawnNativeWindowSourceTests"
           dotnet build tools/ProGPU.SampleMemoryProfiler/ProGPU.SampleMemoryProfiler.csproj \
             --configuration Release
 

--- a/tools/prepare-avalonia-12.0.5-source.sh
+++ b/tools/prepare-avalonia-12.0.5-source.sh
@@ -111,7 +111,32 @@ fi
 
 if [[ ! -e "${avalonia_root}/.git" ]]; then
   mkdir -p "$(dirname "${avalonia_root}")"
-  git -C "${source_repo}" worktree add --detach "${avalonia_root}" "${expected_revision}"
+  # Git for Windows commonly enables core.autocrlf globally. Keep the owned
+  # patched worktree byte-stable so the reviewed LF patches apply identically
+  # on Windows, Linux, and macOS.
+  git \
+    -c core.autocrlf=false \
+    -c core.eol=lf \
+    -C "${source_repo}" \
+    worktree add --detach "${avalonia_root}" "${expected_revision}"
+fi
+
+if git -C "${avalonia_root}" diff --quiet &&
+    git -C "${avalonia_root}" diff --cached --quiet; then
+  # Force a byte-stable checkout after worktree creation as well. Git for
+  # Windows does not consistently propagate command-scoped checkout settings
+  # through worktree-add's internal reset, and an older script may also have
+  # left a pristine CRLF worktree behind after its first patch check failed.
+  git \
+    -c core.autocrlf=false \
+    -c core.eol=lf \
+    -C "${avalonia_root}" \
+    reset --hard "${expected_revision}"
+  git \
+    -c core.autocrlf=false \
+    -c core.eol=lf \
+    -C "${avalonia_root}" \
+    checkout-index --all --force
 fi
 
 actual_revision="$(git -C "${avalonia_root}" rev-parse HEAD)"


### PR DESCRIPTION
## Summary

- force LF checkout semantics for the owned pinned Avalonia worktree so reviewed patches apply under Git for Windows `core.autocrlf=true`
- recover pristine CRLF worktrees produced by the previous preparation script
- point the native Dawn workflow at the clean-room `ProGPU.Avalonia.ContractTests` project and its current focused test class

## Root causes

Run https://github.com/wieslawsoltes/ProGPU/actions/runs/30305868830 failed because Windows converted the pinned worktree to CRLF before `git apply`, while Linux completed the ControlCatalog build and then referenced the removed pre-clean-room `tests/Avalonia.ProGpu.UnitTests` path.

## Validation

- simulated fresh Windows `core.autocrlf=true` worktree: all seven pinned patches applied and reverse-validated
- simulated pre-existing pristine CRLF worktree: normalized and patched successfully
- corrected `DawnNativeWindowSourceTests` command: 8 passed
- enforced Avalonia clean-room audit: 0 imported paths, notices, or reachable import commits
- Browser Release AOT artifact: 83 assemblies published and full gallery rendered in Chromium without the prior `Generic.xaml` provider exception