### PR TITLE
Fix late Activity Monitor review findings

### DIFF
--- a/src/ProGPU.Samples.ActivityMonitor/Monitoring/MacOsActivityMonitorDataSource.cs
+++ b/src/ProGPU.Samples.ActivityMonitor/Monitoring/MacOsActivityMonitorDataSource.cs
@@ -578,7 +578,7 @@ internal sealed class MacOsActivityMonitorDataSource : IActivityMonitorDataSourc
             }
         }
 
-        long cached = Math.Max(0, (inactivePages + speculativePages + fileBackedPages) * pageSize);
+        long cached = ComputeCachedMemoryBytes(fileBackedPages, pageSize, physical);
         long available = Math.Max(0, (freePages + inactivePages + speculativePages) * pageSize);
         long used = Math.Max(0, physical - Math.Min(physical, available));
         return new MemoryCounters(
@@ -589,6 +589,22 @@ internal sealed class MacOsActivityMonitorDataSource : IActivityMonitorDataSourc
             Math.Max(0, wiredPages * pageSize),
             Math.Max(0, compressedPages * pageSize),
             swapUsed);
+    }
+
+    internal static long ComputeCachedMemoryBytes(
+        long fileBackedPages,
+        long pageSize,
+        long physicalMemoryBytes)
+    {
+        if (fileBackedPages <= 0 || pageSize <= 0 || physicalMemoryBytes <= 0)
+        {
+            return 0;
+        }
+
+        long cachedBytes = fileBackedPages > long.MaxValue / pageSize
+            ? long.MaxValue
+            : fileBackedPages * pageSize;
+        return Math.Min(cachedBytes, physicalMemoryBytes);
     }
 
     private static BatterySnapshot CaptureBattery(CancellationToken cancellationToken)

--- a/src/ProGPU.Samples.ActivityMonitor/Presentation/ActivityMonitorView.cs
+++ b/src/ProGPU.Samples.ActivityMonitor/Presentation/ActivityMonitorView.cs
@@ -67,6 +67,7 @@ internal sealed class ActivityMonitorView : Grid
     private ActivityCategory _category;
     private ActivityProcessScope _processScope = ActivityProcessScope.AllProcesses;
     private int? _selectedProcessId;
+    private DateTimeOffset? _selectedProcessStartTime;
     private SystemSnapshot? _previousSystem;
     private DateTimeOffset? _previousCapturedAt;
     private long _diskReadRate;
@@ -132,7 +133,9 @@ internal sealed class ActivityMonitorView : Grid
         };
         _dataGrid.SelectionChanged += (_, _) =>
         {
-            _selectedProcessId = SelectedProcess?.ProcessId;
+            ProcessSnapshot? selectedProcess = SelectedProcess;
+            _selectedProcessId = selectedProcess?.ProcessId;
+            _selectedProcessStartTime = selectedProcess?.StartTime;
             UpdateSelectionCommands();
             SelectionChanged?.Invoke(this, EventArgs.Empty);
         };
@@ -218,6 +221,14 @@ internal sealed class ActivityMonitorView : Grid
         }
         UpdateSubtitle();
         RefreshVisibleRows();
+    }
+
+    internal bool SelectVisibleProcess(int processId)
+    {
+        int index = _dataGrid.ItemsSource.FindIndex(
+            item => item is ProcessSnapshot process && process.ProcessId == processId);
+        _dataGrid.SelectedIndex = index;
+        return index >= 0;
     }
 
     internal void SetSearchText(string text)
@@ -645,7 +656,23 @@ internal sealed class ActivityMonitorView : Grid
             return;
         }
 
