### PR TITLE
Add typed portable native activation callback

### DIFF
--- a/src/ProGPU.Tests/PortableWindowActivationCallbacksTests.cs
+++ b/src/ProGPU.Tests/PortableWindowActivationCallbacksTests.cs
@@ -1,0 +1,36 @@
+using ProGPU.Wpf.Interop;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class PortableWindowActivationCallbacksTests
+{
+    [Fact]
+    public void RequestActivationPreservesTypedActivationIdentity()
+    {
+        var activation = new object();
+        object? requestedActivation = null;
+        var callbacks = new PortableWindowActivationCallbacks(
+            activate: _ => activation,
+            requestActivation: candidate =>
+            {
+                requestedActivation = candidate;
+                return ReferenceEquals(candidate, activation);
+            });
+
+        object? resolvedActivation = callbacks.Activate(new object());
+
+        Assert.Same(activation, resolvedActivation);
+        Assert.NotNull(callbacks.RequestActivation);
+        Assert.True(callbacks.RequestActivation(resolvedActivation!));
+        Assert.Same(activation, requestedActivation);
+    }
+
+    [Fact]
+    public void RequestActivationRemainsOptionalForExistingHosts()
+    {
+        var callbacks = new PortableWindowActivationCallbacks(activate: value => value);
+
+        Assert.Null(callbacks.RequestActivation);
+    }
+}

--- a/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
@@ -475,7 +475,8 @@ public sealed class PortableWindowActivationCallbacks
         Action<object>? dispose = null,
         Func<object, bool>? dragMove = null,
         Func<object, IntPtr>? getHandle = null,
-        Func<IntPtr, PortableWindowRegion, bool>? setWindowRegion = null)
+        Func<IntPtr, PortableWindowRegion, bool>? setWindowRegion = null,
+        Func<object, bool>? requestActivation = null)
     {
         Activate = activate ?? throw new ArgumentNullException(nameof(activate));
         Show = show;
@@ -492,6 +493,7 @@ public sealed class PortableWindowActivationCallbacks
         DragMove = dragMove;
         GetHandle = getHandle;
         SetWindowRegion = setWindowRegion;
+        RequestActivation = requestActivation;
     }
 
     public Func<object, object?> Activate { get; }
@@ -523,6 +525,16 @@ public sealed class PortableWindowActivationCallbacks
     public Func<object, IntPtr>? GetHandle { get; }
 
     public Func<IntPtr, PortableWindowRegion, bool>? SetWindowRegion { get; }
+
+    /// <summary>
+    /// Requests native foreground activation for an existing portable window host.
+    /// </summary>
+    /// <remarks>
+    /// This callback is distinct from <see cref="Activate"/>, which creates or resolves
+    /// the portable activation object. Hosts should return <see langword="true"/> only
+    /// when the native platform accepted the foreground request.
+    /// </remarks>
+    public Func<object, bool>? RequestActivation { get; }
 }
 
 public sealed class PortableWindowInputEvent


### PR DESCRIPTION
Summary:
- add an optional typed callback that requests native foreground activation for an existing portable WPF host
- keep activation-object creation and native foreground activation as separate contracts
- cover identity propagation and backward-compatible optional behavior

Validation:
- focused PortableWindowActivationCallbacksTests passed 2/2 in Release

This closes the reflection-free interop gap required for LibreWPF Window.Activate and ShowActivated=false correctness on macOS and Linux.