### PR TITLE
Optimize Avalonia.Skia surface and image hot paths

### DIFF
--- a/docs/AVALONIA_SKIA_SURFACE_HOTPATH_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_SURFACE_HOTPATH_RESEARCH.md
@@ -1,0 +1,114 @@
+# Avalonia.Skia surface hot-path research
+
+## Scope and observed framework contract
+
+This clean-room slice optimizes the official SkiaSharp surface/image contracts
+that Avalonia.Skia uses for reusable render targets. At Avalonia commit
+[`fee9c561`](https://github.com/AvaloniaUI/Avalonia/tree/fee9c561ce036e8a3e8cee2397c75ca599b4790d),
+[`SurfaceRenderTarget`](https://github.com/AvaloniaUI/Avalonia/blob/fee9c561ce036e8a3e8cee2397c75ca599b4790d/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs)
+reuses an `SKSurface`, flushes its canvas, draws one surface into another, and
+creates immutable snapshots. The
+[`FramebufferRenderTarget`](https://github.com/AvaloniaUI/Avalonia/blob/fee9c561ce036e8a3e8cee2397c75ca599b4790d/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs)
+conversion fallback snapshots a pointer-backed surface and reads that image into
+the destination framebuffer. `WriteableBitmapImpl` similarly retains immutable
+image snapshots. These observed public calls, not foreign implementation text,
+define the benchmark and regression-test workloads.
+
+## Primary-source comparison
+
+| Engine or specification | Relevant public/architectural contract | ProGPU clean-room decision |
+| --- | --- | --- |
+| [Skia `SkSurface`](https://skia.googlesource.com/skia/+/refs/heads/main/include/core/SkSurface.h), [`SkSurface` implementation boundary](https://skia.googlesource.com/skia/+/refs/heads/main/src/image/SkSurface.cpp), and [`SkSurface_Base`](https://skia.googlesource.com/skia/+/refs/heads/main/src/image/SkSurface_Base.h) | A snapshot is immutable; unchanged content may share an image generation, while a later write preserves any externally retained generation. Surface drawing is allowed to use a temporary image representation instead of requiring a permanent full snapshot. | Adopt the observable immutable-generation and copy-on-write contract. A ProGPU-owned surface transfers its existing texture into a reference-counted image generation. A later write reclaims it in `O(1)` when no external lease remains, or performs one GPU copy when an image/draw command still retains the old generation. The ownership state machine, types, and control flow are original ProGPU code. |
+| [Direct2D resource domains](https://learn.microsoft.com/en-us/windows/win32/direct2d/resources-and-resource-domains), [render targets](https://learn.microsoft.com/en-us/windows/win32/direct2d/render-targets-overview), and [Direct2D/Direct3D interoperation](https://learn.microsoft.com/en-us/windows/win32/Direct2D/direct2d-and-direct3d-interoperation-overview) | Render targets and bitmaps are device resources; commands are batched and `Flush` submits pending work without changing resource-domain ownership. | Keep surface backing, immutable generations, readback staging, and retained texture leases in one typed `WgpuContext` device domain. Reject CPU round-trips for same-device composition. |
+| [Win2D `CanvasRenderTarget`](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasRenderTarget.htm) and [drawing-session contract](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasDrawingSession.htm) | An offscreen target is both drawable and sampleable; ending a drawing session submits work, and device resources should be reused. | Preserve one renderable/sampleable texture per mutable surface and one reusable owned command visual. Do not create a second CPU display list or per-flush surface object. |
+| [WebGPU object destruction](https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-destroy), [queue submission](https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit), and [submitted-work completion](https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone) | Submitted command buffers retain the resources needed for execution. Dropping application references does not cancel submitted work; explicit external storage has a separate lifetime boundary. | Release ordinary native wrapper references without a per-frame queue wait. Route production submissions through `WgpuContext.Submit`, poll every two submissions, and force a drain after eight undrained submissions. Imported external texture owners still force an immediate wait before disposal. This makes queue/resource residency independent of total frame count. |
+| [WebRender rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html) and [render-task source](https://searchfox.org/firefox-main/source/gfx/wr/webrender/src/render_task.rs) | Retained scene/resource identity is reused while render tasks and texture-cache residency remain renderer-owned and bounded. | Reuse one typed `IOwnedRenderCommandCache` visual per surface. Compile the current commands directly and clear their retained leases after submission; do not allocate and append into a new `DrawingVisual` every flush. |
+| [Vello](https://github.com/linebender/vello) | Scene encoding is separate from the explicit `wgpu` device, queue, and target texture; parallel raster/composition work stays on the GPU. | Keep command recording typed and CPU-retained while rendering, texture copies, sampling, and composition remain WebGPU operations. Reject CPU tessellation or a separate software surface renderer. |
+| [Skia shaped-text design](https://docs.skia.org/docs/dev/design/text_shaper/), [SkParagraph](https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/), [DirectWrite](https://learn.microsoft.com/en-us/windows/win32/directwrite/direct-write-portal), [HarfBuzz shaping](https://harfbuzz.github.io/shaping-and-shape-plans.html), and [Parley](https://github.com/linebender/parley) | Unicode/OpenType shaping and line layout are reusable CPU results, independent of surface generation and queue lifetime. | Leave shaping, fallback, glyph IDs, line layout, DPI/subpixel policy, glyph/path atlases, visibility culling, and device-loss invalidation unchanged. This slice changes only surface/image ownership, submission, and readback staging. |
+
+Rejected alternatives are an unconditional snapshot texture copy, borrowing a
+mutable surface texture without copy-on-write, blocking the device queue every
+frame, an unbounded asynchronous submission queue, an always-resident duplicate
+CPU image, reflection-based Avalonia adapters, and source-derived Skia control
+flow.
+
+## Resulting algorithms and bounds
+
+- Stable `Snapshot(bounds)` is `O(1)` time and one compact image-view
+  allocation. It does not submit a texture copy.
+- The first write after a snapshot is `O(1)` when the generation has no other
+  references. With an outstanding snapshot or deferred draw lease it performs
+  one `O(P)` GPU texture copy for `P` pixels, preserving immutable pixels.
+- Surface flush compilation is `O(C)` for `C` retained commands and reads the
+  existing command storage directly. It no longer performs a second `O(C)`
+  append or allocates a visual/command array per flush.
+- Surface and image readback remain necessarily `O(P)` GPU/CPU bandwidth.
+  Each long-lived source owns one staging buffer and one exact-size managed
+  pixel array, so repeated reads use `O(P)` retained storage with bounded
+  per-call object allocation. Pointer-backed snapshots transfer the already
+  completed canonical RGBA generation instead of mapping the GPU twice.
+- Queue accounting is `O(1)` per submission. Completed work is polled every two
+  submissions; eight undrained submissions is the fixed forced-drain bound.
+  External native owners retain the stricter immediate-drain rule.
+
+## Validation protocol
+
+The benchmark runner executes three alternating official-SkiaSharp/ProGPU
+Release process pairs, 32 warmups and 24 samples per process, and requires exact
+semantic checksums. The surface family covers stable frames, surface-to-surface
+composition, pointer-backed snapshot conversion, direct surface readback, and
+repeated immutable-image readback. Focused tests additionally cover retained
+snapshot immutability, deferred draws followed by source mutation, `O(1)`
+backing reclamation, subset-relative reads, BGRA conversion, external-owner
+drains, and the bounded submission policy.
+
+macOS validation pairs EventPipe CPU samples with Xcode Allocations, Time
+Profiler, and Metal System Trace captures of the same Release composition
+workload. Raw `.nettrace`, `.trace`, Xcode scratch, and exported XML data are
+temporary; compact benchmark JSON/Markdown, top-function text, profiler logs,
+manifests, and summaries are retained.
+
+## Measured result
+
+The uninstrumented Release comparison used Preview.45 (`ab21744b`) as the
+before binary and `2d4e725e` as the product-code endpoint. The final runner
+executed three alternating official-SkiaSharp/ProGPU process pairs with 32
+warmups and 24 samples per process. The working tree differed from that endpoint
+only by this research document. All listed checksums matched across every run.
+
+| Avalonia-shaped ProGPU workload | Preview.45 median | Final median | Change | Preview.45 allocation | Final allocation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Reusable surface composition | 1,483,329 ns | 658,568 ns | -55.6% | 16,248 B/op | 991 B/op (-93.9%) |
+| Framebuffer conversion readback | 6,220,693 ns | 3,169,493 ns | -49.1% | 17,646 B/op | 14,088 B/op (-20.2%) |
+| Stable surface frame enqueue | 85,726 ns | 342,653 ns | +299.7% | 3,241 B/op | 441 B/op (-86.4%) |
+
+The stable-frame workload deliberately runs faster than presentation pacing and
+has no terminal readback. It therefore measures the selected completed-work
+backpressure as well as command encoding: every eighth undrained submission is
+retired before more work is admitted. The CPU enqueue median is slower than the
+old per-frame cleanup policy, while allocation is substantially lower and
+native residency no longer grows with the total frame count. Composition and
+conversion, the framework paths that consume or present the result, retain the
+material latency improvements above. A looser 64-submission experiment reached
+about 0.267 ms composition but retained roughly 85 MB of IOAccelerator VM; an
+unbounded experiment retained roughly 378 MB. Both were rejected.
+
+Matched Xcode Instruments runs used the same 18-second/8-second-window Release
+composition workload. Preview.45 measured 1,849,262 ns/op and 16,248 B/op under
+instrumentation; the selected bound measured 713,420 ns/op and 992 B/op, a
+61.4% timing and 93.9% allocation reduction. Persistent heap plus anonymous VM
+was 125,743,408 B before and 159,348,000 B after. IOAccelerator VM was
+12,419,072 B before and 37,191,680 B after; the final fixed high-water state had
+45 `MTLResourceList` entries totaling 2,211,840 B. This is the measured cost of
+retaining a small amount of GPU overlap rather than synchronizing every cleanup.
+The final Metal capture reported zero command-buffer errors, potential hangs,
+hang risks, drawable waits, and compiler spills. EventPipe attributed 77.1% of
+sampled exclusive CPU time to the intentional bounded `PollDevice(true)`
+backpressure, confirming the remaining dominant cost rather than hiding it in
+managed work.
+
+Timing ratios are evidence from one shared Apple Silicon machine rather than
+narrow CI gates. Exact checksums, API metadata, bounded residency, focused
+ownership tests, and full regression gates remain hard requirements. Raw
+EventPipe and Instruments traces were deleted after retaining compact JSON,
+Markdown, logs, manifests, and top-function evidence.

--- a/src/ProGPU.Avalonia/ProGpuHostControl.cs
+++ b/src/ProGPU.Avalonia/ProGpuHostControl.cs
@@ -1263,7 +1263,7 @@ public class ProGpuHostControl : Control
         var cmdBufferDesc = new CommandBufferDescriptor();
         var cmdBuffer = _wgpuContext.Api.CommandEncoderFinish(encoder, &cmdBufferDesc);
         
-        _wgpuContext.Api.QueueSubmit(_wgpuContext.Queue, 1, &cmdBuffer);
+        _wgpuContext.Submit(1, &cmdBuffer);
         _wgpuContext.Api.CommandBufferRelease(cmdBuffer);
         _wgpuContext.Api.CommandEncoderRelease(encoder);
     }

--- a/src/ProGPU.Backend/GpuBuffer.cs
+++ b/src/ProGPU.Backend/GpuBuffer.cs
@@ -232,7 +232,7 @@ public unsafe class GpuBuffer : IDisposable
             throw new InvalidOperationException("Failed to finish buffer readback command encoder.");
         }
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 

--- a/src/ProGPU.Backend/GpuNv12Processor.cs
+++ b/src/ProGPU.Backend/GpuNv12Processor.cs
@@ -515,8 +515,7 @@ public static unsafe class GpuNv12Processor
                 throw new InvalidOperationException(
                     "Failed to finish the RGBA-to-NV12 command buffer.");
             }
-            wgpu.QueueSubmit(
-                context.Queue,
+            context.Submit(
                 1,
                 &commandBuffer);
         }
@@ -656,8 +655,7 @@ public static unsafe class GpuNv12Processor
                 throw new InvalidOperationException(
                     "Failed to finish the NV12 processor command buffer.");
             }
-            wgpu.QueueSubmit(
-                context.Queue,
+            context.Submit(
                 1,
                 &commandBuffer);
         }
@@ -788,8 +786,7 @@ public static unsafe class GpuNv12Processor
                 throw new InvalidOperationException(
                     "Failed to finish the NV12-to-RGBA command buffer.");
             }
-            wgpu.QueueSubmit(
-                context.Queue,
+            context.Submit(
                 1,
                 &commandBuffer);
         }
@@ -854,8 +851,7 @@ public static unsafe class GpuNv12Processor
                 throw new InvalidOperationException(
                     "Failed to finish the NV12 solid-color command buffer.");
             }
-            wgpu.QueueSubmit(
-                context.Queue,
+            context.Submit(
                 1,
                 &commandBuffer);
         }

--- a/src/ProGPU.Backend/GpuTexture.cs
+++ b/src/ProGPU.Backend/GpuTexture.cs
@@ -452,7 +452,7 @@ public unsafe class GpuTexture : IDisposable
                 throw new InvalidOperationException("Failed to finish command buffer for texture clear.");
             }
 
-            wgpu.QueueSubmit(_context.Queue, 1, &commandBuffer);
+            _context.Submit(1, &commandBuffer);
         }
         finally
         {
@@ -792,7 +792,7 @@ public unsafe class GpuTexture : IDisposable
             commandBuffer = wgpu.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                wgpu.QueueSubmit(_context.Queue, 1, &commandBuffer);
+                _context.Submit(1, &commandBuffer);
             }
         }
         finally
