### PR TITLE
Compact immutable SKImage subset views

### DIFF
--- a/docs/SKIASHARP_API_PARITY.md
+++ b/docs/SKIASHARP_API_PARITY.md
@@ -1467,3 +1467,76 @@ suite passes 3,238/3,238 and the headless suite passes 225/225. The official
 SkiaSharp metadata gate reports `reference=4222`, `matching=4222`, `missing=0`,
 and `extra=998`; the one-entry extension-count movement is compiler-emitted
 nullable metadata redistribution, not a new public member.
+
+## Compact immutable image views after Preview.38
+
+`SKImage` subsets now share one root-invariant `TextureStorage` containing the
+texture, pixel format, alpha format, color space, portable pixel snapshot, row
+width, texture-backed classification, ownership callbacks, and atomic lifetime.
+Each immutable view retains only that storage reference, its width and height,
+one composed origin pair, and lazily created view-specific state. `Info` remains
+an official value-returning boundary and is reconstructed from those fields.
+Nested subsets compose checked origins in `O(1)` time, never copy pixels, never
+upload another texture, and remain valid after their parent view is disposed.
+The compare/exchange retain loop deliberately preserves the existing
+no-resurrection ownership rule; a tempting increment-and-rollback shortcut was
+rejected because concurrent retainers could observe the rollback after final
+release.
+
+This clean-room design used Skia's public
+[`SkImage` immutability and subset contract](https://api.skia.org/classSkImage.html),
+the [WebGPU texture-view model](https://gpuweb.github.io/gpuweb/),
+[Direct2D source rectangles](https://learn.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1devicecontext-drawbitmap%28id2d1bitmap_constd2d1_rect_f__float_d2d1_interpolation_mode_constd2d1_rect_f__constd2d1_matrix_4x4_f_%29),
+[Win2D image source rectangles](https://microsoft.github.io/Win2D/WinUI3/html/M_Microsoft_Graphics_Canvas_CanvasDrawingSession_DrawImage_8.htm),
+[WebRender's retained-scene model](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html),
+and [Vello's wgpu renderer](https://github.com/linebender/vello). ProGPU adopts
+immutable shared backing storage, cheap typed views, explicit ownership, and
+deferred source-rectangle evaluation. It rejects copied implementation
+structure, per-view pixel buffers, texture duplication, reflection, and an
+unbounded view cache. The text boundary was reviewed against
+[Skia's shaping architecture](https://skia.org/docs/dev/design/text_shaper/),
+[Parley](https://github.com/linebender/parley), and
+[HarfBuzz](https://harfbuzz.github.io/harfbuzz-hb-shape.html); this storage
+change does not move shaping, layout, glyph caching, or renderer work. No
+foreign implementation source was consulted.
+
+Three alternating Apple M3 Pro Release process pairs compared exact
+Preview.38 commit `65f86cf4` with implementation commit `c7046673` after 2,000
+dynamic-PGO warmups and 192 samples. The exact checksum remained
+`15041971963811491075`. Aggregate median subset latency fell from `29.312` to
+`26.450` ns/op (`9.76%`), or `10.82%` more operations per second. Managed
+allocation fell from `105.694` to `65.693` B/op (`37.85%`). Scheduler
+interruptions dominate the raw p95 values, so no tail-latency improvement is
+claimed. A stabilized official SkiaSharp 4.151.0 differential measured
+`339.927` versus `26.450` ns/op with the same checksum. Official managed
+allocation was `104.021` B/op versus ProGPU's `65.693` B/op, but that counter
+excludes Skia's native heap, so it is not treated as a total-memory comparison.
+
+Matched macOS 26.4.1 profiling isolated one long-lived immutable source image
+from source upload by overriding only the benchmark operation count. Each Time
+Profiler and EventPipe process constructed 400 million subset views. Time
+Profiler measured exact Preview.38 at `36.429` and the candidate at `32.553`
+ns/op (`10.64%` lower); EventPipe measured `40.414` versus `35.315` ns/op
+(`12.62%` lower), with about `96%` exclusive sampled CPU in the intended
+benchmark body. The same sustained path allocated exactly `104` versus `64`
+managed B/op (`38.46%` lower). A bounded 40-million-view Allocations plus VM
+Tracker lane measured `37.198` versus `33.065` ns/op. Its native heap and VM
+totals include runtime/device startup and did not show a retained regression;
+they are not used as evidence for the managed object-size claim.
+
+The matched 40-million-view Metal System Trace lane measured `37.882` versus
+`33.152` ns/op. Both binaries exported exactly `26` target resource-allocation
+rows, `42` current-allocation-size intervals, the same `1,196,032`-byte peak,
+and zero target command-buffer submissions, errors, compiler spills, or hangs.
+Thus source creation remains the only GPU work and view count does not multiply
+GPU resources. Raw Instruments traces, table exports, EventPipe traces, and
+temporary exact-baseline binaries were removed after these summaries were
+extracted. Reproducible benchmark distributions remain under
+`artifacts/performance/skiasharp-image-view-c7046673`.
+
+A 10,000-view focused allocation guard requires at most `72` managed B/view;
+image, surface, pixmap, and effect ownership tests pass. The complete macOS
+core suite passes 3,239/3,239 and the headless suite passes 225/225. The
+official API metadata gate remains `reference=4222`, `matching=4222`,
+`missing=0`, and `extra=998`; this implementation and its benchmark operation
+override add no public API.

--- a/src/ProGPU.Tests/SkImageApiParityTests.cs
+++ b/src/ProGPU.Tests/SkImageApiParityTests.cs
@@ -122,6 +122,35 @@ public sealed class SkImageApiParityTests
     }
 
     [Fact]
+    public void BoundedSubsetViewAllocationRemainsCompact()
+    {
+        using var image = SKImage.FromPixelCopy(
+            new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul),
+            Enumerable.Repeat((byte)255, 64).ToArray());
+        var subsetBounds = new SKRectI(1, 1, 3, 3);
+        const int iterations = 10_000;
+
+        for (var index = 0; index < 2_000; index++)
+        {
+            using var warmup = image.Subset(subsetBounds);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        var checksum = 0;
+        for (var index = 0; index < iterations; index++)
+        {
+            using var subset = image.Subset(subsetBounds);
+            checksum += subset.Width + subset.Height;
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(iterations * 4, checksum);
+        Assert.True(
+            allocated <= iterations * 72L,
+            $"Expected one compact immutable image view per subset, but measured {allocated / (double)iterations:F3} B/op.");
+    }
+
+    [Fact]
     public void SurfaceSnapshotsShareOneImmutableTexturePerContentGeneration()
     {
         using var surface = SKSurface.Create(

--- a/src/SkiaSharp/SKImage.Api.cs
+++ b/src/SkiaSharp/SKImage.Api.cs
@@ -189,26 +189,22 @@ public partial class SKImage
         }
 
         if (context is not null &&
-            (context.IsAbandoned || (_isTextureBacked && !IsValid(context))))
+            (context.IsAbandoned || (IsTextureBacked && !IsValid(context))))
         {
             return null!;
         }
 
-        if (_isTextureBacked && context is null)
+        if (IsTextureBacked && context is null)
         {
             return null!;
         }
 
         return new SKImage(
             _textureStorage,
-            new SKImageInfo(subset.Width, subset.Height, ColorType, AlphaType, ColorSpace),
-            _portableRgbaPixels,
-            checked(_portableOriginX + subset.Left),
-            checked(_portableOriginY + subset.Top),
-            _portableRowWidth,
-            checked(_textureOriginX + (uint)subset.Left),
-            checked(_textureOriginY + (uint)subset.Top),
-            _isTextureBacked);
+            subset.Width,
+            subset.Height,
+            checked(_originX + subset.Left),
+            checked(_originY + subset.Top));
     }
 
     public SKImage ToTextureImage(GRContext context) =>
@@ -244,8 +240,8 @@ public partial class SKImage
             {
                 texture.CopyBaseLevelRegionFrom(
                     Texture,
-                    _textureOriginX,
-                    _textureOriginY,
+                    checked((uint)_originX),
+                    checked((uint)_originY),
                     0,
                     0,
                     checked((uint)Width),
@@ -258,8 +254,8 @@ public partial class SKImage
                 return new SKImage(
                     texture,
                     true,
-                    _info,
-                    _portableRgbaPixels is null
+                    Info,
+                    _textureStorage.PortableRgbaPixels is null
                         ? null
                         : CopyPortablePixels(),
                     true);
@@ -278,7 +274,7 @@ public partial class SKImage
             targetContext,
             mipmapped,
             "SKImage Cross-context Texture");
-        return new SKImage(transferred, true, _info, pixels, true);
+        return new SKImage(transferred, true, Info, pixels, true);
     }
 
     public SKImage ApplyImageFilter(
@@ -334,7 +330,7 @@ public partial class SKImage
         if (sourceBounds.Width <= 0 || sourceBounds.Height <= 0 ||
             outputBounds.Width <= 0 || outputBounds.Height <= 0 ||
             (context is not null &&
-             (context.IsAbandoned || (_isTextureBacked && !IsValid(context)))))
+             (context.IsAbandoned || (IsTextureBacked && !IsValid(context)))))
         {
             outSubset = SKRectI.Empty;
             outOffset = SKPointI.Empty;
@@ -367,7 +363,7 @@ public partial class SKImage
 
     private static SKImage TransferToRecordingContext(SKImage image, GRRecordingContext context)
     {
-        var info = image._info;
+        var info = image.Info;
         var pixels = image.ReadTexturePixelsAsRgba8888();
         var texture = CreateTextureFromRgbaPixels(
             image.CreateReadbackInfo(),

--- a/src/SkiaSharp/SKImage.Compatibility.cs
+++ b/src/SkiaSharp/SKImage.Compatibility.cs
@@ -143,7 +143,7 @@ public partial class SKImage
     {
         ArgumentNullException.ThrowIfNull(pixmap);
         var optionalState = Volatile.Read(ref _optionalState);
-        if (_isTextureBacked && optionalState?.RasterPixels is null)
+        if (IsTextureBacked && optionalState?.RasterPixels is null)
         {
             pixmap.Reset();
             return false;
@@ -151,10 +151,11 @@ public partial class SKImage
 
         EnsureRasterPixels();
         optionalState = EnsureOptionalState();
+        var info = Info;
         pixmap.Reset(
-            _info,
+            info,
             optionalState.RasterPixelsHandle.AddrOfPinnedObject(),
-            _info.RowBytes);
+            info.RowBytes);
         pixmap.SetPixelSource(this);
         return true;
     }
@@ -188,10 +189,11 @@ public partial class SKImage
         var optionalState = EnsureOptionalState();
         lock (optionalState.RasterPixelLock)
         {
+            var info = Info;
             if (optionalState.RasterPixels is null)
             {
                 optionalState.RasterPixels = GC.AllocateUninitializedArray<byte>(
-                    checked((int)_info.BytesSize64));
+                    checked((int)info.BytesSize64));
             }
 
             if (!optionalState.RasterPixelsHandle.IsAllocated &&
@@ -201,9 +203,9 @@ public partial class SKImage
                     optionalState.RasterPixels,
                     GCHandleType.Pinned);
                 if (!ReadPixels(
-                        _info,
+                        info,
                         optionalState.RasterPixelsHandle.AddrOfPinnedObject(),
-                        _info.RowBytes,
+                        info.RowBytes,
                         0,
                         0,
                         SKImageCachingHint.Allow))

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -38,16 +38,31 @@ public partial class SKImage : SKObject
         public TextureStorage(
             GpuTexture texture,
             bool ownsTexture,
+            SKImageInfo info,
+            byte[]? portableRgbaPixels,
+            bool isTextureBacked,
             SKImageTextureReleaseDelegate? releaseProc = null,
             object? releaseContext = null)
         {
             Texture = texture;
             _ownsTexture = ownsTexture;
+            ColorType = info.ColorType;
+            AlphaType = info.AlphaType;
+            ColorSpace = info.ColorSpace;
+            PortableRgbaPixels = portableRgbaPixels;
+            PortableRowWidth = info.Width;
+            IsTextureBacked = isTextureBacked;
             _releaseProc = releaseProc;
             _releaseContext = releaseContext;
         }
 
         public GpuTexture Texture { get; }
+        public SKColorType ColorType { get; }
+        public SKAlphaType AlphaType { get; }
+        public SKColorSpace? ColorSpace { get; }
+        public byte[]? PortableRgbaPixels { get; }
+        public int PortableRowWidth { get; }
+        public bool IsTextureBacked { get; }
 
         public void AddReference()
         {
@@ -87,24 +102,20 @@ public partial class SKImage : SKObject
 
     private readonly TextureStorage _textureStorage;
     internal GpuTexture Texture => _textureStorage.Texture;
-    private readonly SKImageInfo _info;
-    private readonly byte[]? _portableRgbaPixels;
-    private readonly int _portableOriginX;
-    private readonly int _portableOriginY;
-    private readonly int _portableRowWidth;
-    private readonly uint _textureOriginX;
-    private readonly uint _textureOriginY;
-    private readonly bool _isTextureBacked;
+    private readonly int _width;
+    private readonly int _height;
+    private readonly int _originX;
+    private readonly int _originY;
     private ImageOptionalState? _optionalState;
-    public int Width => _info.Width;
-    public int Height => _info.Height;
-    public SKImageInfo Info => _info;
-    public SKColorType ColorType => _info.ColorType;
-    public SKAlphaType AlphaType => _info.AlphaType;
-    public SKColorSpace? ColorSpace => _info.ColorSpace;
+    public int Width => _width;
+    public int Height => _height;
+    public SKImageInfo Info => new(Width, Height, ColorType, AlphaType, ColorSpace);
+    public SKColorType ColorType => _textureStorage.ColorType;
+    public SKAlphaType AlphaType => _textureStorage.AlphaType;
+    public SKColorSpace? ColorSpace => _textureStorage.ColorSpace;
     public bool IsAlphaOnly => ColorType == SKColorType.Alpha8;
     public bool IsLazyGenerated => false;
-    public bool IsTextureBacked => _isTextureBacked;
+    public bool IsTextureBacked => _textureStorage.IsTextureBacked;
 
     public SKData EncodedData => _optionalState?.EncodedBytes is not { } bytes
         ? null!
@@ -128,41 +139,29 @@ public partial class SKImage : SKObject
         _textureStorage = new TextureStorage(
             texture,
             ownsTexture,
+            info,
+            portableRgbaPixels,
+            isTextureBacked,
             textureReleaseProc,
             textureReleaseContext);
-        _portableRgbaPixels = portableRgbaPixels;
-        _portableRowWidth = info.Width;
-        _isTextureBacked = isTextureBacked;
-        _info = new SKImageInfo(
-            info.Width,
-            info.Height,
-            info.ColorType,
-            info.AlphaType,
-            info.ColorSpace);
+        _width = info.Width;
+        _height = info.Height;
     }
 
     private SKImage(
         TextureStorage textureStorage,
-        SKImageInfo info,
-        byte[]? portableRgbaPixels,
-        int portableOriginX,
-        int portableOriginY,
-        int portableRowWidth,
-        uint textureOriginX,
-        uint textureOriginY,
-        bool isTextureBacked)
+        int width,
+        int height,
+        int originX,
+        int originY)
         : base(SKObjectHandle.Create(), owns: true)
     {
         textureStorage.AddReference();
         _textureStorage = textureStorage;
-        _portableRgbaPixels = portableRgbaPixels;
-        _portableOriginX = portableOriginX;
-        _portableOriginY = portableOriginY;
-        _portableRowWidth = portableRowWidth;
-        _textureOriginX = textureOriginX;
-        _textureOriginY = textureOriginY;
-        _isTextureBacked = isTextureBacked;
-        _info = info;
+        _width = width;
+        _height = height;
+        _originX = originX;
+        _originY = originY;
     }
 
     public static SKImage FromBitmap(SKBitmap bitmap)
@@ -425,14 +424,10 @@ public partial class SKImage : SKObject
 
         return new SKImage(
             _textureStorage,
-            new SKImageInfo(subset.Width, subset.Height, ColorType, AlphaType, ColorSpace),
-            _portableRgbaPixels,
-            checked(_portableOriginX + subset.Left),
-            checked(_portableOriginY + subset.Top),
-            _portableRowWidth,
-            checked(_textureOriginX + (uint)subset.Left),
-            checked(_textureOriginY + (uint)subset.Top),
-            _isTextureBacked);
+            subset.Width,
+            subset.Height,
+            checked(_originX + subset.Left),
+            checked(_originY + subset.Top));
     }
 
     private static uint CalculateMipLevelCount(uint width, uint height)
@@ -460,8 +455,8 @@ public partial class SKImage : SKObject
             alphaMode: Texture.AlphaMode);
         texture.CopyBaseLevelRegionFrom(
             Texture,
-            _textureOriginX,
-            _textureOriginY,
+            checked((uint)_originX),
+            checked((uint)_originY),
             0,
             0,
             checked((uint)Width),
@@ -469,8 +464,8 @@ public partial class SKImage : SKObject
         return new SKImage(
             texture,
             ownsTexture: true,
-            _info,
-            _portableRgbaPixels is null
+            Info,
+            _textureStorage.PortableRgbaPixels is null
                 ? null
                 : CopyPortablePixels());
     }
@@ -485,7 +480,7 @@ public partial class SKImage : SKObject
             return Texture;
         }
 
-        if (_portableRgbaPixels is null)
+        if (_textureStorage.PortableRgbaPixels is null)
         {
             throw new InvalidOperationException(
                 "SKCanvas.DrawImage cannot draw an SKImage from a different WebGPU context. " +
@@ -529,7 +524,7 @@ public partial class SKImage : SKObject
             }
 
             var texture = CreateTextureFromRgbaPixels(
-                _info,
+                Info,
                 GetPortablePixelsForUpload(),
                 requiredContext,
                 generateMipmaps: false,
@@ -549,8 +544,8 @@ public partial class SKImage : SKObject
         var texture = GetTextureForContext(requiredContext);
         if (ReferenceEquals(texture, Texture))
         {
-            sourceX = _textureOriginX;
-            sourceY = _textureOriginY;
+            sourceX = checked((uint)_originX);
+            sourceY = checked((uint)_originY);
         }
         else
         {
@@ -563,17 +558,18 @@ public partial class SKImage : SKObject
 
     private ReadOnlySpan<byte> GetPortablePixelsForUpload()
     {
-        if (_portableRgbaPixels is null)
+        var portableRgbaPixels = _textureStorage.PortableRgbaPixels;
+        if (portableRgbaPixels is null)
         {
             return default;
         }
 
-        if (_portableOriginX == 0 &&
-            _portableOriginY == 0 &&
-            _portableRowWidth == Width &&
-            _portableRgbaPixels.Length == checked(Width * Height * 4))
+        if (_originX == 0 &&
+            _originY == 0 &&
+            _textureStorage.PortableRowWidth == Width &&
+            portableRgbaPixels.Length == checked(Width * Height * 4))
         {
-            return _portableRgbaPixels;
+            return portableRgbaPixels;
         }
 
         return CopyPortablePixelRegion();
@@ -581,17 +577,18 @@ public partial class SKImage : SKObject
 
     private byte[] CopyPortablePixels()
     {
-        if (_portableRgbaPixels is null)
+        var portableRgbaPixels = _textureStorage.PortableRgbaPixels;
+        if (portableRgbaPixels is null)
         {
             return [];
         }
 
-        if (_portableOriginX == 0 &&
-            _portableOriginY == 0 &&
-            _portableRowWidth == Width &&
-            _portableRgbaPixels.Length == checked(Width * Height * 4))
+        if (_originX == 0 &&
+            _originY == 0 &&
+            _textureStorage.PortableRowWidth == Width &&
+            portableRgbaPixels.Length == checked(Width * Height * 4))
         {
-            return _portableRgbaPixels.ToArray();
+            return portableRgbaPixels.ToArray();
         }
 
         return CopyPortablePixelRegion();
@@ -600,10 +597,12 @@ public partial class SKImage : SKObject
     private byte[] CopyPortablePixelRegion()
     {
         var pixels = GC.AllocateUninitializedArray<byte>(checked(Width * Height * 4));
+        var portableRgbaPixels = _textureStorage.PortableRgbaPixels!;
+        var portableRowWidth = _textureStorage.PortableRowWidth;
         for (var row = 0; row < Height; row++)
         {
-            _portableRgbaPixels!.AsSpan(
-                    checked(((_portableOriginY + row) * _portableRowWidth + _portableOriginX) * 4),
+            portableRgbaPixels.AsSpan(
+                    checked(((_originY + row) * portableRowWidth + _originX) * 4),
                     checked(Width * 4))
                 .CopyTo(pixels.AsSpan(checked(row * Width * 4)));
         }
@@ -682,7 +681,7 @@ public partial class SKImage : SKObject
         var image = new SKImage(
             texture,
             ownsTexture: true,
-            _info,
+            Info,
             rgbaPixels,
             isTextureBacked: false);
         image.SetMaterializedRasterPixels(
@@ -720,14 +719,14 @@ public partial class SKImage : SKObject
 
     private byte[] ReadTexturePixelsAsRgba8888()
     {
-        if (_portableRgbaPixels is not null)
+        if (_textureStorage.PortableRgbaPixels is not null)
         {
             return CopyPortablePixels();
         }
 
         byte[] pixels;
-        if (_textureOriginX == 0 &&
-            _textureOriginY == 0 &&
+        if (_originX == 0 &&
+            _originY == 0 &&
             Texture.Width == checked((uint)Width) &&
             Texture.Height == checked((uint)Height))
         {
@@ -745,8 +744,8 @@ public partial class SKImage : SKObject
                 alphaMode: Texture.AlphaMode);
             texture.CopyBaseLevelRegionFrom(
                 Texture,
-                _textureOriginX,
-                _textureOriginY,
+                checked((uint)_originX),
+                checked((uint)_originY),
                 0,
                 0,
                 checked((uint)Width),

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -117,7 +117,9 @@ internal static class ProgramEntry
             // warm the gradient factories through their final dynamic-PGO tier.
             new BenchmarkCase("shader-gradient-factories", 16_000, RunShaderGradientFactories),
             new BenchmarkCase("runtime-effect-uniform-snapshot", 1_000, RunRuntimeEffectUniformSnapshot),
-            new BenchmarkCase("image-bounded-subset", 100, RunImageBoundedSubset),
+            // Amortize the one-time image upload so the distribution measures the
+            // allocation and reference-count path of each immutable subset view.
+            new BenchmarkCase("image-bounded-subset", 10_000, RunImageBoundedSubset),
             new BenchmarkCase("surface-bounded-snapshot", 10_000, RunSurfaceBoundedSnapshot),
             new BenchmarkCase("string-encoding-roundtrip", 10_000, RunStringEncodingRoundtrip),
             new BenchmarkCase("unicode-character-code", 100_000, RunUnicodeCharacterCode),

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -80,7 +80,10 @@ internal static class ProgramEntry
         // for ProGPU while the native P/Invoke wrapper has already stabilized.
         var warmupCount = options.OptionalInt("warmup", 32);
         var sampleCount = options.OptionalInt("samples", 24);
+        var operationOverride = options.OptionalInt("operations", 0);
         if (warmupCount < 1 || sampleCount < 3)
+            throw new ArgumentOutOfRangeException(nameof(options));
+        if (operationOverride < 0)
             throw new ArgumentOutOfRangeException(nameof(options));
 
         var cases = new[]
@@ -139,8 +142,11 @@ internal static class ProgramEntry
         var results = new List<BenchmarkCaseResult>(selectedCases.Length);
         foreach (var benchmark in selectedCases)
         {
+            var operations = operationOverride > 0
+                ? operationOverride
+                : benchmark.Operations;
             for (var index = 0; index < warmupCount; index++)
-                Volatile.Write(ref s_sink, unchecked((long)benchmark.Body(benchmark.Operations)));
+                Volatile.Write(ref s_sink, unchecked((long)benchmark.Body(operations)));
 
             var elapsed = new double[sampleCount];
             var allocated = new double[sampleCount];
@@ -149,7 +155,7 @@ internal static class ProgramEntry
             {
                 var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
                 var started = Stopwatch.GetTimestamp();
-                checksum = benchmark.Body(benchmark.Operations);
+                checksum = benchmark.Body(operations);
                 var finished = Stopwatch.GetTimestamp();
                 var allocatedAfter = GC.GetAllocatedBytesForCurrentThread();
                 Volatile.Write(ref s_sink, unchecked((long)checksum));
@@ -157,16 +163,16 @@ internal static class ProgramEntry
                 elapsed[index] =
                     (finished - started) * 1_000_000_000d /
                     Stopwatch.Frequency /
-                    benchmark.Operations;
+                    operations;
                 allocated[index] =
                     (allocatedAfter - allocatedBefore) /
-                    (double)benchmark.Operations;
+                    operations;
             }
 
             results.Add(
                 new BenchmarkCaseResult(
                     benchmark.Name,
-                    benchmark.Operations,
+                    operations,
                     checksum,
                     elapsed,
                     allocated,


### PR DESCRIPTION
## Summary

- move root-invariant `SKImage` format, color-space, portable-pixel, row-width, texture classification, and ownership into the existing reference-counted texture storage
- keep each immutable subset view to width, height, one composed origin, shared storage, and lazy per-view optional state
- preserve zero-copy nested ownership, exact readback regions, cross-context materialization, and release callbacks
- add a benchmark operation override for representative sustained profiling and a 10,000-view allocation guard

## Performance

- three alternating exact-Preview.38 pairs, 2,000 warmups and 192 samples: `29.312` to `26.450` ns/op, `105.694` to `65.693` B/op, exact checksum retained
- sustained 400-million-view Time Profiler lane: `36.429` to `32.553` ns/op; EventPipe: `40.414` to `35.315` ns/op
- sustained allocation: `104` to `64` B/view; bounded Allocations/VM Tracker: `37.198` to `33.065` ns/op
- Metal System Trace: `37.882` to `33.152` ns/op, identical 26 target resource rows, identical 1,196,032-byte peak, zero target submissions/errors/spills/hangs
- official SkiaSharp 4.151.0 differential: `339.927` versus `26.450` ns/op with the same checksum; native managed accounting excludes native allocations

## Validation

- full core suite: 3,239/3,239
- headless suite: 225/225
- official SkiaSharp API metadata: 4,222/4,222 exact, zero missing
- portable packages: 37 package and symbol pairs verified
- isolated packaged XAML source-generator/CLI consumer passed with byte-identical output
- docs/package manifest and clean-room marker gates passed
- raw `.trace`/`.nettrace` data and the temporary Preview.38 worktree were removed after summary extraction

## Clean-room research

Designed from the public [SkImage contract](https://api.skia.org/classSkImage.html), [WebGPU texture-view model](https://gpuweb.github.io/gpuweb/), [Direct2D source rectangles](https://learn.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1devicecontext-drawbitmap%28id2d1bitmap_constd2d1_rect_f__float_d2d1_interpolation_mode_constd2d1_rect_f__constd2d1_matrix_4x4_f_%29), [Win2D image drawing](https://microsoft.github.io/Win2D/WinUI3/html/M_Microsoft_Graphics_Canvas_CanvasDrawingSession_DrawImage_8.htm), [WebRender retained scenes](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html), and [Vello](https://github.com/linebender/vello). Skia shaping, Parley, and HarfBuzz were reviewed at the text boundary; shaping/layout are unchanged. No foreign implementation source was consulted.
