### PR TITLE
Expose portable WPF window transparency state

### DIFF
--- a/src/ProGPU.Wpf.Interop/PortableWindowState.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWindowState.cs
@@ -55,6 +55,10 @@ public sealed class PortableWindowState
 
     public bool ShowActivated { get; set; }
 
+    public bool HasAllowsTransparency { get; set; }
+
+    public bool AllowsTransparency { get; set; }
+
     public bool HasOwner { get; set; }
 
     public object? Owner { get; set; }


### PR DESCRIPTION
## Summary
- add typed `PortableWindowState` flags for `Window.AllowsTransparency`
- unblock LibreWPF transparent native framebuffer creation without reflection

## Validation
- `dotnet build src/ProGPU.Wpf.Interop/ProGPU.Wpf.Interop.csproj -c Release`
- downstream LibreWPF focused bridge tests and source-built PresentationFramework Release build pass

Coordinates with wieslawsoltes/wpf#38.