@@ -1250,7 +1250,7 @@ public unsafe class GpuTexture : IDisposable
 
         var commandBufferDesc = new CommandBufferDescriptor();
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 
@@ -1331,7 +1331,7 @@ public unsafe class GpuTexture : IDisposable
         var commandBuffer = _context.Api.CommandEncoderFinish(
             encoder,
             &commandBufferDescriptor);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 
@@ -1434,7 +1434,7 @@ public unsafe class GpuTexture : IDisposable
         var commandBuffer = _context.Api.CommandEncoderFinish(
             encoder,
             &commandBufferDescriptor);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 

--- a/src/ProGPU.Backend/GpuTextureBlitter.cs
+++ b/src/ProGPU.Backend/GpuTextureBlitter.cs
@@ -225,7 +225,7 @@ public static unsafe class GpuTextureBlitter
                 throw new InvalidOperationException("Failed to finish command buffer for GPU texture blit.");
             }
 
-            wgpu.QueueSubmit(context.Queue, 1, &commandBuffer);
+            context.Submit(1, &commandBuffer);
         }
         finally
         {

--- a/src/ProGPU.Backend/GpuTextureClearer.cs
+++ b/src/ProGPU.Backend/GpuTextureClearer.cs
@@ -125,8 +125,7 @@ public static unsafe class GpuTextureClearer
                     "Failed to finish the GPU texture-clear command buffer.");
             }
 
-            wgpu.QueueSubmit(
-                context.Queue,
+            context.Submit(
                 1,
                 &commandBuffer);
         }

--- a/src/ProGPU.Backend/GpuTextureGaussianBlur.cs
+++ b/src/ProGPU.Backend/GpuTextureGaussianBlur.cs
@@ -417,8 +417,7 @@ public static unsafe class GpuTextureGaussianBlur
                     "Failed to finish the Gaussian command buffer.");
             }
 
-            wgpu.QueueSubmit(
-                context.Queue,
+            context.Submit(
                 1,
                 &commandBuffer);
             intermediate.MarkContentsDirty();

--- a/src/ProGPU.Backend/GpuTextureLayerCompositor.cs
+++ b/src/ProGPU.Backend/GpuTextureLayerCompositor.cs
@@ -323,8 +323,7 @@ public sealed unsafe class GpuTextureLayerCompositor :
                 throw new InvalidOperationException(
                     "Failed to finish the texture-layer command buffer.");
             }
-            wgpu.QueueSubmit(
-                _context.Queue,
+            _context.Submit(
                 1,
                 &commandBuffer);
         }

--- a/src/ProGPU.Backend/GpuTextureReadbackBuffer.cs
+++ b/src/ProGPU.Backend/GpuTextureReadbackBuffer.cs
@@ -273,7 +273,7 @@ public unsafe sealed class GpuTextureReadbackBuffer : IDisposable
         var commandBufferDesc = new CommandBufferDescriptor();
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
     }

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -29,6 +29,7 @@ public enum WgpuBackendKind
 
 public unsafe class WgpuContext : IDisposable
 {
+    private const int DeferredReleaseDrainInterval = 8;
     private SharedDeviceLifetime? _sharedDeviceLifetime;
     private IWebGpuExternalDeviceLifetime? _externalDeviceLifetime;
     private WgpuDeviceResourceDomain? _deviceResourceDomain;
@@ -135,6 +136,7 @@ public unsafe class WgpuContext : IDisposable
     public readonly List<IDisposable> PendingExternalTextureOwners =
         new();
     private readonly HashSet<IntPtr> _pendingSnapshotSeen = new();
+    private int _deferredReleaseBatchCount;
 
     public void QueueBufferDisposal(IntPtr ptr)
     {
@@ -325,12 +327,24 @@ public unsafe class WgpuContext : IDisposable
                     }
                 }
 
-                if (views.Length > 0 || textures.Length > 0 || buffers.Length > 0 || bindGroups.Length > 0 ||
-                    layouts.Length > 0 || pipeLayouts.Length > 0 || renderPipes.Length > 0 ||
-                    computePipes.Length > 0 || samplers.Length > 0 || shaders.Length > 0 ||
-                    externalTextureOwners is not null)
+                // WebGPU command buffers retain ordinary referenced resources
+                // until submitted work completes, so dropping the application's
+                // native handle references must not serialize every frame on the
+                // device queue. Imported external storage is different: its
+                // platform owner sits outside WebGPU's reference graph and must
+                // remain alive until all previously submitted use has completed.
+                var hasWebGpuReferences =
+                    views.Length > 0 || textures.Length > 0 ||
+                    buffers.Length > 0 || bindGroups.Length > 0 ||
+                    layouts.Length > 0 || pipeLayouts.Length > 0 ||
+                    renderPipes.Length > 0 || computePipes.Length > 0 ||
+                    samplers.Length > 0 || shaders.Length > 0;
+                if (externalTextureOwners is not null ||
+                    (hasWebGpuReferences &&
+                     ++_deferredReleaseBatchCount >= DeferredReleaseDrainInterval))
                 {
                     WaitIdle();
+                    _deferredReleaseBatchCount = 0;
                 }
 
                 // Release dependants before their immutable ABI objects. This

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -29,7 +29,8 @@ public enum WgpuBackendKind
 
 public unsafe class WgpuContext : IDisposable
 {
-    private const int DeferredReleaseDrainInterval = 8;
+    private const int QueuePollSubmissionInterval = 32;
+    private const int MaxDeferredQueueSubmissions = 1024;
     private SharedDeviceLifetime? _sharedDeviceLifetime;
     private IWebGpuExternalDeviceLifetime? _externalDeviceLifetime;
     private WgpuDeviceResourceDomain? _deviceResourceDomain;
@@ -136,7 +137,27 @@ public unsafe class WgpuContext : IDisposable
     public readonly List<IDisposable> PendingExternalTextureOwners =
         new();
     private readonly HashSet<IntPtr> _pendingSnapshotSeen = new();
-    private int _deferredReleaseBatchCount;
+    private long _queueSubmissionCount;
+    private long _drainedQueueSubmissionCount;
+    private long _polledQueueSubmissionCount;
+
+    public void Submit(
+        nuint commandCount,
+        CommandBuffer** commandBuffers)
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        if (commandCount == 0)
+        {
+            return;
+        }
+        if (commandBuffers == null)
+        {
+            throw new ArgumentNullException(nameof(commandBuffers));
+        }
+
+        Api.QueueSubmit(Queue, commandCount, commandBuffers);
+        Interlocked.Increment(ref _queueSubmissionCount);
+    }
 
     public void QueueBufferDisposal(IntPtr ptr)
     {
@@ -330,21 +351,37 @@ public unsafe class WgpuContext : IDisposable
                 // WebGPU command buffers retain ordinary referenced resources
                 // until submitted work completes, so dropping the application's
                 // native handle references must not serialize every frame on the
-                // device queue. Imported external storage is different: its
+                // device queue. A periodic non-blocking poll retires completed
+                // work, and a fixed submission bound forces a full drain so
+                // native command/resource residency cannot grow with frame
+                // count. Imported external storage is different: its
                 // platform owner sits outside WebGPU's reference graph and must
                 // remain alive until all previously submitted use has completed.
-                var hasWebGpuReferences =
-                    views.Length > 0 || textures.Length > 0 ||
-                    buffers.Length > 0 || bindGroups.Length > 0 ||
-                    layouts.Length > 0 || pipeLayouts.Length > 0 ||
-                    renderPipes.Length > 0 || computePipes.Length > 0 ||
-                    samplers.Length > 0 || shaders.Length > 0;
+                var submittedQueueWork =
+                    Volatile.Read(ref _queueSubmissionCount);
+                var drainedQueueWork =
+                    Volatile.Read(ref _drainedQueueSubmissionCount);
+                var deferredQueueSubmissions =
+                    submittedQueueWork - drainedQueueWork;
                 if (externalTextureOwners is not null ||
-                    (hasWebGpuReferences &&
-                     ++_deferredReleaseBatchCount >= DeferredReleaseDrainInterval))
+                    deferredQueueSubmissions >= MaxDeferredQueueSubmissions)
                 {
                     WaitIdle();
-                    _deferredReleaseBatchCount = 0;
+                    Volatile.Write(
+                        ref _drainedQueueSubmissionCount,
+                        submittedQueueWork);
+                    Volatile.Write(
+                        ref _polledQueueSubmissionCount,
+                        submittedQueueWork);
+                }
+                else if (submittedQueueWork -
+                         Volatile.Read(ref _polledQueueSubmissionCount) >=
+                         QueuePollSubmissionInterval)
+                {
+                    PollDevice(wait: false);
+                    Volatile.Write(
+                        ref _polledQueueSubmissionCount,
+                        submittedQueueWork);
                 }
 
                 // Release dependants before their immutable ABI objects. This

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -29,8 +29,8 @@ public enum WgpuBackendKind
 
 public unsafe class WgpuContext : IDisposable
 {
-    private const int QueuePollSubmissionInterval = 32;
-    private const int MaxDeferredQueueSubmissions = 1024;
+    private const int QueuePollSubmissionInterval = 2;
+    private const int MaxDeferredQueueSubmissions = 8;
     private SharedDeviceLifetime? _sharedDeviceLifetime;
     private IWebGpuExternalDeviceLifetime? _externalDeviceLifetime;
     private WgpuDeviceResourceDomain? _deviceResourceDomain;

--- a/src/ProGPU.Compute/ComputeAccelerator.cs
+++ b/src/ProGPU.Compute/ComputeAccelerator.cs
@@ -751,7 +751,7 @@ public unsafe class ComputeAccelerator : IDisposable
         var cmdBuffer = _context.Api.CommandEncoderFinish(encoder, &cmdDesc);
         SilkMarshal.Free((nint)cmdDesc.Label);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+        _context.Submit(1, &cmdBuffer);
 
         // Release resources
         _context.Api.CommandBufferRelease(cmdBuffer);
@@ -832,7 +832,7 @@ public unsafe class ComputeAccelerator : IDisposable
         var commandDesc = new CommandBufferDescriptor { Label = (byte*)SilkMarshal.StringToPtr("Compute Morphology Buffer") };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDesc);
         SilkMarshal.Free((nint)commandDesc.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
         ReleaseBindGroups(bindGroupsToRelease[..bindGroupToReleaseCount]);
@@ -920,7 +920,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1037,7 +1037,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1125,7 +1125,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1205,7 +1205,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1300,7 +1300,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1372,7 +1372,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1459,7 +1459,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1538,7 +1538,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1608,7 +1608,7 @@ public unsafe class ComputeAccelerator : IDisposable
         };
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
         SilkMarshal.Free((nint)commandDescriptor.Label);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
 
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1863,7 +1863,7 @@ public unsafe class ComputeAccelerator : IDisposable
         var cmdBuffer = _context.Api.CommandEncoderFinish(encoder, &cmdDesc);
         SilkMarshal.Free((nint)cmdDesc.Label);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+        _context.Submit(1, &cmdBuffer);
 
         _context.Api.CommandBufferRelease(cmdBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -1934,7 +1934,7 @@ public unsafe class ComputeAccelerator : IDisposable
         var cmdBuffer = _context.Api.CommandEncoderFinish(encoder, &cmdDesc);
         SilkMarshal.Free((nint)cmdDesc.Label);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+        _context.Submit(1, &cmdBuffer);
 
         _context.Api.CommandBufferRelease(cmdBuffer);
         _context.Api.CommandEncoderRelease(encoder);
@@ -2028,7 +2028,7 @@ public unsafe class ComputeAccelerator : IDisposable
 
         var commandDescriptor = new CommandBufferDescriptor();
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
     }