-        int? selectedId = SelectedProcess?.ProcessId ?? _selectedProcessId;
+        ProcessSnapshot? selectedProcess = SelectedProcess;
+        int? selectedId = selectedProcess?.ProcessId ?? _selectedProcessId;
+        DateTimeOffset? selectedStartTime =
+            selectedProcess?.StartTime ?? _selectedProcessStartTime;
+        bool selectionIdentityExists =
+            selectedId.HasValue &&
+            _snapshot.Processes.Any(process =>
+                ReferenceEquals(process, selectedProcess) ||
+                HasStableProcessIdentity(process, selectedId.Value, selectedStartTime));
+        bool selectionWasRemoved = selectedId.HasValue && !selectionIdentityExists;
+        if (selectionWasRemoved)
+        {
+            selectedId = null;
+            selectedStartTime = null;
+            _selectedProcessId = null;
+            _selectedProcessStartTime = null;
+        }
         string query = _search.Text.Trim();
         IEnumerable<ProcessSnapshot> filtered = _snapshot.Processes;
         string currentUser = Environment.UserName;
@@ -668,8 +695,15 @@ internal sealed class ActivityMonitorView : Grid
                 process.GpuTime.GetValueOrDefault() > TimeSpan.Zero),
             ActivityProcessScope.Applications =>
                 filtered.Where(process => process.IsApplication),
-            ActivityProcessScope.SelectedProcesses when selectedId.HasValue =>
-                filtered.Where(process => process.ProcessId == selectedId.Value),
+            ActivityProcessScope.SelectedProcesses =>
+                selectedId.HasValue
+                    ? filtered.Where(process =>
+                        ReferenceEquals(process, selectedProcess) ||
+                        HasStableProcessIdentity(
+                            process,
+                            selectedId.Value,
+                            selectedStartTime))
+                    : Enumerable.Empty<ProcessSnapshot>(),
             _ => filtered
         };
         if (query.Length > 0)
@@ -718,11 +752,30 @@ internal sealed class ActivityMonitorView : Grid
         if (selectedId.HasValue)
         {
             _dataGrid.SelectedIndex = _dataGrid.ItemsSource.FindIndex(
-                item => item is ProcessSnapshot process && process.ProcessId == selectedId.Value);
+                item =>
+                    item is ProcessSnapshot process &&
+                    (ReferenceEquals(process, selectedProcess) ||
+                     HasStableProcessIdentity(
+                         process,
+                         selectedId.Value,
+                         selectedStartTime)));
+        }
+        else if (selectionWasRemoved)
+        {
+            SelectionChanged?.Invoke(this, EventArgs.Empty);
         }
         UpdateSelectionCommands();
         _dataGrid.Invalidate();
     }
+
+    private static bool HasStableProcessIdentity(
+        ProcessSnapshot process,
+        int processId,
+        DateTimeOffset? startTime) =>
+        process.ProcessId == processId &&
+        startTime.HasValue &&
+        process.StartTime.HasValue &&
+        process.StartTime.Value.Equals(startTime.Value);
 
     private IReadOnlyList<ProcessSnapshot> ArrangeHierarchically(
         IEnumerable<ProcessSnapshot> processes)

--- a/src/ProGPU.Tests.Headless/ActivityMonitorViewTests.cs
+++ b/src/ProGPU.Tests.Headless/ActivityMonitorViewTests.cs
@@ -38,7 +38,24 @@ public sealed class ActivityMonitorViewTests
             100,
             MacOsActivityMonitorDataSource.ExtractCounterSum(
                 output,
-                "\"Bytes (Write)\"="));
+            "\"Bytes (Write)\"="));
+    }
+
+    [Fact]
+    public void CachedMemoryUsesOnlyTheNonOverlappingFileBackedCounter()
+    {
+        Assert.Equal(
+            40_960,
+            MacOsActivityMonitorDataSource.ComputeCachedMemoryBytes(
+                fileBackedPages: 10,
+                pageSize: 4096,
+                physicalMemoryBytes: 1_000_000));
+        Assert.Equal(
+            1_000_000,
+            MacOsActivityMonitorDataSource.ComputeCachedMemoryBytes(
+                fileBackedPages: long.MaxValue,
+                pageSize: 4096,
+                physicalMemoryBytes: 1_000_000));
     }
 
     [Fact]
