### PR TITLE
Stabilize non-client allocation CI gate

### DIFF
--- a/src/ProGPU.Tests/InputNonClientPointerSourceTests.cs
+++ b/src/ProGPU.Tests/InputNonClientPointerSourceTests.cs
@@ -480,18 +480,23 @@ public sealed class InputNonClientPointerSourceTests
             WindowId id = window.Id;
             var point = new Point(100, 20);
 
-            _ = InputNonClientPointerSourceRegistration
-                .NotifyPointerMoved(
-                    id,
-                    NonClientRegionKind.Caption,
-                    PointerDeviceType.Mouse,
-                    true,
-                    point);
-            _ = InputNonClientPointerSourceRegistration
-                .IsPointInRegion(
-                    id,
-                    NonClientRegionKind.Caption,
-                    point);
+            for (int index = 0;
+                 index < 100;
+                 index++)
+            {
+                _ = InputNonClientPointerSourceRegistration
+                    .NotifyPointerMoved(
+                        id,
+                        NonClientRegionKind.Caption,
+                        PointerDeviceType.Mouse,
+                        true,
+                        point);
+                _ = InputNonClientPointerSourceRegistration
+                    .IsPointInRegion(
+                        id,
+                        NonClientRegionKind.Caption,
+                        point);
+            }
             _ = GC.GetAllocatedBytesForCurrentThread();
             long before =
                 GC.GetAllocatedBytesForCurrentThread();


### PR DESCRIPTION
## Outcome

Stabilizes the allocation-free non-client pointer dispatch test exposed by the post-merge macOS Build run.

## Cause

The test warmed each dispatch path only once, so tiered JIT optimization could occur inside the measured 100,000-iteration region and be attributed to the product hot path. The observed 6,192 bytes were runtime compilation activity; the identical code passed in the preceding PR run.

## Change

Warm both typed dispatch and region-hit-test paths for 100 iterations before the allocation counter. The measured workload and zero-allocation assertion remain unchanged.

## Validation

- focused test passed in three fresh test hosts
- full ProGPU.Tests suite: 3,173/3,173 passed
- git diff --check

This changes tests only; preview.33 package binaries are unaffected.