@@ -2060,7 +2060,7 @@ public unsafe class ComputeAccelerator : IDisposable
         RunComputePass(encoder, _combinedBlurVertPipeline, verticalBinding, width, height);
         var commandDescriptor = new CommandBufferDescriptor();
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
     }

--- a/src/ProGPU.Compute/GpuOpenTypeRunPipeline.cs
+++ b/src/ProGPU.Compute/GpuOpenTypeRunPipeline.cs
@@ -345,7 +345,7 @@ public unsafe sealed class GpuOpenTypeRunPipeline : IDisposable
             CommandBufferDescriptor commandDescriptor = default;
             CommandBuffer* command = _context.Api.CommandEncoderFinish(encoder, &commandDescriptor);
             if (command == null) throw new InvalidOperationException("Failed to finish the OpenType shaping command buffer.");
-            try { _context.Api.QueueSubmit(_context.Queue, 1, &command); }
+            try { _context.Submit(1, &command); }
             finally { _context.Api.CommandBufferRelease(command); }
         }
         finally

--- a/src/ProGPU.DirectX/ProGpuDirectXDeviceContext.cs
+++ b/src/ProGPU.DirectX/ProGpuDirectXDeviceContext.cs
@@ -1415,7 +1415,7 @@ public sealed unsafe class ProGpuDirectXDeviceContext : IDisposable
             commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 command.Texture?.MarkBackendContentsChanged();
                 SubmittedClearCount++;
             }
@@ -1479,7 +1479,7 @@ public sealed unsafe class ProGpuDirectXDeviceContext : IDisposable
             commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 SubmittedCopyCount++;
             }
         }
@@ -1591,7 +1591,7 @@ public sealed unsafe class ProGpuDirectXDeviceContext : IDisposable
             commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 destinationResource.MarkBackendContentsChanged();
                 SubmittedResolveCount++;
             }
@@ -1730,7 +1730,7 @@ public sealed unsafe class ProGpuDirectXDeviceContext : IDisposable
             commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 command.Texture?.MarkBackendContentsChanged();
                 SubmittedClearCount++;
             }
@@ -2039,7 +2039,7 @@ public sealed unsafe class ProGpuDirectXDeviceContext : IDisposable
             commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 command.Texture?.MarkBackendContentsChanged();
                 SubmittedDrawCount++;
             }
@@ -2531,7 +2531,7 @@ public sealed unsafe class ProGpuDirectXDeviceContext : IDisposable
             commandBuffer = context.Api.CommandEncoderFinish(encoder, &commandBufferDesc);
             if (commandBuffer != null)
             {
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 SubmittedDispatchCount++;
             }
         }

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -3560,7 +3560,7 @@ SceneStateUploadComplete:
             encoder,
             "Compositor Command Buffer\0"u8);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+        _context.Submit(1, &cmdBuffer);
         RecallSubmittedSceneUpload();
 
         _context.Api.CommandBufferRelease(cmdBuffer);
@@ -15029,7 +15029,7 @@ SceneStateUploadComplete:
             encoder,
             "Offscreen Compositor Command Buffer\0"u8);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+        _context.Submit(1, &cmdBuffer);
         RecallSubmittedSceneUpload();
 
         _context.Api.CommandBufferRelease(cmdBuffer);

--- a/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/Mesh3DExtensionPipeline.cs
@@ -1689,7 +1689,7 @@ namespace ProGPU.Scene.Extensions
                     buffers[i] = (CommandBuffer*)_pendingCommandBuffers[i];
                 }
 
-                wgpu.QueueSubmit(queue, (uint)count, buffers);
+                compositor.Context.Submit((uint)count, buffers);
 
                 for (int i = 0; i < count; i++)
                 {

--- a/src/ProGPU.Scene/Extensions/VoxelTerrainExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/VoxelTerrainExtensionPipeline.cs
@@ -209,8 +209,7 @@ public sealed unsafe class VoxelTerrainExtensionPipeline : ICompositorExtension,
             buffers[index] = (CommandBuffer*)_pendingCommandBuffers[index];
         }
 
-        compositor.Context.Api.QueueSubmit(
-            compositor.Context.Queue,
+        compositor.Context.Submit(
             (uint)_pendingCommandBuffers.Count,
             buffers);
         ReleasePendingCommandBuffers(compositor.Context);

--- a/src/ProGPU.Tests/SkImageApiParityTests.cs
+++ b/src/ProGPU.Tests/SkImageApiParityTests.cs
@@ -178,6 +178,43 @@ public sealed class SkImageApiParityTests
     }
 
     [Fact]