@@ -223,6 +240,49 @@ public sealed class ActivityMonitorViewTests
             Assert.Equal([parent.ProcessId, child.ProcessId], view.VisibleProcessIds);
             Assert.Equal(0, view.VisibleHierarchyDepth(parent.ProcessId));
             Assert.Equal(1, view.VisibleHierarchyDepth(child.ProcessId));
+        }
+        finally
+        {
+            Application.Current = previousApplication;
+            ThemeManager.CurrentTheme = previousTheme;
+            ThemeManager.CurrentThemeFamily = previousFamily;
+            PopupService.DefaultFont = previousPopupFont;
+        }
+    }
+
+    [Fact]
+    public void SelectionDoesNotFollowAReusedProcessIdentifier()
+    {
+        Application previousApplication = Application.Current;
+        ElementTheme previousTheme = ThemeManager.CurrentTheme;
+        VisualThemeFamily previousFamily = ThemeManager.CurrentThemeFamily;
+        TtfFont? previousPopupFont = PopupService.DefaultFont;
+        try
+        {
+            Application.Current = new App();
+            InterFontFamily.RegisterFonts();
+            PopupService.DefaultFont = InterFontFamily.Regular;
+            var view = new ActivityMonitorView(InterFontFamily.Regular);
+            ActivitySnapshot snapshot = CreateSnapshot();
+            ProcessSnapshot selected = snapshot.Processes[0];
+            view.ApplySnapshot(snapshot);
+            Assert.True(view.SelectVisibleProcess(selected.ProcessId));
+            Assert.Equal(selected.StartTime, view.SelectedProcess?.StartTime);
+
+            ProcessSnapshot replacement = selected with
+            {
+                Name = "Replacement",
+                StartTime = selected.StartTime?.AddMinutes(1)
+            };
+            view.ApplySnapshot(snapshot with
+            {
+                CapturedAt = snapshot.CapturedAt.AddSeconds(2),
+                Processes = [replacement, .. snapshot.Processes.Skip(1)]
+            });
+
+            Assert.Null(view.SelectedProcess);
+            view.SelectProcessScope(ActivityProcessScope.SelectedProcesses);
+            Assert.Equal(0, view.VisibleProcessCount);
         }
         finally
         {

--- a/src/ProGPU.Tests/WinUiAnimationObjectModelTests.cs
+++ b/src/ProGPU.Tests/WinUiAnimationObjectModelTests.cs
@@ -944,6 +944,39 @@ public sealed class WinUiAnimationObjectModelTests
     }
 
     [Fact]
+    public void CommandBarDefaultLabelPositionPreservesCommandOverrides()
+    {
+        var commandBar = new CommandBar
+        {
+            DefaultLabelPosition = CommandBarDefaultLabelPosition.Bottom
+        };
+        var hidden = new AppBarButton
+        {
+            Label = "Hidden",
+            LabelPosition = CommandBarLabelPosition.Collapsed
+        };
+        var inherited = new AppBarToggleButton
+        {
+            Label = "Inherited",
+            LabelPosition = CommandBarLabelPosition.Default
+        };
+        commandBar.PrimaryCommands.Add(hidden);
+        commandBar.PrimaryCommands.Add(inherited);
+
+        Assert.Equal(CommandBarLabelPosition.Collapsed, hidden.LabelPosition);
+        Assert.False(hidden.IsLabelVisible);
+        Assert.Equal(CommandBarLabelPosition.Default, inherited.LabelPosition);
+        Assert.True(inherited.IsLabelVisible);
+
+        commandBar.DefaultLabelPosition = CommandBarDefaultLabelPosition.Collapsed;
+
+        Assert.Equal(CommandBarLabelPosition.Collapsed, hidden.LabelPosition);
+        Assert.False(hidden.IsLabelVisible);
+        Assert.Equal(CommandBarLabelPosition.Default, inherited.LabelPosition);
+        Assert.False(inherited.IsLabelVisible);
+    }
+
+    [Fact]
     public void SelectorBarSynchronizesWinUiSelectedItemAndItemState()
     {
         var selectorBar = new SelectorBar();
@@ -1122,6 +1155,25 @@ public sealed class WinUiAnimationObjectModelTests
         Assert.True(radio.DesiredSize.X >= 210);
         Assert.True(submenu.AreCheckStatesEnabled);
         Assert.IsType<RadioMenuFlyoutItem>(Assert.Single(submenu.Items));
+    }
+
+    [Fact]
+    public void MenuFlyoutLeafDismissesItsCompleteSubmenuChain()
+    {
+        var target = new Border();
+        target.Arrange(new ProGPU.Scene.Rect(0, 0, 100, 30));
+        var root = new MenuFlyout();
+        var child = new MenuFlyout { ParentFlyout = root };
+        root.ShowAt(target);
+        child.ShowAt(target);
+
+        Assert.True(root.IsOpen);
+        Assert.True(child.IsOpen);
+
+        child.HideFlyoutChain();
+
+        Assert.False(child.IsOpen);
+        Assert.False(root.IsOpen);
     }
 
     [Fact]

--- a/src/ProGPU.WinUI/Controls/AppBarButton.cs
+++ b/src/ProGPU.WinUI/Controls/AppBarButton.cs
@@ -22,6 +22,8 @@ public class AppBarButton : Button, ICommandBarElement
 {
     private readonly StackPanel _presentation;
     private readonly TextBlock _labelText;
+    private CommandBarDefaultLabelPosition _owningCommandBarLabelPosition =
+        CommandBarDefaultLabelPosition.Bottom;
 
     public AppBarButtonTemplateSettings TemplateSettings { get; } = new();
 
@@ -91,6 +93,25 @@ public class AppBarButton : Button, ICommandBarElement
         set => SetValue(LabelPositionProperty, value);
     }
 
+    internal CommandBarDefaultLabelPosition OwningCommandBarLabelPosition
+    {
+        get => _owningCommandBarLabelPosition;
+        set
+        {
+            if (_owningCommandBarLabelPosition == value)
+            {
+                return;
+            }
+            _owningCommandBarLabelPosition = value;
+            RebuildPresentation();
+        }
+    }
+
+    internal bool IsLabelVisible =>
+        LabelPosition != CommandBarLabelPosition.Collapsed &&
+        _owningCommandBarLabelPosition != CommandBarDefaultLabelPosition.Collapsed &&
+        Label.Length > 0;
+
     public bool IsInOverflow => (bool)(GetValue(IsInOverflowProperty) ?? false);
 
     public int DynamicOverflowOrder
@@ -127,8 +148,7 @@ public class AppBarButton : Button, ICommandBarElement
             _presentation.AddChild(Icon);
         }
         _labelText.Text = Label;
