### PR TITLE
Optimize Avalonia Skia hot paths

### DIFF
--- a/docs/SKIASHARP_API_PARITY.md
+++ b/docs/SKIASHARP_API_PARITY.md
@@ -1030,6 +1030,29 @@ native and outside the managed counter. The remaining ProGPU command-storage
 and snapshot gaps are explicit optimization targets; these shared-machine
 figures establish the direction and do not claim final cross-platform parity.
 
+Matched final-binary macOS profiling compared exact pre-lease commit
+`1c60239b` with exact candidate `79d86548` on the same Apple M3 Pro, macOS
+26.4.1, and .NET 10.0.5 workload. Time Profiler measured `327,088.874` versus
+`816.041` median ns/draw; Allocations plus VM Tracker measured `82,988.745`
+versus `929.165`; Metal System Trace measured `49,527.290` versus `797.290`;
+and EventPipe measured `60,615.875` versus `627.041`. EventPipe retained the
+exact checksum while managed allocation fell from `2,831` to `2,486` B/draw
+(`12.2%`). Profiler overhead perturbs the absolute latency, so the ordinary
+Release process numbers above remain the throughput result and these matched
+captures provide causal evidence.
+
+The Metal capture reduced target resource-allocation rows from `188` to `53`
+and target application command-buffer submission rows from `5,627` to zero.
+The baseline target stack contains WebGPU `copy_texture_to_texture`; the
+candidate target stack does not. Both captures reported zero Metal
+command-buffer errors, compiler spills, and hang risks. Completion and
+`currentAllocatedSize` row counts include process/device sampling and are not
+interpreted as bytes or per-draw totals. The Allocations template did not
+export a native retained-byte table on this Xcode version, so no unsupported
+native-memory claim is made. Compact results are recorded here; the 221 MiB of
+raw trace and EventPipe data, temporary publishes, packages, and exact-baseline
+worktree were removed after the audit.
+
 ### Retained canvas contract and empty-clip checkpoint
 
 `SKCanvas` now closes all 45 missing entries in its official 4.151.0 owner

--- a/docs/SKIASHARP_API_PARITY.md
+++ b/docs/SKIASHARP_API_PARITY.md
@@ -979,6 +979,57 @@ main build and resolves the packaged RID-native WebGPU directory on Linux,
 macOS, and Windows. This fixes the prior Ubuntu `libwgpu_native` loader failure
 without skipping the GPU workload or relaxing comparison evidence.
 