+    public unsafe void TextureBackedSubsetReadPixelsUsesViewRelativeCoordinates()
+    {
+        using var surface = SKSurface.Create(
+            new SKImageInfo(3, 1, SKColorType.Rgba8888, SKAlphaType.Premul));
+        using var red = new SKPaint { Color = SKColors.Red };
+        using var green = new SKPaint { Color = SKColors.Green };
+        using var blue = new SKPaint { Color = SKColors.Blue };
+        surface.Canvas.DrawRect(0, 0, 1, 1, red);
+        surface.Canvas.DrawRect(1, 0, 1, 1, green);
+        surface.Canvas.DrawRect(2, 0, 1, 1, blue);
+        using var subset = surface.Snapshot(new SKRectI(1, 0, 3, 1));
+        var destination = new byte[8];
+        fixed (byte* destinationAddress = destination)
+        {
+            Assert.True(subset.ReadPixels(
+                new SKImageInfo(
+                    2,
+                    1,
+                    SKColorType.Rgba8888,
+                    SKAlphaType.Premul),
+                (IntPtr)destinationAddress,
+                8,
+                0,
+                0,
+                SKImageCachingHint.Disallow));
+        }
+
+        Assert.Equal(
+            new byte[]
+            {
+                0, 128, 0, 255,
+                0, 0, 255, 255
+            },
+            destination);
+    }
+
+    [Fact]
     public void DrawingSubsetMaterializesOnlyItsComposedTextureRegion()
     {
         using var image = SKImage.FromPixelCopy(

--- a/src/ProGPU.Tests/SkSurfaceApiParityTests.cs
+++ b/src/ProGPU.Tests/SkSurfaceApiParityTests.cs
@@ -91,6 +91,55 @@ public sealed class SkSurfaceApiParityTests
     }
 
     [Fact]
+    public unsafe void ExternalPixelSnapshotReadbackRemainsImmutableAcrossSurfaceFrames()
+    {
+        var info = new SKImageInfo(
+            2,
+            2,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        var surfacePixels = new byte[info.BytesSize];
+        var firstPixels = new byte[info.BytesSize];
+        var secondPixels = new byte[info.BytesSize];
+        fixed (byte* surfaceAddress = surfacePixels)
+        fixed (byte* firstAddress = firstPixels)
+        fixed (byte* secondAddress = secondPixels)
+        {
+            using var surface = SKSurface.Create(
+                info,
+                (IntPtr)surfaceAddress,
+                info.RowBytes);
+            surface.Canvas.Clear(SKColors.Red);
+            using var first = surface.Snapshot();
+
+            surface.Canvas.Clear(SKColors.Blue);
+            using var second = surface.Snapshot();
+
+            Assert.True(first.ReadPixels(
+                info,
+                (IntPtr)firstAddress,
+                info.RowBytes));
+            Assert.True(second.ReadPixels(
+                info,
+                (IntPtr)secondAddress,
+                info.RowBytes));
+        }
+
+        Assert.All(Enumerable.Range(0, 4), index =>
+        {
+            Assert.Equal(255, firstPixels[index * 4]);
+            Assert.Equal(0, firstPixels[index * 4 + 1]);
+            Assert.Equal(0, firstPixels[index * 4 + 2]);
+            Assert.Equal(255, firstPixels[index * 4 + 3]);
+
+            Assert.Equal(0, secondPixels[index * 4]);
+            Assert.Equal(0, secondPixels[index * 4 + 1]);
+            Assert.Equal(255, secondPixels[index * 4 + 2]);
+            Assert.Equal(255, secondPixels[index * 4 + 3]);
+        });
+    }
+
+    [Fact]
     public void RasterSurfaceCreatesOneLazyStableCpuView()
     {
         using var surface = SKSurface.Create(

--- a/src/ProGPU.Tests/SkSurfaceApiParityTests.cs
+++ b/src/ProGPU.Tests/SkSurfaceApiParityTests.cs
@@ -140,6 +140,42 @@ public sealed class SkSurfaceApiParityTests
     }
 
     [Fact]
+    public unsafe void ExternalPixelSurfaceReadPixelsUsesTheCurrentFrame()
+    {
+        var info = new SKImageInfo(
+            2,
+            2,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        var surfacePixels = new byte[info.BytesSize];
+        var destinationPixels = new byte[info.BytesSize];
+        fixed (byte* surfaceAddress = surfacePixels)
+        fixed (byte* destinationAddress = destinationPixels)
+        {
+            using var surface = SKSurface.Create(
+                info,
+                (IntPtr)surfaceAddress,
+                info.RowBytes);
+            surface.Canvas.Clear(SKColors.Blue);
+
+            Assert.True(surface.ReadPixels(
+                info,
+                (IntPtr)destinationAddress,
+                info.RowBytes,
+                0,
+                0));
+        }
+
+        Assert.All(Enumerable.Range(0, 4), index =>
+        {
+            Assert.Equal(0, destinationPixels[index * 4]);
+            Assert.Equal(0, destinationPixels[index * 4 + 1]);
+            Assert.Equal(255, destinationPixels[index * 4 + 2]);
+            Assert.Equal(255, destinationPixels[index * 4 + 3]);
+        });
+    }
+
+    [Fact]
     public void RasterSurfaceCreatesOneLazyStableCpuView()
     {
         using var surface = SKSurface.Create(

--- a/src/ProGPU.Tests/SkSurfaceBackendRenderTargetTests.cs
+++ b/src/ProGPU.Tests/SkSurfaceBackendRenderTargetTests.cs
@@ -178,6 +178,60 @@ public sealed class SkSurfaceBackendRenderTargetTests
         AssertPixel(pixels, 8, 6, 1, 0, 0, 255, 255);
     }
 
+    [Fact]
+    public void ReleasedSnapshotGenerationReusesTheSurfaceBackingTexture()
+    {
+        using var surface = SKSurface.Create(
+            new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.Red);
+        using var first = surface.Snapshot();
+        var firstTexture = first.Texture;
+        first.Dispose();
+
+        surface.Canvas.Clear(SKColors.Blue);
+        surface.Flush();
+        using var second = surface.Snapshot();
+
+        Assert.Same(firstTexture, second.Texture);
+        AssertPixel(second.Texture.ReadPixels(), 4, 2, 2, 0, 0, 255, 255);
+    }
+
+    [Fact]
+    public void RetainedSnapshotGenerationCopiesOnTheNextSurfaceWrite()
+    {
+        using var surface = SKSurface.Create(
+            new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.Red);
+        using var first = surface.Snapshot();
+
+        surface.Canvas.Clear(SKColors.Blue);
+        surface.Flush();
+        using var second = surface.Snapshot();
+
+        Assert.NotSame(first.Texture, second.Texture);
+        AssertPixel(first.Texture.ReadPixels(), 4, 2, 2, 255, 0, 0, 255);
+        AssertPixel(second.Texture.ReadPixels(), 4, 2, 2, 0, 0, 255, 255);
+    }
+
+    [Fact]
+    public void DeferredSurfaceDrawKeepsTheRecordedSourceGenerationImmutable()
+    {
+        using var source = SKSurface.Create(
+            new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul));
+        using var destination = SKSurface.Create(
+            new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul));
+        source.Canvas.Clear(SKColors.Red);
+        source.Draw(destination.Canvas, 0f, 0f, null);
+
+        source.Canvas.Clear(SKColors.Blue);
+        destination.Flush();
+
+        using var sourceSnapshot = source.Snapshot();
+        using var destinationSnapshot = destination.Snapshot();
+        AssertPixel(sourceSnapshot.Texture.ReadPixels(), 4, 2, 2, 0, 0, 255, 255);
+        AssertPixel(destinationSnapshot.Texture.ReadPixels(), 4, 2, 2, 255, 0, 0, 255);
+    }
+
     [Theory]
     [InlineData(SKBlendMode.Multiply)]
     [InlineData(SKBlendMode.Screen)]

--- a/src/ProGPU.Tests/SkSurfaceBackendRenderTargetTests.cs
+++ b/src/ProGPU.Tests/SkSurfaceBackendRenderTargetTests.cs
@@ -160,6 +160,50 @@ public sealed class SkSurfaceBackendRenderTargetTests
     }
 
     [Fact]
+    public void BgraBackendSurfaceReadPixelsConvertsToRequestedRgba()
+    {
+        using var grContext = GRContext.CreateGl() ??
+            throw new InvalidOperationException("Failed to create GRContext.");
+        using var texture = new GpuTexture(
+            grContext.Context,
+            2,
+            2,
+            TextureFormat.Bgra8Unorm,
+            TextureUsage.RenderAttachment | TextureUsage.CopySrc |
+            TextureUsage.CopyDst | TextureUsage.TextureBinding,
+            "SKSurface wrapped BGRA direct readback test");
+        using var renderTarget = new GRBackendRenderTarget(2, 2, texture);
+        using var surface = SKSurface.Create(
+            grContext,
+            renderTarget,
+            GRSurfaceOrigin.TopLeft,
+            SKColorType.Bgra8888);
+        surface.Canvas.Clear(SKColors.Red);
+
+        var pixels = Marshal.AllocHGlobal(16);
+        try
+        {
+            Assert.True(surface.ReadPixels(
+                new SKImageInfo(
+                    2,
+                    2,
+                    SKColorType.Rgba8888,
+                    SKAlphaType.Premul),
+                pixels,
+                8,
+                0,
+                0));
+            var readback = new byte[16];
+            Marshal.Copy(pixels, readback, 0, readback.Length);
+            AssertPixel(readback, 2, 1, 1, 255, 0, 0, 255);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(pixels);
+        }
+    }
+
+    [Fact]
     public void RepeatedFlushesPreserveExistingGpuSurfaceContents()
     {
         using var surface = SKSurface.Create(new SKImageInfo(8, 4, SKColorType.Rgba8888, SKAlphaType.Premul));

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -130,7 +130,7 @@ public sealed class WgpuContextTests
             BrowserWebGpuApi.QueueHandle,
             TextureFormat.Bgra8Unorm);
 
-        for (var index = 0; index < 1024; index++)
+        for (var index = 0; index < 8; index++)
         {
             using (var texture = new GpuTexture(
                        context,
@@ -144,14 +144,14 @@ public sealed class WgpuContextTests
             var commandBuffer = (CommandBuffer*)1;
             context.Submit(1, &commandBuffer);
             context.CleanupPendingResources();
-            if (index < 1023)
+            if (index < 7)
             {
                 Assert.Equal(0, lifetime.WaitingPollCount);
             }
         }
 
         Assert.Equal(1, lifetime.WaitingPollCount);
-        Assert.Equal(31, lifetime.NonBlockingPollCount);
+        Assert.Equal(3, lifetime.NonBlockingPollCount);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -69,6 +69,85 @@ public sealed class WgpuContextTests
     }
 
     [Fact]
+    public unsafe void PendingWebGpuReferenceCleanupDoesNotWaitForTheQueue()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext();
+        context.InitializeExternalNativeDevice(
+            api,
+            lifetime,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm);
+        using (var texture = new GpuTexture(
+                   context,
+                   4,
+                   4,
+                   TextureFormat.Rgba8Unorm,
+                   TextureUsage.TextureBinding | TextureUsage.CopyDst))
+        {
+        }
+
+        context.CleanupPendingResources();
+
+        Assert.Equal(0, lifetime.WaitingPollCount);
+        Assert.Empty(context.PendingTextureViews);
+        Assert.Empty(context.PendingTextures);
+    }
+
+    [Fact]
+    public unsafe void ExternalTextureOwnerCleanupWaitsForTheQueue()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext();
+        context.InitializeExternalNativeDevice(
+            api,
+            lifetime,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm);
+        var owner = new RecordingDisposable();
+        context.QueueExternalTextureOwnerDisposal(owner);
+
+        context.CleanupPendingResources();
+
+        Assert.Equal(1, lifetime.WaitingPollCount);
+        Assert.True(owner.IsDisposed);
+    }
+
+    [Fact]
+    public unsafe void DeferredWebGpuReferenceCleanupDrainsAtABoundedInterval()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext();
+        context.InitializeExternalNativeDevice(
+            api,
+            lifetime,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm);
+
+        for (var index = 0; index < 8; index++)
+        {
+            using (var texture = new GpuTexture(
+                       context,
+                       4,
+                       4,
+                       TextureFormat.Rgba8Unorm,
+                       TextureUsage.TextureBinding | TextureUsage.CopyDst))
+            {
+            }
+
+            context.CleanupPendingResources();
+        }
+
+        Assert.Equal(1, lifetime.WaitingPollCount);
+    }
+
+    [Fact]
     public void Tier1TextureFormatsFailBeforeBackendAllocationWhenUnsupported()
     {
         using var context = new WgpuContext();

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -130,7 +130,7 @@ public sealed class WgpuContextTests
             BrowserWebGpuApi.QueueHandle,
             TextureFormat.Bgra8Unorm);
 