-        if (LabelPosition != CommandBarLabelPosition.Collapsed &&
-            Label.Length > 0)
+        if (IsLabelVisible)
         {
             _presentation.AddChild(_labelText);
         }
@@ -152,6 +172,8 @@ public class AppBarToggleButton : ToggleButton, ICommandBarElement
 {
     private readonly StackPanel _presentation;
     private readonly TextBlock _labelText;
+    private CommandBarDefaultLabelPosition _owningCommandBarLabelPosition =
+        CommandBarDefaultLabelPosition.Bottom;
 
     public AppBarToggleButtonTemplateSettings TemplateSettings { get; } = new();
 
@@ -222,6 +244,25 @@ public class AppBarToggleButton : ToggleButton, ICommandBarElement
         set => SetValue(LabelPositionProperty, value);
     }
 
+    internal CommandBarDefaultLabelPosition OwningCommandBarLabelPosition
+    {
+        get => _owningCommandBarLabelPosition;
+        set
+        {
+            if (_owningCommandBarLabelPosition == value)
+            {
+                return;
+            }
+            _owningCommandBarLabelPosition = value;
+            RebuildPresentation();
+        }
+    }
+
+    internal bool IsLabelVisible =>
+        LabelPosition != CommandBarLabelPosition.Collapsed &&
+        _owningCommandBarLabelPosition != CommandBarDefaultLabelPosition.Collapsed &&
+        Label.Length > 0;
+
     public bool IsInOverflow => (bool)(GetValue(IsInOverflowProperty) ?? false);
 
     public int DynamicOverflowOrder