+### Avalonia immutable-image upload and deferred-draw checkpoint
+
+The source-built Avalonia 12 `WriteableBitmapImpl` creates an immutable image
+with `SKImage.FromPixels(info, address, rowBytes)` whenever its writable pixel
+version changes, then reuses that image across draws. ProGPU now copies common
+RGBA, sRGBA, and BGRA rows directly into one tight immutable portable snapshot
+and uploads that same snapshot to WebGPU. The former temporary `SKBitmap`
+wrapper and its second row walk are gone; arbitrary supported formats keep the
+conservative conversion fallback. Snapshot work remains `O(P)` time and
+storage for `P` pixels because the public pointer is caller-owned and the image
+must remain immutable after the writable framebuffer changes.
+
+Whole images drawn in the same WebGPU device now cross the retained-command
+boundary through `IProGpuContextTextureLeaseSource`. The first draw records one
+bounded lifetime lease and every subsequent draw in that context reuses the
+same `GpuTexture`, texture view, and bindable identity. Disposal of the public
+`SKImage` releases its ownership but cannot destroy the texture while a
+deferred context or picture still holds a lease. Subsets, cross-device images,
+and mipmap generation retain their normalized materialization paths. This makes
+ordinary same-device recording `O(C)` command work for `C` draws with one GPU
+texture and one lease, rather than `O(C * P)` texture allocation and copy
+bandwidth.
+
+The clean-room design follows Skia's public
+[immutable image contract](https://api.skia.org/classSkImage.html), WebGPU's
+[texture ownership and copy model](https://www.w3.org/TR/webgpu/#textures),
+Direct2D's
+[device-context bitmap drawing contract](https://learn.microsoft.com/windows/win32/direct2d/id2d1devicecontext-drawbitmap-overload),
+Win2D's
+[CanvasBitmap contract](https://learn.microsoft.com/uwp/api/microsoft.graphics.canvas.canvasbitmap),
+WebRender's
+[external-image frame split](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html),
+and Vello's
+[explicit wgpu scene-to-texture pipeline](https://github.com/linebender/vello).
+ProGPU adopts immutable CPU ownership at the public pointer boundary and typed
+same-device leases at the deferred GPU boundary; it rejects borrowed pointer
+lifetime assumptions, per-draw GPU copies, reflection, and backend-specific
+public handles. Text shaping remains unchanged at the reusable CPU-result
+boundary established by SkParagraph, DirectWrite, Parley, and HarfBuzz.
+
+On the Apple M3 Pro Release baseline, the 16-by-16 Avalonia snapshot workload
+improved from `13,356.445` to `10,934.730` ns/op and from `1,568` to `1,424`
+managed B/op with the exact native checksum. The new 1,000-draw retained-picture
+workload isolates reuse of that immutable image: replacing one GPU texture copy
+per draw with one lifetime lease reduced ProGPU from `69,164.500` to `608.354`
+ns/draw and from `2,831.500` to `2,486.000` managed B/draw. Native measured
+`48.479` ns/draw and `2` managed B/draw because its retained command storage is
+native and outside the managed counter. The remaining ProGPU command-storage
+and snapshot gaps are explicit optimization targets; these shared-machine
+figures establish the direction and do not claim final cross-platform parity.
+
 ### Retained canvas contract and empty-clip checkpoint
 
 `SKCanvas` now closes all 45 missing entries in its official 4.151.0 owner

--- a/src/ProGPU.Tests/SkBlenderCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkBlenderCompatibilityTests.cs
@@ -68,6 +68,42 @@ public sealed class SkBlenderCompatibilityTests
     }
 
     [Fact]
+    public void ReusedPaintBlendModeStateIsAllocationFreeUntilBlenderIsObserved()
+    {
+        using var paint = new SKPaint();
+        _ = CycleBlendModeState(paint, 1);
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var checksum = CycleBlendModeState(paint, 10_000);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.NotEqual(0u, checksum);
+        Assert.Equal(0, allocated);
+
+        paint.BlendMode = SKBlendMode.DstIn;
+        Assert.NotNull(paint.Blender);
+        Assert.Equal(SKBlendMode.DstIn, paint.BlendMode);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => paint.BlendMode = (SKBlendMode)(-1));
+    }
+
+    private static uint CycleBlendModeState(SKPaint paint, int count)
+    {
+        var checksum = 2166136261u;
+        for (var index = 0; index < count; index++)
+        {
+            paint.BlendMode = (index & 1) == 0
+                ? SKBlendMode.DstIn
+                : SKBlendMode.Src;
+            checksum = (checksum ^ (uint)paint.BlendMode) * 16777619u;
+            paint.Reset();
+            checksum = (checksum ^ (uint)paint.BlendMode) * 16777619u;
+        }
+
+        return checksum;
+    }
+
+    [Fact]
     public void BuiltInBlenderRecordsExistingGpuBlendScope()
     {
         using var recorder = new SKPictureRecorder();

--- a/src/ProGPU.Tests/SkCanvasStateTests.cs
+++ b/src/ProGPU.Tests/SkCanvasStateTests.cs
@@ -1670,8 +1670,11 @@ public sealed class SkCanvasStateTests
 
             Assert.Empty(drawingContext.Commands);
             Assert.Equal(0, drawingContext.RetainedResourceCount);
-            Assert.True(retainedTextureDisposed);
+            Assert.False(retainedTextureDisposed);
             Assert.True(layerTextureDisposed);
+
+            image.Dispose();
+            Assert.True(retainedTextureDisposed);
         }
         finally
         {
@@ -1817,7 +1820,7 @@ public sealed class SkCanvasStateTests
     }
 
     [Fact]
-    public void RestoreLayerReleasesRetainedImageTexturesAfterOffscreenRender()
+    public void RestoreLayerReleasesRetainedImageLeaseAfterOffscreenRender()
     {
         using var surface = SKSurface.Create(new SKImageInfo(32, 32, SKColorType.Rgba8888, SKAlphaType.Premul));
         using var layerPaint = new SKPaint();
@@ -1849,7 +1852,7 @@ public sealed class SkCanvasStateTests
         {
             surface.Canvas.RestoreToCount(restoreCount);
 
-            Assert.True(retainedTextureDisposed);
+            Assert.False(retainedTextureDisposed);
             Assert.Empty(layerContext.Commands);
             Assert.Equal(0, layerContext.RetainedResourceCount);
             Assert.Equal(1, GetSurfaceDrawingContext(surface).RetainedResourceCount);
@@ -1862,7 +1865,7 @@ public sealed class SkCanvasStateTests
     }
 
     [Fact]
-    public void RestoreLayerClearsRetainedImageTexturesWhenLayerBoundsAreSkipped()
+    public void RestoreLayerClearsRetainedImageLeaseWhenLayerBoundsAreSkipped()
     {
         using var surface = SKSurface.Create(new SKImageInfo(32, 32, SKColorType.Rgba8888, SKAlphaType.Premul));
         using var layerPaint = new SKPaint();
@@ -1894,7 +1897,7 @@ public sealed class SkCanvasStateTests
         {
             surface.Canvas.RestoreToCount(restoreCount);
 
-            Assert.True(retainedTextureDisposed);
+            Assert.False(retainedTextureDisposed);
             Assert.Empty(layerContext.Commands);
             Assert.Equal(0, layerContext.RetainedResourceCount);
             Assert.Empty(GetOwnedLayerTextures(surface.Canvas));
@@ -2296,7 +2299,7 @@ public sealed class SkCanvasStateTests
             draw =>
             {
                 Assert.Equal(RenderCommandType.DrawTexture, draw.Type);
-                Assert.NotSame(image.Texture, draw.Texture);
+                Assert.Same(image.Texture, draw.Texture);
                 AssertNear(10f, draw.Rect.X);
                 AssertNear(20f, draw.Rect.Y);
                 AssertNear(20.5f, draw.Rect.Width);
@@ -2349,7 +2352,7 @@ public sealed class SkCanvasStateTests
 
         var command = GetDrawTextureCommand(context.Commands);
         var retainedTexture = command.Texture!;
-        Assert.NotSame(image.Texture, retainedTexture);
+        Assert.Same(image.Texture, retainedTexture);
         Assert.Equal(1, context.RetainedResourceCount);
 
         var retainedTextureDisposed = false;
@@ -2377,6 +2380,25 @@ public sealed class SkCanvasStateTests
         {
             GpuTexture.OnDisposedWithId -= OnTextureDisposed;
         }
+    }
+
+    [Fact]
+    public void RepeatedWholeImageDrawsShareOneTextureLeaseWithoutGpuCopies()
+    {
+        var context = new DrawingContext();
+        using var canvas = new SKCanvas(context, 16f, 16f);
+        using var bitmap = new SKBitmap(1, 1);
+        using var image = SKImage.FromBitmap(bitmap);
+
+        canvas.DrawImage(image, 0f, 0f);
+        canvas.DrawImage(image, 1f, 1f);
+
+        var draws = context.Commands
+            .Where(command => command.Type == RenderCommandType.DrawTexture)
+            .ToArray();
+        Assert.Equal(2, draws.Length);
+        Assert.All(draws, command => Assert.Same(image.Texture, command.Texture));
+        Assert.Equal(1, context.RetainedResourceCount);
     }
 
     [Fact]
@@ -2417,6 +2439,8 @@ public sealed class SkCanvasStateTests
 
             picture.Dispose();
 
+            Assert.False(retainedTextureDisposed);
+            image.Dispose();
             Assert.True(retainedTextureDisposed);
         }
         finally
@@ -2466,8 +2490,10 @@ public sealed class SkCanvasStateTests
 
             target.Clear();
 
-            Assert.True(retainedTextureDisposed);
+            Assert.False(retainedTextureDisposed);
             Assert.Equal(0, target.RetainedResourceCount);
+            image.Dispose();
+            Assert.True(retainedTextureDisposed);
         }
         finally
         {

--- a/src/ProGPU.Tests/SkMatrixCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkMatrixCompatibilityTests.cs
@@ -139,6 +139,21 @@ public sealed class SkMatrixCompatibilityTests
     }
 
     [Fact]
+    public void AffineRectangleMappingPreservesSkewAndNegativeScaleBounds()
+    {
+        var skewed = new SKMatrix(2f, 0.5f, 10f, -0.25f, 3f, 20f, 0f, 0f, 1f);
+        Assert.Equal(
+            new SKRect(13f, 24.5f, 26f, 43.75f),
+            skewed.MapRect(new SKRect(1f, 2f, 6f, 8f)));
+
+        var reflected = SKMatrix.CreateScale(-2f, -3f).PostConcat(
+            SKMatrix.CreateTranslation(10f, 20f));
+        Assert.Equal(
+            new SKRect(-2f, -4f, 8f, 14f),
+            reflected.MapRect(new SKRect(1f, 2f, 6f, 8f)));
+    }
+
+    [Fact]
     public void RadiusEqualityHashAndInternalMatrixConversionMatchNativeValues()
     {
         var matrix = SKMatrix.CreateScale(2f, 3f);

--- a/src/ProGPU.Tests/SkPathBuilderCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPathBuilderCompatibilityTests.cs
@@ -8,6 +8,19 @@ namespace ProGPU.Tests;
 public sealed class SkPathBuilderCompatibilityTests
 {
     [Fact]
+    public void DetachedPackedBuilderComputesTightBoundsOnlyWhenRequested()
+    {
+        using var builder = new SKPathBuilder();
+        builder.MoveTo(0f, 0f);
+        builder.QuadTo(10f, 100f, 20f, 0f);
+        using var path = builder.Detach();
+
+        Assert.Equal(new SKRect(0f, 0f, 20f, 100f), path.Bounds);
+        Assert.Equal(new SKRect(0f, 0f, 20f, 50f), path.TightBounds);
+        Assert.Equal(new SKRect(0f, 0f, 20f, 50f), path.TightBounds);
+    }
+
+    [Fact]
     public void PackedDetachAndBoundsStayBoundedIndependentOfSegmentCount()
     {
         static (long AllocatedBytes, SKRect Bounds) Measure(int segmentCount)

--- a/src/ProGPU.Tests/SkPathMutationCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPathMutationCompatibilityTests.cs
@@ -6,6 +6,70 @@ namespace ProGPU.Tests;
 public sealed class SkPathMutationCompatibilityTests
 {
     [Fact]
+    public void CommonLegacyVerbStreamKeepsTightBoundsAllocationBounded()
+    {
+        static float MeasureOnce()
+        {
+            using var path = new SKPath { FillType = SKPathFillType.EvenOdd };
+            path.MoveTo(0f, 0f);
+            for (var segment = 0; segment < 8; segment++)
+            {
+                var x = segment * 6f;
+                var y = segment * 3f;
+                path.LineTo(x + 1f, y + 2f);
+                path.QuadTo(x + 2f, y - 1f, x + 3f, y + 3f);
+                path.CubicTo(x + 3.5f, y + 4f, x + 4.5f, y - 2f, x + 5f, y + 1f);
+            }
+
+            path.Close();
+            var bounds = path.TightBounds;
+            return bounds.Left + bounds.Top + bounds.Right + bounds.Bottom;
+        }
+
+        _ = MeasureOnce();
+        const int iterations = 1_000;
+        var checksum = 0f;
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < iterations; index++)
+        {
+            checksum += MeasureOnce();
+        }
+
+        var allocatedPerPath =
+            (GC.GetAllocatedBytesForCurrentThread() - allocatedBefore) / iterations;
+        Assert.True(float.IsFinite(checksum));
+        Assert.InRange(allocatedPerPath, 0, 128);
+    }
+
+    [Fact]
+    public void TightCurveBoundsPreserveFractionalTranslation()
+    {
+        static SKRect Build(float offset)
+        {
+            using var path = new SKPath();
+            path.MoveTo(offset, -offset);
+            path.QuadTo(2f + offset, -1f - offset, 3f + offset, 3f - offset);
+            path.CubicTo(
+                3.5f + offset,
+                4f - offset,
+                4.5f + offset,
+                -2f - offset,
+                5f + offset,
+                1f - offset);
+            return path.TightBounds;
+        }
+
+        const float offset = 0.125f;
+        var baseline = Build(0f);
+        var translated = Build(offset);
+
+        Assert.Equal(baseline.Left + offset, translated.Left);
+        Assert.Equal(baseline.Right + offset, translated.Right);
+        Assert.Equal(baseline.Top - offset, translated.Top);
+        Assert.Equal(baseline.Bottom - offset, translated.Bottom);
+    }
+
+    [Fact]
     public void RelativeCommandsUseOneNativeCurrentPointPerVerb()
     {
         using var path = new SKPath();

--- a/src/ProGPU.Tests/SkRoundRectCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkRoundRectCompatibilityTests.cs
@@ -79,7 +79,7 @@ public sealed class SkRoundRectCompatibilityTests
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
         Assert.Equal(85_000f, checksum);
         Assert.True(
-            allocated <= 96L * iterations,
+            allocated <= 72L * iterations,
             $"Expected one bounded SKRoundRect allocation per construction, but measured {allocated / (double)iterations:F3} B/op.");
     }
 

--- a/src/ProGPU.Tests/SkShaderCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkShaderCompatibilityTests.cs
@@ -280,6 +280,89 @@ public sealed class SkShaderCompatibilityTests
     }
 
     [Fact]
+    public void ReusedGradientInputsAndTransformsStayBelowNativeWrapperAllocation()
+    {
+        var colors = new[]
+        {
+            new SKColorF(1f, 0f, 0f, 1f),
+            new SKColorF(0f, 1f, 0f, 1f),
+            new SKColorF(0f, 0f, 1f, 1f),
+        };
+        var positions = new[] { 0f, 0.375f, 1f };
+        using var colorSpace = SKColorSpace.CreateSrgb();
+
+        static nint CreateFamily(
+            SKColorF[] colors,
+            float[] positions,
+            SKColorSpace colorSpace,
+            SKMatrix localMatrix)
+        {
+            using var linear = SKShader.CreateLinearGradient(
+                SKPoint.Empty,
+                new SKPoint(64f, 32f),
+                colors,
+                colorSpace,
+                positions,
+                SKShaderTileMode.Mirror,
+                localMatrix);
+            using var radial = SKShader.CreateRadialGradient(
+                new SKPoint(32f, 32f),
+                24f,
+                colors,
+                colorSpace,
+                positions,
+                SKShaderTileMode.Repeat,
+                localMatrix);
+            using var sweep = SKShader.CreateSweepGradient(
+                new SKPoint(32f, 32f),
+                colors,
+                colorSpace,
+                positions,
+                SKShaderTileMode.Clamp,
+                -45f,
+                315f,
+                localMatrix);
+            using var conical = SKShader.CreateTwoPointConicalGradient(
+                new SKPoint(8f, 8f),
+                4f,
+                new SKPoint(48f, 40f),
+                28f,
+                colors,
+                colorSpace,
+                positions,
+                SKShaderTileMode.Decal,
+                localMatrix);
+            return linear.Handle ^ radial.Handle ^ sweep.Handle ^ conical.Handle;
+        }
+
+        for (var index = 0; index < 16; index++)
+        {
+            _ = CreateFamily(
+                colors,
+                positions,
+                colorSpace,
+                SKMatrix.CreateTranslation(index & 3, index & 7));
+        }
+
+        const int iterations = 1_000;
+        nint checksum = 0;
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < iterations; index++)
+        {
+            checksum ^= CreateFamily(
+                colors,
+                positions,
+                colorSpace,
+                SKMatrix.CreateTranslation(index & 3, index & 7));
+        }
+
+        var allocatedPerFamily =
+            (GC.GetAllocatedBytesForCurrentThread() - allocatedBefore) / iterations;
+        Assert.NotEqual(0, checksum);
+        Assert.InRange(allocatedPerFamily, 0, 400);
+    }
+
+    [Fact]
     public void ShaderWrappersRetainDisposedSources()
     {
         var source = SKShader.CreateColor(SKColors.Cyan);

--- a/src/ProGPU.Tests/SkShaderCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkShaderCompatibilityTests.cs
@@ -332,7 +332,7 @@ public sealed class SkShaderCompatibilityTests
                 positions,
                 SKShaderTileMode.Decal,
                 localMatrix);
-            return linear.Handle ^ radial.Handle ^ sweep.Handle ^ conical.Handle;
+            return linear.Handle | radial.Handle | sweep.Handle | conical.Handle;
         }
 
         for (var index = 0; index < 16; index++)
@@ -349,7 +349,7 @@ public sealed class SkShaderCompatibilityTests
         var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
         for (var index = 0; index < iterations; index++)
         {
-            checksum ^= CreateFamily(
+            checksum |= CreateFamily(
                 colors,
                 positions,
                 colorSpace,

--- a/src/ProGPU.Tests/SkTextBlobTests.cs
+++ b/src/ProGPU.Tests/SkTextBlobTests.cs
@@ -55,6 +55,24 @@ public sealed class SkTextBlobTests
     }
 
     [Fact]
+    public void SingleRunBlobReusesItsImmutableSnapshotAsAggregateStorage()
+    {
+        using var builder = new SKTextBlobBuilder();
+        using var font = new SKFont(SKTypeface.Default, 12f);
+
+        var run = builder.AllocatePositionedRun(font, 2);
+        run.SetGlyphs(new ushort[] { 42, 43 });
+        run.SetPositions(new[] { new SKPoint(7f, 8f), new SKPoint(9f, 10f) });
+
+        using var blob = builder.Build();
+
+        Assert.NotNull(blob);
+        var retainedRun = Assert.Single(blob.Runs);
+        Assert.Same(retainedRun.GlyphIndices, blob.GlyphIndices);
+        Assert.Same(retainedRun.GlyphPositions, blob.GlyphPositions);
+    }
+
+    [Fact]
     public void GetInterceptsPreservesPerGlyphIntervalsAndTruncatesShortSpans()
     {
         using var font = new SKFont(SKTypeface.Default, 40f);

--- a/src/ProGPU.Tests/SkTextBlobTests.cs
+++ b/src/ProGPU.Tests/SkTextBlobTests.cs
@@ -86,7 +86,7 @@ public sealed class SkTextBlobTests
         var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
 
         Assert.Equal(100, checksum);
-        Assert.InRange(allocated / 100, 0, 720);
+        Assert.InRange(allocated / 100, 0, 128);
     }
 
     private static int BuildPositionedBlob(

--- a/src/ProGPU.Tests/SkTextBlobTests.cs
+++ b/src/ProGPU.Tests/SkTextBlobTests.cs
@@ -73,6 +73,43 @@ public sealed class SkTextBlobTests
     }
 
     [Fact]
+    public void ReusedBuilderKeepsOneBoundedPositionedScratchRun()
+    {
+        using var builder = new SKTextBlobBuilder();
+        using var font = new SKFont(SKTypeface.Default, 12f);
+        var glyphs = new ushort[32];
+        var positions = new SKPoint[32];
+
+        _ = BuildPositionedBlob(builder, font, glyphs, positions, 1);
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var checksum = BuildPositionedBlob(builder, font, glyphs, positions, 100);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.Equal(100, checksum);
+        Assert.InRange(allocated / 100, 0, 720);
+    }
+
+    private static int BuildPositionedBlob(
+        SKTextBlobBuilder builder,
+        SKFont font,
+        ushort[] glyphs,
+        SKPoint[] positions,
+        int count)
+    {
+        var checksum = 0;
+        for (var index = 0; index < count; index++)
+        {
+            var run = builder.AllocatePositionedRun(font, glyphs.Length);
+            run.SetGlyphs(glyphs);
+            run.SetPositions(positions);
+            using var blob = builder.Build();
+            checksum += blob is null ? 0 : 1;
+        }
+
+        return checksum;
+    }
+
+    [Fact]
     public void GetInterceptsPreservesPerGlyphIntervalsAndTruncatesShortSpans()
     {
         using var font = new SKFont(SKTypeface.Default, 40f);

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -281,7 +281,11 @@ public class SKCanvas : SKObject
 
     public SKMatrix TotalMatrix => _currentMatrix;
 
-    public int SaveCount => _savedStateCount + 1;
+    public int SaveCount
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _savedStateCount + 1;
+    }
 
     public SKMatrix44 TotalMatrix44 => SKMatrix44.FromMatrix4x4(_currentMatrix.ToMatrix4x4());
 
@@ -538,6 +542,7 @@ public class SKCanvas : SKObject
         // Retained canvases have no immediate attachment contents to invalidate.
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Save()
     {
         var restoreCount = _savedStateCount + 1;
@@ -623,6 +628,7 @@ public class SKCanvas : SKObject
 
     public int SaveLayer() => SaveLayer(new SKRect(0, 0, _width, _height), null);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Restore()
     {
         if (_savedStateCount > 0)
@@ -666,6 +672,7 @@ public class SKCanvas : SKObject
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void RestoreToCount(int count)
     {
         var targetDepth = Math.Max(1, count) - 1;
@@ -2758,6 +2765,7 @@ public class SKCanvas : SKObject
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void PushRectClipScope(SKRect rect, Matrix4x4 transform)
     {
         int commandIndex = _context.Commands.Count;
@@ -2784,6 +2792,7 @@ public class SKCanvas : SKObject
         _pushedScopes.Push(new PushedScope(PushKind.GeometryClip, _context, commandIndex));
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool TryRemoveEmptyClipScope(PushedScope scope)
     {
         if (scope.Kind is not (PushKind.RectClip or PushKind.GeometryClip) ||
@@ -2814,6 +2823,7 @@ public class SKCanvas : SKObject
         isRect = false;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void UpdateClipForIntersection(SKRect deviceBounds, bool isRect)
     {
         if (_clipState.IsEmpty)
@@ -3079,6 +3089,7 @@ public class SKCanvas : SKObject
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Scale(float s)
     {
         if (s != 1f)
@@ -3087,6 +3098,7 @@ public class SKCanvas : SKObject
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Scale(float sx, float sy)
     {
         _currentMatrix.ScaleX *= sx;
@@ -3191,6 +3203,7 @@ public class SKCanvas : SKObject
         _currentMatrix = SKMatrix.Identity;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Concat(in SKMatrix m)
     {
         _currentMatrix = SKMatrix.Concat(_currentMatrix, m);
@@ -3259,6 +3272,7 @@ public class SKCanvas : SKObject
         return QuickReject(path.Bounds);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ClipRect(SKRect rect, SKClipOperation operation = SKClipOperation.Intersect, bool antialias = false)
     {
         var transform = _currentMatrix.ToMatrix4x4();

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -5779,7 +5779,10 @@ public class SKCanvas : SKObject
         // below because their command-space coordinates or mip levels differ.
         if (!generateMipmaps &&
             image.IsWholeTexture &&
-            _context.TryRetainTexture(image, targetContext, out var leasedTexture))
+            _context.TryRetainTexture(
+                image.TextureLeaseSource,
+                targetContext,
+                out var leasedTexture))
         {
             if (image.ColorSpace is { } leasedColorSpace)
             {

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -3041,7 +3041,7 @@ public class SKCanvas : SKObject
 
     private bool PushPaintBlendMode(SKPaint? paint)
     {
-        if (paint?.Blender?.IsArithmetic == true)
+        if (paint?.HasArithmeticBlender == true)
         {
             throw new NotSupportedException(
                 "Arithmetic SKBlender rendering requires destination-sampling compositor support.");

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -5771,6 +5771,25 @@ public class SKCanvas : SKObject
             : currentContext != null && !currentContext.IsDisposed
                 ? currentContext
                 : image.Texture.Context;
+
+        // Whole immutable images already own a texture in the target device.
+        // Retain that ownership through the drawing context instead of making
+        // a second GPU allocation and copy for every DrawImage recording.
+        // Subsets and mipmap generation still materialize a normalized texture
+        // below because their command-space coordinates or mip levels differ.
+        if (!generateMipmaps &&
+            image.IsWholeTexture &&
+            _context.TryRetainTexture(image, targetContext, out var leasedTexture))
+        {
+            if (image.ColorSpace is { } leasedColorSpace)
+            {
+                s_textureColorSpaces.AddOrUpdate(
+                    leasedTexture,
+                    new TextureColorSpace(leasedColorSpace));
+            }
+            return leasedTexture;
+        }
+
         var source = image.GetTextureRegionForContext(
             targetContext,
             out var sourceX,

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -3833,12 +3833,14 @@ public class SKCanvas : SKObject
 
     private static bool TryGetUniformRadii(SKRoundRect rect, out float radiusX, out float radiusY)
     {
-        radiusX = rect.CornerRadii[0].X;
-        radiusY = rect.CornerRadii[0].Y;
-        for (int i = 1; i < rect.CornerRadii.Length; i++)
+        var firstRadius = rect.GetRadii(SKRoundRectCorner.UpperLeft);
+        radiusX = firstRadius.X;
+        radiusY = firstRadius.Y;
+        for (int i = 1; i < 4; i++)
         {
-            if (MathF.Abs(rect.CornerRadii[i].X - radiusX) > 0.0001f ||
-                MathF.Abs(rect.CornerRadii[i].Y - radiusY) > 0.0001f)
+            var radius = rect.GetRadii((SKRoundRectCorner)i);
+            if (MathF.Abs(radius.X - radiusX) > 0.0001f ||
+                MathF.Abs(radius.Y - radiusY) > 0.0001f)
             {
                 return false;
             }

--- a/src/SkiaSharp/SKImage.Api.cs
+++ b/src/SkiaSharp/SKImage.Api.cs
@@ -571,6 +571,24 @@ public partial class SKImage
             throw new ArgumentException("The pixel buffer is smaller than the declared image storage.", nameof(pixels));
         }
 
+        if (info.ColorType is SKColorType.Rgba8888 or SKColorType.Srgba8888 or SKColorType.Bgra8888)
+        {
+            byte[] rgbaPixels = CopyCommonPixelsToTightRgba(info, pixels, rowBytes);
+            var context = SKContextHelper.GetContext();
+            var texture = CreateTextureFromRgbaPixels(
+                info,
+                rgbaPixels,
+                context,
+                generateMipmaps: false,
+                "SKImage Pixel Copy Texture");
+            return new SKImage(
+                texture,
+                ownsTexture: true,
+                info,
+                portableRgbaPixels: rgbaPixels,
+                isTextureBacked: false);
+        }
+
         unsafe
         {
             fixed (byte* pointer = pixels)
@@ -584,6 +602,43 @@ public partial class SKImage
                 return FromBitmap(bitmap);
             }
         }
+    }
+
+    private static byte[] CopyCommonPixelsToTightRgba(
+        SKImageInfo info,
+        ReadOnlySpan<byte> pixels,
+        int rowBytes)
+    {
+        int tightRowBytes = checked(info.Width * 4);
+        byte[] result = GC.AllocateUninitializedArray<byte>(
+            checked(tightRowBytes * info.Height));
+        for (var row = 0; row < info.Height; row++)
+        {
+            ReadOnlySpan<byte> sourceRow = pixels.Slice(
+                checked(row * rowBytes),
+                tightRowBytes);
+            Span<byte> destinationRow = result.AsSpan(
+                checked(row * tightRowBytes),
+                tightRowBytes);
+            if (info.ColorType == SKColorType.Bgra8888)
+            {
+                PixelChannelSwizzler.SwapRedBlue32(
+                    sourceRow,
+                    destinationRow,
+                    info.Width);
+            }
+            else
+            {
+                sourceRow.CopyTo(destinationRow);
+            }
+        }
+
+        if (info.AlphaType == SKAlphaType.Opaque)
+        {
+            ForceOpaqueAlpha(result);
+        }
+
+        return result;
     }
 
     private static int ValidatePixelStorage(SKImageInfo info, int rowBytes)

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -10,7 +10,7 @@ using Silk.NET.WebGPU;
 
 namespace SkiaSharp;
 
-public partial class SKImage : SKObject
+public partial class SKImage : SKObject, IProGpuContextTextureLeaseSource
 {
     private sealed class ImageOptionalState
     {
@@ -64,6 +64,12 @@ public partial class SKImage : SKObject
         public int PortableRowWidth { get; }
         public bool IsTextureBacked { get; }
 
+        public IProGpuTextureLease AcquireTextureLease()
+        {
+            AddReference();
+            return new ImageTextureLease(this, Texture);
+        }
+
         public void AddReference()
         {
             while (true)
@@ -100,8 +106,31 @@ public partial class SKImage : SKObject
         }
     }
 
+    private sealed class ImageTextureLease : IProGpuTextureLease
+    {
+        private TextureStorage? _storage;
+
+        public ImageTextureLease(TextureStorage storage, GpuTexture texture)
+        {
+            _storage = storage;
+            Texture = texture;
+        }
+
+        public GpuTexture Texture { get; }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _storage, null)?.ReleaseReference();
+        }
+    }
+
     private readonly TextureStorage _textureStorage;
     internal GpuTexture Texture => _textureStorage.Texture;
+    internal bool IsWholeTexture =>
+        _originX == 0 &&
+        _originY == 0 &&
+        Texture.Width == (uint)Width &&
+        Texture.Height == (uint)Height;
     private readonly int _width;
     private readonly int _height;
     private readonly int _originX;
@@ -117,9 +146,66 @@ public partial class SKImage : SKObject
     public bool IsLazyGenerated => false;
     public bool IsTextureBacked => _textureStorage.IsTextureBacked;
 
+    bool IProGpuTextureSource.TryGetGpuTexture(out GpuTexture texture) =>
+        TryGetWholeGpuTexture(Texture.Context, out texture);
+
+    bool IProGpuTextureLeaseSource.TryAcquireGpuTextureLease(
+        out IProGpuTextureLease lease) =>
+        TryAcquireWholeGpuTextureLease(Texture.Context, out lease);
+
+    bool IProGpuContextTextureLeaseSource.TryGetGpuTexture(
+        WgpuContext requiredContext,
+        out GpuTexture texture) =>
+        TryGetWholeGpuTexture(requiredContext, out texture);
+
+    bool IProGpuContextTextureLeaseSource.TryAcquireGpuTextureLease(
+        WgpuContext requiredContext,
+        out IProGpuTextureLease lease) =>
+        TryAcquireWholeGpuTextureLease(requiredContext, out lease);
+
     public SKData EncodedData => _optionalState?.EncodedBytes is not { } bytes
         ? null!
         : SKData.CreateCopy(bytes);
+
+    private bool TryGetWholeGpuTexture(
+        WgpuContext requiredContext,
+        out GpuTexture texture)
+    {
+        ArgumentNullException.ThrowIfNull(requiredContext);
+        if (!IsDisposed &&
+            IsWholeTexture &&
+            ReferenceEquals(Texture.Context, requiredContext) &&
+            !Texture.IsDisposed)
+        {
+            texture = Texture;
+            return true;
+        }
+
+        texture = null!;
+        return false;
+    }
+
+    private bool TryAcquireWholeGpuTextureLease(
+        WgpuContext requiredContext,
+        out IProGpuTextureLease lease)
+    {
+        if (!TryGetWholeGpuTexture(requiredContext, out _))
+        {
+            lease = null!;
+            return false;
+        }
+
+        try
+        {
+            lease = _textureStorage.AcquireTextureLease();
+            return true;
+        }
+        catch (ObjectDisposedException)
+        {
+            lease = null!;
+            return false;
+        }
+    }
 
     internal SKImage(GpuTexture texture)
         : this(texture, ownsTexture: false, CreateTextureInfo(texture), portableRgbaPixels: null)

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -10,7 +10,7 @@ using Silk.NET.WebGPU;
 
 namespace SkiaSharp;
 
-public partial class SKImage : SKObject, IProGpuContextTextureLeaseSource
+public partial class SKImage : SKObject
 {
     private sealed class ImageOptionalState
     {
@@ -28,7 +28,7 @@ public partial class SKImage : SKObject, IProGpuContextTextureLeaseSource
         public int ReleaseInvoked;
     }
 
-    private sealed class TextureStorage
+    private sealed class TextureStorage : IProGpuContextTextureLeaseSource
     {
         private int _referenceCount = 1;
         private readonly bool _ownsTexture;
@@ -64,10 +64,66 @@ public partial class SKImage : SKObject, IProGpuContextTextureLeaseSource
         public int PortableRowWidth { get; }
         public bool IsTextureBacked { get; }
 
+        bool IProGpuTextureSource.TryGetGpuTexture(out GpuTexture texture) =>
+            TryGetGpuTexture(Texture.Context, out texture);
+
+        bool IProGpuTextureLeaseSource.TryAcquireGpuTextureLease(
+            out IProGpuTextureLease lease) =>
+            TryAcquireGpuTextureLease(Texture.Context, out lease);
+
+        bool IProGpuContextTextureLeaseSource.TryGetGpuTexture(
+            WgpuContext requiredContext,
+            out GpuTexture texture) =>
+            TryGetGpuTexture(requiredContext, out texture);
+
+        bool IProGpuContextTextureLeaseSource.TryAcquireGpuTextureLease(
+            WgpuContext requiredContext,
+            out IProGpuTextureLease lease) =>
+            TryAcquireGpuTextureLease(requiredContext, out lease);
+
         public IProGpuTextureLease AcquireTextureLease()
         {
             AddReference();
             return new ImageTextureLease(this, Texture);
+        }
+
+        private bool TryGetGpuTexture(
+            WgpuContext requiredContext,
+            out GpuTexture texture)
+        {
+            ArgumentNullException.ThrowIfNull(requiredContext);
+            if (Volatile.Read(ref _referenceCount) > 0 &&
+                ReferenceEquals(Texture.Context, requiredContext) &&
+                !Texture.IsDisposed)
+            {
+                texture = Texture;
+                return true;
+            }
+
+            texture = null!;
+            return false;
+        }
+
+        private bool TryAcquireGpuTextureLease(
+            WgpuContext requiredContext,
+            out IProGpuTextureLease lease)
+        {
+            if (!TryGetGpuTexture(requiredContext, out _))
+            {
+                lease = null!;
+                return false;
+            }
+
+            try
+            {
+                lease = AcquireTextureLease();
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                lease = null!;
+                return false;
+            }
         }
 
         public void AddReference()
@@ -126,6 +182,7 @@ public partial class SKImage : SKObject, IProGpuContextTextureLeaseSource
 
     private readonly TextureStorage _textureStorage;
     internal GpuTexture Texture => _textureStorage.Texture;
+    internal IProGpuContextTextureLeaseSource TextureLeaseSource => _textureStorage;
     internal bool IsWholeTexture =>
         _originX == 0 &&
         _originY == 0 &&
@@ -146,66 +203,9 @@ public partial class SKImage : SKObject, IProGpuContextTextureLeaseSource
     public bool IsLazyGenerated => false;
     public bool IsTextureBacked => _textureStorage.IsTextureBacked;
 
-    bool IProGpuTextureSource.TryGetGpuTexture(out GpuTexture texture) =>
-        TryGetWholeGpuTexture(Texture.Context, out texture);
-
-    bool IProGpuTextureLeaseSource.TryAcquireGpuTextureLease(
-        out IProGpuTextureLease lease) =>
-        TryAcquireWholeGpuTextureLease(Texture.Context, out lease);
-
-    bool IProGpuContextTextureLeaseSource.TryGetGpuTexture(
-        WgpuContext requiredContext,
-        out GpuTexture texture) =>
-        TryGetWholeGpuTexture(requiredContext, out texture);
-
-    bool IProGpuContextTextureLeaseSource.TryAcquireGpuTextureLease(
-        WgpuContext requiredContext,
-        out IProGpuTextureLease lease) =>
-        TryAcquireWholeGpuTextureLease(requiredContext, out lease);
-
     public SKData EncodedData => _optionalState?.EncodedBytes is not { } bytes
         ? null!
         : SKData.CreateCopy(bytes);
-
-    private bool TryGetWholeGpuTexture(
-        WgpuContext requiredContext,
-        out GpuTexture texture)
-    {
-        ArgumentNullException.ThrowIfNull(requiredContext);
-        if (!IsDisposed &&
-            IsWholeTexture &&
-            ReferenceEquals(Texture.Context, requiredContext) &&
-            !Texture.IsDisposed)
-        {
-            texture = Texture;
-            return true;
-        }
-
-        texture = null!;
-        return false;
-    }
-
-    private bool TryAcquireWholeGpuTextureLease(
-        WgpuContext requiredContext,
-        out IProGpuTextureLease lease)
-    {
-        if (!TryGetWholeGpuTexture(requiredContext, out _))
-        {
-            lease = null!;
-            return false;
-        }
-
-        try
-        {
-            lease = _textureStorage.AcquireTextureLease();
-            return true;
-        }
-        catch (ObjectDisposedException)
-        {
-            lease = null!;
-            return false;
-        }
-    }
 
     internal SKImage(GpuTexture texture)
         : this(texture, ownsTexture: false, CreateTextureInfo(texture), portableRgbaPixels: null)

--- a/src/SkiaSharp/SKMatrix.cs
+++ b/src/SkiaSharp/SKMatrix.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace SkiaSharp;
 
@@ -289,8 +290,26 @@ public partial struct SKMatrix
     public static void Concat(ref SKMatrix target, SKMatrix first, SKMatrix second) =>
         target = Concat(first, second);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly SKRect MapRect(SKRect source)
     {
+        if (!HasPerspective)
+        {
+            var leftScale = source.Left * _scaleX;
+            var rightScale = source.Right * _scaleX;
+            var topSkew = source.Top * _skewX;
+            var bottomSkew = source.Bottom * _skewX;
+            var leftSkew = source.Left * _skewY;
+            var rightSkew = source.Right * _skewY;
+            var topScale = source.Top * _scaleY;
+            var bottomScale = source.Bottom * _scaleY;
+            return new SKRect(
+                MathF.Min(leftScale, rightScale) + MathF.Min(topSkew, bottomSkew) + _transX,
+                MathF.Min(leftSkew, rightSkew) + MathF.Min(topScale, bottomScale) + _transY,
+                MathF.Max(leftScale, rightScale) + MathF.Max(topSkew, bottomSkew) + _transX,
+                MathF.Max(leftSkew, rightSkew) + MathF.Max(topScale, bottomScale) + _transY);
+        }
+
         Span<SKPoint> corners =
         [
             new SKPoint(source.Left, source.Top),
@@ -299,17 +318,7 @@ public partial struct SKMatrix
             new SKPoint(source.Left, source.Bottom)
         ];
 
-        if (HasPerspective)
-        {
-            return MapPerspectiveRect(corners);
-        }
-
-        for (var index = 0; index < corners.Length; index++)
-        {
-            corners[index] = MapPoint(corners[index]);
-        }
-
-        return GetBounds(corners);
+        return MapPerspectiveRect(corners);
     }
 
     public readonly SKPoint MapPoint(SKPoint point) => MapPoint(point.X, point.Y);

--- a/src/SkiaSharp/SKPaint.cs
+++ b/src/SkiaSharp/SKPaint.cs
@@ -21,6 +21,7 @@ public partial class SKPaint : SKObject
     private const float HairlineStrokeWidth = 1f;
     private SKShader? _shader;
     private SKBlender? _blender;
+    private SKBlendMode _blendMode = SKBlendMode.SrcOver;
     private SKPathEffect? _pathEffect;
     private float _strokeWidth;
 
@@ -82,18 +83,39 @@ public partial class SKPaint : SKObject
     }
     public SKBlender? Blender
     {
-        get => _blender;
-        set => _blender = value;
+        get
+        {
+            if (_blender == null && _blendMode != SKBlendMode.SrcOver)
+            {
+                _blender = SKBlender.CreateBlendMode(_blendMode);
+            }
+
+            return _blender;
+        }
+        set
+        {
+            _blender = value;
+            _blendMode = value != null && value.TryGetBlendMode(out var mode)
+                ? mode
+                : SKBlendMode.SrcOver;
+        }
     }
     public SKBlendMode BlendMode
     {
-        get => Blender != null && Blender.TryGetBlendMode(out var mode)
-            ? mode
-            : SKBlendMode.SrcOver;
-        set => Blender = value == SKBlendMode.SrcOver
-            ? null
-            : SKBlender.CreateBlendMode(value);
+        get => _blendMode;
+        set
+        {
+            if (!Enum.IsDefined(value))
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            _blendMode = value;
+            _blender = null;
+        }
     }
+
+    internal bool HasArithmeticBlender => _blender?.IsArithmetic == true;
     public bool IsAntialias
     {
         get => _isAntialias;
@@ -130,11 +152,12 @@ public partial class SKPaint : SKObject
             ColorFilter = ColorFilter,
             ImageFilter = ImageFilter,
             PathEffect = PathEffect,
-            Blender = Blender,
             IsAntialias = IsAntialias,
             IsDither = IsDither,
             MaskFilter = MaskFilter,
         };
+        clone._blender = _blender;
+        clone._blendMode = _blendMode;
         clone.CopyLegacyTextStateFrom(this);
         return clone;
     }

--- a/src/SkiaSharp/SKPaint.cs
+++ b/src/SkiaSharp/SKPaint.cs
@@ -1190,14 +1190,16 @@ public partial class SKShader : SKObject
     private static float[]? s_lastGradientPositionsF;
     [ThreadStatic]
     private static GradientStopStorage? s_lastColorFGradientStops;
+    // UI themes commonly reuse a small transform palette across multiple gradient
+    // kinds. Share immutable inverse storage so each shader retains one reference
+    // instead of nine floats; the per-thread cache is strictly bounded.
+    private const int GradientTransformCacheCapacity = 8;
+    private static readonly GradientTransformStorage s_identityGradientTransform =
+        new(SKMatrix.Identity, SKMatrix.Identity);
     [ThreadStatic]
-    private static SKMatrix s_lastGradientLocalMatrix;
+    private static GradientTransformStorage?[]? s_gradientTransformCache;
     [ThreadStatic]
-    private static SKMatrix s_lastGradientCoordinateTransform;
-    [ThreadStatic]
-    private static bool s_hasLastGradientCoordinateTransform;
-    [ThreadStatic]
-    private static bool s_lastGradientMatrixWasInvertible;
+    private static int s_gradientTransformCacheCursor;
     private readonly object? _data;
     private readonly ShaderDataKind _dataKind;
     private int _referenceCount = 1;
@@ -1458,7 +1460,7 @@ public partial class SKShader : SKObject
             GetGradientStops(colors, colorPos),
             MapTileMode(mode),
             GradientColorInterpolationMode.SRgbLinearInterpolation,
-            SKMatrix.Identity);
+            s_identityGradientTransform);
 
     public static SKShader CreateLinearGradient(
         SKPoint start,
@@ -1531,7 +1533,7 @@ public partial class SKShader : SKObject
             GetGradientStops(colors, colorPos),
             MapTileMode(mode),
             GradientColorInterpolationMode.SRgbLinearInterpolation,
-            SKMatrix.Identity);
+            s_identityGradientTransform);
 
     public static SKShader CreateRadialGradient(
         SKPoint center,
@@ -1608,7 +1610,7 @@ public partial class SKShader : SKObject
             GetGradientStops(colors, colorPos),
             MapTileMode(mode),
             GradientColorInterpolationMode.SRgbLinearInterpolation,
-            SKMatrix.Identity);
+            s_identityGradientTransform);
 
     public static SKShader CreateTwoPointConicalGradient(
         SKPoint start,
@@ -2151,6 +2153,18 @@ public partial class SKShader : SKObject
             offset);
     }
 
+    private sealed class GradientTransformStorage
+    {
+        public GradientTransformStorage(SKMatrix localMatrix, SKMatrix coordinateTransform)
+        {
+            LocalMatrix = localMatrix;
+            CoordinateTransform = coordinateTransform;
+        }
+
+        public SKMatrix LocalMatrix { get; }
+        public SKMatrix CoordinateTransform { get; }
+    }
+
     // Most UI gradients contain two or three stops. The bounded per-thread lookup
     // shares immutable compact stop storage only while the caller's inputs remain
     // unchanged; larger gradients keep an owned overflow array. Typed descriptors
@@ -2159,14 +2173,14 @@ public partial class SKShader : SKObject
     private abstract class GradientShaderData : SKShader
     {
         private readonly GradientStopStorage _stops;
-        private readonly SKMatrix _coordinateTransform;
+        private readonly GradientTransformStorage _coordinateTransform;
         private readonly byte _options;
 
         protected GradientShaderData(
             GradientStopStorage stops,
             GradientSpreadMethod spreadMethod,
             GradientColorInterpolationMode interpolationMode,
-            SKMatrix coordinateTransform)
+            GradientTransformStorage coordinateTransform)
         {
             _options = PackOptions(spreadMethod, interpolationMode);
             _coordinateTransform = coordinateTransform;
@@ -2176,7 +2190,8 @@ public partial class SKShader : SKObject
         protected GradientSpreadMethod SpreadMethod => (GradientSpreadMethod)(_options & 0x3);
         protected GradientColorInterpolationMode InterpolationMode =>
             (GradientColorInterpolationMode)((_options >> 2) & 0x1);
-        protected Matrix4x4 CoordinateTransform => _coordinateTransform.ToMatrix4x4();
+        protected Matrix4x4 CoordinateTransform =>
+            _coordinateTransform.CoordinateTransform.ToMatrix4x4();
 
         public abstract Brush ToBrushCore();
 
@@ -2202,7 +2217,7 @@ public partial class SKShader : SKObject
             GradientStopStorage stops,
             GradientSpreadMethod spreadMethod,
             GradientColorInterpolationMode interpolationMode,
-            SKMatrix coordinateTransform)
+            GradientTransformStorage coordinateTransform)
             : base(stops, spreadMethod, interpolationMode, coordinateTransform)
         {
             _start = new Vector2(start.X, start.Y);
@@ -2228,7 +2243,7 @@ public partial class SKShader : SKObject
             GradientStopStorage stops,
             GradientSpreadMethod spreadMethod,
             GradientColorInterpolationMode interpolationMode,
-            SKMatrix coordinateTransform)
+            GradientTransformStorage coordinateTransform)
             : base(stops, spreadMethod, interpolationMode, coordinateTransform)
         {
             _center = new Vector2(center.X, center.Y);
@@ -2258,7 +2273,7 @@ public partial class SKShader : SKObject
             GradientStopStorage stops,
             GradientSpreadMethod spreadMethod,
             GradientColorInterpolationMode interpolationMode,
-            SKMatrix coordinateTransform)
+            GradientTransformStorage coordinateTransform)
             : base(stops, spreadMethod, interpolationMode, coordinateTransform)
         {
             _start = new Vector2(start.X, start.Y);
@@ -2291,7 +2306,7 @@ public partial class SKShader : SKObject
             GradientStopStorage stops,
             GradientSpreadMethod spreadMethod,
             GradientColorInterpolationMode interpolationMode,
-            SKMatrix coordinateTransform,
+            GradientTransformStorage coordinateTransform,
             float startAngle,
             float endAngle)
             : base(stops, spreadMethod, interpolationMode, coordinateTransform)
@@ -2444,20 +2459,40 @@ public partial class SKShader : SKObject
 
     private static bool TryGetShaderCoordinateTransform(
         SKMatrix localMatrix,
-        out SKMatrix coordinateTransform)
+        out GradientTransformStorage coordinateTransform)
     {
-        if (s_hasLastGradientCoordinateTransform && localMatrix == s_lastGradientLocalMatrix)
+        if (localMatrix.IsIdentity)
         {
-            coordinateTransform = s_lastGradientCoordinateTransform;
-            return s_lastGradientMatrixWasInvertible;
+            coordinateTransform = s_identityGradientTransform;
+            return true;
         }
 
-        var isInvertible = localMatrix.TryInvert(out coordinateTransform);
-        s_lastGradientLocalMatrix = localMatrix;
-        s_lastGradientCoordinateTransform = coordinateTransform;
-        s_lastGradientMatrixWasInvertible = isInvertible;
-        s_hasLastGradientCoordinateTransform = true;
-        return isInvertible;
+        var cache = s_gradientTransformCache;
+        if (cache is not null)
+        {
+            for (var index = 0; index < cache.Length; index++)
+            {
+                if (cache[index] is { } cached && cached.LocalMatrix == localMatrix)
+                {
+                    coordinateTransform = cached;
+                    return true;
+                }
+            }
+        }
+
+        if (!localMatrix.TryInvert(out var inverse))
+        {
+            coordinateTransform = s_identityGradientTransform;
+            return false;
+        }
+
+        coordinateTransform = new GradientTransformStorage(localMatrix, inverse);
+        cache ??= s_gradientTransformCache =
+            new GradientTransformStorage?[GradientTransformCacheCapacity];
+        cache[s_gradientTransformCacheCursor] = coordinateTransform;
+        s_gradientTransformCacheCursor =
+            (s_gradientTransformCacheCursor + 1) % GradientTransformCacheCapacity;
+        return true;
     }
 
     private static bool IsFinite(Matrix4x4 matrix) =>

--- a/src/SkiaSharp/SKPath.Compatibility.cs
+++ b/src/SkiaSharp/SKPath.Compatibility.cs
@@ -666,7 +666,8 @@ public partial class SKPath
 
     private void ConnectOvalArc(Vector2 start, bool forceMoveTo)
     {
-        if (forceMoveTo || Geometry.Figures.Count == 0)
+        var geometry = Geometry;
+        if (forceMoveTo || geometry.Figures.Count == 0)
         {
             MoveTo(start.X, start.Y);
             return;
@@ -708,6 +709,8 @@ public partial class SKPath
         SKPathDirection direction,
         uint startIndex)
     {
+        _ = Geometry;
+
         Span<Vector2> radii = stackalloc Vector2[4];
         for (var index = 0; index < radii.Length; index++)
         {

--- a/src/SkiaSharp/SKPath.Compatibility.cs
+++ b/src/SkiaSharp/SKPath.Compatibility.cs
@@ -169,7 +169,9 @@ public partial class SKPath
                 "Starting index must be in the range of 0..7 (inclusive).");
         }
 
-        AppendRoundRect(rect.Rect, rect.CornerRadii, direction, startIndex);
+        Span<SKPoint> radii = stackalloc SKPoint[4];
+        rect.CopyCornerRadii(radii);
+        AppendRoundRect(rect.Rect, radii, direction, startIndex);
     }
 
     [Obsolete(UsePathBuilderMessage)]

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using ProGPU.Vector;
 
 namespace SkiaSharp;
@@ -33,6 +34,191 @@ internal readonly struct PackedPathCommand
     public Vector2 Point2 { get; }
 }
 
+internal struct SKPathBoundsAccumulator
+{
+    private Vector2 _min;
+    private Vector2 _max;
+    private bool _hasBounds;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Include(Vector2 point)
+    {
+        if (!float.IsFinite(point.X) || !float.IsFinite(point.Y))
+        {
+            return;
+        }
+
+        if (!_hasBounds)
+        {
+            _min = point;
+            _max = point;
+            _hasBounds = true;
+            return;
+        }
+
+        _min = Vector2.Min(_min, point);
+        _max = Vector2.Max(_max, point);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly SKRect ToRect() => _hasBounds
+        ? new SKRect(_min.X, _min.Y, _max.X, _max.Y)
+        : SKRect.Empty;
+}
+
+internal static class SKPathTightBounds
+{
+    private const double Epsilon = 1e-12;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void IncludeQuadratic(
+        ref SKPathBoundsAccumulator bounds,
+        Vector2 p0,
+        Vector2 p1,
+        Vector2 p2)
+    {
+        if (p1.X < MathF.Min(p0.X, p2.X) || p1.X > MathF.Max(p0.X, p2.X))
+        {
+            IncludeQuadraticAxis(ref bounds, p0.X, p1.X, p2.X, p0, p1, p2);
+        }
+
+        if (p1.Y < MathF.Min(p0.Y, p2.Y) || p1.Y > MathF.Max(p0.Y, p2.Y))
+        {
+            IncludeQuadraticAxis(ref bounds, p0.Y, p1.Y, p2.Y, p0, p1, p2);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void IncludeCubic(
+        ref SKPathBoundsAccumulator bounds,
+        Vector2 p0,
+        Vector2 p1,
+        Vector2 p2,
+        Vector2 p3)
+    {
+        var minX = MathF.Min(p0.X, p3.X);
+        var maxX = MathF.Max(p0.X, p3.X);
+        if (p1.X < minX || p1.X > maxX || p2.X < minX || p2.X > maxX)
+        {
+            IncludeCubicAxis(ref bounds, p0.X, p1.X, p2.X, p3.X, p0, p1, p2, p3);
+        }
+
+        var minY = MathF.Min(p0.Y, p3.Y);
+        var maxY = MathF.Max(p0.Y, p3.Y);
+        if (p1.Y < minY || p1.Y > maxY || p2.Y < minY || p2.Y > maxY)
+        {
+            IncludeCubicAxis(ref bounds, p0.Y, p1.Y, p2.Y, p3.Y, p0, p1, p2, p3);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void IncludeQuadraticAxis(
+        ref SKPathBoundsAccumulator bounds,
+        double v0,
+        double v1,
+        double v2,
+        Vector2 p0,
+        Vector2 p1,
+        Vector2 p2)
+    {
+        var denominator = v0 - 2d * v1 + v2;
+        if (Math.Abs(denominator) <= Epsilon)
+        {
+            return;
+        }
+
+        var t = (v0 - v1) / denominator;
+        if (t > 0d && t < 1d)
+        {
+            bounds.Include(EvaluateQuadratic(p0, p1, p2, t));
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void IncludeCubicAxis(
+        ref SKPathBoundsAccumulator bounds,
+        double v0,
+        double v1,
+        double v2,
+        double v3,
+        Vector2 p0,
+        Vector2 p1,
+        Vector2 p2,
+        Vector2 p3)
+    {
+        var a = -v0 + 3d * v1 - 3d * v2 + v3;
+        var b = 2d * (v0 - 2d * v1 + v2);
+        var c = v1 - v0;
+
+        if (Math.Abs(a) <= Epsilon)
+        {
+            if (Math.Abs(b) > Epsilon)
+            {
+                IncludeCubicAt(ref bounds, -c / b, p0, p1, p2, p3);
+            }
+
+            return;
+        }
+
+        var discriminant = b * b - 4d * a * c;
+        if (discriminant < 0d)
+        {
+            return;
+        }
+
+        var root = Math.Sqrt(Math.Max(0d, discriminant));
+        var denominator = 2d * a;
+        IncludeCubicAt(ref bounds, (-b + root) / denominator, p0, p1, p2, p3);
+        if (root > Epsilon)
+        {
+            IncludeCubicAt(ref bounds, (-b - root) / denominator, p0, p1, p2, p3);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void IncludeCubicAt(
+        ref SKPathBoundsAccumulator bounds,
+        double t,
+        Vector2 p0,
+        Vector2 p1,
+        Vector2 p2,
+        Vector2 p3)
+    {
+        if (t > 0d && t < 1d && double.IsFinite(t))
+        {
+            bounds.Include(EvaluateCubic(p0, p1, p2, p3, t));
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector2 EvaluateQuadratic(Vector2 p0, Vector2 p1, Vector2 p2, double t)
+    {
+        var oneMinusT = 1d - t;
+        return new Vector2(
+            (float)(oneMinusT * oneMinusT * p0.X + 2d * oneMinusT * t * p1.X + t * t * p2.X),
+            (float)(oneMinusT * oneMinusT * p0.Y + 2d * oneMinusT * t * p1.Y + t * t * p2.Y));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector2 EvaluateCubic(Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3, double t)
+    {
+        var oneMinusT = 1d - t;
+        var oneMinusTSquared = oneMinusT * oneMinusT;
+        var tSquared = t * t;
+        return new Vector2(
+            (float)(
+                oneMinusTSquared * oneMinusT * p0.X +
+                3d * oneMinusTSquared * t * p1.X +
+                3d * oneMinusT * tSquared * p2.X +
+                tSquared * t * p3.X),
+            (float)(
+                oneMinusTSquared * oneMinusT * p0.Y +
+                3d * oneMinusTSquared * t * p1.Y +
+                3d * oneMinusT * tSquared * p2.Y +
+                tSquared * t * p3.Y));
+    }
+}
+
 /// <summary>
 /// Retains the common path-builder verbs in one pooled, contiguous stream. The
 /// public object graph is expanded only when a caller requests <see cref="SKPath.Geometry"/>
@@ -50,6 +236,7 @@ internal sealed class PackedPathData : IDisposable
     private Vector2 _contourStart;
     private Vector2 _boundsMin;
     private Vector2 _boundsMax;
+    private SKPathBoundsAccumulator _tightBounds;
     private bool _hasOpenFigure;
     private bool _figureHasSegments;
     private bool _hasBounds;
@@ -63,6 +250,7 @@ internal sealed class PackedPathData : IDisposable
     public bool IsEmpty => _count == 0;
     public Vector2 CurrentPoint => _currentPoint;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static PackedPathData Rent()
     {
         var data = s_threadCache;
@@ -79,6 +267,7 @@ internal sealed class PackedPathData : IDisposable
         return data;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MoveTo(float x, float y)
     {
         var point = new Vector2(x, y);
@@ -98,8 +287,10 @@ internal sealed class PackedPathData : IDisposable
         _hasOpenFigure = true;
         _figureHasSegments = false;
         IncludeBounds(point);
+        _tightBounds.Include(point);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void LineTo(float x, float y)
     {
         EnsureFigure();
@@ -108,8 +299,10 @@ internal sealed class PackedPathData : IDisposable
         _currentPoint = point;
         _figureHasSegments = true;
         IncludeBounds(point);
+        _tightBounds.Include(point);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void QuadTo(float x0, float y0, float x1, float y1)
     {
         EnsureFigure();
@@ -118,12 +311,19 @@ internal sealed class PackedPathData : IDisposable
             PackedPathCommandKind.Quadratic,
             new Vector2(x0, y0),
             point));
+        SKPathTightBounds.IncludeQuadratic(
+            ref _tightBounds,
+            _currentPoint,
+            new Vector2(x0, y0),
+            point);
         _currentPoint = point;
         _figureHasSegments = true;
         IncludeBounds(new Vector2(x0, y0));
         IncludeBounds(point);
+        _tightBounds.Include(point);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void CubicTo(float x0, float y0, float x1, float y1, float x2, float y2)
     {
         EnsureFigure();
@@ -133,13 +333,21 @@ internal sealed class PackedPathData : IDisposable
             new Vector2(x0, y0),
             new Vector2(x1, y1),
             point));
+        SKPathTightBounds.IncludeCubic(
+            ref _tightBounds,
+            _currentPoint,
+            new Vector2(x0, y0),
+            new Vector2(x1, y1),
+            point);
         _currentPoint = point;
         _figureHasSegments = true;
         IncludeBounds(new Vector2(x0, y0));
         IncludeBounds(new Vector2(x1, y1));
         IncludeBounds(point);
+        _tightBounds.Include(point);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Close()
     {
         if (!_hasOpenFigure)
@@ -160,6 +368,7 @@ internal sealed class PackedPathData : IDisposable
         _contourStart = default;
         _boundsMin = default;
         _boundsMax = default;
+        _tightBounds = default;
         _hasOpenFigure = false;
         _figureHasSegments = false;
         _hasBounds = false;
@@ -173,6 +382,7 @@ internal sealed class PackedPathData : IDisposable
         clone._contourStart = _contourStart;
         clone._boundsMin = _boundsMin;
         clone._boundsMax = _boundsMax;
+        clone._tightBounds = _tightBounds;
         clone._hasOpenFigure = _hasOpenFigure;
         clone._figureHasSegments = _figureHasSegments;
         clone._hasBounds = _hasBounds;
@@ -192,6 +402,9 @@ internal sealed class PackedPathData : IDisposable
             ? new SKRect(_boundsMin.X, _boundsMin.Y, _boundsMax.X, _boundsMax.Y)
             : SKRect.Empty;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SKRect CalculateTightBounds() => _tightBounds.ToRect();
 
     public PathGeometry Materialize(SKPathFillType fillType)
     {
@@ -265,6 +478,7 @@ internal sealed class PackedPathData : IDisposable
     private PackedPathCommand[] Commands =>
         _commands ?? throw new InvalidOperationException("The packed path has no command storage.");
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureFigure()
     {
         if (!_hasOpenFigure)
@@ -273,6 +487,7 @@ internal sealed class PackedPathData : IDisposable
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void IncludeBounds(Vector2 point)
     {
         if (!float.IsFinite(point.X) || !float.IsFinite(point.Y))
@@ -297,6 +512,8 @@ internal sealed class PackedPathData : IDisposable
         _hasBounds = false;
         _boundsMin = default;
         _boundsMax = default;
+        _tightBounds = default;
+        var current = Vector2.Zero;
         for (var index = 0; index < _count; index++)
         {
             ref readonly var command = ref Commands[index];
@@ -304,21 +521,39 @@ internal sealed class PackedPathData : IDisposable
             {
                 case PackedPathCommandKind.Move:
                 case PackedPathCommandKind.Line:
+                    current = command.Point0;
                     IncludeBounds(command.Point0);
+                    _tightBounds.Include(command.Point0);
                     break;
                 case PackedPathCommandKind.Quadratic:
+                    SKPathTightBounds.IncludeQuadratic(
+                        ref _tightBounds,
+                        current,
+                        command.Point0,
+                        command.Point1);
+                    current = command.Point1;
                     IncludeBounds(command.Point0);
                     IncludeBounds(command.Point1);
+                    _tightBounds.Include(command.Point1);
                     break;
                 case PackedPathCommandKind.Cubic:
+                    SKPathTightBounds.IncludeCubic(
+                        ref _tightBounds,
+                        current,
+                        command.Point0,
+                        command.Point1,
+                        command.Point2);
+                    current = command.Point2;
                     IncludeBounds(command.Point0);
                     IncludeBounds(command.Point1);
                     IncludeBounds(command.Point2);
+                    _tightBounds.Include(command.Point2);
                     break;
             }
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void Append(PackedPathCommand command)
     {
         if (_commands is null)

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -240,6 +240,7 @@ internal sealed class PackedPathData : IDisposable
     private bool _hasOpenFigure;
     private bool _figureHasSegments;
     private bool _hasBounds;
+    private bool _trackTightBounds;
     private int _isRented;
 
     private PackedPathData()
@@ -251,7 +252,7 @@ internal sealed class PackedPathData : IDisposable
     public Vector2 CurrentPoint => _currentPoint;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static PackedPathData Rent()
+    public static PackedPathData Rent(bool trackTightBounds = true)
     {
         var data = s_threadCache;
         if (data is null)
@@ -263,6 +264,7 @@ internal sealed class PackedPathData : IDisposable
             s_threadCache = null;
         }
 
+        data._trackTightBounds = trackTightBounds;
         Volatile.Write(ref data._isRented, 1);
         return data;
     }
@@ -287,7 +289,32 @@ internal sealed class PackedPathData : IDisposable
         _hasOpenFigure = true;
         _figureHasSegments = false;
         IncludeBounds(point);
-        _tightBounds.Include(point);
+        if (_trackTightBounds)
+        {
+            _tightBounds.Include(point);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void MoveToBoundsOnly(float x, float y)
+    {
+        var point = new Vector2(x, y);
+        if (_hasOpenFigure && !_figureHasSegments &&
+            _count > 0 && Commands[_count - 1].Kind == PackedPathCommandKind.Move)
+        {
+            Commands[_count - 1] = new PackedPathCommand(PackedPathCommandKind.Move, point);
+            RecalculateBounds();
+        }
+        else
+        {
+            Append(new PackedPathCommand(PackedPathCommandKind.Move, point));
+        }
+
+        _currentPoint = point;
+        _contourStart = point;
+        _hasOpenFigure = true;
+        _figureHasSegments = false;
+        IncludeBounds(point);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -299,7 +326,21 @@ internal sealed class PackedPathData : IDisposable
         _currentPoint = point;
         _figureHasSegments = true;
         IncludeBounds(point);
-        _tightBounds.Include(point);
+        if (_trackTightBounds)
+        {
+            _tightBounds.Include(point);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void LineToBoundsOnly(float x, float y)
+    {
+        EnsureFigureBoundsOnly();
+        var point = new Vector2(x, y);
+        Append(new PackedPathCommand(PackedPathCommandKind.Line, point));
+        _currentPoint = point;
+        _figureHasSegments = true;
+        IncludeBounds(point);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -311,16 +352,35 @@ internal sealed class PackedPathData : IDisposable
             PackedPathCommandKind.Quadratic,
             new Vector2(x0, y0),
             point));
-        SKPathTightBounds.IncludeQuadratic(
-            ref _tightBounds,
-            _currentPoint,
-            new Vector2(x0, y0),
-            point);
+        if (_trackTightBounds)
+        {
+            SKPathTightBounds.IncludeQuadratic(
+                ref _tightBounds,
+                _currentPoint,
+                new Vector2(x0, y0),
+                point);
+        }
         _currentPoint = point;
         _figureHasSegments = true;
         IncludeBounds(new Vector2(x0, y0));
         IncludeBounds(point);
-        _tightBounds.Include(point);
+        if (_trackTightBounds)
+        {
+            _tightBounds.Include(point);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void QuadToBoundsOnly(float x0, float y0, float x1, float y1)
+    {
+        EnsureFigureBoundsOnly();
+        var control = new Vector2(x0, y0);
+        var point = new Vector2(x1, y1);
+        Append(new PackedPathCommand(PackedPathCommandKind.Quadratic, control, point));
+        _currentPoint = point;
+        _figureHasSegments = true;
+        IncludeBounds(control);
+        IncludeBounds(point);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -333,18 +393,43 @@ internal sealed class PackedPathData : IDisposable
             new Vector2(x0, y0),
             new Vector2(x1, y1),
             point));
-        SKPathTightBounds.IncludeCubic(
-            ref _tightBounds,
-            _currentPoint,
-            new Vector2(x0, y0),
-            new Vector2(x1, y1),
-            point);
+        if (_trackTightBounds)
+        {
+            SKPathTightBounds.IncludeCubic(
+                ref _tightBounds,
+                _currentPoint,
+                new Vector2(x0, y0),
+                new Vector2(x1, y1),
+                point);
+        }
         _currentPoint = point;
         _figureHasSegments = true;
         IncludeBounds(new Vector2(x0, y0));
         IncludeBounds(new Vector2(x1, y1));
         IncludeBounds(point);
-        _tightBounds.Include(point);
+        if (_trackTightBounds)
+        {
+            _tightBounds.Include(point);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void CubicToBoundsOnly(float x0, float y0, float x1, float y1, float x2, float y2)
+    {
+        EnsureFigureBoundsOnly();
+        var firstControl = new Vector2(x0, y0);
+        var secondControl = new Vector2(x1, y1);
+        var point = new Vector2(x2, y2);
+        Append(new PackedPathCommand(
+            PackedPathCommandKind.Cubic,
+            firstControl,
+            secondControl,
+            point));
+        _currentPoint = point;
+        _figureHasSegments = true;
+        IncludeBounds(firstControl);
+        IncludeBounds(secondControl);
+        IncludeBounds(point);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -376,7 +461,7 @@ internal sealed class PackedPathData : IDisposable
 
     public PackedPathData Clone()
     {
-        var clone = Rent();
+        var clone = Rent(_trackTightBounds);
         clone._count = _count;
         clone._currentPoint = _currentPoint;
         clone._contourStart = _contourStart;
@@ -404,7 +489,49 @@ internal sealed class PackedPathData : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public SKRect CalculateTightBounds() => _tightBounds.ToRect();
+    public SKRect CalculateTightBounds()
+    {
+        if (_trackTightBounds)
+        {
+            return _tightBounds.ToRect();
+        }
+
+        var bounds = new SKPathBoundsAccumulator();
+        var current = Vector2.Zero;
+        for (var index = 0; index < _count; index++)
+        {
+            ref readonly var command = ref Commands[index];
+            switch (command.Kind)
+            {
+                case PackedPathCommandKind.Move:
+                case PackedPathCommandKind.Line:
+                    current = command.Point0;
+                    bounds.Include(current);
+                    break;
+                case PackedPathCommandKind.Quadratic:
+                    SKPathTightBounds.IncludeQuadratic(
+                        ref bounds,
+                        current,
+                        command.Point0,
+                        command.Point1);
+                    current = command.Point1;
+                    bounds.Include(current);
+                    break;
+                case PackedPathCommandKind.Cubic:
+                    SKPathTightBounds.IncludeCubic(
+                        ref bounds,
+                        current,
+                        command.Point0,
+                        command.Point1,
+                        command.Point2);
+                    current = command.Point2;
+                    bounds.Include(current);
+                    break;
+            }
+        }
+
+        return bounds.ToRect();
+    }
 
     public PathGeometry Materialize(SKPathFillType fillType)
     {
@@ -488,6 +615,15 @@ internal sealed class PackedPathData : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureFigureBoundsOnly()
+    {
+        if (!_hasOpenFigure)
+        {
+            MoveToBoundsOnly(_currentPoint.X, _currentPoint.Y);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void IncludeBounds(Vector2 point)
     {
         if (!float.IsFinite(point.X) || !float.IsFinite(point.Y))
@@ -523,31 +659,46 @@ internal sealed class PackedPathData : IDisposable
                 case PackedPathCommandKind.Line:
                     current = command.Point0;
                     IncludeBounds(command.Point0);
-                    _tightBounds.Include(command.Point0);
+                    if (_trackTightBounds)
+                    {
+                        _tightBounds.Include(command.Point0);
+                    }
                     break;
                 case PackedPathCommandKind.Quadratic:
-                    SKPathTightBounds.IncludeQuadratic(
-                        ref _tightBounds,
-                        current,
-                        command.Point0,
-                        command.Point1);
+                    if (_trackTightBounds)
+                    {
+                        SKPathTightBounds.IncludeQuadratic(
+                            ref _tightBounds,
+                            current,
+                            command.Point0,
+                            command.Point1);
+                    }
                     current = command.Point1;
                     IncludeBounds(command.Point0);
                     IncludeBounds(command.Point1);
-                    _tightBounds.Include(command.Point1);
+                    if (_trackTightBounds)
+                    {
+                        _tightBounds.Include(command.Point1);
+                    }
                     break;
                 case PackedPathCommandKind.Cubic:
-                    SKPathTightBounds.IncludeCubic(
-                        ref _tightBounds,
-                        current,
-                        command.Point0,
-                        command.Point1,
-                        command.Point2);
+                    if (_trackTightBounds)
+                    {
+                        SKPathTightBounds.IncludeCubic(
+                            ref _tightBounds,
+                            current,
+                            command.Point0,
+                            command.Point1,
+                            command.Point2);
+                    }
                     current = command.Point2;
                     IncludeBounds(command.Point0);
                     IncludeBounds(command.Point1);
                     IncludeBounds(command.Point2);
-                    _tightBounds.Include(command.Point2);
+                    if (_trackTightBounds)
+                    {
+                        _tightBounds.Include(command.Point2);
+                    }
                     break;
             }
         }

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -44,6 +44,7 @@ public partial class SKPath : SKObject
     public SKPath()
         : base(SKObjectHandle.Create(), owns: true)
     {
+        _packedPathData = PackedPathData.Rent();
     }
 
     internal SKPath(PackedPathData packedPathData, SKPathFillType fillType)
@@ -114,67 +115,62 @@ public partial class SKPath : SKObject
     {
         get
         {
+            if (_packedPathData is { } packed)
+            {
+                return packed.CalculateTightBounds();
+            }
+
             if (Geometry.IsCombined)
             {
                 return Bounds;
             }
 
-            var min = new Vector2(float.PositiveInfinity, float.PositiveInfinity);
-            var max = new Vector2(float.NegativeInfinity, float.NegativeInfinity);
-            var hasBounds = false;
-
-            void Include(Vector2 point)
-            {
-                if (!float.IsFinite(point.X) || !float.IsFinite(point.Y))
-                {
-                    return;
-                }
-
-                min = Vector2.Min(min, point);
-                max = Vector2.Max(max, point);
-                hasBounds = true;
-            }
+            var bounds = new SKPathBoundsAccumulator();
 
             foreach (var figure in Geometry.Figures)
             {
                 var current = figure.StartPoint;
-                Include(current);
+                bounds.Include(current);
 
                 foreach (var segment in figure.Segments)
                 {
                     switch (segment)
                     {
                         case LineSegment line:
-                            Include(line.Point);
+                            bounds.Include(line.Point);
                             current = line.Point;
                             break;
 
                         case QuadraticBezierSegment quadratic:
-                            IncludeQuadraticExtrema(current, quadratic.ControlPoint, quadratic.Point, Include);
-                            Include(quadratic.Point);
+                            SKPathTightBounds.IncludeQuadratic(
+                                ref bounds,
+                                current,
+                                quadratic.ControlPoint,
+                                quadratic.Point);
+                            bounds.Include(quadratic.Point);
                             current = quadratic.Point;
                             break;
 
                         case CubicBezierSegment cubic:
-                            IncludeCubicExtrema(
+                            SKPathTightBounds.IncludeCubic(
+                                ref bounds,
                                 current,
                                 cubic.ControlPoint1,
                                 cubic.ControlPoint2,
-                                cubic.Point,
-                                Include);
-                            Include(cubic.Point);
+                                cubic.Point);
+                            bounds.Include(cubic.Point);
                             current = cubic.Point;
                             break;
 
                         case ArcSegment arc:
                             if (ArcSegmentGeometry.TryGetArcBounds(current, arc, out var arcMin, out var arcMax))
                             {
-                                Include(arcMin);
-                                Include(arcMax);
+                                bounds.Include(arcMin);
+                                bounds.Include(arcMax);
                             }
                             else
                             {
-                                Include(arc.Point);
+                                bounds.Include(arc.Point);
                             }
 
                             current = arc.Point;
@@ -183,9 +179,7 @@ public partial class SKPath : SKObject
                 }
             }
 
-            return hasBounds
-                ? new SKRect(min.X, min.Y, max.X, max.Y)
-                : SKRect.Empty;
+            return bounds.ToRect();
         }
     }
 
@@ -218,124 +212,36 @@ public partial class SKPath : SKObject
         return _geometry;
     }
 
-    private static void IncludeQuadraticExtrema(
-        Vector2 p0,
-        Vector2 p1,
-        Vector2 p2,
-        Action<Vector2> include)
-    {
-        IncludeQuadraticAxisExtremum(p0.X, p1.X, p2.X, p0, p1, p2, include);
-        IncludeQuadraticAxisExtremum(p0.Y, p1.Y, p2.Y, p0, p1, p2, include);
-    }
-
-    private static void IncludeQuadraticAxisExtremum(
-        float v0,
-        float v1,
-        float v2,
-        Vector2 p0,
-        Vector2 p1,
-        Vector2 p2,
-        Action<Vector2> include)
-    {
-        var denominator = v0 - 2f * v1 + v2;
-        if (MathF.Abs(denominator) <= 1e-6f)
-        {
-            return;
-        }
-
-        var t = (v0 - v1) / denominator;
-        if (t > 0f && t < 1f)
-        {
-            var oneMinusT = 1f - t;
-            include(oneMinusT * oneMinusT * p0 + 2f * oneMinusT * t * p1 + t * t * p2);
-        }
-    }
-
-    private static void IncludeCubicExtrema(
-        Vector2 p0,
-        Vector2 p1,
-        Vector2 p2,
-        Vector2 p3,
-        Action<Vector2> include)
-    {
-        IncludeCubicAxisExtrema(p0.X, p1.X, p2.X, p3.X, p0, p1, p2, p3, include);
-        IncludeCubicAxisExtrema(p0.Y, p1.Y, p2.Y, p3.Y, p0, p1, p2, p3, include);
-    }
-
-    private static void IncludeCubicAxisExtrema(
-        float v0,
-        float v1,
-        float v2,
-        float v3,
-        Vector2 p0,
-        Vector2 p1,
-        Vector2 p2,
-        Vector2 p3,
-        Action<Vector2> include)
-    {
-        var a = -v0 + 3f * v1 - 3f * v2 + v3;
-        var b = 2f * (v0 - 2f * v1 + v2);
-        var c = v1 - v0;
-
-        if (MathF.Abs(a) <= 1e-6f)
-        {
-            if (MathF.Abs(b) > 1e-6f)
-            {
-                IncludeCubicAt(-c / b, p0, p1, p2, p3, include);
-            }
-
-            return;
-        }
-
-        var discriminant = b * b - 4f * a * c;
-        if (discriminant < 0f)
-        {
-            return;
-        }
-
-        var root = MathF.Sqrt(MathF.Max(0f, discriminant));
-        var denominator = 2f * a;
-        IncludeCubicAt((-b + root) / denominator, p0, p1, p2, p3, include);
-        if (root > 1e-6f)
-        {
-            IncludeCubicAt((-b - root) / denominator, p0, p1, p2, p3, include);
-        }
-    }
-
-    private static void IncludeCubicAt(
-        float t,
-        Vector2 p0,
-        Vector2 p1,
-        Vector2 p2,
-        Vector2 p3,
-        Action<Vector2> include)
-    {
-        if (t <= 0f || t >= 1f || !float.IsFinite(t))
-        {
-            return;
-        }
-
-        var oneMinusT = 1f - t;
-        include(
-            oneMinusT * oneMinusT * oneMinusT * p0 +
-            3f * oneMinusT * oneMinusT * t * p1 +
-            3f * oneMinusT * t * t * p2 +
-            t * t * t * p3);
-    }
-
     private void EnsureFigure()
     {
-        if (_currentFigure == null)
+        if (_currentFigure is not null)
         {
-            _currentFigure = new PathFigure(_currentPoint);
-            Geometry.Figures.Add(_currentFigure);
-            _contourStart = _currentPoint;
+            return;
         }
+
+        var geometry = Geometry;
+        if (_currentFigure is not null)
+        {
+            return;
+        }
+
+        _currentFigure = new PathFigure(_currentPoint);
+        geometry.Figures.Add(_currentFigure);
+        _contourStart = _currentPoint;
     }
 
     [Obsolete(UsePathBuilderMessage)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MoveTo(float x, float y)
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.MoveTo(x, y);
+            _currentPoint = new Vector2(x, y);
+            _contourStart = _currentPoint;
+            return;
+        }
+
         var point = new Vector2(x, y);
         if (_currentFigure is { IsClosed: false, Segments.Count: 0 })
         {
@@ -355,8 +261,16 @@ public partial class SKPath : SKObject
     public void MoveTo(SKPoint point) => MoveTo(point.X, point.Y);
 
     [Obsolete(UsePathBuilderMessage)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void LineTo(float x, float y)
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.LineTo(x, y);
+            _currentPoint = new Vector2(x, y);
+            return;
+        }
+
         EnsureFigure();
         var point = new Vector2(x, y);
         _currentFigure!.Segments.Add(new LineSegment(point));
@@ -367,8 +281,16 @@ public partial class SKPath : SKObject
     public void LineTo(SKPoint point) => LineTo(point.X, point.Y);
 
     [Obsolete(UsePathBuilderMessage)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void QuadTo(float x0, float y0, float x1, float y1)
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.QuadTo(x0, y0, x1, y1);
+            _currentPoint = new Vector2(x1, y1);
+            return;
+        }
+
         EnsureFigure();
         var point = new Vector2(x1, y1);
         _currentFigure!.Segments.Add(new QuadraticBezierSegment(new Vector2(x0, y0), point));
@@ -380,8 +302,16 @@ public partial class SKPath : SKObject
         QuadTo(point0.X, point0.Y, point1.X, point1.Y);
 
     [Obsolete(UsePathBuilderMessage)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void CubicTo(float x0, float y0, float x1, float y1, float x2, float y2)
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.CubicTo(x0, y0, x1, y1, x2, y2);
+            _currentPoint = new Vector2(x2, y2);
+            return;
+        }
+
         EnsureFigure();
         var point = new Vector2(x2, y2);
         _currentFigure!.Segments.Add(new CubicBezierSegment(new Vector2(x0, y0), new Vector2(x1, y1), point));
@@ -409,8 +339,16 @@ public partial class SKPath : SKObject
     }
 
     [Obsolete(UsePathBuilderMessage)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Close()
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.Close();
+            _currentPoint = packed.CurrentPoint;
+            return;
+        }
+
         if (_currentFigure != null)
         {
             _currentFigure.IsClosed = true;
@@ -421,6 +359,14 @@ public partial class SKPath : SKObject
 
     public void Reset()
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.Reset();
+            ResetCurrentState();
+            FillType = SKPathFillType.Winding;
+            return;
+        }
+
         Geometry.Figures.Clear();
         ResetCurrentState();
         FillType = SKPathFillType.Winding;

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -684,13 +684,27 @@ public class SKRoundRect : SKObject
     private const float NearlyZero = 1f / (1 << 12);
     private CornerRadiusBuffer _radii;
     private SKRect _rect;
-    private SKRoundRectType _type;
+    private byte _typeValue;
 
-    private ReadOnlySpan<SKPoint> RadiiReadOnlySpan => _radii;
+    private SKRoundRectType _type
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (SKRoundRectType)_typeValue;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _typeValue = (byte)value;
+    }
 
     public SKRect Rect => _rect;
 
-    public SKPoint[] Radii => RadiiReadOnlySpan.ToArray();
+    public SKPoint[] Radii
+    {
+        get
+        {
+            var radii = new SKPoint[CornerCount];
+            _radii.CopyTo(radii);
+            return radii;
+        }
+    }
 
     public SKRoundRectType Type => _type;
 
@@ -702,7 +716,7 @@ public class SKRoundRect : SKObject
 
     public bool AllCornersCircular => CheckAllCornersCircular(NearlyZero);
 
-    internal ReadOnlySpan<SKPoint> CornerRadii => RadiiReadOnlySpan;
+    internal void CopyCornerRadii(Span<SKPoint> destination) => _radii.CopyTo(destination);
 
     public SKRoundRect()
         : base(SKObjectHandle.Create(), owns: true)
@@ -732,7 +746,7 @@ public class SKRoundRect : SKObject
     {
         _rect = rrect._rect;
         _type = rrect._type;
-        _radii = rrect._radii;
+        _radii = rrect._radii.Clone();
     }
 
     public bool CheckAllCornersCircular(float tolerance)
@@ -890,10 +904,7 @@ public class SKRoundRect : SKObject
             _type = SKRoundRectType.NinePatch;
         }
 
-        _radii[0] = new SKPoint(leftRadius, topRadius);
-        _radii[1] = new SKPoint(rightRadius, topRadius);
-        _radii[2] = new SKPoint(rightRadius, bottomRadius);
-        _radii[3] = new SKPoint(leftRadius, bottomRadius);
+        _radii.SetNinePatch(leftRadius, topRadius, rightRadius, bottomRadius);
         if (ClampToZero())
         {
             SetRect(rect);
@@ -929,9 +940,9 @@ public class SKRoundRect : SKObject
                 SetRect(rect);
                 return;
             }
-
-            _radii[index] = radii[index];
         }
+
+        _radii.Set(radii);
 
         if (ClampToZero())
         {
@@ -1413,15 +1424,12 @@ public class SKRoundRect : SKObject
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ClearRadii() => _radii = default;
+    private void ClearRadii() => _radii.Clear();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void FillRadii(SKPoint radius)
     {
-        _radii[0] = radius;
-        _radii[1] = radius;
-        _radii[2] = radius;
-        _radii[3] = radius;
+        _radii.Fill(radius);
     }
 
     private static double ComputeMinimumScale(double first, double second, double limit, double current) =>
@@ -1456,10 +1464,175 @@ public class SKRoundRect : SKObject
         float.IsFinite(rect.Left) && float.IsFinite(rect.Top) &&
         float.IsFinite(rect.Right) && float.IsFinite(rect.Bottom);
 
-    [InlineArray(CornerCount)]
     private struct CornerRadiusBuffer
     {
-        private SKPoint _element0;
+        private SKPoint _first;
+        private SKPoint _second;
+        private ComplexCornerRadii? _complex;
+
+        public SKPoint this[int index]
+        {
+            readonly get
+            {
+                if ((uint)index >= CornerCount)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                if (_complex is { } complex)
+                {
+                    return complex[index];
+                }
+
+                if (float.IsNaN(_second.X))
+                {
+                    return _first;
+                }
+
+                return index switch
+                {
+                    0 => _first,
+                    1 => new SKPoint(_second.X, _first.Y),
+                    2 => _second,
+                    _ => new SKPoint(_first.X, _second.Y),
+                };
+            }
+            set
+            {
+                EnsureComplex();
+                _complex![index] = value;
+            }
+        }
+
+        public void Clear()
+        {
+            _first = default;
+            _second = new SKPoint(float.NaN, float.NaN);
+            _complex = null;
+        }
+
+        public void Fill(SKPoint radius)
+        {
+            _first = radius;
+            _second = new SKPoint(float.NaN, float.NaN);
+            _complex = null;
+        }
+
+        public void SetNinePatch(float left, float top, float right, float bottom)
+        {
+            _first = new SKPoint(left, top);
+            _second = new SKPoint(right, bottom);
+            _complex = null;
+        }
+
+        public void Set(ReadOnlySpan<SKPoint> radii)
+        {
+            if (radii[0] == radii[1] && radii[1] == radii[2] && radii[2] == radii[3])
+            {
+                Fill(radii[0]);
+                return;
+            }
+
+            if (radii[0].X == radii[3].X &&
+                radii[0].Y == radii[1].Y &&
+                radii[1].X == radii[2].X &&
+                radii[3].Y == radii[2].Y)
+            {
+                SetNinePatch(radii[0].X, radii[0].Y, radii[1].X, radii[3].Y);
+                return;
+            }
+
+            _complex = new ComplexCornerRadii(radii);
+            _first = default;
+            _second = default;
+        }
+
+        public readonly void CopyTo(Span<SKPoint> destination)
+        {
+            if (destination.Length < CornerCount)
+            {
+                throw new ArgumentException("Destination must hold four corner radii.", nameof(destination));
+            }
+
+            for (var index = 0; index < CornerCount; index++)
+            {
+                destination[index] = this[index];
+            }
+        }
+
+        public readonly CornerRadiusBuffer Clone()
+        {
+            var clone = this;
+            if (_complex is not null)
+            {
+                clone._complex = _complex.Clone();
+            }
+
+            return clone;
+        }
+
+        private void EnsureComplex()
+        {
+            if (_complex is not null)
+            {
+                return;
+            }
+
+            Span<SKPoint> radii = stackalloc SKPoint[CornerCount];
+            CopyTo(radii);
+            _complex = new ComplexCornerRadii(radii);
+        }
+    }
+
+    private sealed class ComplexCornerRadii
+    {
+        private SKPoint _radius0;
+        private SKPoint _radius1;
+        private SKPoint _radius2;
+        private SKPoint _radius3;
+
+        public ComplexCornerRadii(ReadOnlySpan<SKPoint> radii)
+        {
+            _radius0 = radii[0];
+            _radius1 = radii[1];
+            _radius2 = radii[2];
+            _radius3 = radii[3];
+        }
+
+        public SKPoint this[int index]
+        {
+            get => index switch
+            {
+                0 => _radius0,
+                1 => _radius1,
+                2 => _radius2,
+                3 => _radius3,
+                _ => throw new IndexOutOfRangeException(),
+            };
+            set
+            {
+                switch (index)
+                {
+                    case 0: _radius0 = value; break;
+                    case 1: _radius1 = value; break;
+                    case 2: _radius2 = value; break;
+                    case 3: _radius3 = value; break;
+                    default: throw new IndexOutOfRangeException();
+                }
+            }
+        }
+
+        public ComplexCornerRadii Clone()
+        {
+            Span<SKPoint> radii = stackalloc SKPoint[CornerCount]
+            {
+                _radius0,
+                _radius1,
+                _radius2,
+                _radius3,
+            };
+            return new ComplexCornerRadii(radii);
+        }
     }
 }
 

--- a/src/SkiaSharp/SKPathBuilder.cs
+++ b/src/SkiaSharp/SKPathBuilder.cs
@@ -1,5 +1,7 @@
 #pragma warning disable CS0618 // The builder delegates to the shim's official legacy SKPath contract.
 
+using System.Runtime.CompilerServices;
+
 namespace SkiaSharp;
 
 public class SKPathBuilder : SKObject
@@ -11,7 +13,7 @@ public class SKPathBuilder : SKObject
     public SKPathBuilder()
         : base(SKObjectHandle.Create(), owns: true)
     {
-        _packedPath = PackedPathData.Rent();
+        _packedPath = PackedPathData.Rent(trackTightBounds: false);
     }
 
     public SKPathBuilder(SKPath path)
@@ -48,6 +50,7 @@ public class SKPathBuilder : SKObject
         previous?.Dispose();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SKPath Detach()
     {
         SKPath path;
@@ -84,15 +87,20 @@ public class SKPathBuilder : SKObject
 
     public void MoveTo(SKPoint point) => MoveTo(point.X, point.Y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MoveTo(float x, float y)
     {
-        if (_path is not null)
+        if (_packedPath is { } packed)
         {
-            _path.MoveTo(x, y);
+            packed.MoveToBoundsOnly(x, y);
+        }
+        else if (_path is { } path)
+        {
+            path.MoveTo(x, y);
         }
         else
         {
-            EnsurePackedPath().MoveTo(x, y);
+            EnsurePackedPath().MoveToBoundsOnly(x, y);
         }
     }
 
@@ -112,15 +120,20 @@ public class SKPathBuilder : SKObject
 
     public void LineTo(SKPoint point) => LineTo(point.X, point.Y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void LineTo(float x, float y)
     {
-        if (_path is not null)
+        if (_packedPath is { } packed)
         {
-            _path.LineTo(x, y);
+            packed.LineToBoundsOnly(x, y);
+        }
+        else if (_path is { } path)
+        {
+            path.LineTo(x, y);
         }
         else
         {
-            EnsurePackedPath().LineTo(x, y);
+            EnsurePackedPath().LineToBoundsOnly(x, y);
         }
     }
 
@@ -141,15 +154,20 @@ public class SKPathBuilder : SKObject
     public void QuadTo(SKPoint point0, SKPoint point1) =>
         QuadTo(point0.X, point0.Y, point1.X, point1.Y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void QuadTo(float x0, float y0, float x1, float y1)
     {
-        if (_path is not null)
+        if (_packedPath is { } packed)
         {
-            _path.QuadTo(x0, y0, x1, y1);
+            packed.QuadToBoundsOnly(x0, y0, x1, y1);
+        }
+        else if (_path is { } path)
+        {
+            path.QuadTo(x0, y0, x1, y1);
         }
         else
         {
-            EnsurePackedPath().QuadTo(x0, y0, x1, y1);
+            EnsurePackedPath().QuadToBoundsOnly(x0, y0, x1, y1);
         }
     }
 
@@ -187,15 +205,20 @@ public class SKPathBuilder : SKObject
     public void CubicTo(SKPoint point0, SKPoint point1, SKPoint point2) =>
         CubicTo(point0.X, point0.Y, point1.X, point1.Y, point2.X, point2.Y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void CubicTo(float x0, float y0, float x1, float y1, float x2, float y2)
     {
-        if (_path is not null)
+        if (_packedPath is { } packed)
         {
-            _path.CubicTo(x0, y0, x1, y1, x2, y2);
+            packed.CubicToBoundsOnly(x0, y0, x1, y1, x2, y2);
+        }
+        else if (_path is { } path)
+        {
+            path.CubicTo(x0, y0, x1, y1, x2, y2);
         }
         else
         {
-            EnsurePackedPath().CubicTo(x0, y0, x1, y1, x2, y2);
+            EnsurePackedPath().CubicToBoundsOnly(x0, y0, x1, y1, x2, y2);
         }
     }
 
@@ -255,11 +278,16 @@ public class SKPathBuilder : SKObject
         float y) =>
         GetMutablePath().RArcTo(rx, ry, xAxisRotate, largeArc, sweep, x, y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Close()
     {
-        if (_path is not null)
+        if (_packedPath is { } packed)
         {
-            _path.Close();
+            packed.Close();
+        }
+        else if (_path is { } path)
+        {
+            path.Close();
         }
         else
         {
@@ -316,9 +344,11 @@ public class SKPathBuilder : SKObject
 
     public void ReverseAddPath(SKPath other) => GetMutablePath().AddPathReverse(other);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private PackedPathData EnsurePackedPath() =>
-        _packedPath ??= PackedPathData.Rent();
+        _packedPath ??= PackedPathData.Rent(trackTightBounds: false);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private PackedPathData TakePackedPath()
     {
         var packedPath = EnsurePackedPath();

--- a/src/SkiaSharp/SKTextBlob.cs
+++ b/src/SkiaSharp/SKTextBlob.cs
@@ -35,6 +35,7 @@ public partial class SKTextBlob : SKObject
 {
     private static int s_nextUniqueId;
     private SKRect? _bounds;
+    private SKTextBlobBuilderRun? _leasedBuilderRun;
 
     internal SKTextBlobRun[] Runs { get; }
     internal SKFont Font => Runs[0].Font;
@@ -50,6 +51,11 @@ public partial class SKTextBlob : SKObject
     }
 
     internal SKTextBlob(SKTextBlobRun[] runs)
+        : this(runs, leasedBuilderRun: null)
+    {
+    }
+
+    internal SKTextBlob(SKTextBlobRun[] runs, SKTextBlobBuilderRun? leasedBuilderRun)
         : base(SKObjectHandle.Create(), owns: true)
     {
         ArgumentNullException.ThrowIfNull(runs);
@@ -59,6 +65,7 @@ public partial class SKTextBlob : SKObject
         }
 
         Runs = runs;
+        _leasedBuilderRun = leasedBuilderRun;
         if (runs.Length == 1)
         {
             var run = runs[0];
@@ -458,6 +465,13 @@ public partial class SKTextBlob : SKObject
 
     protected override void Dispose(bool disposing)
     {
+        if (disposing)
+        {
+            var leasedBuilderRun = _leasedBuilderRun;
+            _leasedBuilderRun = null;
+            leasedBuilderRun?.ReturnLease();
+        }
+
         base.Dispose(disposing);
     }
 

--- a/src/SkiaSharp/SKTextBlob.cs
+++ b/src/SkiaSharp/SKTextBlob.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace SkiaSharp;
 
-internal sealed class SKTextBlobRun
+internal readonly struct SKTextBlobRun
 {
     public SKFont Font { get; }
     public ushort[] GlyphIndices { get; }
@@ -59,6 +59,15 @@ public partial class SKTextBlob : SKObject
         }
 
         Runs = runs;
+        if (runs.Length == 1)
+        {
+            var run = runs[0];
+            GlyphIndices = run.GlyphIndices;
+            GlyphPositions = run.GlyphPositions;
+            HasEmboldenedRuns = run.Font.Embolden;
+            return;
+        }
+
         var glyphCount = 0;
         foreach (var run in runs)
         {

--- a/src/SkiaSharp/SKTextBlobBuilder.cs
+++ b/src/SkiaSharp/SKTextBlobBuilder.cs
@@ -16,6 +16,12 @@ internal enum SKTextBlobRunPlacement
 
 internal sealed class SKTextBlobBuilderRun
 {
+    private SKTextBlobBuilder? _returnOwner;
+    private SKTextBlobRun[]? _leasedSnapshots;
+    private bool _canLeaseSnapshot;
+    private bool _glyphsInitialized;
+    private bool _positionedPositionsInitialized;
+
     public SKTextBlobBuilderRun(
         SKFont font,
         int count,
@@ -55,6 +61,7 @@ internal sealed class SKTextBlobBuilderRun
     public SKRotationScaleMatrix[]? RotationScalePositions { get; set; }
     public SKTextBlobRun? Completed { get; }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryResetPositioned(SKFont font, int count)
     {
         if (Completed.HasValue ||
@@ -70,12 +77,13 @@ internal sealed class SKTextBlobBuilderRun
         Font = font;
         X = 0f;
         Y = 0f;
-        Array.Clear(Glyphs);
-        Array.Clear(Clusters);
-        Array.Clear(PositionedPositions);
+        _glyphsInitialized = false;
+        _positionedPositionsInitialized = false;
+        _canLeaseSnapshot = false;
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CanCacheAsPositionedScratch(int maximumGlyphCount) =>
         !Completed.HasValue &&
         Placement == SKTextBlobRunPlacement.Positioned &&
@@ -83,6 +91,105 @@ internal sealed class SKTextBlobBuilderRun
         Text.Length == 0 &&
         Clusters.Length == Glyphs.Length &&
         PositionedPositions?.Length == Glyphs.Length;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryPrepareDetachedPositioned(SKFont font, int count)
+    {
+        if (Completed.HasValue ||
+            Placement != SKTextBlobRunPlacement.Positioned ||
+            Glyphs.Length != count ||
+            Text.Length != 0 ||
+            PositionedPositions?.Length != count)
+        {
+            return false;
+        }
+
+        Font = font;
+        return true;
+    }
+
+    public bool CanLeaseSnapshot => _canLeaseSnapshot;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void MarkSnapshotLeaseable() => _canLeaseSnapshot = true;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<ushort> GetGlyphSpan()
+    {
+        if (!_glyphsInitialized)
+        {
+            Array.Clear(Glyphs);
+            _glyphsInitialized = true;
+        }
+
+        return Glyphs;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetGlyphs(ReadOnlySpan<ushort> glyphs)
+    {
+        glyphs.CopyTo(Glyphs);
+        Glyphs.AsSpan(glyphs.Length).Clear();
+        _glyphsInitialized = true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<SKPoint> GetPositionedPositionSpan()
+    {
+        if (!_positionedPositionsInitialized)
+        {
+            Array.Clear(PositionedPositions!);
+            _positionedPositionsInitialized = true;
+        }
+
+        return PositionedPositions!;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetPositionedPositions(ReadOnlySpan<SKPoint> positions)
+    {
+        positions.CopyTo(PositionedPositions);
+        PositionedPositions.AsSpan(positions.Length).Clear();
+        _positionedPositionsInitialized = true;
+    }
+
+    public void PrepareRawPositionedBuffers()
+    {
+        _ = GetGlyphSpan();
+        _ = GetPositionedPositionSpan();
+        Array.Clear(Clusters);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SKTextBlobRun BorrowPositionedSnapshot()
+    {
+        if (!CanCacheAsPositionedScratch(int.MaxValue))
+        {
+            throw new InvalidOperationException("Only a complete positioned run can be borrowed.");
+        }
+
+        _ = GetGlyphSpan();
+        _ = GetPositionedPositionSpan();
+        return new SKTextBlobRun(Font, Glyphs, PositionedPositions!);
+    }
+
+    public void LeaseTo(SKTextBlobBuilder owner, SKTextBlobRun[] snapshots)
+    {
+        _returnOwner = owner;
+        _leasedSnapshots = snapshots;
+    }
+
+    public void ReturnLease()
+    {
+        var owner = _returnOwner;
+        var snapshots = _leasedSnapshots;
+        _returnOwner = null;
+        _leasedSnapshots = null;
+        if (owner is not null && snapshots is not null)
+        {
+            owner.ReturnPositionedRun(this, snapshots);
+        }
+    }
 
     internal static T[] AllocatePinned<T>(int length) =>
         length == 0 ? Array.Empty<T>() : GC.AllocateArray<T>(length, pinned: true);
@@ -188,7 +295,7 @@ public readonly unsafe struct SKRawRunBuffer<T>
 
 public class SKRunBuffer
 {
-    private protected readonly SKTextBlobBuilderRun Run;
+    private protected SKTextBlobBuilderRun Run;
 
     internal SKRunBuffer(SKTextBlobBuilderRun run)
     {
@@ -196,13 +303,20 @@ public class SKRunBuffer
         Size = run.Glyphs.Length;
     }
 
-    public int Size { get; }
-    public Span<ushort> Glyphs => Run.Glyphs;
+    public int Size { get; private set; }
+    public Span<ushort> Glyphs => Run.GetGlyphSpan();
 
-    public void SetGlyphs(ReadOnlySpan<ushort> glyphs) => glyphs.CopyTo(Glyphs);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetGlyphs(ReadOnlySpan<ushort> glyphs) => Run.SetGlyphs(glyphs);
 
     [Obsolete("Use Glyphs instead.", true)]
     public Span<ushort> GetGlyphSpan() => Glyphs;
+
+    private protected void Reset(SKTextBlobBuilderRun run)
+    {
+        Run = run;
+        Size = run.Glyphs.Length;
+    }
 }
 
 public class SKTextRunBuffer : SKRunBuffer
@@ -242,8 +356,11 @@ public sealed class SKPositionedRunBuffer : SKRunBuffer
     {
     }
 
-    public Span<SKPoint> Positions => Run.PositionedPositions!;
-    public void SetPositions(ReadOnlySpan<SKPoint> positions) => positions.CopyTo(Positions);
+    public Span<SKPoint> Positions => Run.GetPositionedPositionSpan();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetPositions(ReadOnlySpan<SKPoint> positions) => Run.SetPositionedPositions(positions);
+
+    internal void ResetRun(SKTextBlobBuilderRun run) => Reset(run);
 
     [Obsolete("Use Positions instead.", true)]
     public Span<SKPoint> GetPositionSpan() => Positions;
@@ -304,6 +421,10 @@ public class SKTextBlobBuilder : SKObject
     private const int MaximumReusablePositionedGlyphs = 1_024;
     private readonly List<SKTextBlobBuilderRun> _runs = new();
     private SKTextBlobBuilderRun? _positionedRunScratch;
+    private SKTextBlobRun[]? _singleRunSnapshotScratch;
+    private SKPositionedRunBuffer? _positionedBufferScratch;
+    private SKTextBlobBuilderRun? _positionedBufferDetachedScratch;
+    private bool _isDisposed;
 
     public SKTextBlobBuilder()
         : base(SKObjectHandle.Create(), owns: true)
@@ -496,11 +617,30 @@ public class SKTextBlobBuilder : SKObject
         return new SKRawRunBuffer<float>(run, run.HorizontalPositions!);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SKPositionedRunBuffer AllocatePositionedRun(
         SKFont font,
         int count,
-        SKRect? bounds = null) =>
-        new(AllocatePositionedRunCore(font, count, textByteCount: 0, bounds));
+        SKRect? bounds = null)
+    {
+        var run = AllocatePositionedRunCore(font, count, textByteCount: 0, bounds);
+        run.MarkSnapshotLeaseable();
+        if (_runs.Count != 1)
+        {
+            return new SKPositionedRunBuffer(run);
+        }
+
+        if (_positionedBufferScratch is null)
+        {
+            _positionedBufferScratch = new SKPositionedRunBuffer(run);
+        }
+        else
+        {
+            _positionedBufferScratch.ResetRun(run);
+        }
+
+        return _positionedBufferScratch;
+    }
 
     public SKRawRunBuffer<SKPoint> AllocateRawPositionedRun(
         SKFont font,
@@ -508,6 +648,7 @@ public class SKTextBlobBuilder : SKObject
         SKRect? bounds = null)
     {
         var run = AllocatePositionedRunCore(font, count, textByteCount: 0, bounds);
+        run.PrepareRawPositionedBuffers();
         return new SKRawRunBuffer<SKPoint>(run, run.PositionedPositions!);
     }
 
@@ -560,11 +701,29 @@ public class SKTextBlobBuilder : SKObject
         return new SKRawRunBuffer<SKRotationScaleMatrix>(run, run.RotationScalePositions!);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SKTextBlob? Build()
     {
         if (_runs.Count == 0)
         {
             return null;
+        }
+
+        if (_runs.Count == 1 &&
+            _runs[0].CanLeaseSnapshot &&
+            _runs[0].CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs))
+        {
+            // Typed run buffers are builder-owned and invalid after Build. Lease
+            // their pinned storage to the immutable blob, redirect the public
+            // wrapper to a bounded shadow, and reclaim both on blob disposal.
+            var leasedRun = _runs[0];
+            var leasedSnapshots = _singleRunSnapshotScratch ?? new SKTextBlobRun[1];
+            _singleRunSnapshotScratch = null;
+            leasedSnapshots[0] = leasedRun.BorrowPositionedSnapshot();
+            _runs.Clear();
+            DetachPositionedBuffer(leasedRun);
+            leasedRun.LeaseTo(this, leasedSnapshots);
+            return new SKTextBlob(leasedSnapshots, leasedRun);
         }
 
         var snapshots = new SKTextBlobRun[_runs.Count];
@@ -573,24 +732,37 @@ public class SKTextBlobBuilder : SKObject
             snapshots[index] = _runs[index].Snapshot();
         }
 
-        var positionedScratch = _runs.Count == 1 &&
-            _runs[0].CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs)
-                ? _runs[0]
-                : null;
         _runs.Clear();
-        if (positionedScratch != null)
-        {
-            _positionedRunScratch = positionedScratch;
-        }
         return new SKTextBlob(snapshots);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ReturnPositionedRun(SKTextBlobBuilderRun run, SKTextBlobRun[] snapshots)
+    {
+        snapshots[0] = default;
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _singleRunSnapshotScratch ??= snapshots;
+        if (_positionedRunScratch is null &&
+            run.CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs))
+        {
+            _positionedRunScratch = run;
+        }
     }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
+            _isDisposed = true;
             _runs.Clear();
             _positionedRunScratch = null;
+            _singleRunSnapshotScratch = null;
+            _positionedBufferScratch = null;
+            _positionedBufferDetachedScratch = null;
         }
         base.Dispose(disposing);
     }
@@ -624,6 +796,7 @@ public class SKTextBlobBuilder : SKObject
         return run;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private SKTextBlobBuilderRun AllocatePositionedRunCore(
         SKFont font,
         int count,
@@ -642,6 +815,34 @@ public class SKTextBlobBuilder : SKObject
         var run = CreateRun(font, count, SKTextBlobRunPlacement.Positioned, 0f, 0f, textByteCount, bounds);
         run.PositionedPositions = SKTextBlobBuilderRun.AllocatePinned<SKPoint>(count);
         return run;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void DetachPositionedBuffer(SKTextBlobBuilderRun leasedRun)
+    {
+        if (_positionedBufferScratch is null)
+        {
+            return;
+        }
+
+        var detached = _positionedBufferDetachedScratch;
+        if (detached is null ||
+            !detached.TryPrepareDetachedPositioned(leasedRun.Font, leasedRun.Glyphs.Length))
+        {
+            detached = new SKTextBlobBuilderRun(
+                leasedRun.Font,
+                leasedRun.Glyphs.Length,
+                SKTextBlobRunPlacement.Positioned,
+                0f,
+                0f,
+                textByteCount: 0)
+            {
+                PositionedPositions = SKTextBlobBuilderRun.AllocatePinned<SKPoint>(leasedRun.Glyphs.Length),
+            };
+            _positionedBufferDetachedScratch = detached;
+        }
+
+        _positionedBufferScratch.ResetRun(detached);
     }
 
     private SKTextBlobBuilderRun AllocateRotationScaleRunCore(

--- a/src/SkiaSharp/SKTextBlobBuilder.cs
+++ b/src/SkiaSharp/SKTextBlobBuilder.cs
@@ -43,17 +43,46 @@ internal sealed class SKTextBlobBuilderRun
         Clusters = Array.Empty<uint>();
     }
 
-    public SKFont Font { get; }
+    public SKFont Font { get; private set; }
     public ushort[] Glyphs { get; }
-    public SKTextBlobRunPlacement Placement { get; }
-    public float X { get; }
-    public float Y { get; }
+    public SKTextBlobRunPlacement Placement { get; private set; }
+    public float X { get; private set; }
+    public float Y { get; private set; }
     public byte[] Text { get; }
     public uint[] Clusters { get; }
     public float[]? HorizontalPositions { get; set; }
     public SKPoint[]? PositionedPositions { get; set; }
     public SKRotationScaleMatrix[]? RotationScalePositions { get; set; }
     public SKTextBlobRun? Completed { get; }
+
+    public bool TryResetPositioned(SKFont font, int count)
+    {
+        if (Completed.HasValue ||
+            Placement != SKTextBlobRunPlacement.Positioned ||
+            Glyphs.Length != count ||
+            Text.Length != 0 ||
+            Clusters.Length != count ||
+            PositionedPositions?.Length != count)
+        {
+            return false;
+        }
+
+        Font = font;
+        X = 0f;
+        Y = 0f;
+        Array.Clear(Glyphs);
+        Array.Clear(Clusters);
+        Array.Clear(PositionedPositions);
+        return true;
+    }
+
+    public bool CanCacheAsPositionedScratch(int maximumGlyphCount) =>
+        !Completed.HasValue &&
+        Placement == SKTextBlobRunPlacement.Positioned &&
+        Glyphs.Length <= maximumGlyphCount &&
+        Text.Length == 0 &&
+        Clusters.Length == Glyphs.Length &&
+        PositionedPositions?.Length == Glyphs.Length;
 
     internal static T[] AllocatePinned<T>(int length) =>
         length == 0 ? Array.Empty<T>() : GC.AllocateArray<T>(length, pinned: true);
@@ -272,7 +301,9 @@ public sealed class SKRotationScaleTextRunBuffer : SKTextRunBuffer
 
 public class SKTextBlobBuilder : SKObject
 {
+    private const int MaximumReusablePositionedGlyphs = 1_024;
     private readonly List<SKTextBlobBuilderRun> _runs = new();
+    private SKTextBlobBuilderRun? _positionedRunScratch;
 
     public SKTextBlobBuilder()
         : base(SKObjectHandle.Create(), owns: true)
@@ -542,7 +573,15 @@ public class SKTextBlobBuilder : SKObject
             snapshots[index] = _runs[index].Snapshot();
         }
 
+        var positionedScratch = _runs.Count == 1 &&
+            _runs[0].CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs)
+                ? _runs[0]
+                : null;
         _runs.Clear();
+        if (positionedScratch != null)
+        {
+            _positionedRunScratch = positionedScratch;
+        }
         return new SKTextBlob(snapshots);
     }
 
@@ -551,6 +590,7 @@ public class SKTextBlobBuilder : SKObject
         if (disposing)
         {
             _runs.Clear();
+            _positionedRunScratch = null;
         }
         base.Dispose(disposing);
     }
@@ -590,6 +630,15 @@ public class SKTextBlobBuilder : SKObject
         int textByteCount,
         SKRect? bounds)
     {
+        if (textByteCount == 0 &&
+            _positionedRunScratch is { } scratch &&
+            scratch.TryResetPositioned(font, count))
+        {
+            _positionedRunScratch = null;
+            _runs.Add(scratch);
+            return scratch;
+        }
+
         var run = CreateRun(font, count, SKTextBlobRunPlacement.Positioned, 0f, 0f, textByteCount, bounds);
         run.PositionedPositions = SKTextBlobBuilderRun.AllocatePinned<SKPoint>(count);
         return run;

--- a/src/SkiaSharp/SKTextBlobBuilder.cs
+++ b/src/SkiaSharp/SKTextBlobBuilder.cs
@@ -187,7 +187,7 @@ internal sealed class SKTextBlobBuilderRun
         _leasedSnapshots = null;
         if (owner is not null && snapshots is not null)
         {
-            owner.ReturnPositionedRun(this, snapshots);
+            SKTextBlobBuilderScratch.ReturnPositionedRun(owner, this, snapshots);
         }
     }
 
@@ -300,10 +300,9 @@ public class SKRunBuffer
     internal SKRunBuffer(SKTextBlobBuilderRun run)
     {
         Run = run;
-        Size = run.Glyphs.Length;
     }
 
-    public int Size { get; private set; }
+    public int Size => Run.Glyphs.Length;
     public Span<ushort> Glyphs => Run.GetGlyphSpan();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -315,7 +314,6 @@ public class SKRunBuffer
     private protected void Reset(SKTextBlobBuilderRun run)
     {
         Run = run;
-        Size = run.Glyphs.Length;
     }
 }
 
@@ -418,13 +416,10 @@ public sealed class SKRotationScaleTextRunBuffer : SKTextRunBuffer
 
 public class SKTextBlobBuilder : SKObject
 {
-    private const int MaximumReusablePositionedGlyphs = 1_024;
+    internal const int MaximumReusablePositionedGlyphs = 1_024;
     private readonly List<SKTextBlobBuilderRun> _runs = new();
-    private SKTextBlobBuilderRun? _positionedRunScratch;
-    private SKTextBlobRun[]? _singleRunSnapshotScratch;
-    private SKPositionedRunBuffer? _positionedBufferScratch;
-    private SKTextBlobBuilderRun? _positionedBufferDetachedScratch;
-    private bool _isDisposed;
+    internal SKTextBlobBuilderScratch Scratch;
+    internal bool IsDisposedForScratch;
 
     public SKTextBlobBuilder()
         : base(SKObjectHandle.Create(), owns: true)
@@ -630,16 +625,16 @@ public class SKTextBlobBuilder : SKObject
             return new SKPositionedRunBuffer(run);
         }
 
-        if (_positionedBufferScratch is null)
+        if (Scratch.PositionedBuffer is null)
         {
-            _positionedBufferScratch = new SKPositionedRunBuffer(run);
+            Scratch.PositionedBuffer = new SKPositionedRunBuffer(run);
         }
         else
         {
-            _positionedBufferScratch.ResetRun(run);
+            Scratch.PositionedBuffer.ResetRun(run);
         }
 
-        return _positionedBufferScratch;
+        return Scratch.PositionedBuffer;
     }
 
     public SKRawRunBuffer<SKPoint> AllocateRawPositionedRun(
@@ -717,11 +712,11 @@ public class SKTextBlobBuilder : SKObject
             // their pinned storage to the immutable blob, redirect the public
             // wrapper to a bounded shadow, and reclaim both on blob disposal.
             var leasedRun = _runs[0];
-            var leasedSnapshots = _singleRunSnapshotScratch ?? new SKTextBlobRun[1];
-            _singleRunSnapshotScratch = null;
+            var leasedSnapshots = Scratch.SingleRunSnapshots ?? new SKTextBlobRun[1];
+            Scratch.SingleRunSnapshots = null;
             leasedSnapshots[0] = leasedRun.BorrowPositionedSnapshot();
             _runs.Clear();
-            DetachPositionedBuffer(leasedRun);
+            Scratch.DetachPositionedBuffer(leasedRun);
             leasedRun.LeaseTo(this, leasedSnapshots);
             return new SKTextBlob(leasedSnapshots, leasedRun);
         }
@@ -736,33 +731,13 @@ public class SKTextBlobBuilder : SKObject
         return new SKTextBlob(snapshots);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void ReturnPositionedRun(SKTextBlobBuilderRun run, SKTextBlobRun[] snapshots)
-    {
-        snapshots[0] = default;
-        if (_isDisposed)
-        {
-            return;
-        }
-
-        _singleRunSnapshotScratch ??= snapshots;
-        if (_positionedRunScratch is null &&
-            run.CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs))
-        {
-            _positionedRunScratch = run;
-        }
-    }
-
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            _isDisposed = true;
+            IsDisposedForScratch = true;
             _runs.Clear();
-            _positionedRunScratch = null;
-            _singleRunSnapshotScratch = null;
-            _positionedBufferScratch = null;
-            _positionedBufferDetachedScratch = null;
+            Scratch = default;
         }
         base.Dispose(disposing);
     }
@@ -804,10 +779,10 @@ public class SKTextBlobBuilder : SKObject
         SKRect? bounds)
     {
         if (textByteCount == 0 &&
-            _positionedRunScratch is { } scratch &&
+            Scratch.PositionedRun is { } scratch &&
             scratch.TryResetPositioned(font, count))
         {
-            _positionedRunScratch = null;
+            Scratch.PositionedRun = null;
             _runs.Add(scratch);
             return scratch;
         }
@@ -815,34 +790,6 @@ public class SKTextBlobBuilder : SKObject
         var run = CreateRun(font, count, SKTextBlobRunPlacement.Positioned, 0f, 0f, textByteCount, bounds);
         run.PositionedPositions = SKTextBlobBuilderRun.AllocatePinned<SKPoint>(count);
         return run;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void DetachPositionedBuffer(SKTextBlobBuilderRun leasedRun)
-    {
-        if (_positionedBufferScratch is null)
-        {
-            return;
-        }
-
-        var detached = _positionedBufferDetachedScratch;
-        if (detached is null ||
-            !detached.TryPrepareDetachedPositioned(leasedRun.Font, leasedRun.Glyphs.Length))
-        {
-            detached = new SKTextBlobBuilderRun(
-                leasedRun.Font,
-                leasedRun.Glyphs.Length,
-                SKTextBlobRunPlacement.Positioned,
-                0f,
-                0f,
-                textByteCount: 0)
-            {
-                PositionedPositions = SKTextBlobBuilderRun.AllocatePinned<SKPoint>(leasedRun.Glyphs.Length),
-            };
-            _positionedBufferDetachedScratch = detached;
-        }
-
-        _positionedBufferScratch.ResetRun(detached);
     }
 
     private SKTextBlobBuilderRun AllocateRotationScaleRunCore(

--- a/src/SkiaSharp/SKTextBlobBuilderScratch.cs
+++ b/src/SkiaSharp/SKTextBlobBuilderScratch.cs
@@ -1,0 +1,60 @@
+namespace SkiaSharp;
+
+internal struct SKTextBlobBuilderScratch
+{
+    public SKTextBlobBuilderRun? PositionedRun;
+    public SKTextBlobRun[]? SingleRunSnapshots;
+    public SKPositionedRunBuffer? PositionedBuffer;
+    public SKTextBlobBuilderRun? DetachedPositionedBuffer;
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public static void ReturnPositionedRun(
+        SKTextBlobBuilder owner,
+        SKTextBlobBuilderRun run,
+        SKTextBlobRun[] snapshots)
+    {
+        snapshots[0] = default;
+        if (owner.IsDisposedForScratch)
+        {
+            return;
+        }
+
+        owner.Scratch.SingleRunSnapshots ??= snapshots;
+        if (owner.Scratch.PositionedRun is null &&
+            run.CanCacheAsPositionedScratch(
+                SKTextBlobBuilder.MaximumReusablePositionedGlyphs))
+        {
+            owner.Scratch.PositionedRun = run;
+        }
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void DetachPositionedBuffer(SKTextBlobBuilderRun leasedRun)
+    {
+        if (PositionedBuffer is null)
+        {
+            return;
+        }
+
+        var detached = DetachedPositionedBuffer;
+        if (detached is null ||
+            !detached.TryPrepareDetachedPositioned(leasedRun.Font, leasedRun.Glyphs.Length))
+        {
+            detached = new SKTextBlobBuilderRun(
+                leasedRun.Font,
+                leasedRun.Glyphs.Length,
+                SKTextBlobRunPlacement.Positioned,
+                0f,
+                0f,
+                textByteCount: 0)
+            {
+                PositionedPositions = SKTextBlobBuilderRun.AllocatePinned<SKPoint>(leasedRun.Glyphs.Length),
+            };
+            DetachedPositionedBuffer = detached;
+        }
+
+        PositionedBuffer.ResetRun(detached);
+    }
+}

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -118,6 +118,9 @@ internal static class ProgramEntry
             new BenchmarkCase("platform-lock-read", 100_000, RunPlatformLockRead),
             new BenchmarkCase("gr-context-options", 100_000, RunGrContextOptions),
             new BenchmarkCase("canvas-retained-state-routing", 10_000, RunCanvasRetainedStateRouting),
+            new BenchmarkCase("canvas-save-restore", 100_000, RunCanvasSaveRestore),
+            new BenchmarkCase("canvas-matrix-routing", 100_000, RunCanvasMatrixRouting),
+            new BenchmarkCase("canvas-clip-routing", 10_000, RunCanvasClipRouting),
             new BenchmarkCase("avalonia-paint-reuse", 100_000, RunAvaloniaPaintReuse),
             new BenchmarkCase("avalonia-positioned-text-blob", 1_000, RunAvaloniaPositionedTextBlob),
             new BenchmarkCase("avalonia-stream-geometry", 1_000, RunAvaloniaStreamGeometry),
@@ -403,6 +406,57 @@ internal static class ProgramEntry
         using var picture = recorder.EndRecording();
         checksum = Mix(checksum, picture is null ? 0u : 1u);
         return checksum;
+    }
+
+    private static ulong RunCanvasSaveRestore(int operations)
+    {
+        using var recorder = new SKPictureRecorder();
+        var canvas = recorder.BeginRecording(new SKRect(0f, 0f, 64f, 64f));
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            var restoreCount = canvas.Save();
+            checksum = Mix(checksum, (uint)canvas.SaveCount);
+            canvas.RestoreToCount(restoreCount);
+        }
+
+        using var picture = recorder.EndRecording();
+        return Mix(checksum, picture is null ? 0u : 1u);
+    }
+
+    private static ulong RunCanvasMatrixRouting(int operations)
+    {
+        using var recorder = new SKPictureRecorder();
+        var canvas = recorder.BeginRecording(new SKRect(0f, 0f, 64f, 64f));
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            canvas.Scale(1.0001f);
+            var translation = SKMatrix.CreateTranslation(index & 3, index & 7);
+            canvas.Concat(in translation);
+            checksum = Mix(checksum, BitConverter.SingleToUInt32Bits(canvas.TotalMatrix.TransX));
+            canvas.ResetMatrix();
+        }
+
+        using var picture = recorder.EndRecording();
+        return Mix(checksum, picture is null ? 0u : 1u);
+    }
+
+    private static ulong RunCanvasClipRouting(int operations)
+    {
+        using var recorder = new SKPictureRecorder();
+        var canvas = recorder.BeginRecording(new SKRect(0f, 0f, 64f, 64f));
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            var restoreCount = canvas.Save();
+            canvas.ClipRect(new SKRect(1f, 2f, 63f, 62f));
+            checksum = Mix(checksum, (uint)canvas.SaveCount);
+            canvas.RestoreToCount(restoreCount);
+        }
+
+        using var picture = recorder.EndRecording();
+        return Mix(checksum, picture is null ? 0u : 1u);
     }
 
     private static ulong RunAvaloniaPaintReuse(int operations)

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -26,6 +26,8 @@ internal static class ProgramEntry
     private static long s_sink;
     private static SKTypeface? s_variableTypeface;
     private static readonly byte[] ImagePixels = CreateImagePixels();
+    private static readonly byte[] AvaloniaWriteableBitmapPixels =
+        CreateAvaloniaWriteableBitmapPixels();
     private static readonly SKColorF[] ShaderColors =
     {
         new(1f, 0f, 0f, 1f),
@@ -132,6 +134,10 @@ internal static class ProgramEntry
             // allocation and reference-count path of each immutable subset view.
             new BenchmarkCase("image-bounded-subset", 10_000, RunImageBoundedSubset),
             new BenchmarkCase("surface-bounded-snapshot", 10_000, RunSurfaceBoundedSnapshot),
+            new BenchmarkCase(
+                "avalonia-writeable-bitmap-snapshot",
+                128,
+                RunAvaloniaWriteableBitmapSnapshot),
             new BenchmarkCase("string-encoding-roundtrip", 10_000, RunStringEncodingRoundtrip),
             new BenchmarkCase("unicode-character-code", 100_000, RunUnicodeCharacterCode),
             new BenchmarkCase("swizzle-in-place-4k", 10_000, RunSwizzleInPlace),
@@ -363,6 +369,32 @@ internal static class ProgramEntry
             using var snapshot = surface.Snapshot(new SKRectI(offset, offset, offset + 32, offset + 32));
             checksum = Mix(checksum, (uint)snapshot.Width);
             checksum = Mix(checksum, (uint)snapshot.Height);
+        }
+
+        return checksum;
+    }
+
+    private static unsafe ulong RunAvaloniaWriteableBitmapSnapshot(int operations)
+    {
+        var info = new SKImageInfo(
+            16,
+            16,
+            SKImageInfo.PlatformColorType,
+            SKAlphaType.Premul);
+        ulong checksum = 1469598103934665603UL;
+        fixed (byte* pixels = AvaloniaWriteableBitmapPixels)
+        {
+            for (var index = 0; index < operations; index++)
+            {
+                using var image = SKImage.FromPixels(
+                    info,
+                    (IntPtr)pixels,
+                    info.RowBytes);
+                checksum = Mix(checksum, unchecked((uint)image.Width));
+                checksum = Mix(checksum, unchecked((uint)image.Height));
+                checksum = Mix(checksum, unchecked((uint)image.ColorType));
+                checksum = Mix(checksum, unchecked((uint)image.AlphaType));
+            }
         }
 
         return checksum;
@@ -1332,6 +1364,21 @@ internal static class ProgramEntry
         var pixels = new byte[4096];
         for (var index = 0; index < pixels.Length; index++)
             pixels[index] = (byte)(index * 37 + 11);
+        return pixels;
+    }
+
+    private static byte[] CreateAvaloniaWriteableBitmapPixels()
+    {
+        var pixels = new byte[16 * 16 * 4];
+        for (var index = 0; index < pixels.Length; index += 4)
+        {
+            var alpha = (byte)(64 + ((index >> 2) % 192));
+            pixels[index] = (byte)(index * 17 + 3);
+            pixels[index + 1] = (byte)(index * 29 + 7);
+            pixels[index + 2] = (byte)(index * 43 + 11);
+            pixels[index + 3] = alpha;
+        }
+
         return pixels;
     }
 

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -33,6 +33,8 @@ internal static class ProgramEntry
         new(0f, 0f, 1f, 1f)
     };
     private static readonly float[] ShaderColorPositions = { 0f, 0.375f, 1f };
+    private static readonly ushort[] AvaloniaGlyphIndices = CreateAvaloniaGlyphIndices();
+    private static readonly SKPoint[] AvaloniaGlyphPositions = CreateAvaloniaGlyphPositions();
     private const string RuntimeEffectSource = """
         uniform float gain;
         uniform float2 offset;
@@ -116,6 +118,9 @@ internal static class ProgramEntry
             new BenchmarkCase("platform-lock-read", 100_000, RunPlatformLockRead),
             new BenchmarkCase("gr-context-options", 100_000, RunGrContextOptions),
             new BenchmarkCase("canvas-retained-state-routing", 10_000, RunCanvasRetainedStateRouting),
+            new BenchmarkCase("avalonia-paint-reuse", 100_000, RunAvaloniaPaintReuse),
+            new BenchmarkCase("avalonia-positioned-text-blob", 1_000, RunAvaloniaPositionedTextBlob),
+            new BenchmarkCase("avalonia-stream-geometry", 1_000, RunAvaloniaStreamGeometry),
             // Keep each sample above the sub-millisecond timer-noise floor and
             // warm the gradient factories through their final dynamic-PGO tier.
             new BenchmarkCase("shader-gradient-factories", 16_000, RunShaderGradientFactories),
@@ -398,6 +403,102 @@ internal static class ProgramEntry
         using var picture = recorder.EndRecording();
         checksum = Mix(checksum, picture is null ? 0u : 1u);
         return checksum;
+    }
+
+    private static ulong RunAvaloniaPaintReuse(int operations)
+    {
+        using var paint = new SKPaint();
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            paint.IsAntialias = (index & 1) == 0;
+            paint.Color = new SKColor(
+                (byte)index,
+                (byte)(index >> 3),
+                (byte)(255 - index),
+                (byte)(192 + (index & 63)));
+            paint.IsStroke = true;
+            paint.StrokeWidth = 1f + (index & 7) * 0.25f;
+            paint.StrokeCap = SKStrokeCap.Square;
+            paint.StrokeJoin = SKStrokeJoin.Round;
+            paint.StrokeMiter = 4f + (index & 3);
+            paint.BlendMode = SKBlendMode.DstIn;
+
+            checksum = Mix(checksum, (uint)paint.Color);
+            checksum = Mix(checksum, BitConverter.SingleToUInt32Bits(paint.StrokeWidth));
+            checksum = Mix(checksum, (uint)paint.BlendMode);
+            paint.Reset();
+        }
+
+        return checksum;
+    }
+
+    private static ulong RunAvaloniaPositionedTextBlob(int operations)
+    {
+        using var font = new SKFont(SKTypeface.Default, 16f);
+        using var builder = new SKTextBlobBuilder();
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            var run = builder.AllocatePositionedRun(font, AvaloniaGlyphIndices.Length);
+            run.SetPositions(AvaloniaGlyphPositions);
+            run.SetGlyphs(AvaloniaGlyphIndices);
+            using var blob = builder.Build() ??
+                throw new InvalidOperationException("A positioned glyph run must produce a text blob.");
+            checksum = Mix(checksum, blob.UniqueId == 0 ? 0u : 1u);
+        }
+
+        return checksum;
+    }
+
+#pragma warning disable CS0618 // Avalonia.Skia 12 currently builds stream geometry through legacy SKPath mutation.
+    private static ulong RunAvaloniaStreamGeometry(int operations)
+    {
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            var offset = (index & 15) * 0.125f;
+            using var path = new SKPath { FillType = SKPathFillType.EvenOdd };
+            path.MoveTo(offset, -offset);
+            for (var segment = 0; segment < 8; segment++)
+            {
+                var x = segment * 6f + offset;
+                var y = segment * 3f - offset;
+                path.LineTo(x + 1f, y + 2f);
+                path.QuadTo(x + 2f, y - 1f, x + 3f, y + 3f);
+                path.CubicTo(
+                    x + 3.5f,
+                    y + 4f,
+                    x + 4.5f,
+                    y - 2f,
+                    x + 5f,
+                    y + 1f);
+            }
+            path.Close();
+            var bounds = path.TightBounds;
+            checksum = Mix(
+                checksum,
+                Combine(bounds.Left + bounds.Right, bounds.Top + bounds.Bottom));
+        }
+
+        return checksum;
+    }
+#pragma warning restore CS0618
+
+    private static ushort[] CreateAvaloniaGlyphIndices()
+    {
+        var glyphs = new ushort[32];
+        for (var index = 0; index < glyphs.Length; index++)
+            glyphs[index] = (ushort)(index + 1);
+        return glyphs;
+    }
+
+    private static SKPoint[] CreateAvaloniaGlyphPositions()
+    {
+        var positions = new SKPoint[32];
+        for (var index = 0; index < positions.Length; index++)
+            positions[index] = new SKPoint(index * 7.5f, (index & 3) * 0.125f);
+        return positions;
     }
 
     private static ulong RunGrContextOptions(int operations)

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -396,7 +396,16 @@ internal static class ProgramEntry
                     info.RowBytes);
                 checksum = Mix(checksum, unchecked((uint)image.Width));
                 checksum = Mix(checksum, unchecked((uint)image.Height));
-                checksum = Mix(checksum, unchecked((uint)image.ColorType));
+                // Skia's native N32 channel order is selected by its build and
+                // can be BGRA where the WebGPU shim deliberately normalizes to
+                // RGBA. Both are the same four-channel Avalonia contract; keep
+                // the semantic checksum sensitive to that contract without
+                // requiring identical backend storage order.
+                checksum = Mix(
+                    checksum,
+                    image.ColorType is SKColorType.Rgba8888 or SKColorType.Bgra8888
+                        ? 4u
+                        : unchecked((uint)image.ColorType));
                 checksum = Mix(checksum, unchecked((uint)image.AlphaType));
             }
         }

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -138,6 +138,10 @@ internal static class ProgramEntry
                 "avalonia-writeable-bitmap-snapshot",
                 128,
                 RunAvaloniaWriteableBitmapSnapshot),
+            new BenchmarkCase(
+                "avalonia-immutable-image-recording",
+                1_000,
+                RunAvaloniaImmutableImageRecording),
             new BenchmarkCase("string-encoding-roundtrip", 10_000, RunStringEncodingRoundtrip),
             new BenchmarkCase("unicode-character-code", 100_000, RunUnicodeCharacterCode),
             new BenchmarkCase("swizzle-in-place-4k", 10_000, RunSwizzleInPlace),
@@ -398,6 +402,52 @@ internal static class ProgramEntry
         }
 
         return checksum;
+    }
+
+    private static unsafe ulong RunAvaloniaImmutableImageRecording(int operations)
+    {
+        var info = new SKImageInfo(
+            16,
+            16,
+            SKImageInfo.PlatformColorType,
+            SKAlphaType.Premul);
+        fixed (byte* pixels = AvaloniaWriteableBitmapPixels)
+        {
+            using var image = SKImage.FromPixels(
+                info,
+                (IntPtr)pixels,
+                info.RowBytes);
+            using var recorder = new SKPictureRecorder();
+            var canvas = recorder.BeginRecording(new SKRect(0f, 0f, 64f, 64f));
+            using var paint = new SKPaint { IsAntialias = false };
+            var source = new SKRect(0f, 0f, 16f, 16f);
+            ulong checksum = 1469598103934665603UL;
+            for (var index = 0; index < operations; index++)
+            {
+                var offset = index & 7;
+                var destination = new SKRect(
+                    offset,
+                    offset,
+                    offset + 16f,
+                    offset + 16f);
+                canvas.DrawImage(
+                    image,
+                    source,
+                    destination,
+                    SKSamplingOptions.Default,
+                    paint);
+                checksum = Mix(checksum, unchecked((uint)offset));
+            }
+
+            using var picture = recorder.EndRecording();
+            checksum = Mix(
+                checksum,
+                BitConverter.SingleToUInt32Bits(picture.CullRect.Width));
+            checksum = Mix(
+                checksum,
+                BitConverter.SingleToUInt32Bits(picture.CullRect.Height));
+            return checksum;
+        }
     }
 
     private static ulong RunImageBoundedSubset(int operations)

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -22,8 +22,10 @@ premultiplied-color conversion, 64-element color-array conversion, OpenType tag
 value/formatting operations, and retained path construction/bounds. It also
 tracks the exact reusable-paint, positioned-text-blob, legacy stream-path, and
 `WriteableBitmapImpl.GetSnapshot()` CPU-framebuffer-to-immutable-image patterns
-used by Avalonia.Skia so shim optimization follows real framework call sites
-rather than metadata frequency alone. Canvas coverage decomposes retained
+used by Avalonia.Skia. A paired retained-picture workload records repeated draws
+of that immutable image and measures whether deferred rendering reuses its GPU
+resource. Shim optimization therefore follows real framework call sites rather
+than metadata frequency alone. Canvas coverage decomposes retained
 save/restore, matrix, and clip routing so regressions can be attributed without
 changing the full framework-shaped workload. Each implemented API cluster adds
 an equivalent workload

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -19,8 +19,11 @@ used as narrow timing gates; dedicated platform runs establish reviewed budgets.
 
 The CPU suite covers value arithmetic, matrix mapping, exhaustive scalar
 premultiplied-color conversion, 64-element color-array conversion, OpenType tag
-value/formatting operations, and retained path construction/bounds. Each
-implemented API cluster adds an equivalent workload
+value/formatting operations, and retained path construction/bounds. It also
+tracks the exact reusable-paint, positioned-text-blob, and legacy stream-path
+patterns used by Avalonia.Skia so shim optimization follows real framework call
+sites rather than metadata frequency alone. Each implemented API cluster adds
+an equivalent workload
 or an explicit explanation that its behavior is already covered by a broader
 component/application benchmark. GPU/rendering clusters additionally require a
 deterministic final-frame workload, image-quality comparison, WebGPU timestamps,

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -20,9 +20,10 @@ used as narrow timing gates; dedicated platform runs establish reviewed budgets.
 The CPU suite covers value arithmetic, matrix mapping, exhaustive scalar
 premultiplied-color conversion, 64-element color-array conversion, OpenType tag
 value/formatting operations, and retained path construction/bounds. It also
-tracks the exact reusable-paint, positioned-text-blob, and legacy stream-path
-patterns used by Avalonia.Skia so shim optimization follows real framework call
-sites rather than metadata frequency alone. Canvas coverage decomposes retained
+tracks the exact reusable-paint, positioned-text-blob, legacy stream-path, and
+`WriteableBitmapImpl.GetSnapshot()` CPU-framebuffer-to-immutable-image patterns
+used by Avalonia.Skia so shim optimization follows real framework call sites
+rather than metadata frequency alone. Canvas coverage decomposes retained
 save/restore, matrix, and clip routing so regressions can be attributed without
 changing the full framework-shaped workload. Each implemented API cluster adds
 an equivalent workload

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -22,7 +22,9 @@ premultiplied-color conversion, 64-element color-array conversion, OpenType tag
 value/formatting operations, and retained path construction/bounds. It also
 tracks the exact reusable-paint, positioned-text-blob, and legacy stream-path
 patterns used by Avalonia.Skia so shim optimization follows real framework call
-sites rather than metadata frequency alone. Each implemented API cluster adds
+sites rather than metadata frequency alone. Canvas coverage decomposes retained
+save/restore, matrix, and clip routing so regressions can be attributed without
+changing the full framework-shaped workload. Each implemented API cluster adds
 an equivalent workload
 or an explicit explanation that its behavior is already covered by a broader
 component/application benchmark. GPU/rendering clusters additionally require a


### PR DESCRIPTION
## Summary

This broad SkiaSharp compatibility/performance tranche is prioritized by API paths used directly by Avalonia.Skia.

- adds same-source native/ProGPU workloads for Avalonia paint reuse, positioned text blobs, legacy stream geometry, decomposed canvas routing, writable-bitmap snapshots, and immutable-image recording
- removes eager blend-wrapper creation from reusable `SKPaint`
- gives positioned text blobs bounded builder-owned storage with immutable disposal-scoped leases
- keeps common legacy `SKPath` verbs in pooled packed storage with exact incremental tight bounds
- separates `SKPathBuilder` control bounds from on-demand tight bounds
- accelerates affine `SKMatrix.MapRect` and retained canvas clipping/state routing
- shares bounded immutable gradient stop and transform snapshots
- compacts common `SKRoundRect` state while retaining independent complex-radii ownership
- directly uploads common Avalonia RGBA/BGRA writable-bitmap snapshots without a temporary `SKBitmap`
- leases whole immutable image textures across deferred draws, avoiding a GPU allocation and copy per recorded draw while keeping the lease implementation off the official `SKImage` surface

## Why

Avalonia.Skia repeatedly resets paint, builds one positioned glyph run, records legacy stream geometry, maps/clips affine rectangles, creates common gradients and rounded rectangles, snapshots writable bitmaps, and records immutable images into deferred pictures. The previous shim performed avoidable managed allocation or expanded retained object graphs on several of those routes; immutable images also allocated and copied a GPU texture for every recorded draw.

The new representations preserve official SkiaSharp contracts while keeping the hot path typed, bounded, and reflection-free. Complex/raw/multi-run, subset, mipmapped, and cross-device cases retain conservative copy ownership; optimized cases fall back safely when lease or representation preconditions do not hold.

## Matched evidence

All workloads use identical source and exact semantic checksums. Shared-machine timing ranges report repeated Release runs; they are evidence rather than narrow CI budgets.

| Workload | Native | ProGPU | Native B/op | ProGPU B/op |
| --- | ---: | ---: | ---: | ---: |
| Avalonia paint reuse | 40–52 ns | 7.6–7.8 ns | 0 | 0 |
| Avalonia positioned text blob | 296 ns | 286 ns | 136 | 89 |
| Avalonia legacy stream geometry | 872 ns | 686 ns | 168 | 80 |
| Retained canvas state routing | 213 ns | 166 ns | 0 | 0 |
| Four gradient factories | 1,197 ns | 218 ns | 416 | 352 |
| Packed path builder/bounds | 698 ns | 406 ns | 168 | 136 |
| Round-rectangle lifetime | 81 ns | 35 ns | 80 | 72 |
| Avalonia writable-bitmap snapshot | 942 ns | 10,935 ns | 248 | 1,424 |
| Avalonia immutable-image recording | 48 ns/draw | 608–702 ns/draw | 2 | 2,486 |

The writable-bitmap snapshot remains slower than native, but the common direct upload reduced the ProGPU result from 13,356 ns and 1,568 B/op to 10,935 ns and 1,424 B/op. Whole-image deferred recording fell from 69,165 ns/draw and 2,831.5 B/draw to 608–702 ns/draw and 2,486 B/draw by removing per-draw GPU texture allocation/copy. The remaining managed command-storage gap and subset/mipmap/cross-device materialization paths are retained follow-up targets.

Matched Apple M3 Pro final-binary Time Profiler, Allocations plus VM Tracker, Metal System Trace, and EventPipe captures compared exact pre-lease `1c60239b` with candidate `79d86548`. EventPipe measured 60,615.875 versus 627.041 median ns/draw with the exact checksum and a 12.2% managed-allocation reduction. Metal target resource-allocation rows fell from 188 to 53 and application command-buffer submissions from 5,627 to zero; the candidate contains no target `copy_texture_to_texture` stack. Both sides reported zero command-buffer errors, compiler spills, and hang risks. Raw trace/publish/package/worktree temp data was removed after the compact evidence was recorded in `docs/SKIASHARP_API_PARITY.md`.

## Validation completed

- all 15 PR checks pass
- official SkiaSharp 4.151.0 metadata: 4,222/4,222 entries match, zero missing; candidate public surface remains at the `main` count of 5,220 entries
- Ubuntu, macOS, and Windows Release build/test lanes
- native/ProGPU matched benchmark lanes on Ubuntu, macOS, and Windows
- native/ProGPU image parity
- native Dawn contracts on Ubuntu and Windows
- source-built Avalonia retained compositor: 28/28
- source-built Avalonia upstream text: 274 passed, 5 intentional skips; focused text: 13/13
- portable and mobile package gates, including isolated packaged XAML consumer and CLI install/compile smoke
- local core and headless macOS hardware validation; headless 225/225
- focused suites: paint/blender 103, path/canvas-shape 133, matrix/canvas 229, shader/gradient 35, text blob 23, image/canvas 133, round-rectangle/drawing 25
- release documentation gate and branch clean-room history audit
- zero review threads

## Clean-room architecture research

The implementation is original and based on public contracts, specifications, and observable behavior. The retained text/scene design was checked against primary material for [Skia text blobs](https://api.skia.org/classSkTextBlob.html), [DirectWrite glyph runs](https://learn.microsoft.com/windows/win32/api/dwrite/ns-dwrite-dwrite_glyph_run), [Win2D `DrawGlyphRun`](https://learn.microsoft.com/uwp/api/microsoft.graphics.canvas.canvasdrawingSession.drawglyphrun), [WebRender](https://github.com/servo/webrender), [Vello](https://github.com/linebender/vello), [Parley](https://github.com/linebender/parley), and [HarfBuzz shaping](https://harfbuzz.github.io/harfbuzz-hb-shape.html). Image ownership and upload decisions were checked against [Skia `SkImage`](https://api.skia.org/classSkImage.html), [WebGPU texture-copy contracts](https://www.w3.org/TR/webgpu/), [Direct2D bitmap drawing](https://learn.microsoft.com/windows/win32/direct2d/id2d1rendertarget-drawbitmap), and [Win2D image drawing](https://learn.microsoft.com/uwp/api/microsoft.graphics.canvas.canvasdrawingsession.drawimage).

Adopted concepts are immutable reusable glyph runs, retained scene commands, bounded caches, explicit lifetime ownership, and delayed expansion at ownership boundaries. ProGPU keeps its own typed managed ownership model and WebGPU compositor contracts; no foreign source or source structure was copied.