-        for (var index = 0; index < 8; index++)
+        for (var index = 0; index < 1024; index++)
         {
             using (var texture = new GpuTexture(
                        context,
@@ -141,10 +141,17 @@ public sealed class WgpuContextTests
             {
             }
 
+            var commandBuffer = (CommandBuffer*)1;
+            context.Submit(1, &commandBuffer);
             context.CleanupPendingResources();
+            if (index < 1023)
+            {
+                Assert.Equal(0, lifetime.WaitingPollCount);
+            }
         }
 
         Assert.Equal(1, lifetime.WaitingPollCount);
+        Assert.Equal(31, lifetime.NonBlockingPollCount);
     }
 
     [Fact]

--- a/src/ProGPU.Text/GlyphAtlas.cs
+++ b/src/ProGPU.Text/GlyphAtlas.cs
@@ -260,7 +260,7 @@ public unsafe class GlyphAtlas : IDisposable
             _batchEncoder,
             "Glyph Rasterizer Batch Command Buffer\0"u8);
 
-        _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+        _context.Submit(1, &cmdBuffer);
         RasterBatchSubmissionCount++;
 
         _context.Api.CommandBufferRelease(cmdBuffer);
@@ -976,7 +976,7 @@ public unsafe class GlyphAtlas : IDisposable
                                     encoder,
                                     "Glyph Rasterizer Command Buffer\0"u8);
 
-                                _context.Api.QueueSubmit(_context.Queue, 1, &cmdBuffer);
+                                _context.Submit(1, &cmdBuffer);
 
                                 // Clean up temporary resources
                                 _context.Api.CommandBufferRelease(cmdBuffer);
@@ -1095,7 +1095,7 @@ public unsafe class GlyphAtlas : IDisposable
             height);
         var commandBufferDescriptor = new CommandBufferDescriptor();
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandBufferDescriptor);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
         _context.Api.BindGroupRelease(bindGroup);
@@ -1693,7 +1693,7 @@ public unsafe class GlyphAtlas : IDisposable
             size);
         var commandBufferDescriptor = new CommandBufferDescriptor();
         var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandBufferDescriptor);
-        _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+        _context.Submit(1, &commandBuffer);
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
     }

--- a/src/ProGPU.Uno/ProGpuHostControl.cs
+++ b/src/ProGPU.Uno/ProGpuHostControl.cs
@@ -505,7 +505,7 @@ public unsafe class ProGpuHostControl : ContentControl
             var cmdBufferDesc = new CommandBufferDescriptor();
             var cmdBuffer = _wgpuContext.Api.CommandEncoderFinish(encoder, &cmdBufferDesc);
             
-            _wgpuContext.Api.QueueSubmit(_wgpuContext.Queue, 1, &cmdBuffer);
+            _wgpuContext.Submit(1, &cmdBuffer);
             _wgpuContext.Api.CommandBufferRelease(cmdBuffer);
             _wgpuContext.Api.CommandEncoderRelease(encoder);
 

--- a/src/ProGPU.Vector/GpuHitTesting.cs
+++ b/src/ProGPU.Vector/GpuHitTesting.cs
@@ -1201,7 +1201,7 @@ public static unsafe class GpuHitTestEngine
                     throw new InvalidOperationException("Failed to finish GPU hit-test command encoder.");
                 }
 
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 context.Api.CommandBufferRelease(commandBuffer);
                 commandBuffer = null;
                 context.Api.CommandEncoderRelease(encoder);
@@ -1512,7 +1512,7 @@ public static unsafe class GpuHitTestEngine
                     throw new InvalidOperationException("Failed to finish GPU hit-test command encoder.");
                 }
 
-                context.Api.QueueSubmit(context.Queue, 1, &commandBuffer);
+                context.Submit(1, &commandBuffer);
                 context.Api.CommandBufferRelease(commandBuffer);
                 commandBuffer = null;
                 context.Api.CommandEncoderRelease(encoder);

--- a/src/ProGPU.Vector/PathAtlas.cs
+++ b/src/ProGPU.Vector/PathAtlas.cs
@@ -3785,7 +3785,7 @@ public unsafe class PathAtlas : IDisposable
             };
             var commandBuffer = _context.Api.CommandEncoderFinish(encoder, &commandBufferDescriptor);
             SilkMarshal.Free((nint)commandBufferDescriptor.Label);
-            _context.Api.QueueSubmit(_context.Queue, 1, &commandBuffer);
+            _context.Submit(1, &commandBuffer);
 
             _context.Api.CommandBufferRelease(commandBuffer);
             _context.Api.CommandEncoderRelease(encoder);

--- a/src/ProGPU.Vector/PathOpGeometrySolver.cs
+++ b/src/ProGPU.Vector/PathOpGeometrySolver.cs
@@ -349,7 +349,7 @@ namespace ProGPU.Vector
                 _cmdBuffer = _context.Api.CommandEncoderFinish(_encoder, &cmdDesc);
                 SilkMarshal.Free((nint)cmdDesc.Label);
                 var submittedCommandBuffer = _cmdBuffer;
-                _context.Api.QueueSubmit(_context.Queue, 1, &submittedCommandBuffer);
+                _context.Submit(1, &submittedCommandBuffer);
                 _context.Api.CommandBufferRelease(_cmdBuffer);
                 _cmdBuffer = null;
                 _context.Api.CommandEncoderRelease(_encoder);

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -34,6 +34,9 @@ public partial class SKImage : SKObject
         private int _ownsTexture;
         private readonly SKImageTextureReleaseDelegate? _releaseProc;
         private readonly object? _releaseContext;
+        private readonly object _readbackLock = new();
+        private GpuTextureReadbackBuffer? _readbackBuffer;
+        private byte[]? _readbackPixels;
 
         public TextureStorage(
             GpuTexture texture,
@@ -63,6 +66,32 @@ public partial class SKImage : SKObject
         public byte[]? PortableRgbaPixels { get; }
         public int PortableRowWidth { get; }
         public bool IsTextureBacked { get; }
+
+        public object ReadbackLock => _readbackLock;
+
+        public byte[] ReadTexturePixels()
+        {
+            var byteCount = checked(
+                (int)(Texture.Width * Texture.Height * 4));
+            if (_readbackPixels is null ||
+                _readbackPixels.Length != byteCount)
+            {
+                _readbackPixels =
+                    GC.AllocateUninitializedArray<byte>(byteCount);
+            }
+
+            _readbackBuffer ??= new GpuTextureReadbackBuffer(Texture.Context);
+            try
+            {
+                Texture.ReadPixels(_readbackPixels, _readbackBuffer);
+            }
+            finally
+            {
+                Texture.Context.CleanupPendingResources();
+            }
+
+            return _readbackPixels;
+        }
 
         bool IProGpuTextureSource.TryGetGpuTexture(out GpuTexture texture) =>
             TryGetGpuTexture(Texture.Context, out texture);
@@ -156,6 +185,13 @@ public partial class SKImage : SKObject
             if (Volatile.Read(ref _ownsTexture) != 0)
             {
                 Texture.Dispose();
+            }
+
+            lock (_readbackLock)
+            {
+                _readbackBuffer?.Dispose();
+                _readbackBuffer = null;
+                _readbackPixels = null;
             }
 
             _releaseProc?.Invoke(_releaseContext!);
@@ -787,14 +823,24 @@ public partial class SKImage : SKObject
             }
         }
 
-        byte[] pixels = ReadTexturePixelsAsRgba8888();
-        fixed (byte* sourcePixels = pixels)
+        lock (_textureStorage.ReadbackLock)
         {
-            using var source = new SKPixmap(
-                CreateReadbackInfo(),
-                (IntPtr)sourcePixels,
-                checked(Width * 4));
-            return source.ReadPixels(dstInfo, dstPixels, dstRowBytes, srcX, srcY);
+            byte[] pixels = _textureStorage.ReadTexturePixels();
+            fixed (byte* sourcePixels = pixels)
+            {
+                var sourceOffset = checked(
+                    (_originY * (int)Texture.Width + _originX) * 4);
+                using var source = new SKPixmap(
+                    CreateNativeTextureReadbackInfo(),
+                    (IntPtr)(sourcePixels + sourceOffset),
+                    checked((int)Texture.Width * 4));
+                return source.ReadPixels(
+                    dstInfo,
+                    dstPixels,
+                    dstRowBytes,
+                    srcX,
+                    srcY);
+            }
         }
     }
 
@@ -988,6 +1034,18 @@ public partial class SKImage : SKObject
         Width,
         Height,
         SKColorType.Rgba8888,
+        Texture.AlphaMode == GpuTextureAlphaMode.Straight
+            ? SKAlphaType.Unpremul
+            : SKAlphaType.Premul,
+        ColorSpace);
+
+    private SKImageInfo CreateNativeTextureReadbackInfo() => new(
+        Width,
+        Height,
+        Texture.Format is TextureFormat.Bgra8Unorm or
+            TextureFormat.Bgra8UnormSrgb
+                ? SKColorType.Bgra8888
+                : SKColorType.Rgba8888,
         Texture.AlphaMode == GpuTextureAlphaMode.Straight
             ? SKAlphaType.Unpremul
             : SKAlphaType.Premul,

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -31,7 +31,7 @@ public partial class SKImage : SKObject
     private sealed class TextureStorage : IProGpuContextTextureLeaseSource
     {
         private int _referenceCount = 1;
-        private readonly bool _ownsTexture;
+        private int _ownsTexture;
         private readonly SKImageTextureReleaseDelegate? _releaseProc;
         private readonly object? _releaseContext;
 
@@ -45,7 +45,7 @@ public partial class SKImage : SKObject
             object? releaseContext = null)
         {
             Texture = texture;
-            _ownsTexture = ownsTexture;
+            _ownsTexture = ownsTexture ? 1 : 0;
             ColorType = info.ColorType;
             AlphaType = info.AlphaType;
             ColorSpace = info.ColorSpace;
@@ -153,12 +153,25 @@ public partial class SKImage : SKObject
                 return;
             }
 
-            if (_ownsTexture)
+            if (Volatile.Read(ref _ownsTexture) != 0)
             {
                 Texture.Dispose();
             }
 
             _releaseProc?.Invoke(_releaseContext!);
+        }
+
+        public bool TryRelinquishSoleTextureOwnership()
+        {
+            if (Volatile.Read(ref _ownsTexture) == 0 ||
+                Interlocked.CompareExchange(ref _referenceCount, -1, 1) != 1)
+            {
+                return false;
+            }
+
+            Interlocked.Exchange(ref _ownsTexture, 0);
+            Volatile.Write(ref _referenceCount, 1);
+            return true;
         }
     }
 
@@ -517,6 +530,13 @@ public partial class SKImage : SKObject
             subset.Height,
             checked(_originX + subset.Left),
             checked(_originY + subset.Top));
