### PR TITLE
Stabilize allocation-free release tests

### DIFF
--- a/src/ProGPU.Tests/InputFocusAndKeyboardTests.cs
+++ b/src/ProGPU.Tests/InputFocusAndKeyboardTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Content;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Input;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using ProGPU.WinUI.Platform;
@@ -690,20 +691,18 @@ public sealed class InputFocusAndKeyboardTests
                 InputLightDismissRegistration
                     .Notify(appWindow.Id));
 
+            Assert.Equal(
+                Count,
+                CountLightDismissNotifications(
+                    appWindow.Id,
+                    Count));
             _ = GC.GetAllocatedBytesForCurrentThread();
             long before =
                 GC.GetAllocatedBytesForCurrentThread();
-            int delivered = 0;
-            for (int index = 0;
-                 index < Count;
-                 index++)
-            {
-                if (InputLightDismissRegistration
-                    .Notify(appWindow.Id))
-                {
-                    delivered++;
-                }
-            }
+            int delivered =
+                CountLightDismissNotifications(
+                    appWindow.Id,
+                    Count);
             long allocated =
                 GC.GetAllocatedBytesForCurrentThread() -
                 before;
@@ -712,6 +711,23 @@ public sealed class InputFocusAndKeyboardTests
             Assert.Equal(0, allocated);
             appWindow.Destroy();
         });
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int CountLightDismissNotifications(
+        Microsoft.UI.WindowId windowId,
+        int count)
+    {
+        int delivered = 0;
+        for (int index = 0; index < count; index++)
+        {
+            if (InputLightDismissRegistration.Notify(windowId))
+            {
+                delivered++;
+            }
+        }
+
+        return delivered;
     }
 
     [Fact]

--- a/src/ProGPU.Tests/SkTextBlobBuilderApiCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkTextBlobBuilderApiCompatibilityTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using SkiaSharp;
 using Xunit;
 
@@ -134,13 +135,9 @@ public sealed class SkTextBlobBuilderApiCompatibilityTests
             SKRotationScaleMatrix.CreateTranslation(10f, 12f),
             rotation.Positions[0]);
 
-        _ = positioned.Positions[0].X;
+        _ = SumPositionX(positioned, 10_000);
         var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-        var checksum = 0f;
-        for (var iteration = 0; iteration < 10_000; iteration++)
-        {
-            checksum += positioned.Positions[0].X;
-        }
+        var checksum = SumPositionX(positioned, 10_000);
         var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
         Assert.Equal(60_000f, checksum);
         Assert.Equal(0, allocated);
@@ -157,6 +154,20 @@ public sealed class SkTextBlobBuilderApiCompatibilityTests
         Assert.Equal(
             SKRotationScaleMatrix.CreateTranslation(10f, 12f),
             blob.Runs[2].RotationScaleMatrices![0]);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static float SumPositionX(
+        SKRawRunBuffer<SKPoint> run,
+        int count)
+    {
+        var checksum = 0f;
+        for (var iteration = 0; iteration < count; iteration++)
+        {
+            checksum += run.Positions[0].X;
+        }
+
+        return checksum;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- move the SKTextBlob raw-span measurement into an aggressively optimized helper and warm that exact helper before measurement
- do the same for subscriber-free light-dismiss dispatch
- preserve the zero-allocation assertions and production paths unchanged

## Evidence
The immutable preview.41 release run 30772151209 reproduced tiered-JIT measurement noise twice: 3,120 bytes in `RawBuffersExposeNativeSpanLengthsAndSnapshotOnBuild`, then 12,336 bytes in `SubscriberFreeLightDismissTriggersAreAllocationFree`.

With this commit, both focused tests pass in 10/10 fresh processes under `DOTNET_TieredCompilation=1 DOTNET_TC_QuickJitForLoops=1`, with each measurement still asserting exactly zero managed allocations. No shipping source changes.