### PR TITLE
Render GDI cardinal curves on GPU

### DIFF
--- a/src/ProGPU.Tests/GdiCurveCompatibilityTests.cs
+++ b/src/ProGPU.Tests/GdiCurveCompatibilityTests.cs
@@ -1,0 +1,77 @@
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class GdiCurveCompatibilityTests
+{
+    [Fact]
+    public void DrawCurveRecordsCardinalSplineAsOneNativePath()
+    {
+        using var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
+        System.Drawing.PointF[] points =
+        [
+            new(0f, 0f),
+            new(30f, 60f),
+            new(90f, 30f),
+            new(120f, 0f)
+        ];
+
+        graphics.DrawCurve(System.Drawing.Pens.Black, points, tension: 0.6f);
+
+        var command = Assert.Single(graphics.DrawingContext.Commands);
+        var figure = Assert.Single(command.Path!.Figures);
+        var segments = figure.Segments.Cast<CubicBezierSegment>().ToArray();
+        Assert.Equal(3, segments.Length);
+        Assert.Equal(new System.Numerics.Vector2(0f, 0f), figure.StartPoint);
+        AssertNear(new System.Numerics.Vector2(6f, 12f), segments[0].ControlPoint1);
+        AssertNear(new System.Numerics.Vector2(12f, 54f), segments[0].ControlPoint2);
+        AssertNear(new System.Numerics.Vector2(30f, 60f), segments[0].Point);
+        AssertNear(new System.Numerics.Vector2(108f, 18f), segments[2].ControlPoint1);
+        AssertNear(new System.Numerics.Vector2(114f, 6f), segments[2].ControlPoint2);
+        AssertNear(new System.Numerics.Vector2(120f, 0f), segments[2].Point);
+    }
+
+    [Fact]
+    public void DrawCurveRangeUsesAdjacentPointsForEndpointTangents()
+    {
+        using var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
+        System.Drawing.Point[] points =
+        [
+            new(0, 0),
+            new(20, 20),
+            new(40, 0),
+            new(80, 20)
+        ];
+
+        graphics.DrawCurve(System.Drawing.Pens.Black, points, offset: 1, numberOfSegments: 2, tension: 0.75f);
+
+        var command = Assert.Single(graphics.DrawingContext.Commands);
+        var figure = Assert.Single(command.Path!.Figures);
+        var segments = figure.Segments.Cast<CubicBezierSegment>().ToArray();
+        Assert.Equal(2, segments.Length);
+        AssertNear(new System.Numerics.Vector2(30f, 20f), segments[0].ControlPoint1);
+        AssertNear(new System.Numerics.Vector2(25f, 0f), segments[0].ControlPoint2);
+        AssertNear(new System.Numerics.Vector2(40f, 0f), segments[0].Point);
+    }
+
+    [Fact]
+    public void DrawCurveRejectsInvalidPointRanges()
+    {
+        using var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
+        System.Drawing.PointF[] points = [new(0f, 0f), new(1f, 1f)];
+
+        Assert.Throws<ArgumentNullException>(() => graphics.DrawCurve(null!, points));
+        Assert.Throws<ArgumentNullException>(() => graphics.DrawCurve(System.Drawing.Pens.Black, (System.Drawing.PointF[])null!));
+        Assert.Throws<ArgumentException>(() => graphics.DrawCurve(
+            System.Drawing.Pens.Black,
+            new System.Drawing.PointF[] { new(0f, 0f) }));
+        Assert.Throws<ArgumentException>(() => graphics.DrawCurve(System.Drawing.Pens.Black, points, -1, 1));
+        Assert.Throws<ArgumentException>(() => graphics.DrawCurve(System.Drawing.Pens.Black, points, 0, 2));
+    }
+
+    private static void AssertNear(System.Numerics.Vector2 expected, System.Numerics.Vector2 actual)
+    {
+        Assert.InRange(System.Numerics.Vector2.Distance(expected, actual), 0f, 0.001f);
+    }
+}

--- a/src/System.Drawing.Common/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/System/Drawing/Graphics.cs
@@ -438,6 +438,101 @@ public class Graphics :
         }
     }
 