+    }
+
+    internal bool TryRelinquishSoleTextureOwnership()
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        return IsWholeTexture &&
+            _textureStorage.TryRelinquishSoleTextureOwnership();
     }
 
     private static uint CalculateMipLevelCount(uint width, uint height)

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -157,10 +157,17 @@ public partial class SKImage : SKObject
 
         public void AddReference()
         {
+            var spin = new SpinWait();
             while (true)
             {
                 var count = Volatile.Read(ref _referenceCount);
-                if (count <= 0)
+                if (count == -1)
+                {
+                    spin.SpinOnce();
+                    continue;
+                }
+
+                if (count == 0)
                 {
                     throw new ObjectDisposedException(nameof(SKImage));
                 }
@@ -177,7 +184,33 @@ public partial class SKImage : SKObject
 
         public void ReleaseReference()
         {
-            if (Interlocked.Decrement(ref _referenceCount) != 0)
+            var spin = new SpinWait();
+            int remaining;
+            while (true)
+            {
+                var count = Volatile.Read(ref _referenceCount);
+                if (count == -1)
+                {
+                    spin.SpinOnce();
+                    continue;
+                }
+
+                if (count <= 0)
+                {
+                    return;
+                }
+
+                remaining = count - 1;
+                if (Interlocked.CompareExchange(
+                        ref _referenceCount,
+                        remaining,
+                        count) == count)
+                {
+                    break;
+                }
+            }
+
+            if (remaining != 0)
             {
                 return;
             }

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -479,13 +479,16 @@ public partial class SKImage : SKObject
         }
     }
 
-    internal static SKImage FromOwnedTexture(GpuTexture texture, SKImageInfo? info = null)
+    internal static SKImage FromOwnedTexture(
+        GpuTexture texture,
+        SKImageInfo? info = null,
+        byte[]? portableRgbaPixels = null)
     {
         return new SKImage(
             texture,
             ownsTexture: true,
             info ?? CreateTextureInfo(texture),
-            portableRgbaPixels: null);
+            portableRgbaPixels);
     }
 
     internal static SKImage FromBorrowedTexture(GpuTexture texture, SKImageInfo info)
@@ -741,6 +744,27 @@ public partial class SKImage : SKObject
         if (dstPixels == IntPtr.Zero)
         {
             return false;
+        }
+
+        var portablePixels = _textureStorage.PortableRgbaPixels;
+        if (portablePixels is not null)
+        {
+            fixed (byte* portableBase = portablePixels)
+            {
+                var portableRowBytes = checked(_textureStorage.PortableRowWidth * 4);
+                var portableOffset = checked(
+                    (_originY * _textureStorage.PortableRowWidth + _originX) * 4);
+                using var source = new SKPixmap(
+                    CreateReadbackInfo(),
+                    (IntPtr)(portableBase + portableOffset),
+                    portableRowBytes);
+                return source.ReadPixels(
+                    dstInfo,
+                    dstPixels,
+                    dstRowBytes,
+                    srcX,
+                    srcY);
+            }
         }
 
         byte[] pixels = ReadTexturePixelsAsRgba8888();

--- a/src/SkiaSharp/SKSurface.Compatibility.cs
+++ b/src/SkiaSharp/SKSurface.Compatibility.cs
@@ -42,7 +42,7 @@ public partial class SKSurface
         return true;
     }
 
-    public bool ReadPixels(
+    public unsafe bool ReadPixels(
         SKImageInfo dstInfo,
         IntPtr dstPixels,
         int dstRowBytes,
@@ -55,8 +55,39 @@ public partial class SKSurface
         }
 
         Flush();
-        using var image = new SKImage(_gpuTexture);
-        return image.ReadPixels(dstInfo, dstPixels, dstRowBytes, srcX, srcY);
+        if (_pixels != IntPtr.Zero)
+        {
+            using var cpuSource = new SKPixmap(
+                new SKImageInfo(
+                    _width,
+                    _height,
+                    _colorType,
+                    _alphaType,
+                    _colorSpace),
+                _pixels,
+                _rowBytes);
+            return cpuSource.ReadPixels(
+                dstInfo,
+                dstPixels,
+                dstRowBytes,
+                srcX,
+                srcY);
+        }
+
+        var readbackPixels = ReadBackingTexturePixels();
+        fixed (byte* readbackAddress = readbackPixels)
+        {
+            using var gpuSource = new SKPixmap(
+                CreateBackingTextureReadbackInfo(),
+                (IntPtr)readbackAddress,
+                checked(_width * 4));
+            return gpuSource.ReadPixels(
+                dstInfo,
+                dstPixels,
+                dstRowBytes,
+                srcX,
+                srcY);
+        }
     }
 
     public void Flush(bool submit, bool synchronous = false)

--- a/src/SkiaSharp/SKSurface.cs
+++ b/src/SkiaSharp/SKSurface.cs
@@ -567,9 +567,22 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
                 (uint)_width,
                 (uint)_height);
 