@@ -258,8 +299,7 @@ public class AppBarToggleButton : ToggleButton, ICommandBarElement
             _presentation.AddChild(Icon);
         }
         _labelText.Text = Label;
-        if (LabelPosition != CommandBarLabelPosition.Collapsed &&
-            Label.Length > 0)
+        if (IsLabelVisible)
         {
             _presentation.AddChild(_labelText);
         }

--- a/src/ProGPU.WinUI/Controls/CommandBar.cs
+++ b/src/ProGPU.WinUI/Controls/CommandBar.cs
@@ -144,17 +144,13 @@ public class CommandBar : AppBar
 
     private void ApplyLabelPosition(ICommandBarElement command)
     {
-        CommandBarLabelPosition position = DefaultLabelPosition ==
-            CommandBarDefaultLabelPosition.Collapsed
-                ? CommandBarLabelPosition.Collapsed
-                : CommandBarLabelPosition.Default;
         if (command is AppBarButton button)
         {
-            button.LabelPosition = position;
+            button.OwningCommandBarLabelPosition = DefaultLabelPosition;
         }
         else if (command is AppBarToggleButton toggleButton)
         {
-            toggleButton.LabelPosition = position;
+            toggleButton.OwningCommandBarLabelPosition = DefaultLabelPosition;
         }
     }
 

--- a/src/ProGPU.WinUI/Controls/MenuFlyout.cs
+++ b/src/ProGPU.WinUI/Controls/MenuFlyout.cs
@@ -17,6 +17,8 @@ public class MenuFlyout : FlyoutBase
 
     public ObservableCollection<MenuFlyoutItemBase> Items { get; } = new();
 
+    internal MenuFlyout? ParentFlyout { get; set; }
+
     public Style? MenuFlyoutPresenterStyle
     {
         get => GetValue(MenuFlyoutPresenterStyleProperty) as Style;
@@ -64,6 +66,14 @@ public class MenuFlyout : FlyoutBase
             }
         }
         selected.IsChecked = true;
+    }
+
+    internal void HideFlyoutChain()
+    {
+        for (MenuFlyout? flyout = this; flyout is not null; flyout = flyout.ParentFlyout)
+        {
+            flyout.Hide();
+        }
     }
 }
 
@@ -191,7 +201,7 @@ public class MenuFlyoutItem : MenuFlyoutItemBase
     {
         if (Command?.CanExecute(CommandParameter) == true) Command.Execute(CommandParameter);
         Click?.Invoke(this, new RoutedEventArgs { OriginalSource = this });
-        OwningFlyout?.Hide();
+        OwningFlyout?.HideFlyoutChain();
     }
 
     protected virtual bool IsSelectionVisible => false;
@@ -443,7 +453,8 @@ public sealed class MenuFlyoutSubItem : MenuFlyoutItemBase
     {
         var flyout = new MenuFlyout
         {
-            Placement = FlyoutPlacementMode.RightEdgeAlignedTop
+            Placement = FlyoutPlacementMode.RightEdgeAlignedTop,
+            ParentFlyout = OwningFlyout
         };
         foreach (MenuFlyoutItemBase item in Items)
         {


### PR DESCRIPTION
Follow-up to #47 for four review findings posted after that PR was merged externally.

- preserve process selection by stable PID + start-time identity so PID reuse cannot retarget destructive actions
- derive cached memory from the non-overlapping file-backed page count
- dismiss the complete parent flyout chain when a submenu leaf executes
- preserve explicit AppBarButton/AppBarToggleButton LabelPosition overrides while applying CommandBar defaults as effective state

Regression coverage is included for each contract. This PR will be marked ready after the complete relevant local gates and GitHub checks pass.