+    public void DrawCurve(Pen pen, PointF[] points) =>
+        DrawCurve(pen, points, 0, GetCurveSegmentCount(points), 0.5f);
+
+    public void DrawCurve(Pen pen, PointF[] points, float tension) =>
+        DrawCurve(pen, points, 0, GetCurveSegmentCount(points), tension);
+
+    public void DrawCurve(Pen pen, PointF[] points, int offset, int numberOfSegments) =>
+        DrawCurve(pen, points, offset, numberOfSegments, 0.5f);
+
+    public void DrawCurve(Pen pen, PointF[] points, int offset, int numberOfSegments, float tension)
+    {
+        ArgumentNullException.ThrowIfNull(pen);
+        ValidateCurveRange(points, offset, numberOfSegments);
+
+        var geometry = new PathGeometry();
+        PointF start = points[offset];
+        var figure = new PathFigure(new Vector2(start.X, start.Y));
+        geometry.Figures.Add(figure);
+        float scale = tension / 3f;
+
+        for (int index = offset; index < offset + numberOfSegments; index++)
+        {
+            PointF current = points[index];
+            PointF previous = index == 0 ? current : points[index - 1];
+            PointF next = points[index + 1];
+            PointF following = index + 2 < points.Length ? points[index + 2] : next;
+            figure.Segments.Add(new CubicBezierSegment(
+                new Vector2(
+                    current.X + ((next.X - previous.X) * scale),
+                    current.Y + ((next.Y - previous.Y) * scale)),
+                new Vector2(
+                    next.X - ((following.X - current.X) * scale),
+                    next.Y - ((following.Y - current.Y) * scale)),
+                new Vector2(next.X, next.Y)));
+        }
+
+        _context.DrawPath(null, TransformPen(pen), geometry, CurrentTransform4x4());
+    }
+
+    public void DrawCurve(Pen pen, Point[] points) =>
+        DrawCurve(pen, points, 0, GetCurveSegmentCount(points), 0.5f);
+
+    public void DrawCurve(Pen pen, Point[] points, float tension) =>
+        DrawCurve(pen, points, 0, GetCurveSegmentCount(points), tension);
+
+    public void DrawCurve(Pen pen, Point[] points, int offset, int numberOfSegments, float tension)
+    {
+        ArgumentNullException.ThrowIfNull(pen);
+        ValidateCurveRange(points, offset, numberOfSegments);
+
+        var geometry = new PathGeometry();
+        Point start = points[offset];
+        var figure = new PathFigure(new Vector2(start.X, start.Y));
+        geometry.Figures.Add(figure);
+        float scale = tension / 3f;
+
+        for (int index = offset; index < offset + numberOfSegments; index++)
+        {
+            Point current = points[index];
+            Point previous = index == 0 ? current : points[index - 1];
+            Point next = points[index + 1];
+            Point following = index + 2 < points.Length ? points[index + 2] : next;
+            figure.Segments.Add(new CubicBezierSegment(
+                new Vector2(
+                    current.X + ((next.X - previous.X) * scale),
+                    current.Y + ((next.Y - previous.Y) * scale)),
+                new Vector2(
+                    next.X - ((following.X - current.X) * scale),
+                    next.Y - ((following.Y - current.Y) * scale)),
+                new Vector2(next.X, next.Y)));
+        }
+
+        _context.DrawPath(null, TransformPen(pen), geometry, CurrentTransform4x4());
+    }
+
+    private static int GetCurveSegmentCount<TPoint>(TPoint[]? points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        return points.Length - 1;
+    }
+
+    private static void ValidateCurveRange<TPoint>(TPoint[]? points, int offset, int numberOfSegments)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        if (points.Length < 2)
+        {
+            throw new ArgumentException("At least two points are required to draw a curve.", nameof(points));
+        }
+
+        if (offset < 0 || numberOfSegments < 1 || offset >= points.Length || numberOfSegments > points.Length - offset - 1)
+        {
+            throw new ArgumentException("The curve offset and segment count must describe a valid point range.", nameof(numberOfSegments));
+        }
+    }
+
     public void DrawRectangle(Pen pen, Rectangle rect) => DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
     public void DrawRectangle(Pen pen, int x, int y, int width, int height) => DrawRectangle(pen, (float)x, y, width, height);
 


### PR DESCRIPTION
Adds the complete public Graphics.DrawCurve overload family for Point and PointF arrays, lowers cardinal splines directly to one retained native cubic path, validates range contracts, and adds focused geometry tests. This unblocks the unchanged dotnet/samples WinFormGraphics application used by LibreWinForms issue #3.