+            // A CPU-backed surface has already completed the required GPU
+            // readback during Flush. Transfer that immutable generation to the
+            // snapshot so ReadPixels and cross-context materialization do not
+            // map the same frame a second time. The surface allocates its next
+            // readback generation only after a subsequent drawing mutation.
+            var portableRgbaPixels = _pixels != IntPtr.Zero
+                ? _readbackPixels
+                : null;
             var generation = SKImage.FromOwnedTexture(
                 snapshotTexture,
-                new SKImageInfo(_width, _height, _colorType, _alphaType, _colorSpace));
+                new SKImageInfo(_width, _height, _colorType, _alphaType, _colorSpace),
+                portableRgbaPixels);
+            if (portableRgbaPixels is not null)
+            {
+                _readbackPixels = null;
+            }
             if (!_ownsTexture)
             {
                 var view = generation.CreateSharedTextureView(bounds);

--- a/src/SkiaSharp/SKSurface.cs
+++ b/src/SkiaSharp/SKSurface.cs
@@ -12,7 +12,7 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
     private static readonly object s_compositorCacheScope = new();
     private readonly WgpuContext? _context;
     private readonly DrawingContext _drawingContext;
-    private readonly GpuTexture? _gpuTexture;
+    private GpuTexture? _gpuTexture;
     private IntPtr _pixels;
     private int _rowBytes;
     private readonly int _width;
@@ -30,6 +30,7 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
     private GpuTextureReadbackBuffer? _readbackBuffer;
     private byte[]? _readbackPixels;
     private bool _hasTextureContents;
+    private bool _surfaceOwnsCurrentTexture;
     private bool _ownsCpuPixels;
     private int _releaseInvoked;
     private SKImage? _immutableSnapshotGeneration;
@@ -75,6 +76,7 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
         _height = height;
         _gpuTexture = texture;
         _ownsTexture = ownsTexture;
+        _surfaceOwnsCurrentTexture = ownsTexture;
         _pixels = pixels;
         _rowBytes = pixels != IntPtr.Zero
             ? ResolveCpuSurfaceRowBytes(width, height, rowBytes, colorType, nameof(rowBytes))
@@ -548,25 +550,6 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
 
         if (_immutableSnapshotGeneration is null || !_ownsTexture)
         {
-            var snapshotTexture = new GpuTexture(
-                _context!,
-                (uint)_width,
-                (uint)_height,
-                _gpuTexture.Format,
-                TextureUsage.TextureBinding | TextureUsage.CopyDst | TextureUsage.CopySrc,
-                "SKSurface Immutable Snapshot Generation",
-                alphaMode: _gpuTexture.AlphaMode
-            );
-
-            snapshotTexture.CopyBaseLevelRegionFrom(
-                _gpuTexture,
-                0,
-                0,
-                0,
-                0,
-                (uint)_width,
-                (uint)_height);
-
             // A CPU-backed surface has already completed the required GPU
             // readback during Flush. Transfer that immutable generation to the
             // snapshot so ReadPixels and cross-context materialization do not
@@ -575,10 +558,51 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
             var portableRgbaPixels = _pixels != IntPtr.Zero
                 ? _readbackPixels
                 : null;
-            var generation = SKImage.FromOwnedTexture(
-                snapshotTexture,
-                new SKImageInfo(_width, _height, _colorType, _alphaType, _colorSpace),
-                portableRgbaPixels);
+            SKImage generation;
+            if (_ownsTexture)
+            {
+                // The immutable generation temporarily owns the surface backing.
+                // A subsequent write either reclaims it in O(1) when no snapshot
+                // lease remains, or performs one copy-on-write when a consumer
+                // still retains the old pixels.
+                generation = SKImage.FromOwnedTexture(
+                    _gpuTexture,
+                    new SKImageInfo(_width, _height, _colorType, _alphaType, _colorSpace),
+                    portableRgbaPixels);
+                _surfaceOwnsCurrentTexture = false;
+            }
+            else
+            {
+                var snapshotTexture = new GpuTexture(
+                    _context!,
+                    (uint)_width,
+                    (uint)_height,
+                    _gpuTexture.Format,
+                    TextureUsage.TextureBinding | TextureUsage.CopyDst | TextureUsage.CopySrc,
+                    "SKSurface Immutable Snapshot Generation",
+                    alphaMode: _gpuTexture.AlphaMode);
+                try
+                {
+                    snapshotTexture.CopyBaseLevelRegionFrom(
+                        _gpuTexture,
+                        0,
+                        0,
+                        0,
+                        0,
+                        (uint)_width,
+                        (uint)_height);
+                    generation = SKImage.FromOwnedTexture(
+                        snapshotTexture,
+                        new SKImageInfo(_width, _height, _colorType, _alphaType, _colorSpace),
+                        portableRgbaPixels);
+                }
+                catch
+                {
+                    snapshotTexture.Dispose();
+                    throw;
+                }
+            }
+
             if (portableRgbaPixels is not null)
             {
                 _readbackPixels = null;
@@ -598,7 +622,55 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
 
     private void OnSurfaceCommandAdded(int commandIndex)
     {
-        _immutableSnapshotGeneration?.Dispose();
+        var immutableGeneration = _immutableSnapshotGeneration;
+        if (immutableGeneration is null)
+        {
+            return;
+        }
+
+        if (_ownsTexture &&
+            immutableGeneration.TryRelinquishSoleTextureOwnership())
+        {
+            _surfaceOwnsCurrentTexture = true;
+            immutableGeneration.Dispose();
+            _immutableSnapshotGeneration = null;
+            return;
+        }
+
+        if (_ownsTexture)
+        {
+            var previousTexture = _gpuTexture!;
+            var writableTexture = new GpuTexture(
+                _context!,
+                (uint)_width,
+                (uint)_height,
+                previousTexture.Format,
+                TextureUsage.RenderAttachment | TextureUsage.CopySrc |
+                TextureUsage.CopyDst | TextureUsage.TextureBinding,
+                "SKSurface Copy-on-write Backing Texture",
+                alphaMode: previousTexture.AlphaMode);
+            try
+            {
+                writableTexture.CopyBaseLevelRegionFrom(
+                    previousTexture,
+                    0,
+                    0,
+                    0,
+                    0,
+                    (uint)_width,
+                    (uint)_height);
+            }
+            catch
+            {
+                writableTexture.Dispose();
+                throw;
+            }
+
+            _gpuTexture = writableTexture;
+            _surfaceOwnsCurrentTexture = true;
+        }
+
+        immutableGeneration.Dispose();
         _immutableSnapshotGeneration = null;
     }
 
@@ -765,8 +837,6 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
     protected override void DisposeManaged()
     {
         _drawingContext.UnsubscribeCommandAdded(_invalidateSnapshotGeneration);
-        _immutableSnapshotGeneration?.Dispose();
-        _immutableSnapshotGeneration = null;
         if (_pixels != IntPtr.Zero)
         {
             GpuFramebufferPresentationRegistry.Unregister(_pixels, this);
@@ -787,10 +857,13 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
             {
                 try
                 {
-                    if (_ownsTexture)
+                    if (_surfaceOwnsCurrentTexture)
                     {
                         _gpuTexture?.Dispose();
                     }
+
+                    _immutableSnapshotGeneration?.Dispose();
+                    _immutableSnapshotGeneration = null;
                 }
                 finally
                 {

--- a/src/SkiaSharp/SKSurface.cs
+++ b/src/SkiaSharp/SKSurface.cs
@@ -9,9 +9,24 @@ namespace SkiaSharp;
 
 public partial class SKSurface : SKObject, IGpuFramebufferPresenter
 {
+    private sealed class SurfaceRenderVisual : Visual, IOwnedRenderCommandCache
+    {
+        private readonly DrawingContext _commands;
+
+        public SurfaceRenderVisual(DrawingContext commands)
+        {
+            _commands = commands;
+        }
+
+        public bool HasRenderCommands => _commands.Commands.Count != 0;
+
+        public DrawingContext GetOrUpdateRenderCommandCache() => _commands;
+    }
+
     private static readonly object s_compositorCacheScope = new();
     private readonly WgpuContext? _context;
     private readonly DrawingContext _drawingContext;
+    private readonly SurfaceRenderVisual _renderVisual;
     private GpuTexture? _gpuTexture;
     private IntPtr _pixels;
     private int _rowBytes;
@@ -94,6 +109,16 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
         _isNullSurface = isNullSurface;
 
         _drawingContext = new DrawingContext();
+        _renderVisual = new SurfaceRenderVisual(_drawingContext)
+        {
+            Size = new Vector2(width, height)
+        };
+        if (_origin == GRSurfaceOrigin.BottomLeft)
+        {
+            _renderVisual.Transform =
+                Matrix4x4.CreateScale(1f, -1f, 1f) *
+                Matrix4x4.CreateTranslation(0f, height, 0f);
+        }
         _invalidateSnapshotGeneration = OnSurfaceCommandAdded;
         _drawingContext.SubscribeCommandAdded(_invalidateSnapshotGeneration);
         Canvas = new SKCanvas(_drawingContext, width, height, context, Flush);
@@ -363,26 +388,18 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
 
         var cpuReadbackRegions = Canvas.TakeCpuReadbackRegions();
 
-        var visual = new DrawingVisual();
-        visual.Size = new Vector2(_width, _height);
-        if (_origin == GRSurfaceOrigin.BottomLeft)
-        {
-            visual.Transform = Matrix4x4.CreateScale(1f, -1f, 1f) * Matrix4x4.CreateTranslation(0f, _height, 0f);
-        }
-
-        visual.Context.Append(_drawingContext);
-
         var compositor = GetCompositorForContext(_context!, _gpuTexture.Format);
         try
         {
-            try
-            {
-                compositor.RenderOffscreen(visual, (uint)_width, (uint)_height, _gpuTexture, 0f, 1f, null, _hasTextureContents);
-            }
-            finally
-            {
-                visual.Context.Clear();
-            }
+            compositor.RenderOffscreen(
+                _renderVisual,
+                (uint)_width,
+                (uint)_height,
+                _gpuTexture,
+                0f,
+                1f,
+                null,
+                _hasTextureContents);
 
             _hasTextureContents = true;
 
@@ -622,6 +639,7 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
 
     private void OnSurfaceCommandAdded(int commandIndex)
     {
+        _renderVisual.Invalidate();
         var immutableGeneration = _immutableSnapshotGeneration;
         if (immutableGeneration is null)
         {

--- a/src/SkiaSharp/SKSurface.cs
+++ b/src/SkiaSharp/SKSurface.cs
@@ -406,21 +406,9 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
             // If CPU-backed surface, read pixels back and copy to memory pointer
             if (copyToCpu && _pixels != IntPtr.Zero)
             {
-                int readbackByteCount = checked(_width * _height * 4);
-                if (_readbackPixels == null || _readbackPixels.Length != readbackByteCount)
-                {
-                    _readbackPixels = GC.AllocateUninitializedArray<byte>(readbackByteCount);
-                }
-                _readbackBuffer ??= new GpuTextureReadbackBuffer(_context!);
-                try
-                {
-                    _gpuTexture.ReadPixels(_readbackPixels, _readbackBuffer);
-                }
-                finally
-                {
-                    _context!.CleanupPendingResources();
-                }
-                CopyReadbackToCpu(_readbackPixels, cpuReadbackRegions);
+                CopyReadbackToCpu(
+                    ReadBackingTexturePixels(),
+                    cpuReadbackRegions);
             }
         }
         finally
@@ -429,6 +417,49 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
             _drawingContext.Clear();
             Canvas.ReleaseLayerTexturesAfterFlush();
         }
+    }
+
+    private byte[] ReadBackingTexturePixels()
+    {
+        var readbackByteCount = checked(_width * _height * 4);
+        if (_readbackPixels is null ||
+            _readbackPixels.Length != readbackByteCount)
+        {
+            _readbackPixels =
+                GC.AllocateUninitializedArray<byte>(readbackByteCount);
+        }
+
+        _readbackBuffer ??= new GpuTextureReadbackBuffer(_context!);
+        try
+        {
+            _gpuTexture!.ReadPixels(
+                _readbackPixels,
+                _readbackBuffer);
+        }
+        finally
+        {
+            _context!.CleanupPendingResources();
+        }
+
+        return _readbackPixels;
+    }
+
+    private SKImageInfo CreateBackingTextureReadbackInfo()
+    {
+        var colorType = _gpuTexture!.Format is
+            TextureFormat.Bgra8Unorm or TextureFormat.Bgra8UnormSrgb
+                ? SKColorType.Bgra8888
+                : SKColorType.Rgba8888;
+        var alphaType = _gpuTexture.AlphaMode ==
+            GpuTextureAlphaMode.Straight
+                ? SKAlphaType.Unpremul
+                : SKAlphaType.Premul;
+        return new SKImageInfo(
+            _width,
+            _height,
+            colorType,
+            alphaType,
+            _colorSpace);
     }
 
     void IGpuFramebufferPresenter.Present(WgpuContext context, IntPtr surfaceHandle)

--- a/src/SkiaSharp/SKSurface.cs
+++ b/src/SkiaSharp/SKSurface.cs
@@ -922,6 +922,12 @@ public partial class SKSurface : SKObject, IGpuFramebufferPresenter
                     if (_context is { IsDisposed: false })
                     {
                         _context.CleanupPendingResources();
+                        // Surface disposal is a lifecycle boundary. Poll once
+                        // after dropping its final native references so already
+                        // completed command/resource generations are retired
+                        // without turning target teardown into a blocking queue
+                        // drain.
+                        _context.PollDevice(wait: false);
                     }
 
                     _surfaceProperties.Dispose();

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -147,6 +147,10 @@ internal static class ProgramEntry
                 32,
                 RunAvaloniaSurfaceConversionReadback),
             new BenchmarkCase(
+                "avalonia-surface-direct-readback",
+                32,
+                RunAvaloniaSurfaceDirectReadback),
+            new BenchmarkCase(
                 "avalonia-writeable-bitmap-snapshot",
                 128,
                 RunAvaloniaWriteableBitmapSnapshot),
@@ -517,6 +521,51 @@ internal static class ProgramEntry
                 {
                     throw new InvalidOperationException(
                         "The Avalonia conversion benchmark could not read its frame.");
+                }
+
+                checksum = Mix(checksum, destinationPixels[0]);
+                checksum = Mix(checksum, destinationPixels[1]);
+                checksum = Mix(checksum, destinationPixels[2]);
+                checksum = Mix(checksum, destinationPixels[3]);
+            }
+        }
+
+        return checksum;
+    }
+
+    private static unsafe ulong RunAvaloniaSurfaceDirectReadback(int operations)
+    {
+        const int width = 64;
+        const int height = 48;
+        var info = new SKImageInfo(
+            width,
+            height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        var destinationPixels = new byte[checked(width * height * 4)];
+        ulong checksum = 1469598103934665603UL;
+        fixed (byte* destinationAddress = destinationPixels)
+        {
+            using var surface = SKSurface.Create(
+                info,
+                new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+            var canvas = surface.Canvas;
+            for (var index = 0; index < operations; index++)
+            {
+                canvas.Clear(new SKColor(
+                    (byte)(index * 13),
+                    (byte)(index * 7),
+                    (byte)(index * 5),
+                    255));
+                if (!surface.ReadPixels(
+                        info,
+                        (IntPtr)destinationAddress,
+                        info.RowBytes,
+                        0,
+                        0))
+                {
+                    throw new InvalidOperationException(
+                        "The direct surface-readback benchmark could not read its frame.");
                 }
 
                 checksum = Mix(checksum, destinationPixels[0]);

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -151,6 +151,10 @@ internal static class ProgramEntry
                 32,
                 RunAvaloniaSurfaceDirectReadback),
             new BenchmarkCase(
+                "avalonia-image-repeated-readback",
+                32,
+                RunAvaloniaImageRepeatedReadback),
+            new BenchmarkCase(
                 "avalonia-writeable-bitmap-snapshot",
                 128,
                 RunAvaloniaWriteableBitmapSnapshot),
@@ -566,6 +570,48 @@ internal static class ProgramEntry
                 {
                     throw new InvalidOperationException(
                         "The direct surface-readback benchmark could not read its frame.");
+                }
+
+                checksum = Mix(checksum, destinationPixels[0]);
+                checksum = Mix(checksum, destinationPixels[1]);
+                checksum = Mix(checksum, destinationPixels[2]);
+                checksum = Mix(checksum, destinationPixels[3]);
+            }
+        }
+
+        return checksum;
+    }
+
+    private static unsafe ulong RunAvaloniaImageRepeatedReadback(int operations)
+    {
+        const int width = 64;
+        const int height = 48;
+        var info = new SKImageInfo(
+            width,
+            height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        var destinationPixels = new byte[checked(width * height * 4)];
+        using var surface = SKSurface.Create(
+            info,
+            new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+        surface.Canvas.Clear(new SKColor(31, 79, 143, 255));
+        using var image = surface.Snapshot();
+        ulong checksum = 1469598103934665603UL;
+        fixed (byte* destinationAddress = destinationPixels)
+        {
+            for (var index = 0; index < operations; index++)
+            {
+                if (!image.ReadPixels(
+                        info,
+                        (IntPtr)destinationAddress,
+                        info.RowBytes,
+                        0,
+                        0,
+                        SKImageCachingHint.Disallow))
+                {
+                    throw new InvalidOperationException(
+                        "The repeated image-readback benchmark could not read its frame.");
                 }
 
                 checksum = Mix(checksum, destinationPixels[0]);

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -135,6 +135,18 @@ internal static class ProgramEntry
             new BenchmarkCase("image-bounded-subset", 10_000, RunImageBoundedSubset),
             new BenchmarkCase("surface-bounded-snapshot", 10_000, RunSurfaceBoundedSnapshot),
             new BenchmarkCase(
+                "avalonia-surface-frame",
+                256,
+                RunAvaloniaSurfaceFrame),
+            new BenchmarkCase(
+                "avalonia-surface-compose",
+                128,
+                RunAvaloniaSurfaceCompose),
+            new BenchmarkCase(
+                "avalonia-surface-conversion-readback",
+                32,
+                RunAvaloniaSurfaceConversionReadback),
+            new BenchmarkCase(
                 "avalonia-writeable-bitmap-snapshot",
                 128,
                 RunAvaloniaWriteableBitmapSnapshot),
@@ -377,6 +389,141 @@ internal static class ProgramEntry
             using var snapshot = surface.Snapshot(new SKRectI(offset, offset, offset + 32, offset + 32));
             checksum = Mix(checksum, (uint)snapshot.Width);
             checksum = Mix(checksum, (uint)snapshot.Height);
+        }
+
+        return checksum;
+    }
+
+    private static unsafe ulong RunAvaloniaSurfaceFrame(int operations)
+    {
+        const int width = 128;
+        const int height = 96;
+        var info = new SKImageInfo(
+            width,
+            height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        using var surface = SKSurface.Create(
+            info,
+            new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+        var canvas = surface.Canvas;
+        for (var index = 0; index < operations; index++)
+        {
+            canvas.Clear(new SKColor(
+                (byte)index,
+                (byte)(index * 3),
+                (byte)(index * 7),
+                255));
+            canvas.Flush();
+        }
+
+        var pixels = new byte[checked(width * height * 4)];
+        fixed (byte* destination = pixels)
+        {
+            using var snapshot = surface.Snapshot();
+            if (!snapshot.ReadPixels(info, (IntPtr)destination, info.RowBytes))
+            {
+                throw new InvalidOperationException(
+                    "The Avalonia surface-frame benchmark could not read its final frame.");
+            }
+        }
+
+        return MixPixels(pixels);
+    }
+
+    private static unsafe ulong RunAvaloniaSurfaceCompose(int operations)
+    {
+        const int width = 96;
+        const int height = 64;
+        var info = new SKImageInfo(
+            width,
+            height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        using var source = SKSurface.Create(
+            info,
+            new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+        using var destination = SKSurface.Create(
+            info,
+            new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+        var sourceCanvas = source.Canvas;
+        var destinationCanvas = destination.Canvas;
+        for (var index = 0; index < operations; index++)
+        {
+            sourceCanvas.Clear(new SKColor(
+                (byte)(index * 5),
+                (byte)(index * 3),
+                (byte)index,
+                255));
+            sourceCanvas.Flush();
+            destinationCanvas.Clear(SKColors.Transparent);
+            source.Draw(destinationCanvas, 0f, 0f, null);
+            destinationCanvas.Flush();
+        }
+
+        var pixels = new byte[checked(width * height * 4)];
+        fixed (byte* destinationPixels = pixels)
+        {
+            using var snapshot = destination.Snapshot();
+            if (!snapshot.ReadPixels(
+                    info,
+                    (IntPtr)destinationPixels,
+                    info.RowBytes))
+            {
+                throw new InvalidOperationException(
+                    "The Avalonia surface-compose benchmark could not read its final frame.");
+            }
+        }
+
+        return MixPixels(pixels);
+    }
+
+    private static unsafe ulong RunAvaloniaSurfaceConversionReadback(int operations)
+    {
+        const int width = 64;
+        const int height = 48;
+        var info = new SKImageInfo(
+            width,
+            height,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        var surfacePixels = new byte[checked(width * height * 4)];
+        var destinationPixels = new byte[surfacePixels.Length];
+        ulong checksum = 1469598103934665603UL;
+        fixed (byte* surfaceAddress = surfacePixels)
+        fixed (byte* destinationAddress = destinationPixels)
+        {
+            using var surface = SKSurface.Create(
+                info,
+                (IntPtr)surfaceAddress,
+                info.RowBytes,
+                new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+            var canvas = surface.Canvas;
+            for (var index = 0; index < operations; index++)
+            {
+                canvas.Clear(new SKColor(
+                    (byte)(index * 11),
+                    (byte)(index * 7),
+                    (byte)(index * 3),
+                    255));
+                using var snapshot = surface.Snapshot();
+                if (!snapshot.ReadPixels(
+                        info,
+                        (IntPtr)destinationAddress,
+                        info.RowBytes,
+                        0,
+                        0,
+                        SKImageCachingHint.Disallow))
+                {
+                    throw new InvalidOperationException(
+                        "The Avalonia conversion benchmark could not read its frame.");
+                }
+
+                checksum = Mix(checksum, destinationPixels[0]);
+                checksum = Mix(checksum, destinationPixels[1]);
+                checksum = Mix(checksum, destinationPixels[2]);
+                checksum = Mix(checksum, destinationPixels[3]);
+            }
         }
 
         return checksum;
@@ -1512,6 +1659,17 @@ internal static class ProgramEntry
 
     private static ulong Mix(ulong state, ulong value) =>
         (state ^ value) * 1099511628211UL;
+
+    private static ulong MixPixels(ReadOnlySpan<byte> pixels)
+    {
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < pixels.Length; index++)
+        {
+            checksum = Mix(checksum, pixels[index]);
+        }
+
+        return checksum;
+    }
 
     private static double Median(IEnumerable<double> values)
     {

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -41,5 +41,7 @@ The Avalonia surface family mirrors its reusable render-target lifecycle: a
 surface is cleared and flushed for successive frames, one surface is composed
 into another through `SKSurface.Draw`, and the framebuffer conversion fallback
 snapshots a CPU-backed surface before reading it into the destination format.
+The family also measures repeated direct `SKSurface.ReadPixels` calls so staging
+buffer reuse is covered independently from snapshot ownership.
 Each workload validates the final or per-frame pixels so asynchronous submission
 or retained-content optimizations cannot silently omit rendering work.

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -36,3 +36,10 @@ or an explicit explanation that its behavior is already covered by a broader
 component/application benchmark. GPU/rendering clusters additionally require a
 deterministic final-frame workload, image-quality comparison, WebGPU timestamps,
 and the platform-native profiler specified by the repository performance policy.
+
+The Avalonia surface family mirrors its reusable render-target lifecycle: a
+surface is cleared and flushed for successive frames, one surface is composed
+into another through `SKSurface.Draw`, and the framebuffer conversion fallback
+snapshots a CPU-backed surface before reading it into the destination format.
+Each workload validates the final or per-frame pixels so asynchronous submission
+or retained-content optimizations cannot silently omit rendering work.

--- a/tools/ProGPU.SkiaSharp.Benchmarks/README.md
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/README.md
@@ -42,6 +42,8 @@ surface is cleared and flushed for successive frames, one surface is composed
 into another through `SKSurface.Draw`, and the framebuffer conversion fallback
 snapshots a CPU-backed surface before reading it into the destination format.
 The family also measures repeated direct `SKSurface.ReadPixels` calls so staging
-buffer reuse is covered independently from snapshot ownership.
+buffer reuse is covered independently from snapshot ownership, plus repeated
+`SKImage.ReadPixels` calls against one immutable GPU snapshot so image-owned
+staging lifetime is measured directly.
 Each workload validates the final or per-frame pixels so asynchronous submission
 or retained-content optimizations cannot silently omit rendering work.


### PR DESCRIPTION
## Summary

- model the Avalonia.Skia reusable `SKSurface` lifecycle with matched official-SkiaSharp/ProGPU benchmarks
- transfer owned surface backings into immutable snapshot generations and use copy-on-write only when a live snapshot or deferred draw still retains the prior generation
- reuse the surface render visual, command storage, GPU readback staging, and immutable-image readback staging
- route production WebGPU submissions through one typed context seam and bound undrained queue residency to eight submissions while retaining immediate drains for imported external storage
- add focused snapshot, mutation, readback, pixel-format, subset, deferred-draw, and queue-lifetime regressions
- document the mandatory clean-room cross-engine research, complexity bounds, rejected alternatives, and matched profiler evidence

## Why

Avalonia.Skia repeatedly flushes reusable surfaces, composes one surface into another, snapshots pointer-backed surfaces for framebuffer conversion, and reads immutable images. Preview.45 duplicated command storage and GPU/CPU generations in those paths and serialized ordinary WebGPU reference cleanup. The new ownership model keeps stable same-device work on the GPU, avoids redundant mappings and allocations, and preserves immutable snapshot pixels through typed reference-counted generations.

## Measured impact

Three alternating Release process pairs (32 warmups, 24 samples) on Apple Silicon, with exact checksums:

| Workload | Preview.45 | This PR | Allocation |
| --- | ---: | ---: | ---: |
| reusable surface composition | 1.483 ms | 0.659 ms (-55.6%) | 16,248 -> 991 B/op (-93.9%) |
| framebuffer conversion readback | 6.221 ms | 3.169 ms (-49.1%) | 17,646 -> 14,088 B/op (-20.2%) |
| stable frame enqueue | 0.086 ms | 0.343 ms | 3,241 -> 441 B/op (-86.4%) |

The stable enqueue microbenchmark intentionally outruns presentation and therefore includes the fixed eight-submission completed-work backpressure. Looser/unbounded experiments were faster but retained about 85 MB/378 MB of IOAccelerator VM and were rejected. Final matched Instruments composition was 0.713 ms versus 1.849 ms under Preview.45, with zero Metal command-buffer errors, hangs, hang risks, drawable waits, or compiler spills. The selected fixed high-water capture retained 37.2 MB IOAccelerator VM.

## Validation

- Release macOS build: zero warnings/errors
- core tests: 3,212 passed (macOS CI-equivalent shaping exclusion)
- headless render tests: 225 passed
- focused surface/image tests after final ownership hardening: 66 passed
- official SkiaSharp 4.151.0 metadata: 4,222/4,222 matching, zero missing
- docs and package-manifest gates
- 37 portable NuGet packages and isolated packaged XAML consumer
- three-pair benchmark checksum validation
- EventPipe plus Xcode Allocations, Time Profiler, and Metal System Trace
- branch diff/history clean-room and accidental-vendoring audit

Raw profiler traces and temporary Xcode exports were removed after compact evidence was retained.