### PR TITLE
Optimize Avalonia.Skia geometry and region hot paths

### DIFF
--- a/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md
@@ -18,7 +18,7 @@ copied, translated, or adapted.
 | Engine or specification | Relevant public or architectural contract | ProGPU clean-room decision |
 | --- | --- | --- |
 | [Skia `SkPathMeasure`](https://api.skia.org/classSkPathMeasure.html) | Construction copies the parts required for measurement, so the source can be changed or deleted; `resScale` trades work for precision. | Read ProGPU's packed command stream directly and retain an independent measured-contour snapshot. Reuse bounded per-thread contour storage; keep queries allocation-free. |
-| [Skia `SkPath`](https://api.skia.org/classSkPath.html) | Path copies are value-identical and internally share storage until mutation; translation replaces the destination path. | Keep pooled packed command storage, copy only the active command range, and specialize identity/translation transforms so cached loose and tight bounds translate exactly without recomputing curve extrema. A future copy-on-write backing can remove the remaining command copy without changing the public contract. |
+| [Skia `SkPath`](https://api.skia.org/classSkPath.html) | Path copies are value-identical and internally share storage until mutation; translation replaces the destination path. | Share reference-counted packed command storage until mutation. Compose translations lazily while updating cached loose/tight bounds exactly; detach and materialize only when a later command or general transform requires writable coordinates. |
 | [Skia `SkRegion`](https://api.skia.org/classSkRegion.html) | Regions compactly represent one integer rectangle or run-length encoded rectangles and expose canonical containment, intersection, complexity, and iteration results. | Accumulate Avalonia's union-only dirty rectangles and bounds in `O(1)` per append, then normalize once at the first semantic query. Reuse bounded thread-local sort, interval, merge, and band-map storage; canonical output remains deterministic. |
 | [Direct2D geometry realizations](https://learn.microsoft.com/en-us/windows/win32/direct2d/geometry-realizations-overview) and [`CombineWithGeometry`](https://learn.microsoft.com/en-us/windows/win32/direct2d/id2d1geometry-combinewithgeometry) | Curves are flattened to a caller-controlled maximum error; lower tolerances improve fidelity at greater cost, and device-dependent realizations should be reused. Geometry combinations emit a simplified result through a sink. | Replace fixed segment counts with bounded adaptive de Casteljau subdivision at a maximum quarter-device-pixel control-to-chord error. Retain WebGPU path-operation shader modules, compute pipelines, and bind-group layouts per device; reconstruct readback directly from mapped storage. |
 | [Win2D overview](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/in-a-core-app) and [DPI/DIP guidance](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/dpi-and-dips) | GPU-accelerated vector drawing includes stroke expansion, path measurement, tessellation, and boolean operations in XAML's DIP coordinate system. | Preserve SkiaSharp-compatible synchronous CPU observations in logical coordinates. `resScale` tightens stroke subdivision; final fill rasterization and non-trivial boolean solving remain WebGPU operations. |
@@ -38,16 +38,21 @@ reflection-based Avalonia adapters, and source-derived foreign control flow.
   measurement spans `S`; its retained storage is bounded and reused on the
   constructing thread. Position/tangent queries are `O(log S)` and allocate
   zero managed bytes after warmup.
-- Packed path copy is `O(C)` and rents one bounded command array. Identity is
-  `O(1)`. Translation is `O(C)` with exact `O(1)` updates to loose/tight bounds;
-  general affine/perspective transforms remain `O(C)` and recompute extrema.
+- Packed path copy and identity are `O(1)` and share the immutable command
+  buffer. Translation is `O(1)`, composes a pending offset, and updates cached
+  loose/tight bounds exactly. The first later mutation detaches in `O(C)` for
+  `C` commands; general affine/perspective transforms remain `O(C)` and
+  recompute extrema.
 - Union-only dirty-region recording is `O(1)` per rectangle. Canonicalization is
   `O(R log R + B)` for `R` rectangles and `B` output bands, uses bounded reusable
   scratch storage, and runs only before a query that observes canonical topology.
 - Stroke flattening performs adaptive subdivision to a maximum error of
   `0.25 / resScale` logical pixels and a fixed depth of eight. Average work follows
   visible curvature; worst-case work and temporary storage are `O(2^8)` per
-  curve. Join/cap triangles are emitted into fixed stack spans.
+  curve. Join/cap triangles are emitted into fixed stack spans and appended to
+  packed path storage in one reserved batch, avoiding repeated capacity and
+  bounds bookkeeping. Retained thread-local command capacity is capped at 4,096
+  commands.
 - A non-trivial boolean operation compiles `A + B` input segments, dispatches
   WebGPU compute, and reads at most `15(A + B)` output segments (minimum capacity
   64). Shader modules, compute pipelines, and layouts are retained per device.
@@ -58,8 +63,11 @@ reflection-based Avalonia adapters, and source-derived foreign control flow.
 ## Validation and measured evidence
 
 The Release benchmark runner uses the same semantic workload against official
-SkiaSharp 4.151 and the ProGPU shim. Each final comparison uses alternating
-processes, 32 warmups, 24 samples, and exact checksum equality. Focused tests
+SkiaSharp 4.151 and the ProGPU shim. The final query and stroke confirmations
+use three alternating processes, 32 warmups, 24 samples, and exact checksum
+equality. Other table rows use stable alternating-process medians with the same
+operation counts and exact checksums. Longer default operation counts keep the
+create, copy, and region samples above the timer-noise floor. Focused tests
 cover source-mutation isolation, contour traversal, transformed tight bounds,
 bounded allocation, region canonicalization, stroke caps/joins/dashes, path-op
 resource cleanup, AOT-safe callbacks, and rendered boolean output.
@@ -68,12 +76,12 @@ Representative best stable medians on Apple Silicon during implementation:
 
 | Avalonia-shaped workload | Official SkiaSharp | ProGPU final | Allocation, official / ProGPU |
 | --- | ---: | ---: | ---: |
-| Path-measure construction | 2,319 ns | 570 ns | 80 / 56 B/op |
-| Path-measure query | 29.7 ns | 23.5 ns | 0 / 0 B/op |
-| Packed copy plus translation | 875 ns | 859 ns | 88 / 80 B/op |
-| Dirty-region unions plus queries | 2,940 ns | 1,240 ns | 0 / 0 B/op |
-| Stroke expansion | 27,404 ns | 24,990 ns | 168 / 83 B/op |
-| Synchronous non-trivial path combine | 4,094 ns | 1,729,497 ns | 144 / 4,078 B/op |
+| Path-measure construction | 2,052 ns | 516 ns | 80 / 56 B/op |
+| Path-measure query | 26.790 ns | 22.511 ns | 0 / 0 B/op |
+| Packed copy plus translation | 403.812 ns | 136.904 ns | 88 / 80 B/op |
+| Dirty-region unions plus queries | 2,424.975 ns | 1,156.994 ns | 0 / 0 B/op |
+| Stroke expansion | 24,116.771 ns | 21,622.250 ns | 168 / 83 B/op |
+| Synchronous non-trivial path combine | 3,692.625 ns | 1,644,322.875 ns | 144 / 4,079 B/op |
 
 The boolean row is intentionally reported as an open latency boundary, not a
 performance win. This slice reduces its previous ProGPU median from 5,368,755 ns
@@ -85,8 +93,27 @@ observable topology and mutation isolation while allowing retained rendering to
 consume an unresolved GPU operation; it must not hide the gap with an incorrect
 bounds-only result or CPU raster fallback.
 
-Before integration, matched EventPipe and Xcode Allocations, Time Profiler, and
-Metal System Trace runs use the same final Release workload. Raw `.nettrace`,
-`.trace`, Instruments scratch, and exported XML are temporary and are deleted
-after retaining compact benchmark JSON/Markdown, manifests, logs, top-function
-tables, and the final summary.
+The WebGPU path-combine resource change was profiled at exact commit `ebb105be`
+against the benchmark baseline. EventPipe measured 6,442,824 to 1,907,781 ns/op
+and 6,353 to 3,721 B/op with the same checksum. The baseline attributed 34.68%
+exclusive time to synchronous map, 25.08% to the removed sleep, 24.88% to shader
+module creation, and 6.13% to pipeline creation; the candidate retained only
+synchronous map (72.94%) and device polling (12.91%) as material costs. Matched
+Time Profiler measured 8,561,072 to 1,996,378 ns/op. Allocations plus VM Tracker
+reduced persistent heap plus anonymous VM from 123,952,704 to 118,978,704 bytes
+and total allocation from 4,351,609,392 to 1,703,119,040 bytes. Metal System
+Trace retained the same 2,523,136-byte IOAccelerator and 344,064-byte resource
+list state, with zero command-buffer errors, drawable waits, hangs, hang risks,
+or compiler spills.
+
+The final packed-stroke change was also captured from matched Release binaries:
+`2c1062c8` before batching and `d7a71fab` after batching. Time Profiler measured
+25,735.015 to 21,807.133 ns/op; the Allocations workload measured 25,716.550 to
+21,810.053 ns/op and preserved 80 managed B/op. Persistent native heap plus
+anonymous VM changed from 105,450,992 to 105,433,888 bytes, with anonymous VM
+unchanged at 101,793,792 bytes. The CPU-only workload submitted no Metal work.
+
+Raw `.nettrace`, `.trace`, `.ktrace`, Instruments scratch, and exported XML were
+deleted after retaining compact benchmark JSON, manifests, target logs,
+top-function tables, and summaries. The temporary baseline worktree and launch
+JSON files were also removed.

--- a/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md
@@ -1,0 +1,92 @@
+# Avalonia.Skia geometry and region hot-path research
+
+## Scope and observed framework contract
+
+This clean-room slice optimizes the official SkiaSharp geometry contracts used
+by Avalonia.Skia. At Avalonia commit
+[`fee9c561`](https://github.com/AvaloniaUI/Avalonia/tree/fee9c561ce036e8a3e8cee2397c75ca599b4790d),
+`GeometryImpl` retains `SKPathMeasure`, queries path bounds and containment, and
+expands strokes with `SKPaint.GetFillPath`; `TransformedGeometryImpl` copies and
+transforms paths; `CombinedGeometryImpl` uses `SKPath.Op`; and `SkiaRegionImpl`
+accumulates integer dirty rectangles before querying or iterating the canonical
+region. These observed public calls define the benchmark workloads. No Avalonia,
+Skia, Direct2D, Win2D, WebRender, Vello, or HarfBuzz implementation text was
+copied, translated, or adapted.
+
+## Primary-source comparison
+
+| Engine or specification | Relevant public or architectural contract | ProGPU clean-room decision |
+| --- | --- | --- |
+| [Skia `SkPathMeasure`](https://api.skia.org/classSkPathMeasure.html) | Construction copies the parts required for measurement, so the source can be changed or deleted; `resScale` trades work for precision. | Read ProGPU's packed command stream directly and retain an independent measured-contour snapshot. Reuse bounded per-thread contour storage; keep queries allocation-free. |
+| [Skia `SkPath`](https://api.skia.org/classSkPath.html) | Path copies are value-identical and internally share storage until mutation; translation replaces the destination path. | Keep pooled packed command storage, copy only the active command range, and specialize identity/translation transforms so cached loose and tight bounds translate exactly without recomputing curve extrema. A future copy-on-write backing can remove the remaining command copy without changing the public contract. |
+| [Skia `SkRegion`](https://api.skia.org/classSkRegion.html) | Regions compactly represent one integer rectangle or run-length encoded rectangles and expose canonical containment, intersection, complexity, and iteration results. | Accumulate Avalonia's union-only dirty rectangles and bounds in `O(1)` per append, then normalize once at the first semantic query. Reuse bounded thread-local sort, interval, merge, and band-map storage; canonical output remains deterministic. |
+| [Direct2D geometry realizations](https://learn.microsoft.com/en-us/windows/win32/direct2d/geometry-realizations-overview) and [`CombineWithGeometry`](https://learn.microsoft.com/en-us/windows/win32/direct2d/id2d1geometry-combinewithgeometry) | Curves are flattened to a caller-controlled maximum error; lower tolerances improve fidelity at greater cost, and device-dependent realizations should be reused. Geometry combinations emit a simplified result through a sink. | Replace fixed segment counts with bounded adaptive de Casteljau subdivision at a maximum quarter-device-pixel control-to-chord error. Retain WebGPU path-operation shader modules, compute pipelines, and bind-group layouts per device; reconstruct readback directly from mapped storage. |
+| [Win2D overview](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/in-a-core-app) and [DPI/DIP guidance](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/dpi-and-dips) | GPU-accelerated vector drawing includes stroke expansion, path measurement, tessellation, and boolean operations in XAML's DIP coordinate system. | Preserve SkiaSharp-compatible synchronous CPU observations in logical coordinates. `resScale` tightens stroke subdivision; final fill rasterization and non-trivial boolean solving remain WebGPU operations. |
+| [WebRender rendering overview](https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst) | A compact display list becomes a retained scene, is culled to a frame, and reuses renderer-owned GPU resources; dirty rectangles avoid rebuilding unaffected content. | Keep packed CPU geometry as retained input, delay dirty-region canonicalization until it is observable, and keep shader/pipeline lifetime in the WebGPU device domain rather than rebuilding it per operation. |
+| [Vello](https://github.com/linebender/vello) | Compact scene encoding is separate from GPU compute rasterization; prefix-sum and other parallel work use WebGPU-compatible compute with bounded temporary storage. | Preserve typed compact command streams and move only parallel raster/boolean work to WebGPU. CPU path measurement, bounds, transforms, and region queries remain deterministic synchronous value operations. |
+| [HarfBuzz shaping output](https://harfbuzz.github.io/shaping-and-shape-plans.html) and [glyph rendering boundary](https://harfbuzz.github.io/glyphs-and-rendering.html) | Shaping produces reusable positioned glyphs; outline extraction/rasterization is a later stage. | Leave text shaping, fallback, glyph IDs, DPI/subpixel policy, and glyph atlases unchanged. Geometry optimizations consume retained outlines without adding shaping or character-map work. |
+
+Rejected alternatives are fixed uniform curve subdivision, normalizing a dirty
+region after every union, materializing the public path object graph for every
+measure/copy, rebuilding WebGPU shader pipelines per boolean operation, copying
+mapped GPU output into intermediate managed arrays, CPU bitmap rasterization,
+reflection-based Avalonia adapters, and source-derived foreign control flow.
+
+## Resulting algorithms and bounds
+
+- Packed measure construction is `O(C + S)` for `C` commands and generated
+  measurement spans `S`; its retained storage is bounded and reused on the
+  constructing thread. Position/tangent queries are `O(log S)` and allocate
+  zero managed bytes after warmup.
+- Packed path copy is `O(C)` and rents one bounded command array. Identity is
+  `O(1)`. Translation is `O(C)` with exact `O(1)` updates to loose/tight bounds;
+  general affine/perspective transforms remain `O(C)` and recompute extrema.
+- Union-only dirty-region recording is `O(1)` per rectangle. Canonicalization is
+  `O(R log R + B)` for `R` rectangles and `B` output bands, uses bounded reusable
+  scratch storage, and runs only before a query that observes canonical topology.
+- Stroke flattening performs adaptive subdivision to a maximum error of
+  `0.25 / resScale` logical pixels and a fixed depth of eight. Average work follows
+  visible curvature; worst-case work and temporary storage are `O(2^8)` per
+  curve. Join/cap triangles are emitted into fixed stack spans.
+- A non-trivial boolean operation compiles `A + B` input segments, dispatches
+  WebGPU compute, and reads at most `15(A + B)` output segments (minimum capacity
+  64). Shader modules, compute pipelines, and layouts are retained per device.
+  Readback reconstruction uses a 256-byte stack usage map or one pooled larger
+  map and no intermediate segment copy; its current contour-linking worst case
+  remains `O(S^2)` for `S` output segments.
+
+## Validation and measured evidence
+
+The Release benchmark runner uses the same semantic workload against official
+SkiaSharp 4.151 and the ProGPU shim. Each final comparison uses alternating
+processes, 32 warmups, 24 samples, and exact checksum equality. Focused tests
+cover source-mutation isolation, contour traversal, transformed tight bounds,
+bounded allocation, region canonicalization, stroke caps/joins/dashes, path-op
+resource cleanup, AOT-safe callbacks, and rendered boolean output.
+
+Representative best stable medians on Apple Silicon during implementation:
+
+| Avalonia-shaped workload | Official SkiaSharp | ProGPU final | Allocation, official / ProGPU |
+| --- | ---: | ---: | ---: |
+| Path-measure construction | 2,319 ns | 570 ns | 80 / 56 B/op |
+| Path-measure query | 29.7 ns | 23.5 ns | 0 / 0 B/op |
+| Packed copy plus translation | 875 ns | 859 ns | 88 / 80 B/op |
+| Dirty-region unions plus queries | 2,940 ns | 1,240 ns | 0 / 0 B/op |
+| Stroke expansion | 27,404 ns | 24,990 ns | 168 / 83 B/op |
+| Synchronous non-trivial path combine | 4,094 ns | 1,729,497 ns | 144 / 4,078 B/op |
+
+The boolean row is intentionally reported as an open latency boundary, not a
+performance win. This slice reduces its previous ProGPU median from 5,368,755 ns
+and 6,710 B/op by retaining per-device pipelines, removing an unnecessary sleep
+after blocking device polling, and eliminating intermediate readback arrays.
+The remaining cost is the synchronous CPU-to-GPU-to-CPU round trip required by
+the current `SKPath.Op` implementation. The follow-up design must preserve
+observable topology and mutation isolation while allowing retained rendering to
+consume an unresolved GPU operation; it must not hide the gap with an incorrect
+bounds-only result or CPU raster fallback.
+
+Before integration, matched EventPipe and Xcode Allocations, Time Profiler, and
+Metal System Trace runs use the same final Release workload. Raw `.nettrace`,
+`.trace`, Instruments scratch, and exported XML are temporary and are deleted
+after retaining compact benchmark JSON/Markdown, manifests, logs, top-function
+tables, and the final summary.

--- a/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md
@@ -49,8 +49,10 @@ reflection-based Avalonia adapters, and source-derived foreign control flow.
 - Stroke flattening performs adaptive subdivision to a maximum error of
   `0.25 / resScale` logical pixels and a fixed depth of eight. Average work follows
   visible curvature; worst-case work and temporary storage are `O(2^8)` per
-  curve. Join/cap triangles are emitted into fixed stack spans and appended to
-  packed path storage in one reserved batch, avoiding repeated capacity and
+  curve. Flatness additionally requires control-point projections to stay
+  inside and ordered along the chord, so collinear overshoot and reversal still
+  subdivide. Join/cap triangles are emitted into fixed stack spans and appended
+  to packed path storage in one reserved batch, avoiding repeated capacity and
   bounds bookkeeping. Retained thread-local command capacity is capped at 4,096
   commands.
 - A non-trivial boolean operation compiles `A + B` input segments, dispatches
@@ -80,7 +82,7 @@ Representative best stable medians on Apple Silicon during implementation:
 | Path-measure query | 26.790 ns | 22.511 ns | 0 / 0 B/op |
 | Packed copy plus translation | 403.812 ns | 136.904 ns | 88 / 80 B/op |
 | Dirty-region unions plus queries | 2,424.975 ns | 1,156.994 ns | 0 / 0 B/op |
-| Stroke expansion | 24,116.771 ns | 21,622.250 ns | 168 / 83 B/op |
+| Stroke expansion | 25,977.708 ns | 22,603.645 ns | 168 / 83 B/op |
 | Synchronous non-trivial path combine | 3,692.625 ns | 1,644,322.875 ns | 144 / 4,079 B/op |
 
 The boolean row is intentionally reported as an open latency boundary, not a
@@ -107,10 +109,11 @@ list state, with zero command-buffer errors, drawable waits, hangs, hang risks,
 or compiler spills.
 
 The final packed-stroke change was also captured from matched Release binaries:
-`2c1062c8` before batching and `d7a71fab` after batching. Time Profiler measured
-25,735.015 to 21,807.133 ns/op; the Allocations workload measured 25,716.550 to
-21,810.053 ns/op and preserved 80 managed B/op. Persistent native heap plus
-anonymous VM changed from 105,450,992 to 105,433,888 bytes, with anonymous VM
+`2c1062c8` before batching and `12c551a4` after batching plus reversal-safe
+flatness. Time Profiler measured 25,735.015 to 23,149.362 ns/op; the Allocations
+workload measured 25,716.550 to 22,634.872 ns/op and preserved 80 managed B/op.
+Persistent native heap plus anonymous VM changed from 105,450,992 to 105,274,672
+bytes, with anonymous VM
 unchanged at 101,793,792 bytes. The CPU-only workload submitted no Metal work.
 
 Raw `.nettrace`, `.trace`, `.ktrace`, Instruments scratch, and exported XML were

--- a/src/ProGPU.Tests/ArcPathCompilerTests.cs
+++ b/src/ProGPU.Tests/ArcPathCompilerTests.cs
@@ -428,6 +428,22 @@ public class ArcPathCompilerTests
     }
 
     [Fact]
+    public void PathOperationPipelineInitializationRollsBackPartialResources()
+    {
+        string source = File.ReadAllText(FindPathOpGeometrySolverSource()).Replace("\r\n", "\n");
+        int resourcesIndex = source.IndexOf("private sealed class PathOpPipelineResources", StringComparison.Ordinal);
+        int resourcesEnd = source.IndexOf("private static void DisposePipelineResources", resourcesIndex, StringComparison.Ordinal);
+
+        Assert.True(resourcesIndex >= 0 && resourcesEnd > resourcesIndex);
+
+        string resources = source[resourcesIndex..resourcesEnd];
+        Assert.Contains("catch\n                {\n                    Dispose();\n                    throw;\n                }", resources, StringComparison.Ordinal);
+        Assert.Contains("if (GeometryBindGroupLayout != null)", resources, StringComparison.Ordinal);
+        Assert.Contains("if (FinalizerBindGroupLayout != null)", resources, StringComparison.Ordinal);
+        Assert.Contains("_cache.Dispose();", resources, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PathOperationSolverUsesAotSafeAsyncReadback()
     {
         string source = File.ReadAllText(FindPathOpGeometrySolverSource()).Replace("\r\n", "\n");

--- a/src/ProGPU.Tests/ArcPathCompilerTests.cs
+++ b/src/ProGPU.Tests/ArcPathCompilerTests.cs
@@ -414,9 +414,7 @@ public class ArcPathCompilerTests
         Assert.Contains("CommandBufferRelease(_cmdBuffer);", cleanup, StringComparison.Ordinal);
         Assert.Contains("CommandEncoderRelease(_encoder);", cleanup, StringComparison.Ordinal);
         Assert.Contains("BindGroupRelease(_bgGeom);", cleanup, StringComparison.Ordinal);
-        Assert.Contains("BindGroupLayoutRelease(_bindGroupLayoutGeom);", cleanup, StringComparison.Ordinal);
         Assert.Contains("BindGroupRelease(_bgFinal);", cleanup, StringComparison.Ordinal);
-        Assert.Contains("BindGroupLayoutRelease(_bindGroupLayoutFinal);", cleanup, StringComparison.Ordinal);
         Assert.Contains("_recordsBufferA?.Dispose();", cleanup, StringComparison.Ordinal);
         Assert.Contains("_segmentsBufferA?.Dispose();", cleanup, StringComparison.Ordinal);
         Assert.Contains("_recordsBufferB?.Dispose();", cleanup, StringComparison.Ordinal);
@@ -424,7 +422,9 @@ public class ArcPathCompilerTests
         Assert.Contains("_destRecordBuffer?.Dispose();", cleanup, StringComparison.Ordinal);
         Assert.Contains("_destSegmentsBuffer?.Dispose();", cleanup, StringComparison.Ordinal);
         Assert.Contains("_uniformBuffer?.Dispose();", cleanup, StringComparison.Ordinal);
-        Assert.Contains("_cache?.Dispose();", cleanup, StringComparison.Ordinal);
+        Assert.Contains("BindGroupLayoutRelease(GeometryBindGroupLayout);", source, StringComparison.Ordinal);
+        Assert.Contains("BindGroupLayoutRelease(FinalizerBindGroupLayout);", source, StringComparison.Ordinal);
+        Assert.Contains("_cache.Dispose();", source, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/SkPaintFillPathOverloadCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPaintFillPathOverloadCompatibilityTests.cs
@@ -6,6 +6,30 @@ namespace ProGPU.Tests;
 public sealed class SkPaintFillPathOverloadCompatibilityTests
 {
     [Fact]
+    public void CollinearReversingCurvesRetainTheirStrokeExtrema()
+    {
+        using var paint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 2f,
+        };
+        using var quadratic = new SKPath();
+        quadratic.MoveTo(0f, 0f);
+        quadratic.QuadTo(100f, 0f, 1f, 0f);
+        using var quadraticStroke = paint.GetFillPath(quadratic);
+        using var cubic = new SKPath();
+        cubic.MoveTo(0f, 0f);
+        cubic.CubicTo(100f, 0f, -100f, 0f, 1f, 0f);
+        using var cubicStroke = paint.GetFillPath(cubic);
+
+        Assert.NotNull(quadraticStroke);
+        Assert.True(quadraticStroke!.Bounds.Right > 50f);
+        Assert.NotNull(cubicStroke);
+        Assert.True(cubicStroke!.Bounds.Left < -20f);
+        Assert.True(cubicStroke.Bounds.Right > 20f);
+    }
+
+    [Fact]
     public void ReturnOverloadsTreatCullAsHintAndMatrixAsResolutionScale()
     {
         using var source = CreateCurve(SKPathFillType.EvenOdd);

--- a/src/ProGPU.Tests/SkPaintFillPathOverloadCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPaintFillPathOverloadCompatibilityTests.cs
@@ -144,6 +144,32 @@ public sealed class SkPaintFillPathOverloadCompatibilityTests
         Assert.True(result.IsEmpty);
     }
 
+    [Fact]
+    public void WarmedCallerOwnedStrokeDestinationKeepsManagedAllocationBounded()
+    {
+        using var source = CreateCurve();
+        using var destination = new SKPath();
+        using var paint = CreateStrokePaint();
+
+#pragma warning disable CS0618
+        for (var index = 0; index < 64; index++)
+        {
+            Assert.True(paint.GetFillPath(source, destination));
+        }
+
+        const int iterations = 256;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < iterations; index++)
+        {
+            paint.GetFillPath(source, destination);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+#pragma warning restore CS0618
+
+        Assert.True(allocated <= iterations * 128L, $"Allocated {allocated} bytes.");
+        Assert.False(destination.IsEmpty);
+    }
+
     private static SKPath CreateCurve(SKPathFillType fillType = SKPathFillType.Winding)
     {
         var path = new SKPath { FillType = fillType };

--- a/src/ProGPU.Tests/SkPathBuilderCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPathBuilderCompatibilityTests.cs
@@ -131,12 +131,37 @@ public sealed class SkPathBuilderCompatibilityTests
         var transformedBounds = transformed.TightBounds;
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
-        Assert.InRange(allocated, 0, 96);
+        Assert.InRange(allocated, 0, 128);
         Assert.Equal(sourceBounds, source.TightBounds);
         Assert.Equal(sourceBounds.Left + 5f, transformedBounds.Left);
         Assert.Equal(sourceBounds.Top - 7f, transformedBounds.Top);
         Assert.Equal(sourceBounds.Right + 5f, transformedBounds.Right);
         Assert.Equal(sourceBounds.Bottom - 7f, transformedBounds.Bottom);
+    }
+
+    [Fact]
+    public void PackedCopyOnWriteTranslationSurvivesSourceMutationAndDisposal()
+    {
+        using var builder = new SKPathBuilder();
+        builder.MoveTo(1f, 2f);
+        builder.LineTo(5f, 6f);
+        var source = builder.Detach();
+        using var transformed = new SKPath(source);
+
+        transformed.Transform(SKMatrix.CreateTranslation(10f, -4f));
+        source.LineTo(9f, 10f);
+        source.Dispose();
+        transformed.RLineTo(2f, 3f);
+
+        Assert.Equal(
+            new[]
+            {
+                new SKPoint(11f, -2f),
+                new SKPoint(15f, 2f),
+                new SKPoint(17f, 5f),
+            },
+            transformed.Points);
+        Assert.Equal(new SKRect(11f, -2f, 17f, 5f), transformed.Bounds);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/SkPathBuilderCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPathBuilderCompatibilityTests.cs
@@ -100,6 +100,46 @@ public sealed class SkPathBuilderCompatibilityTests
     }
 
     [Fact]
+    public void PackedCopyTransformUsesBoundedStorageAndDoesNotMutateSource()
+    {
+        using var builder = new SKPathBuilder();
+        builder.MoveTo(1f, 2f);
+        for (var index = 0; index < 32; index++)
+        {
+            builder.LineTo(index + 3f, index + 4f);
+            builder.QuadTo(index + 5f, index + 6f, index + 7f, index + 8f);
+            builder.CubicTo(
+                index + 9f,
+                index + 10f,
+                index + 11f,
+                index + 12f,
+                index + 13f,
+                index + 14f);
+        }
+        using var source = builder.Detach();
+        var sourceBounds = source.TightBounds;
+
+        using (var warmup = new SKPath(source))
+        {
+            warmup.Transform(SKMatrix.CreateTranslation(5f, -7f));
+            _ = warmup.TightBounds;
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        using var transformed = new SKPath(source);
+        transformed.Transform(SKMatrix.CreateTranslation(5f, -7f));
+        var transformedBounds = transformed.TightBounds;
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.InRange(allocated, 0, 96);
+        Assert.Equal(sourceBounds, source.TightBounds);
+        Assert.Equal(sourceBounds.Left + 5f, transformedBounds.Left);
+        Assert.Equal(sourceBounds.Top - 7f, transformedBounds.Top);
+        Assert.Equal(sourceBounds.Right + 5f, transformedBounds.Right);
+        Assert.Equal(sourceBounds.Bottom - 7f, transformedBounds.Bottom);
+    }
+
+    [Fact]
     public void RelativeCommandsAndConicsRetainCurrentPointAcrossClose()
     {
         using var builder = new SKPathBuilder();

--- a/src/ProGPU.Tests/SkPathMeasureCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPathMeasureCompatibilityTests.cs
@@ -189,6 +189,31 @@ public sealed class SkPathMeasureCompatibilityTests
         Assert.InRange(MathF.Abs(preciseMeasure.Length - 133.7622f), 0f, 0.03f);
     }
 
+    [Fact]
+    public void WarmedPackedMeasuresRetainStorageAndRemainMutationIsolated()
+    {
+        using var path = CreateMeasuredPathWithoutConic();
+        using (var warmup = new SKPathMeasure(path))
+        {
+            Assert.True(warmup.Length > 0f);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        using var measure = new SKPathMeasure(path);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        var originalLength = measure.Length;
+
+        path.LineTo(500f, 600f);
+
+        Assert.InRange(allocated, 0, 64);
+        Assert.Equal(originalLength, measure.Length);
+        Assert.True(measure.GetPositionAndTangent(
+            originalLength * 0.5f,
+            out var position,
+            out var tangent));
+        Assert.True(float.IsFinite(position.X + position.Y + tangent.X + tangent.Y));
+    }
+
     private static SKPath CreateMeasuredPath()
     {
         var path = new SKPath();
@@ -197,6 +222,16 @@ public sealed class SkPathMeasureCompatibilityTests
         path.QuadTo(60f, 20f, 60f, 40f);
         path.ConicTo(60f, 60f, 40f, 60f, 0.70710677f);
         path.CubicTo(20f, 60f, 10f, 50f, 10f, 40f);
+        return path;
+    }
+
+    private static SKPath CreateMeasuredPathWithoutConic()
+    {
+        var path = new SKPath();
+        path.MoveTo(10f, 20f);
+        path.LineTo(40f, 20f);
+        path.QuadTo(60f, 20f, 60f, 40f);
+        path.CubicTo(40f, 60f, 10f, 50f, 10f, 40f);
         return path;
     }
 

--- a/src/ProGPU.Tests/SkRegionCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkRegionCompatibilityTests.cs
@@ -184,6 +184,45 @@ public sealed class SkRegionCompatibilityTests
         Assert.False(boundary.Contains(25f, 5f));
     }
 
+    [Fact]
+    public void WarmedDirtyRegionUnionAndQueriesAllocateNoManagedMemory()
+    {
+        using var region = new SKRegion();
+
+        static bool Update(SKRegion target)
+        {
+            var valid = true;
+            target.SetEmpty();
+            for (var index = 0; index < 24; index++)
+            {
+                var x = index * 3;
+                valid &= target.Op(
+                    x,
+                    index & 3,
+                    x + 12,
+                    (index & 3) + 10,
+                    SKRegionOperation.Union);
+            }
+
+            valid &= target.Bounds == new SKRectI(0, 0, 81, 13);
+            valid &= target.Contains(15, 5);
+            valid &= target.Intersects(new SKRectI(48, 2, 54, 8));
+            return valid;
+        }
+
+        Assert.True(Update(region));
+        var valid = true;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var iteration = 0; iteration < 1_000; iteration++)
+        {
+            valid &= Update(region);
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(valid);
+        Assert.Equal(0, allocated);
+    }
+
     private static SKRectI[] ReadRects(SKRegion.RectIterator iterator)
     {
         var rects = new List<SKRectI>();

--- a/src/ProGPU.Tests/SkRegionCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkRegionCompatibilityTests.cs
@@ -185,6 +185,27 @@ public sealed class SkRegionCompatibilityTests
     }
 
     [Fact]
+    public void RegionAndIntersectMutationsRestoreCanonicalTopology()
+    {
+        using var adjacent = new SKRegion(new SKRectI(0, 0, 10, 10));
+        using var right = new SKRegion(new SKRectI(10, 0, 20, 10));
+
+        Assert.True(adjacent.Op(right, SKRegionOperation.Union));
+        Assert.True(adjacent.IsRect);
+        Assert.Equal(
+            new[] { new SKRectI(0, 0, 20, 10) },
+            ReadRects(adjacent.CreateRectIterator()));
+
+        using var clipped = new SKRegion(new SKRectI(0, 0, 10, 10));
+        clipped.Op(new SKRectI(5, 5, 15, 15), SKRegionOperation.Union);
+        Assert.True(clipped.Op(new SKRectI(5, 0, 10, 15), SKRegionOperation.Intersect));
+        Assert.True(clipped.IsRect);
+        Assert.Equal(
+            new[] { new SKRectI(5, 0, 10, 15) },
+            ReadRects(clipped.CreateRectIterator()));
+    }
+
+    [Fact]
     public void WarmedDirtyRegionUnionAndQueriesAllocateNoManagedMemory()
     {
         using var region = new SKRegion();

--- a/src/ProGPU.Tests/TextContractParityTests.cs
+++ b/src/ProGPU.Tests/TextContractParityTests.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Text;
 using Microsoft.UI.Xaml.Controls;
 using ProGPU.WinUI.Text;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Windows.Foundation.Metadata;
 using Xunit;
 
@@ -89,21 +90,29 @@ public sealed class TextContractParityTests
     public void FontWeightReadsRemainAllocationFree()
     {
         const int Count = 100_000;
-        _ = FontWeights.Bold.Weight;
+        _ = ReadFontWeightChecksum(Count);
         _ = GC.GetAllocatedBytesForCurrentThread();
         long before = GC.GetAllocatedBytesForCurrentThread();
+        ushort checksum = ReadFontWeightChecksum(Count);
+
+        long allocated =
+            GC.GetAllocatedBytesForCurrentThread() - before;
+        GC.KeepAlive(checksum);
+        Assert.Equal(0, allocated);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static ushort ReadFontWeightChecksum(int count)
+    {
         ushort checksum = 0;
-        for (int index = 0; index < Count; index++)
+        for (int index = 0; index < count; index++)
         {
             checksum ^= FontWeights.Thin.Weight;
             checksum ^= FontWeights.Normal.Weight;
             checksum ^= FontWeights.ExtraBlack.Weight;
         }
 
-        long allocated =
-            GC.GetAllocatedBytesForCurrentThread() - before;
-        GC.KeepAlive(checksum);
-        Assert.Equal(0, allocated);
+        return checksum;
     }
 
     [Fact]

--- a/src/ProGPU.Vector/PathOpGeometrySolver.cs
+++ b/src/ProGPU.Vector/PathOpGeometrySolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -14,6 +15,13 @@ namespace ProGPU.Vector
         public const uint MaxOutputSegmentsPerInputSegment = 15;
         public const uint MinimumOutputSegments = 64;
 
+        private static readonly ConditionalWeakTable<WgpuContext, PathOpPipelineResources> PipelineResources = new();
+
+        static PathOpGeometrySolver()
+        {
+            WgpuContext.Disposing += DisposePipelineResources;
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         private struct PathOpDispatchUniforms
         {
@@ -28,6 +36,57 @@ namespace ProGPU.Vector
             public readonly System.Threading.ManualResetEventSlim Signal = new(false);
             public BufferMapAsyncStatus Status = BufferMapAsyncStatus.ValidationError;
             public GCHandle Handle;
+        }
+
+        private sealed class PathOpPipelineResources : IDisposable
+        {
+            private readonly WgpuContext _context;
+            private readonly RenderPipelineCache _cache;
+
+            public PathOpPipelineResources(WgpuContext context)
+            {
+                _context = context;
+                _cache = new RenderPipelineCache(context);
+                var geometryModule = _cache.GetOrCreateShader(
+                    "PathOpGeometry",
+                    Shaders.PathOpGeometryShader,
+                    "PathOpGeometryShader");
+                GeometryPipeline = _cache.GetOrCreateComputePipeline(
+                    "PathOpGeometry",
+                    geometryModule,
+                    "cs_main");
+                var finalizerModule = _cache.GetOrCreateShader(
+                    "PathOpRecordFinalizer",
+                    Shaders.PathOpRecordFinalizerShader,
+                    "PathOpRecordFinalizerShader");
+                FinalizerPipeline = _cache.GetOrCreateComputePipeline(
+                    "PathOpRecordFinalizer",
+                    finalizerModule,
+                    "cs_main");
+                GeometryBindGroupLayout = context.Api.ComputePipelineGetBindGroupLayout(GeometryPipeline, 0);
+                FinalizerBindGroupLayout = context.Api.ComputePipelineGetBindGroupLayout(FinalizerPipeline, 0);
+            }
+
+            public ComputePipeline* GeometryPipeline { get; }
+            public ComputePipeline* FinalizerPipeline { get; }
+            public BindGroupLayout* GeometryBindGroupLayout { get; }
+            public BindGroupLayout* FinalizerBindGroupLayout { get; }
+
+            public void Dispose()
+            {
+                _context.Api.BindGroupLayoutRelease(GeometryBindGroupLayout);
+                _context.Api.BindGroupLayoutRelease(FinalizerBindGroupLayout);
+                _cache.Dispose();
+            }
+        }
+
+        private static void DisposePipelineResources(WgpuContext context)
+        {
+            if (PipelineResources.TryGetValue(context, out var resources))
+            {
+                PipelineResources.Remove(context);
+                resources.Dispose();
+            }
         }
 
         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -249,10 +308,7 @@ namespace ProGPU.Vector
             private GpuBuffer? _destRecordBuffer;
             private GpuBuffer? _destSegmentsBuffer;
             private GpuBuffer? _uniformBuffer;
-            private RenderPipelineCache? _cache;
-            private BindGroupLayout* _bindGroupLayoutGeom;
             private BindGroup* _bgGeom;
-            private BindGroupLayout* _bindGroupLayoutFinal;
             private BindGroup* _bgFinal;
             private CommandEncoder* _encoder;
             private CommandBuffer* _cmdBuffer;
@@ -288,17 +344,16 @@ namespace ProGPU.Vector
                 uint zero = 0;
                 _context.Api.QueueWriteBuffer(_context.Queue, _destSegmentsBuffer.BufferPtr, 0, &zero, 4);
 
-                _cache = new RenderPipelineCache(_context);
-                var geometryModule = _cache.GetOrCreateShader("PathOpGeometry", Shaders.PathOpGeometryShader, "PathOpGeometryShader");
-                var geometryPipeline = _cache.GetOrCreateComputePipeline("PathOpGeometry", geometryModule, "cs_main");
-                var finalizerModule = _cache.GetOrCreateShader("PathOpRecordFinalizer", Shaders.PathOpRecordFinalizerShader, "PathOpRecordFinalizerShader");
-                var finalizerPipeline = _cache.GetOrCreateComputePipeline("PathOpRecordFinalizer", finalizerModule, "cs_main");
+                var pipelines = PipelineResources.GetValue(
+                    _context,
+                    static context => new PathOpPipelineResources(context));
+                var geometryPipeline = pipelines.GeometryPipeline;
+                var finalizerPipeline = pipelines.FinalizerPipeline;
 
                 var uniforms = new PathOpDispatchUniforms { Op = (uint)op, MaxDestSegments = _maxDestSegments };
                 _uniformBuffer = new GpuBuffer(_context, (uint)Unsafe.SizeOf<PathOpDispatchUniforms>(), BufferUsage.Uniform | BufferUsage.CopyDst, "Uniforms Buffer");
                 _uniformBuffer.Write(new ReadOnlySpan<PathOpDispatchUniforms>(&uniforms, 1));
 
-                _bindGroupLayoutGeom = _context.Api.ComputePipelineGetBindGroupLayout(geometryPipeline, 0);
                 var entriesGeom = stackalloc BindGroupEntry[7];
                 entriesGeom[0] = new BindGroupEntry { Binding = 0, Buffer = _uniformBuffer.BufferPtr, Size = _uniformBuffer.Size };
                 entriesGeom[1] = new BindGroupEntry { Binding = 1, Buffer = _recordsBufferA.BufferPtr, Size = _recordsBufferA.Size };
@@ -307,17 +362,16 @@ namespace ProGPU.Vector
                 entriesGeom[4] = new BindGroupEntry { Binding = 4, Buffer = _segmentsBufferB.BufferPtr, Size = _segmentsBufferB.Size };
                 entriesGeom[5] = new BindGroupEntry { Binding = 5, Buffer = _destRecordBuffer.BufferPtr, Size = _destRecordBuffer.Size };
                 entriesGeom[6] = new BindGroupEntry { Binding = 6, Buffer = _destSegmentsBuffer.BufferPtr, Size = _destSegmentsBuffer.Size };
-                var bgDescGeom = new BindGroupDescriptor { Layout = _bindGroupLayoutGeom, EntryCount = 7, Entries = entriesGeom };
+                var bgDescGeom = new BindGroupDescriptor { Layout = pipelines.GeometryBindGroupLayout, EntryCount = 7, Entries = entriesGeom };
                 _bgGeom = _context.Api.DeviceCreateBindGroup(_context.Device, &bgDescGeom);
 
-                _bindGroupLayoutFinal = _context.Api.ComputePipelineGetBindGroupLayout(finalizerPipeline, 0);
                 var entriesFinal = stackalloc BindGroupEntry[5];
                 entriesFinal[0] = new BindGroupEntry { Binding = 0, Buffer = _uniformBuffer.BufferPtr, Size = _uniformBuffer.Size };
                 entriesFinal[1] = new BindGroupEntry { Binding = 1, Buffer = _recordsBufferA.BufferPtr, Size = _recordsBufferA.Size };
                 entriesFinal[2] = new BindGroupEntry { Binding = 2, Buffer = _recordsBufferB.BufferPtr, Size = _recordsBufferB.Size };
                 entriesFinal[3] = new BindGroupEntry { Binding = 3, Buffer = _destRecordBuffer.BufferPtr, Size = _destRecordBuffer.Size };
                 entriesFinal[4] = new BindGroupEntry { Binding = 4, Buffer = _destSegmentsBuffer.BufferPtr, Size = 16 };
-                var bgDescFinal = new BindGroupDescriptor { Layout = _bindGroupLayoutFinal, EntryCount = 5, Entries = entriesFinal };
+                var bgDescFinal = new BindGroupDescriptor { Layout = pipelines.FinalizerBindGroupLayout, EntryCount = 5, Entries = entriesFinal };
                 _bgFinal = _context.Api.DeviceCreateBindGroup(_context.Device, &bgDescFinal);
 
                 var encoderDesc = new CommandEncoderDescriptor { Label = (byte*)SilkMarshal.StringToPtr("Path Op Solver Geometry Encoder") };
@@ -385,7 +439,6 @@ namespace ProGPU.Vector
                 while (!mapState.Signal.IsSet)
                 {
                     _context.WaitIdle();
-                    System.Threading.Thread.Sleep(1);
                     if (swTimeout.ElapsedMilliseconds > 5000)
                     {
                         throw new TimeoutException("WebGPU BufferMapAsync timed out after 5 seconds during path op solver readback.");
@@ -408,9 +461,9 @@ namespace ProGPU.Vector
                     if (mappedPtr == null) return;
                     uint count = Math.Min(*(uint*)mappedPtr, _maxDestSegments);
                     var source = (GpuPathSegment*)((byte*)mappedPtr + 16);
-                    var output = new GpuPathSegment[count];
-                    for (uint index = 0; index < count; index++) output[index] = source[index];
-                    Result.Figures.AddRange(ReconstructFigures(output));
+                    AppendReconstructedFigures(
+                        new ReadOnlySpan<GpuPathSegment>(source, checked((int)count)),
+                        Result.Figures);
                 }
             }
 
@@ -443,9 +496,7 @@ namespace ProGPU.Vector
                 if (_cmdBuffer != null) _context.Api.CommandBufferRelease(_cmdBuffer);
                 if (_encoder != null) _context.Api.CommandEncoderRelease(_encoder);
                 if (_bgGeom != null) _context.Api.BindGroupRelease(_bgGeom);
-                if (_bindGroupLayoutGeom != null) _context.Api.BindGroupLayoutRelease(_bindGroupLayoutGeom);
                 if (_bgFinal != null) _context.Api.BindGroupRelease(_bgFinal);
-                if (_bindGroupLayoutFinal != null) _context.Api.BindGroupLayoutRelease(_bindGroupLayoutFinal);
                 _recordsBufferA?.Dispose();
                 _segmentsBufferA?.Dispose();
                 _recordsBufferB?.Dispose();
@@ -453,7 +504,6 @@ namespace ProGPU.Vector
                 _destRecordBuffer?.Dispose();
                 _destSegmentsBuffer?.Dispose();
                 _uniformBuffer?.Dispose();
-                _cache?.Dispose();
             }
         }
 
@@ -519,56 +569,94 @@ namespace ProGPU.Vector
 
         public static List<PathFigure> ReconstructFigures(GpuPathSegment[] segments)
         {
+            ArgumentNullException.ThrowIfNull(segments);
             var figures = new List<PathFigure>();
-            if (segments.Length == 0) return figures;
+            AppendReconstructedFigures(segments, figures);
+            return figures;
+        }
 
-            var unused = new List<GpuPathSegment>(segments);
-
-            while (unused.Count > 0)
+        private static void AppendReconstructedFigures(
+            ReadOnlySpan<GpuPathSegment> segments,
+            List<PathFigure> figures)
+        {
+            if (segments.IsEmpty)
             {
-                var currentSeg = unused[0];
-                unused.RemoveAt(0);
-
-                var figure = new PathFigure(currentSeg.P0, isClosed: false);
-                Vector2 currentPt = currentSeg.P0;
-                AddSegmentToFigure(figure, currentSeg, ref currentPt);
-
-                bool foundNext = true;
-                while (foundNext && unused.Count > 0)
-                {
-                    foundNext = false;
-                    for (int i = 0; i < unused.Count; i++)
-                    {
-                        var nextSeg = unused[i];
-                        if (Vector2.DistanceSquared(nextSeg.P0, currentPt) < 0.25f)
-                        {
-                            AddSegmentToFigure(figure, nextSeg, ref currentPt);
-                            unused.RemoveAt(i);
-                            foundNext = true;
-                            break;
-                        }
-
-                        if (Vector2.DistanceSquared(GetSegmentEndPoint(nextSeg), currentPt) < 0.25f)
-                        {
-                            nextSeg = ReverseSegment(nextSeg);
-                            AddSegmentToFigure(figure, nextSeg, ref currentPt);
-                            unused.RemoveAt(i);
-                            foundNext = true;
-                            break;
-                        }
-                    }
-
-                    if (Vector2.DistanceSquared(currentPt, figure.StartPoint) < 0.25f)
-                    {
-                        figure.IsClosed = true;
-                        break;
-                    }
-                }
-
-                figures.Add(figure);
+                return;
             }
 
-            return figures;
+            byte[]? rentedUsage = null;
+            Span<byte> used = segments.Length <= 256
+                ? stackalloc byte[segments.Length]
+                : (rentedUsage = ArrayPool<byte>.Shared.Rent(segments.Length)).AsSpan(0, segments.Length);
+            used.Clear();
+            try
+            {
+                var remaining = segments.Length;
+                while (remaining > 0)
+                {
+                    var firstUnused = 0;
+                    while (used[firstUnused] != 0)
+                    {
+                        firstUnused++;
+                    }
+
+                    var currentSeg = segments[firstUnused];
+                    used[firstUnused] = 1;
+                    remaining--;
+
+                    var figure = new PathFigure(currentSeg.P0, isClosed: false);
+                    Vector2 currentPt = currentSeg.P0;
+                    AddSegmentToFigure(figure, currentSeg, ref currentPt);
+
+                    bool foundNext = true;
+                    while (foundNext && remaining > 0)
+                    {
+                        foundNext = false;
+                        for (int index = 0; index < segments.Length; index++)
+                        {
+                            if (used[index] != 0)
+                            {
+                                continue;
+                            }
+
+                            var nextSeg = segments[index];
+                            if (Vector2.DistanceSquared(nextSeg.P0, currentPt) < 0.25f)
+                            {
+                                AddSegmentToFigure(figure, nextSeg, ref currentPt);
+                                used[index] = 1;
+                                remaining--;
+                                foundNext = true;
+                                break;
+                            }
+
+                            if (Vector2.DistanceSquared(GetSegmentEndPoint(nextSeg), currentPt) < 0.25f)
+                            {
+                                nextSeg = ReverseSegment(nextSeg);
+                                AddSegmentToFigure(figure, nextSeg, ref currentPt);
+                                used[index] = 1;
+                                remaining--;
+                                foundNext = true;
+                                break;
+                            }
+                        }
+
+                        if (Vector2.DistanceSquared(currentPt, figure.StartPoint) < 0.25f)
+                        {
+                            figure.IsClosed = true;
+                            break;
+                        }
+                    }
+
+                    figures.Add(figure);
+                }
+            }
+            finally
+            {
+                if (rentedUsage is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(rentedUsage);
+                }
+            }
         }
 
         private static Vector2 GetSegmentEndPoint(GpuPathSegment segment)

--- a/src/ProGPU.Vector/PathOpGeometrySolver.cs
+++ b/src/ProGPU.Vector/PathOpGeometrySolver.cs
@@ -47,24 +47,32 @@ namespace ProGPU.Vector
             {
                 _context = context;
                 _cache = new RenderPipelineCache(context);
-                var geometryModule = _cache.GetOrCreateShader(
-                    "PathOpGeometry",
-                    Shaders.PathOpGeometryShader,
-                    "PathOpGeometryShader");
-                GeometryPipeline = _cache.GetOrCreateComputePipeline(
-                    "PathOpGeometry",
-                    geometryModule,
-                    "cs_main");
-                var finalizerModule = _cache.GetOrCreateShader(
-                    "PathOpRecordFinalizer",
-                    Shaders.PathOpRecordFinalizerShader,
-                    "PathOpRecordFinalizerShader");
-                FinalizerPipeline = _cache.GetOrCreateComputePipeline(
-                    "PathOpRecordFinalizer",
-                    finalizerModule,
-                    "cs_main");
-                GeometryBindGroupLayout = context.Api.ComputePipelineGetBindGroupLayout(GeometryPipeline, 0);
-                FinalizerBindGroupLayout = context.Api.ComputePipelineGetBindGroupLayout(FinalizerPipeline, 0);
+                try
+                {
+                    var geometryModule = _cache.GetOrCreateShader(
+                        "PathOpGeometry",
+                        Shaders.PathOpGeometryShader,
+                        "PathOpGeometryShader");
+                    GeometryPipeline = _cache.GetOrCreateComputePipeline(
+                        "PathOpGeometry",
+                        geometryModule,
+                        "cs_main");
+                    var finalizerModule = _cache.GetOrCreateShader(
+                        "PathOpRecordFinalizer",
+                        Shaders.PathOpRecordFinalizerShader,
+                        "PathOpRecordFinalizerShader");
+                    FinalizerPipeline = _cache.GetOrCreateComputePipeline(
+                        "PathOpRecordFinalizer",
+                        finalizerModule,
+                        "cs_main");
+                    GeometryBindGroupLayout = context.Api.ComputePipelineGetBindGroupLayout(GeometryPipeline, 0);
+                    FinalizerBindGroupLayout = context.Api.ComputePipelineGetBindGroupLayout(FinalizerPipeline, 0);
+                }
+                catch
+                {
+                    Dispose();
+                    throw;
+                }
             }
 
             public ComputePipeline* GeometryPipeline { get; }
@@ -74,8 +82,16 @@ namespace ProGPU.Vector
 
             public void Dispose()
             {
-                _context.Api.BindGroupLayoutRelease(GeometryBindGroupLayout);
-                _context.Api.BindGroupLayoutRelease(FinalizerBindGroupLayout);
+                if (GeometryBindGroupLayout != null)
+                {
+                    _context.Api.BindGroupLayoutRelease(GeometryBindGroupLayout);
+                }
+
+                if (FinalizerBindGroupLayout != null)
+                {
+                    _context.Api.BindGroupLayoutRelease(FinalizerBindGroupLayout);
+                }
+
                 _cache.Dispose();
             }
         }

--- a/src/ProGPU.Vector/StrokeCapGeometry.cs
+++ b/src/ProGPU.Vector/StrokeCapGeometry.cs
@@ -26,6 +26,82 @@ public static class StrokeCapGeometry
             maxRoundSegments);
     }
 
+    public static int WriteLineCap(
+        Span<StrokeJoinTriangle> destination,
+        PenLineCap lineCap,
+        float thickness,
+        Vector2 lineStart,
+        Vector2 lineEnd,
+        bool isStart,
+        int maxRoundSegments = MaxTrianglesPerCap)
+    {
+        if (lineCap == PenLineCap.Flat || !float.IsFinite(thickness) || thickness <= Epsilon)
+        {
+            return 0;
+        }
+
+        var delta = lineEnd - lineStart;
+        var length = delta.Length();
+        if (!float.IsFinite(length) || length <= Epsilon)
+        {
+            return 0;
+        }
+
+        var direction = delta / length;
+        var center = isStart ? lineStart : lineEnd;
+        var radius = thickness * 0.5f;
+        var outward = isStart ? -direction : direction;
+        var normal = new Vector2(-direction.Y, direction.X) * radius;
+        if (lineCap == PenLineCap.Square)
+        {
+            EnsureDestination(destination, 2);
+            var inner0 = center - normal;
+            var inner1 = center + normal;
+            var outer0 = center + outward * radius - normal;
+            var outer1 = center + outward * radius + normal;
+            destination[0] = new StrokeJoinTriangle(inner0, outer0, outer1);
+            destination[1] = new StrokeJoinTriangle(inner0, outer1, inner1);
+            return 2;
+        }
+
+        if (lineCap == PenLineCap.Triangle)
+        {
+            EnsureDestination(destination, 1);
+            destination[0] = new StrokeJoinTriangle(
+                center - normal,
+                center + outward * radius,
+                center + normal);
+            return 1;
+        }
+
+        var segmentCount = Math.Clamp(maxRoundSegments, 1, MaxTrianglesPerCap);
+        EnsureDestination(destination, segmentCount);
+        var baseAngle = MathF.Atan2(outward.Y, outward.X);
+        var start = baseAngle - MathF.PI * 0.5f;
+        for (var index = 0; index < segmentCount; index++)
+        {
+            var angle0 = start + MathF.PI * index / segmentCount;
+            var angle1 = start + MathF.PI * (index + 1) / segmentCount;
+            var point0 = new Vector2(
+                center.X + MathF.Cos(angle0) * radius,
+                center.Y + MathF.Sin(angle0) * radius);
+            var point1 = new Vector2(
+                center.X + MathF.Cos(angle1) * radius,
+                center.Y + MathF.Sin(angle1) * radius);
+            destination[index] = new StrokeJoinTriangle(center, point0, point1);
+        }
+
+        return segmentCount;
+    }
+
+    private static void EnsureDestination(Span<StrokeJoinTriangle> destination, int count)
+    {
+        if (destination.Length < count)
+        {
+            throw new ArgumentException("The destination cannot hold the generated cap triangles.", nameof(destination));
+        }
+    }
+
     public static StrokeJoinTriangle[] CreateDirectionalCap(
         PenLineCap lineCap,
         float thickness,

--- a/src/ProGPU.Vector/StrokeJoinGeometry.cs
+++ b/src/ProGPU.Vector/StrokeJoinGeometry.cs
@@ -44,6 +44,112 @@ public static class StrokeJoinGeometry
             maxRoundSegments);
     }
 
+    public static int WriteLineJoin(
+        Span<StrokeJoinTriangle> destination,
+        PenLineJoin lineJoin,
+        float thickness,
+        float miterLimit,
+        Vector2 previousPoint,
+        Vector2 joinPoint,
+        Vector2 nextPoint,
+        bool isSmoothJoin = false,
+        int maxRoundSegments = MaxTrianglesPerJoin)
+    {
+        if (isSmoothJoin || !float.IsFinite(thickness) || thickness <= Epsilon ||
+            !TryNormalize(joinPoint - previousPoint, out var incomingDirection) ||
+            !TryNormalize(nextPoint - joinPoint, out var outgoingDirection))
+        {
+            return 0;
+        }
+
+        var turn = Cross(incomingDirection, outgoingDirection);
+        if (MathF.Abs(turn) <= Epsilon)
+        {
+            return 0;
+        }
+
+        var radius = thickness * 0.5f;
+        var outerSign = turn > 0f ? -1f : 1f;
+        var previousOuterPoint = joinPoint + GetLeftNormal(incomingDirection) * outerSign * radius;
+        var nextOuterPoint = joinPoint + GetLeftNormal(outgoingDirection) * outerSign * radius;
+        if (lineJoin == PenLineJoin.Bevel)
+        {
+            EnsureDestination(destination, 1);
+            destination[0] = new StrokeJoinTriangle(previousOuterPoint, joinPoint, nextOuterPoint);
+            return 1;
+        }
+
+        if (lineJoin == PenLineJoin.Miter)
+        {
+            var clampedMiterLimit = float.IsFinite(miterLimit) && miterLimit >= 1f ? miterLimit : 1f;
+            var hasMiter = TryIntersectLines(
+                previousOuterPoint,
+                incomingDirection,
+                nextOuterPoint,
+                outgoingDirection,
+                out var miterPoint) &&
+                Vector2.Distance(joinPoint, miterPoint) <= radius * clampedMiterLimit + Epsilon;
+            var count = hasMiter ? 2 : 1;
+            EnsureDestination(destination, count);
+            destination[0] = new StrokeJoinTriangle(previousOuterPoint, joinPoint, nextOuterPoint);
+            if (hasMiter)
+            {
+                destination[1] = new StrokeJoinTriangle(previousOuterPoint, miterPoint, nextOuterPoint);
+            }
+            return count;
+        }
+
+        var start = MathF.Atan2(
+            previousOuterPoint.Y - joinPoint.Y,
+            previousOuterPoint.X - joinPoint.X);
+        var end = MathF.Atan2(
+            nextOuterPoint.Y - joinPoint.Y,
+            nextOuterPoint.X - joinPoint.X);
+        if (turn > 0f)
+        {
+            while (end < start)
+            {
+                end += MathF.PI * 2f;
+            }
+        }
+        else
+        {
+            while (end > start)
+            {
+                end -= MathF.PI * 2f;
+            }
+        }
+
+        var sweep = end - start;
+        var segmentCount = Math.Clamp(
+            (int)MathF.Ceiling(MathF.Abs(sweep) / (MathF.PI / 8f)),
+            1,
+            Math.Clamp(maxRoundSegments, 1, MaxTrianglesPerJoin));
+        EnsureDestination(destination, segmentCount);
+        for (var index = 0; index < segmentCount; index++)
+        {
+            var angle0 = start + sweep * index / segmentCount;
+            var angle1 = start + sweep * (index + 1) / segmentCount;
+            var point0 = new Vector2(
+                joinPoint.X + MathF.Cos(angle0) * radius,
+                joinPoint.Y + MathF.Sin(angle0) * radius);
+            var point1 = new Vector2(
+                joinPoint.X + MathF.Cos(angle1) * radius,
+                joinPoint.Y + MathF.Sin(angle1) * radius);
+            destination[index] = new StrokeJoinTriangle(joinPoint, point0, point1);
+        }
+
+        return segmentCount;
+    }
+
+    private static void EnsureDestination(Span<StrokeJoinTriangle> destination, int count)
+    {
+        if (destination.Length < count)
+        {
+            throw new ArgumentException("The destination cannot hold the generated join triangles.", nameof(destination));
+        }
+    }
+
     public static StrokeJoinTriangle[] CreateDirectionalJoin(
         PenLineJoin lineJoin,
         float thickness,

--- a/src/SkiaSharp/SKPaint.cs
+++ b/src/SkiaSharp/SKPaint.cs
@@ -1206,7 +1206,7 @@ public partial class SKPaint : SKObject
         int depthRemaining)
     {
         if (depthRemaining == 0 ||
-            DistanceToLineSquared(point1, point0, point2) <= toleranceSquared)
+            IsQuadraticFlat(point0, point1, point2, toleranceSquared))
         {
             destination.Add(point2);
             return;
@@ -1241,9 +1241,7 @@ public partial class SKPaint : SKObject
         int depthRemaining)
     {
         if (depthRemaining == 0 ||
-            MathF.Max(
-                DistanceToLineSquared(point1, point0, point3),
-                DistanceToLineSquared(point2, point0, point3)) <= toleranceSquared)
+            IsCubicFlat(point0, point1, point2, point3, toleranceSquared))
         {
             destination.Add(point3);
             return;
@@ -1274,18 +1272,61 @@ public partial class SKPaint : SKObject
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float DistanceToLineSquared(Vector2 point, Vector2 lineStart, Vector2 lineEnd)
+    private static bool IsQuadraticFlat(
+        Vector2 point0,
+        Vector2 point1,
+        Vector2 point2,
+        float toleranceSquared)
     {
-        var line = lineEnd - lineStart;
-        var lengthSquared = line.LengthSquared();
-        if (lengthSquared <= 0.0000001f)
+        var chordX = point2.X - point0.X;
+        var chordY = point2.Y - point0.Y;
+        var chordLengthSquared = chordX * chordX + chordY * chordY;
+        if (chordLengthSquared <= 0.0000001f)
         {
-            return Vector2.DistanceSquared(point, lineStart);
+            return Vector2.DistanceSquared(point1, point0) <= toleranceSquared;
         }
 
-        var cross = line.X * (lineStart.Y - point.Y) -
-                    (lineStart.X - point.X) * line.Y;
-        return cross * cross / lengthSquared;
+        var controlX = point1.X - point0.X;
+        var controlY = point1.Y - point0.Y;
+        var projection = controlX * chordX + controlY * chordY;
+        var cross = chordX * controlY - chordY * controlX;
+        return projection >= 0f &&
+               projection <= chordLengthSquared &&
+               cross * cross <= toleranceSquared * chordLengthSquared;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsCubicFlat(
+        Vector2 point0,
+        Vector2 point1,
+        Vector2 point2,
+        Vector2 point3,
+        float toleranceSquared)
+    {
+        var chordX = point3.X - point0.X;
+        var chordY = point3.Y - point0.Y;
+        var chordLengthSquared = chordX * chordX + chordY * chordY;
+        if (chordLengthSquared <= 0.0000001f)
+        {
+            return MathF.Max(
+                Vector2.DistanceSquared(point1, point0),
+                Vector2.DistanceSquared(point2, point0)) <= toleranceSquared;
+        }
+
+        var firstX = point1.X - point0.X;
+        var firstY = point1.Y - point0.Y;
+        var secondX = point2.X - point0.X;
+        var secondY = point2.Y - point0.Y;
+        var firstProjection = firstX * chordX + firstY * chordY;
+        var secondProjection = secondX * chordX + secondY * chordY;
+        var firstCross = chordX * firstY - chordY * firstX;
+        var secondCross = chordX * secondY - chordY * secondX;
+        var scaledTolerance = toleranceSquared * chordLengthSquared;
+        return firstProjection >= 0f &&
+               firstProjection <= secondProjection &&
+               secondProjection <= chordLengthSquared &&
+               firstCross * firstCross <= scaledTolerance &&
+               secondCross * secondCross <= scaledTolerance;
     }
 
     private static void ReturnStrokePoints(List<Vector2> points)

--- a/src/SkiaSharp/SKPaint.cs
+++ b/src/SkiaSharp/SKPaint.cs
@@ -874,24 +874,25 @@ public partial class SKPaint : SKObject
 
     private void AddStrokeJoins(
         SKPath destination,
-        IReadOnlyList<Vector2> points,
+        List<Vector2> points,
         bool isClosed,
         float strokeWidth)
     {
-        if (points.Count < 3)
+        var pointCount = points.Count;
+        if (pointCount < 3)
         {
             return;
         }
 
         var first = isClosed ? 0 : 1;
-        var end = isClosed ? points.Count : points.Count - 1;
+        var end = isClosed ? pointCount : pointCount - 1;
         var lineJoin = MapStrokeJoin(StrokeJoin);
         Span<StrokeJoinTriangle> triangles = stackalloc StrokeJoinTriangle[StrokeJoinGeometry.MaxTrianglesPerJoin];
         for (var index = first; index < end; index++)
         {
-            var previous = points[(index - 1 + points.Count) % points.Count];
+            var previous = points[index == 0 ? pointCount - 1 : index - 1];
             var current = points[index];
-            var next = points[(index + 1) % points.Count];
+            var next = points[index + 1 == pointCount ? 0 : index + 1];
             var triangleCount = StrokeJoinGeometry.WriteLineJoin(
                 triangles,
                 lineJoin,
@@ -906,7 +907,7 @@ public partial class SKPaint : SKObject
 
     private void AddStrokeCaps(
         SKPath destination,
-        IReadOnlyList<Vector2> points,
+        List<Vector2> points,
         float strokeWidth)
     {
         if (points.Count < 2 || StrokeCap == SKStrokeCap.Butt)
@@ -967,14 +968,7 @@ public partial class SKPaint : SKObject
         SKPath destination,
         ReadOnlySpan<StrokeJoinTriangle> triangles)
     {
-        for (var index = 0; index < triangles.Length; index++)
-        {
-            var triangle = triangles[index];
-            destination.MoveTo(triangle.P0.X, triangle.P0.Y);
-            destination.LineTo(triangle.P1.X, triangle.P1.Y);
-            destination.LineTo(triangle.P2.X, triangle.P2.Y);
-            destination.Close();
-        }
+        destination.AddTriangles(triangles);
     }
 
     private static bool IsDegenerateFigure(IReadOnlyList<Vector2> points)

--- a/src/SkiaSharp/SKPaint.cs
+++ b/src/SkiaSharp/SKPaint.cs
@@ -18,6 +18,9 @@ public enum SKPaintStyle
 
 public partial class SKPaint : SKObject
 {
+    [ThreadStatic]
+    private static List<Vector2>? s_strokePointCache;
+
     private const float HairlineStrokeWidth = 1f;
     private SKShader? _shader;
     private SKBlender? _blender;
@@ -507,18 +510,23 @@ public partial class SKPaint : SKObject
     {
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
-        if (!TryCreateFillPath(src, NormalizeResolutionScale(resScale), out var result))
+        var normalizedScale = NormalizeResolutionScale(resScale);
+        if (!ReferenceEquals(src, dst) &&
+            PathEffect is not { IsDash: false } &&
+            (Style != SKPaintStyle.Stroke || StrokeWidth != 0f))
+        {
+            dst.Reset();
+            return TryPopulateFillPath(src, normalizedScale, dst);
+        }
+
+        if (!TryCreateFillPath(src, normalizedScale, out var result))
         {
             result.Dispose();
             return false;
         }
 
-        using (result)
-        {
-            dst.Reset();
-            dst.FillType = result.FillType;
-            dst.AddPath(result);
-        }
+        dst.ReplaceWithOwned(result);
+        result.Dispose();
 
         return true;
     }
@@ -577,6 +585,11 @@ public partial class SKPaint : SKObject
     private bool TryCreateFillPath(SKPath source, float resScale, out SKPath destination)
     {
         destination = new SKPath();
+        return TryPopulateFillPath(source, resScale, destination);
+    }
+
+    private bool TryPopulateFillPath(SKPath source, float resScale, SKPath destination)
+    {
         if (PathEffect is { IsDash: false } materializedEffect)
         {
             var applied = materializedEffect.TryApply(
@@ -586,13 +599,20 @@ public partial class SKPaint : SKObject
                 out var paintAdjustment);
             if (applied)
             {
-                destination.Dispose();
                 using (effectedPath)
                 using (var paint = Clone())
                 {
                     paint.PathEffect = null;
                     paintAdjustment.Apply(paint);
-                    return paint.TryCreateFillPath(effectedPath, resScale, out destination);
+                    if (!paint.TryCreateFillPath(effectedPath, resScale, out var result))
+                    {
+                        result.Dispose();
+                        return false;
+                    }
+
+                    destination.ReplaceWithOwned(result);
+                    result.Dispose();
+                    return true;
                 }
             }
             effectedPath.Dispose();
@@ -629,52 +649,59 @@ public partial class SKPaint : SKObject
             }
 
             var points = FlattenFigure(figure, resScale);
-            RemoveConsecutiveDuplicatePoints(points);
-            if (figure.IsClosed &&
-                points.Count > 1 &&
-                Vector2.DistanceSquared(points[0], points[^1]) <= 0.0000001f)
+            try
             {
-                points.RemoveAt(points.Count - 1);
-            }
-
-            if (!figure.IsClosed && figure.Segments.Count > 0 && IsDegenerateFigure(points))
-            {
-                if (StrokeCap == SKStrokeCap.Round)
+                RemoveConsecutiveDuplicatePoints(points);
+                if (figure.IsClosed &&
+                    points.Count > 1 &&
+                    Vector2.DistanceSquared(points[0], points[^1]) <= 0.0000001f)
                 {
-                    destination.AddCircle(figure.StartPoint.X, figure.StartPoint.Y, halfWidth);
-                }
-                else if (StrokeCap == SKStrokeCap.Square)
-                {
-                    destination.AddRect(new SKRect(
-                        figure.StartPoint.X - halfWidth,
-                        figure.StartPoint.Y - halfWidth,
-                        figure.StartPoint.X + halfWidth,
-                        figure.StartPoint.Y + halfWidth));
+                    points.RemoveAt(points.Count - 1);
                 }
 
-                continue;
-            }
+                if (!figure.IsClosed && figure.Segments.Count > 0 && IsDegenerateFigure(points))
+                {
+                    if (StrokeCap == SKStrokeCap.Round)
+                    {
+                        destination.AddCircle(figure.StartPoint.X, figure.StartPoint.Y, halfWidth);
+                    }
+                    else if (StrokeCap == SKStrokeCap.Square)
+                    {
+                        destination.AddRect(new SKRect(
+                            figure.StartPoint.X - halfWidth,
+                            figure.StartPoint.Y - halfWidth,
+                            figure.StartPoint.X + halfWidth,
+                            figure.StartPoint.Y + halfWidth));
+                    }
 
-            if (PathEffect is { IsDash: true, Intervals.Length: > 0 } dashEffect)
-            {
-                AddDashedStrokeSegments(destination, points, figure.IsClosed, halfWidth, dashEffect);
-                continue;
-            }
+                    continue;
+                }
 
-            for (var i = 1; i < points.Count; i++)
-            {
-                AddStrokeSegment(destination, points[i - 1], points[i], halfWidth);
-            }
+                if (PathEffect is { IsDash: true, Intervals.Length: > 0 } dashEffect)
+                {
+                    AddDashedStrokeSegments(destination, points, figure.IsClosed, halfWidth, dashEffect);
+                    continue;
+                }
 
-            if (figure.IsClosed && points.Count > 1)
-            {
-                AddStrokeSegment(destination, points[^1], points[0], halfWidth);
-            }
+                for (var i = 1; i < points.Count; i++)
+                {
+                    AddStrokeSegment(destination, points[i - 1], points[i], halfWidth);
+                }
 
-            AddStrokeJoins(destination, points, figure.IsClosed, halfWidth * 2f);
-            if (!figure.IsClosed)
+                if (figure.IsClosed && points.Count > 1)
+                {
+                    AddStrokeSegment(destination, points[^1], points[0], halfWidth);
+                }
+
+                AddStrokeJoins(destination, points, figure.IsClosed, halfWidth * 2f);
+                if (!figure.IsClosed)
+                {
+                    AddStrokeCaps(destination, points, halfWidth * 2f);
+                }
+            }
+            finally
             {
-                AddStrokeCaps(destination, points, halfWidth * 2f);
+                ReturnStrokePoints(points);
             }
         }
 
@@ -694,10 +721,17 @@ public partial class SKPaint : SKObject
         for (var index = 0; index < figures.Count; index++)
         {
             var points = FlattenFigure(figures[index]);
-            var winding = GetSignedArea(points);
-            if (MathF.Abs(winding) > 0.0001f && MathF.Sign(winding) != desiredWinding)
+            try
             {
-                figures[index] = ReverseFigure(figures[index]);
+                var winding = GetSignedArea(points);
+                if (MathF.Abs(winding) > 0.0001f && MathF.Sign(winding) != desiredWinding)
+                {
+                    figures[index] = ReverseFigure(figures[index]);
+                }
+            }
+            finally
+            {
+                ReturnStrokePoints(points);
             }
         }
     }
@@ -707,10 +741,18 @@ public partial class SKPaint : SKObject
         var dominantArea = 0f;
         for (var index = 0; index < figures.Count; index++)
         {
-            var area = GetSignedArea(FlattenFigure(figures[index]));
-            if (MathF.Abs(area) > MathF.Abs(dominantArea))
+            var points = FlattenFigure(figures[index]);
+            try
             {
-                dominantArea = area;
+                var area = GetSignedArea(points);
+                if (MathF.Abs(area) > MathF.Abs(dominantArea))
+                {
+                    dominantArea = area;
+                }
+            }
+            finally
+            {
+                ReturnStrokePoints(points);
             }
         }
 
@@ -844,20 +886,21 @@ public partial class SKPaint : SKObject
         var first = isClosed ? 0 : 1;
         var end = isClosed ? points.Count : points.Count - 1;
         var lineJoin = MapStrokeJoin(StrokeJoin);
+        Span<StrokeJoinTriangle> triangles = stackalloc StrokeJoinTriangle[StrokeJoinGeometry.MaxTrianglesPerJoin];
         for (var index = first; index < end; index++)
         {
             var previous = points[(index - 1 + points.Count) % points.Count];
             var current = points[index];
             var next = points[(index + 1) % points.Count];
-            AddStrokeTriangles(
-                destination,
-                StrokeJoinGeometry.CreateLineJoin(
-                    lineJoin,
-                    strokeWidth,
-                    StrokeMiter,
-                    previous,
-                    current,
-                    next));
+            var triangleCount = StrokeJoinGeometry.WriteLineJoin(
+                triangles,
+                lineJoin,
+                strokeWidth,
+                StrokeMiter,
+                previous,
+                current,
+                next);
+            AddStrokeTriangles(destination, triangles[..triangleCount]);
         }
     }
 
@@ -872,28 +915,29 @@ public partial class SKPaint : SKObject
         }
 
         var lineCap = MapStrokeCap(StrokeCap);
+        Span<StrokeJoinTriangle> triangles = stackalloc StrokeJoinTriangle[StrokeCapGeometry.MaxTrianglesPerCap];
         if (TryFindDistinctPoint(points, 0, 1, out var firstNeighbor))
         {
-            AddStrokeTriangles(
-                destination,
-                StrokeCapGeometry.CreateLineCap(
-                    lineCap,
-                    strokeWidth,
-                    points[0],
-                    firstNeighbor,
-                    isStart: true));
+            var triangleCount = StrokeCapGeometry.WriteLineCap(
+                triangles,
+                lineCap,
+                strokeWidth,
+                points[0],
+                firstNeighbor,
+                isStart: true);
+            AddStrokeTriangles(destination, triangles[..triangleCount]);
         }
 
         if (TryFindDistinctPoint(points, points.Count - 1, -1, out var lastNeighbor))
         {
-            AddStrokeTriangles(
-                destination,
-                StrokeCapGeometry.CreateLineCap(
-                    lineCap,
-                    strokeWidth,
-                    lastNeighbor,
-                    points[^1],
-                    isStart: false));
+            var triangleCount = StrokeCapGeometry.WriteLineCap(
+                triangles,
+                lineCap,
+                strokeWidth,
+                lastNeighbor,
+                points[^1],
+                isStart: false);
+            AddStrokeTriangles(destination, triangles[..triangleCount]);
         }
     }
 
@@ -921,9 +965,9 @@ public partial class SKPaint : SKObject
 
     private static void AddStrokeTriangles(
         SKPath destination,
-        IReadOnlyList<StrokeJoinTriangle> triangles)
+        ReadOnlySpan<StrokeJoinTriangle> triangles)
     {
-        for (var index = 0; index < triangles.Count; index++)
+        for (var index = 0; index < triangles.Length; index++)
         {
             var triangle = triangles[index];
             destination.MoveTo(triangle.P0.X, triangle.P0.Y);
@@ -1102,14 +1146,16 @@ public partial class SKPaint : SKObject
 
     private static List<Vector2> FlattenFigure(PathFigure figure, float resScale = 1f)
     {
-        // Skia increases stroker precision with the device resolution. The square-root
-        // schedule preserves sub-pixel quality without making large transforms linear
-        // in scale; the cap keeps adversarial matrices bounded.
-        var curveSegments = Math.Clamp(
-            (int)MathF.Ceiling(24f * MathF.Sqrt(NormalizeResolutionScale(resScale))),
-            24,
-            192);
-        var result = new List<Vector2> { figure.StartPoint };
+        // Subdivide only until the control polygon is within 1/4 logical pixel
+        // of its chord. Higher device resolution tightens that tolerance while
+        // the fixed depth keeps adversarial curves bounded to O(2^8) spans.
+        var tolerance = 0.25f / NormalizeResolutionScale(resScale);
+        var toleranceSquared = tolerance * tolerance;
+        const int maximumDepth = 8;
+        var result = s_strokePointCache ?? new List<Vector2>();
+        s_strokePointCache = null;
+        result.Clear();
+        result.Add(figure.StartPoint);
         var current = figure.StartPoint;
         foreach (var segment in figure.Segments)
         {
@@ -1120,27 +1166,25 @@ public partial class SKPaint : SKObject
                     current = line.Point;
                     break;
                 case QuadraticBezierSegment quadratic:
-                    for (var i = 1; i <= curveSegments; i++)
-                    {
-                        result.Add(BezierSegmentGeometry.EvaluateQuadratic(
-                            current,
-                            quadratic.ControlPoint,
-                            quadratic.Point,
-                            (float)i / curveSegments));
-                    }
+                    FlattenQuadratic(
+                        result,
+                        current,
+                        quadratic.ControlPoint,
+                        quadratic.Point,
+                        toleranceSquared,
+                        maximumDepth);
 
                     current = quadratic.Point;
                     break;
                 case CubicBezierSegment cubic:
-                    for (var i = 1; i <= curveSegments; i++)
-                    {
-                        result.Add(BezierSegmentGeometry.EvaluateCubic(
-                            current,
-                            cubic.ControlPoint1,
-                            cubic.ControlPoint2,
-                            cubic.Point,
-                            (float)i / curveSegments));
-                    }
+                    FlattenCubic(
+                        result,
+                        current,
+                        cubic.ControlPoint1,
+                        cubic.ControlPoint2,
+                        cubic.Point,
+                        toleranceSquared,
+                        maximumDepth);
 
                     current = cubic.Point;
                     break;
@@ -1157,6 +1201,106 @@ public partial class SKPaint : SKObject
         }
 
         return result;
+    }
+
+    private static void FlattenQuadratic(
+        List<Vector2> destination,
+        Vector2 point0,
+        Vector2 point1,
+        Vector2 point2,
+        float toleranceSquared,
+        int depthRemaining)
+    {
+        if (depthRemaining == 0 ||
+            DistanceToLineSquared(point1, point0, point2) <= toleranceSquared)
+        {
+            destination.Add(point2);
+            return;
+        }
+
+        var point01 = (point0 + point1) * 0.5f;
+        var point12 = (point1 + point2) * 0.5f;
+        var midpoint = (point01 + point12) * 0.5f;
+        FlattenQuadratic(
+            destination,
+            point0,
+            point01,
+            midpoint,
+            toleranceSquared,
+            depthRemaining - 1);
+        FlattenQuadratic(
+            destination,
+            midpoint,
+            point12,
+            point2,
+            toleranceSquared,
+            depthRemaining - 1);
+    }
+
+    private static void FlattenCubic(
+        List<Vector2> destination,
+        Vector2 point0,
+        Vector2 point1,
+        Vector2 point2,
+        Vector2 point3,
+        float toleranceSquared,
+        int depthRemaining)
+    {
+        if (depthRemaining == 0 ||
+            MathF.Max(
+                DistanceToLineSquared(point1, point0, point3),
+                DistanceToLineSquared(point2, point0, point3)) <= toleranceSquared)
+        {
+            destination.Add(point3);
+            return;
+        }
+
+        var point01 = (point0 + point1) * 0.5f;
+        var point12 = (point1 + point2) * 0.5f;
+        var point23 = (point2 + point3) * 0.5f;
+        var point012 = (point01 + point12) * 0.5f;
+        var point123 = (point12 + point23) * 0.5f;
+        var midpoint = (point012 + point123) * 0.5f;
+        FlattenCubic(
+            destination,
+            point0,
+            point01,
+            point012,
+            midpoint,
+            toleranceSquared,
+            depthRemaining - 1);
+        FlattenCubic(
+            destination,
+            midpoint,
+            point123,
+            point23,
+            point3,
+            toleranceSquared,
+            depthRemaining - 1);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float DistanceToLineSquared(Vector2 point, Vector2 lineStart, Vector2 lineEnd)
+    {
+        var line = lineEnd - lineStart;
+        var lengthSquared = line.LengthSquared();
+        if (lengthSquared <= 0.0000001f)
+        {
+            return Vector2.DistanceSquared(point, lineStart);
+        }
+
+        var cross = line.X * (lineStart.Y - point.Y) -
+                    (lineStart.X - point.X) * line.Y;
+        return cross * cross / lengthSquared;
+    }
+
+    private static void ReturnStrokePoints(List<Vector2> points)
+    {
+        points.Clear();
+        if (s_strokePointCache is null && points.Capacity <= 4_096)
+        {
+            s_strokePointCache = points;
+        }
     }
 
     private static void AddStrokeSegment(SKPath path, Vector2 start, Vector2 end, float halfWidth)

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -237,7 +237,7 @@ internal static class SKPathTightBounds
 internal sealed class PackedPathData : IDisposable
 {
     private const int InitialCommandCapacity = 64;
-    private const int MaximumRetainedCommandCapacity = 1_024;
+    private const int MaximumRetainedCommandCapacity = 4_096;
     [ThreadStatic]
     private static PackedPathData? s_threadCache;
     private sealed class CommandBuffer
@@ -249,7 +249,7 @@ internal sealed class PackedPathData : IDisposable
             Commands = commands;
         }
 
-        public PackedPathCommand[] Commands { get; }
+        public PackedPathCommand[] Commands { get; set; }
         public bool IsShared => Volatile.Read(ref _references) != 1;
 
         public void AddReference() => Interlocked.Increment(ref _references);
@@ -932,6 +932,14 @@ internal sealed class PackedPathData : IDisposable
         var replacement = ArrayPool<PackedPathCommand>.Shared.Rent(
             Math.Max(capacity, requiredCapacity));
         previous.Commands.AsSpan(0, _count).CopyTo(replacement);
+        if (!previous.IsShared)
+        {
+            var previousCommands = previous.Commands;
+            previous.Commands = replacement;
+            ArrayPool<PackedPathCommand>.Shared.Return(previousCommands);
+            return;
+        }
+
         _commandBuffer = new CommandBuffer(replacement);
         if (previous.Release())
         {

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -250,6 +250,8 @@ internal sealed class PackedPathData : IDisposable
     public int Count => _count;
     public bool IsEmpty => _count == 0;
     public Vector2 CurrentPoint => _currentPoint;
+    internal ReadOnlySpan<PackedPathCommand> CommandSpan =>
+        _count == 0 ? ReadOnlySpan<PackedPathCommand>.Empty : Commands.AsSpan(0, _count);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static PackedPathData Rent(bool trackTightBounds = true)
@@ -473,12 +475,108 @@ internal sealed class PackedPathData : IDisposable
         clone._hasBounds = _hasBounds;
         if (_count != 0)
         {
-            clone._commands = ArrayPool<PackedPathCommand>.Shared.Rent(
-                Math.Max(InitialCommandCapacity, _count));
+            if (clone._commands is null || clone._commands.Length < _count)
+            {
+                if (clone._commands is { } undersized)
+                {
+                    ArrayPool<PackedPathCommand>.Shared.Return(undersized);
+                }
+
+                clone._commands = ArrayPool<PackedPathCommand>.Shared.Rent(
+                    Math.Max(InitialCommandCapacity, _count));
+            }
             Commands.AsSpan(0, _count).CopyTo(clone._commands);
         }
 
         return clone;
+    }
+
+    public void Transform(SKMatrix matrix)
+    {
+        _hasBounds = false;
+        _boundsMin = default;
+        _boundsMax = default;
+        _tightBounds = default;
+        var current = Vector2.Zero;
+        for (var index = 0; index < _count; index++)
+        {
+            ref var command = ref Commands[index];
+            switch (command.Kind)
+            {
+                case PackedPathCommandKind.Move:
+                case PackedPathCommandKind.Line:
+                {
+                    var point = MapPoint(matrix, command.Point0);
+                    command = new PackedPathCommand(command.Kind, point);
+                    current = point;
+                    IncludeBounds(point);
+                    if (_trackTightBounds)
+                    {
+                        _tightBounds.Include(point);
+                    }
+                    break;
+                }
+
+                case PackedPathCommandKind.Quadratic:
+                {
+                    var control = MapPoint(matrix, command.Point0);
+                    var point = MapPoint(matrix, command.Point1);
+                    command = new PackedPathCommand(command.Kind, control, point);
+                    if (_trackTightBounds)
+                    {
+                        SKPathTightBounds.IncludeQuadratic(
+                            ref _tightBounds,
+                            current,
+                            control,
+                            point);
+                    }
+                    current = point;
+                    IncludeBounds(control);
+                    IncludeBounds(point);
+                    if (_trackTightBounds)
+                    {
+                        _tightBounds.Include(point);
+                    }
+                    break;
+                }
+
+                case PackedPathCommandKind.Cubic:
+                {
+                    var firstControl = MapPoint(matrix, command.Point0);
+                    var secondControl = MapPoint(matrix, command.Point1);
+                    var point = MapPoint(matrix, command.Point2);
+                    command = new PackedPathCommand(command.Kind, firstControl, secondControl, point);
+                    if (_trackTightBounds)
+                    {
+                        SKPathTightBounds.IncludeCubic(
+                            ref _tightBounds,
+                            current,
+                            firstControl,
+                            secondControl,
+                            point);
+                    }
+                    current = point;
+                    IncludeBounds(firstControl);
+                    IncludeBounds(secondControl);
+                    IncludeBounds(point);
+                    if (_trackTightBounds)
+                    {
+                        _tightBounds.Include(point);
+                    }
+                    break;
+                }
+            }
+        }
+
+        _currentPoint = MapPoint(matrix, _currentPoint);
+        _contourStart = MapPoint(matrix, _contourStart);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector2 MapPoint(SKMatrix matrix, Vector2 point)
+    {
+        var mapped = matrix.MapPoint(point.X, point.Y);
+        return new Vector2(mapped.X, mapped.Y);
     }
 
     public SKRect CalculateBounds()

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -240,7 +240,24 @@ internal sealed class PackedPathData : IDisposable
     private const int MaximumRetainedCommandCapacity = 1_024;
     [ThreadStatic]
     private static PackedPathData? s_threadCache;
-    private PackedPathCommand[]? _commands;
+    private sealed class CommandBuffer
+    {
+        private int _references = 1;
+
+        public CommandBuffer(PackedPathCommand[] commands)
+        {
+            Commands = commands;
+        }
+
+        public PackedPathCommand[] Commands { get; }
+        public bool IsShared => Volatile.Read(ref _references) != 1;
+
+        public void AddReference() => Interlocked.Increment(ref _references);
+
+        public bool Release() => Interlocked.Decrement(ref _references) == 0;
+    }
+
+    private CommandBuffer? _commandBuffer;
     private int _count;
     private Vector2 _currentPoint;
     private Vector2 _contourStart;
@@ -251,6 +268,7 @@ internal sealed class PackedPathData : IDisposable
     private bool _figureHasSegments;
     private bool _hasBounds;
     private bool _trackTightBounds;
+    private Vector2 _pendingTranslation;
     private int _isRented;
 
     private PackedPathData()
@@ -260,8 +278,15 @@ internal sealed class PackedPathData : IDisposable
     public int Count => _count;
     public bool IsEmpty => _count == 0;
     public Vector2 CurrentPoint => _currentPoint;
-    internal ReadOnlySpan<PackedPathCommand> CommandSpan =>
-        _count == 0 ? ReadOnlySpan<PackedPathCommand>.Empty : Commands.AsSpan(0, _count);
+    public Vector2 ContourStart => _contourStart;
+    internal ReadOnlySpan<PackedPathCommand> CommandSpan
+    {
+        get
+        {
+            ApplyPendingTranslation();
+            return _count == 0 ? ReadOnlySpan<PackedPathCommand>.Empty : Commands.AsSpan(0, _count);
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static PackedPathData Rent(bool trackTightBounds = true)
@@ -284,10 +309,12 @@ internal sealed class PackedPathData : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MoveTo(float x, float y)
     {
+        ApplyPendingTranslation();
         var point = new Vector2(x, y);
         if (_hasOpenFigure && !_figureHasSegments &&
             _count > 0 && Commands[_count - 1].Kind == PackedPathCommandKind.Move)
         {
+            EnsureWritableCommandStorage(_count);
             Commands[_count - 1] = new PackedPathCommand(PackedPathCommandKind.Move, point);
             RecalculateBounds();
         }
@@ -310,10 +337,12 @@ internal sealed class PackedPathData : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MoveToBoundsOnly(float x, float y)
     {
+        ApplyPendingTranslation();
         var point = new Vector2(x, y);
         if (_hasOpenFigure && !_figureHasSegments &&
             _count > 0 && Commands[_count - 1].Kind == PackedPathCommandKind.Move)
         {
+            EnsureWritableCommandStorage(_count);
             Commands[_count - 1] = new PackedPathCommand(PackedPathCommandKind.Move, point);
             RecalculateBounds();
         }
@@ -469,11 +498,13 @@ internal sealed class PackedPathData : IDisposable
         _hasOpenFigure = false;
         _figureHasSegments = false;
         _hasBounds = false;
+        _pendingTranslation = default;
     }
 
     public PackedPathData Clone()
     {
         var clone = Rent(_trackTightBounds);
+        clone.ReleaseCommandBuffer();
         clone._count = _count;
         clone._currentPoint = _currentPoint;
         clone._contourStart = _contourStart;
@@ -483,19 +514,11 @@ internal sealed class PackedPathData : IDisposable
         clone._hasOpenFigure = _hasOpenFigure;
         clone._figureHasSegments = _figureHasSegments;
         clone._hasBounds = _hasBounds;
-        if (_count != 0)
+        clone._pendingTranslation = _pendingTranslation;
+        if (_commandBuffer is { } commandBuffer)
         {
-            if (clone._commands is null || clone._commands.Length < _count)
-            {
-                if (clone._commands is { } undersized)
-                {
-                    ArrayPool<PackedPathCommand>.Shared.Return(undersized);
-                }
-
-                clone._commands = ArrayPool<PackedPathCommand>.Shared.Rent(
-                    Math.Max(InitialCommandCapacity, _count));
-            }
-            Commands.AsSpan(0, _count).CopyTo(clone._commands);
+            commandBuffer.AddReference();
+            clone._commandBuffer = commandBuffer;
         }
 
         return clone;
@@ -516,6 +539,9 @@ internal sealed class PackedPathData : IDisposable
             Translate(new Vector2(matrix.TransX, matrix.TransY));
             return;
         }
+
+        ApplyPendingTranslation();
+        EnsureWritableCommandStorage(_count);
 
         _hasBounds = false;
         _boundsMin = default;
@@ -598,25 +624,7 @@ internal sealed class PackedPathData : IDisposable
 
     private void Translate(Vector2 offset)
     {
-        for (var index = 0; index < _count; index++)
-        {
-            ref var command = ref Commands[index];
-            command = command.Kind switch
-            {
-                PackedPathCommandKind.Move or PackedPathCommandKind.Line =>
-                    new PackedPathCommand(command.Kind, command.Point0 + offset),
-                PackedPathCommandKind.Quadratic =>
-                    new PackedPathCommand(command.Kind, command.Point0 + offset, command.Point1 + offset),
-                PackedPathCommandKind.Cubic =>
-                    new PackedPathCommand(
-                        command.Kind,
-                        command.Point0 + offset,
-                        command.Point1 + offset,
-                        command.Point2 + offset),
-                _ => command,
-            };
-        }
-
+        _pendingTranslation += offset;
         if (_hasBounds)
         {
             _boundsMin += offset;
@@ -625,6 +633,25 @@ internal sealed class PackedPathData : IDisposable
         _tightBounds.Translate(offset);
         _currentPoint += offset;
         _contourStart += offset;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static PackedPathCommand TranslateCommand(PackedPathCommand command, Vector2 offset)
+    {
+        return command.Kind switch
+        {
+            PackedPathCommandKind.Move or PackedPathCommandKind.Line =>
+                new PackedPathCommand(command.Kind, command.Point0 + offset),
+            PackedPathCommandKind.Quadratic =>
+                new PackedPathCommand(command.Kind, command.Point0 + offset, command.Point1 + offset),
+            PackedPathCommandKind.Cubic =>
+                new PackedPathCommand(
+                    command.Kind,
+                    command.Point0 + offset,
+                    command.Point1 + offset,
+                    command.Point2 + offset),
+            _ => command,
+        };
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -649,6 +676,7 @@ internal sealed class PackedPathData : IDisposable
             return _tightBounds.ToRect();
         }
 
+        ApplyPendingTranslation();
         var bounds = new SKPathBoundsAccumulator();
         var current = Vector2.Zero;
         for (var index = 0; index < _count; index++)
@@ -688,6 +716,7 @@ internal sealed class PackedPathData : IDisposable
 
     public PathGeometry Materialize(SKPathFillType fillType)
     {
+        ApplyPendingTranslation();
         var geometry = new PathGeometry
         {
             FillRule = fillType is SKPathFillType.EvenOdd or SKPathFillType.InverseEvenOdd
@@ -736,10 +765,13 @@ internal sealed class PackedPathData : IDisposable
         }
 
         Reset();
-        if (_commands is { Length: > MaximumRetainedCommandCapacity } oversized)
+        if (_commandBuffer is { IsShared: true })
         {
-            _commands = null;
-            ArrayPool<PackedPathCommand>.Shared.Return(oversized);
+            ReleaseCommandBuffer();
+        }
+        else if (_commandBuffer is { Commands.Length: > MaximumRetainedCommandCapacity })
+        {
+            ReleaseCommandBuffer();
         }
 
         if (s_threadCache is null)
@@ -748,15 +780,11 @@ internal sealed class PackedPathData : IDisposable
             return;
         }
 
-        if (_commands is { } commands)
-        {
-            _commands = null;
-            ArrayPool<PackedPathCommand>.Shared.Return(commands);
-        }
+        ReleaseCommandBuffer();
     }
 
     private PackedPathCommand[] Commands =>
-        _commands ?? throw new InvalidOperationException("The packed path has no command storage.");
+        _commandBuffer?.Commands ?? throw new InvalidOperationException("The packed path has no command storage.");
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureFigure()
@@ -860,19 +888,68 @@ internal sealed class PackedPathData : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void Append(PackedPathCommand command)
     {
-        if (_commands is null)
+        ApplyPendingTranslation();
+        EnsureWritableCommandStorage(checked(_count + 1));
+        Commands[_count++] = command;
+    }
+
+    private void ApplyPendingTranslation()
+    {
+        if (_pendingTranslation == default || _count == 0)
         {
-            _commands = ArrayPool<PackedPathCommand>.Shared.Rent(InitialCommandCapacity);
-        }
-        else if (_count == _commands.Length)
-        {
-            var expanded = ArrayPool<PackedPathCommand>.Shared.Rent(
-                checked(_commands.Length * 2));
-            _commands.AsSpan(0, _count).CopyTo(expanded);
-            ArrayPool<PackedPathCommand>.Shared.Return(_commands);
-            _commands = expanded;
+            _pendingTranslation = default;
+            return;
         }
 
-        _commands[_count++] = command;
+        var offset = _pendingTranslation;
+        EnsureWritableCommandStorage(_count);
+        for (var index = 0; index < _count; index++)
+        {
+            ref var command = ref Commands[index];
+            command = TranslateCommand(command, offset);
+        }
+        _pendingTranslation = default;
+    }
+
+    private void EnsureWritableCommandStorage(int requiredCapacity)
+    {
+        if (_commandBuffer is null)
+        {
+            _commandBuffer = new CommandBuffer(ArrayPool<PackedPathCommand>.Shared.Rent(
+                Math.Max(InitialCommandCapacity, requiredCapacity)));
+            return;
+        }
+
+        if (!_commandBuffer.IsShared && _commandBuffer.Commands.Length >= requiredCapacity)
+        {
+            return;
+        }
+
+        var previous = _commandBuffer;
+        var capacity = previous.Commands.Length >= requiredCapacity
+            ? previous.Commands.Length
+            : checked(previous.Commands.Length * 2);
+        var replacement = ArrayPool<PackedPathCommand>.Shared.Rent(
+            Math.Max(capacity, requiredCapacity));
+        previous.Commands.AsSpan(0, _count).CopyTo(replacement);
+        _commandBuffer = new CommandBuffer(replacement);
+        if (previous.Release())
+        {
+            ArrayPool<PackedPathCommand>.Shared.Return(previous.Commands);
+        }
+    }
+
+    private void ReleaseCommandBuffer()
+    {
+        if (_commandBuffer is not { } commandBuffer)
+        {
+            return;
+        }
+
+        _commandBuffer = null;
+        if (commandBuffer.Release())
+        {
+            ArrayPool<PackedPathCommand>.Shared.Return(commandBuffer.Commands);
+        }
     }
 }

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -487,6 +487,40 @@ internal sealed class PackedPathData : IDisposable
         _figureHasSegments = false;
     }
 
+    public void AddTriangles(ReadOnlySpan<StrokeJoinTriangle> triangles)
+    {
+        if (triangles.IsEmpty)
+        {
+            return;
+        }
+
+        ApplyPendingTranslation();
+        EnsureWritableCommandStorage(checked(_count + triangles.Length * 4));
+        var commands = Commands;
+        for (var index = 0; index < triangles.Length; index++)
+        {
+            var triangle = triangles[index];
+            commands[_count++] = new PackedPathCommand(PackedPathCommandKind.Move, triangle.P0);
+            commands[_count++] = new PackedPathCommand(PackedPathCommandKind.Line, triangle.P1);
+            commands[_count++] = new PackedPathCommand(PackedPathCommandKind.Line, triangle.P2);
+            commands[_count++] = new PackedPathCommand(PackedPathCommandKind.Close);
+            IncludeBounds(triangle.P0);
+            IncludeBounds(triangle.P1);
+            IncludeBounds(triangle.P2);
+            if (_trackTightBounds)
+            {
+                _tightBounds.Include(triangle.P0);
+                _tightBounds.Include(triangle.P1);
+                _tightBounds.Include(triangle.P2);
+            }
+        }
+
+        _currentPoint = triangles[^1].P0;
+        _contourStart = _currentPoint;
+        _hasOpenFigure = false;
+        _figureHasSegments = false;
+    }
+
     public void Reset()
     {
         _count = 0;

--- a/src/SkiaSharp/SKPath.Packed.cs
+++ b/src/SkiaSharp/SKPath.Packed.cs
@@ -64,6 +64,16 @@ internal struct SKPathBoundsAccumulator
     public readonly SKRect ToRect() => _hasBounds
         ? new SKRect(_min.X, _min.Y, _max.X, _max.Y)
         : SKRect.Empty;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Translate(Vector2 offset)
+    {
+        if (_hasBounds)
+        {
+            _min += offset;
+            _max += offset;
+        }
+    }
 }
 
 internal static class SKPathTightBounds
@@ -493,6 +503,20 @@ internal sealed class PackedPathData : IDisposable
 
     public void Transform(SKMatrix matrix)
     {
+        if (matrix.IsIdentity)
+        {
+            return;
+        }
+
+        if (matrix.ScaleX == 1f && matrix.ScaleY == 1f &&
+            matrix.SkewX == 0f && matrix.SkewY == 0f &&
+            matrix.Persp0 == 0f && matrix.Persp1 == 0f && matrix.Persp2 == 1f &&
+            float.IsFinite(matrix.TransX) && float.IsFinite(matrix.TransY))
+        {
+            Translate(new Vector2(matrix.TransX, matrix.TransY));
+            return;
+        }
+
         _hasBounds = false;
         _boundsMin = default;
         _boundsMax = default;
@@ -570,6 +594,37 @@ internal sealed class PackedPathData : IDisposable
 
         _currentPoint = MapPoint(matrix, _currentPoint);
         _contourStart = MapPoint(matrix, _contourStart);
+    }
+
+    private void Translate(Vector2 offset)
+    {
+        for (var index = 0; index < _count; index++)
+        {
+            ref var command = ref Commands[index];
+            command = command.Kind switch
+            {
+                PackedPathCommandKind.Move or PackedPathCommandKind.Line =>
+                    new PackedPathCommand(command.Kind, command.Point0 + offset),
+                PackedPathCommandKind.Quadratic =>
+                    new PackedPathCommand(command.Kind, command.Point0 + offset, command.Point1 + offset),
+                PackedPathCommandKind.Cubic =>
+                    new PackedPathCommand(
+                        command.Kind,
+                        command.Point0 + offset,
+                        command.Point1 + offset,
+                        command.Point2 + offset),
+                _ => command,
+            };
+        }
+
+        if (_hasBounds)
+        {
+            _boundsMin += offset;
+            _boundsMax += offset;
+        }
+        _tightBounds.Translate(offset);
+        _currentPoint += offset;
+        _contourStart += offset;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -25,6 +25,8 @@ public partial class SKPath : SKObject
     private PathGeometry? _geometry;
     private PackedPathData? _packedPathData;
 
+    internal PackedPathData? PackedPathData => _packedPathData;
+
     public PathGeometry Geometry => EnsureGeometry();
     public SKPathFillType FillType
     {
@@ -59,6 +61,15 @@ public partial class SKPath : SKObject
         : base(SKObjectHandle.Create(), owns: true)
     {
         ArgumentNullException.ThrowIfNull(path);
+        if (path._packedPathData is { } packed)
+        {
+            _packedPathData = packed.Clone();
+            _currentPoint = path._currentPoint;
+            _contourStart = path._contourStart;
+            _fillType = path._fillType;
+            return;
+        }
+
         PathFigure? copiedCurrentFigure = null;
         foreach (var figure in path.Geometry.Figures)
         {
@@ -499,6 +510,16 @@ public partial class SKPath : SKObject
 
     public void Transform(SKMatrix matrix)
     {
+        if (_packedPathData is { } packed)
+        {
+            packed.Transform(matrix);
+            var current = matrix.MapPoint(_currentPoint.X, _currentPoint.Y);
+            var contourStart = matrix.MapPoint(_contourStart.X, _contourStart.Y);
+            _currentPoint = new Vector2(current.X, current.Y);
+            _contourStart = new Vector2(contourStart.X, contourStart.Y);
+            return;
+        }
+
         var m = matrix.ToMatrix4x4();
         foreach (var fig in Geometry.Figures)
         {

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -1867,8 +1867,7 @@ public class SKRegion : SKObject
     {
         if (!TryGetSingleAxisAlignedRect(path, out var rect))
         {
-            _rects.Clear();
-            _bounds = SKRectI.Empty;
+            SetEmpty();
             return false;
         }
 
@@ -1960,6 +1959,7 @@ public class SKRegion : SKObject
             previousRuns = currentRuns;
         }
 
+        _rectsNormalized = false;
         NormalizeRects();
         UpdateBounds();
         return !IsEmpty;
@@ -2258,6 +2258,7 @@ public class SKRegion : SKObject
         region.EnsureNormalized();
         using var leftSnapshot = new SKRegion(this);
         using var rightSnapshot = new SKRegion(region);
+        _rectsNormalized = false;
         switch (op)
         {
             case SKRegionOperation.Replace:
@@ -2412,10 +2413,11 @@ public class SKRegion : SKObject
     {
         if (!IsValid(rect))
         {
-            _rects.Clear();
+            SetEmpty();
             return;
         }
 
+        _rectsNormalized = false;
         for (int i = _rects.Count - 1; i >= 0; i--)
         {
             var intersection = Intersect(_rects[i], rect);
@@ -2445,6 +2447,7 @@ public class SKRegion : SKObject
 
         _rects.Clear();
         _rects.AddRange(result);
+        _rectsNormalized = false;
     }
 
     private void ReverseDifferenceWith(SKRectI rect)
@@ -2463,6 +2466,7 @@ public class SKRegion : SKObject
 
         _rects.Clear();
         _rects.AddRange(result);
+        _rectsNormalized = false;
     }
 
     private void XorWith(SKRectI rect)
@@ -2488,6 +2492,7 @@ public class SKRegion : SKObject
         _rects.Clear();
         _rects.AddRange(left);
         _rects.AddRange(right);
+        _rectsNormalized = false;
     }
 
     private static void AddDifference(List<SKRectI> result, SKRectI source, SKRectI cutter)

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -54,6 +54,8 @@ public partial class SKPath : SKObject
     {
         _geometry = null;
         _packedPathData = packedPathData ?? throw new ArgumentNullException(nameof(packedPathData));
+        _currentPoint = packedPathData.CurrentPoint;
+        _contourStart = packedPathData.ContourStart;
         _fillType = fillType;
     }
 
@@ -64,8 +66,8 @@ public partial class SKPath : SKObject
         if (path._packedPathData is { } packed)
         {
             _packedPathData = packed.Clone();
-            _currentPoint = path._currentPoint;
-            _contourStart = path._contourStart;
+            _currentPoint = packed.CurrentPoint;
+            _contourStart = packed.ContourStart;
             _fillType = path._fillType;
             return;
         }

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -393,6 +393,26 @@ public partial class SKPath : SKObject
         }
     }
 
+    internal void AddTriangles(ReadOnlySpan<StrokeJoinTriangle> triangles)
+    {
+        if (_packedPathData is { } packed)
+        {
+            packed.AddTriangles(triangles);
+            _currentPoint = packed.CurrentPoint;
+            _contourStart = packed.ContourStart;
+            return;
+        }
+
+        for (var index = 0; index < triangles.Length; index++)
+        {
+            var triangle = triangles[index];
+            MoveTo(triangle.P0.X, triangle.P0.Y);
+            LineTo(triangle.P1.X, triangle.P1.Y);
+            LineTo(triangle.P2.X, triangle.P2.Y);
+            Close();
+        }
+    }
+
     public void Reset()
     {
         if (_packedPathData is { } packed)

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -533,13 +533,30 @@ public partial class SKPath : SKObject
 
     public void Transform(SKMatrix matrix)
     {
+        if (matrix.IsIdentity)
+        {
+            return;
+        }
+
         if (_packedPathData is { } packed)
         {
             packed.Transform(matrix);
-            var current = matrix.MapPoint(_currentPoint.X, _currentPoint.Y);
-            var contourStart = matrix.MapPoint(_contourStart.X, _contourStart.Y);
-            _currentPoint = new Vector2(current.X, current.Y);
-            _contourStart = new Vector2(contourStart.X, contourStart.Y);
+            if (matrix.ScaleX == 1f && matrix.ScaleY == 1f &&
+                matrix.SkewX == 0f && matrix.SkewY == 0f &&
+                matrix.Persp0 == 0f && matrix.Persp1 == 0f && matrix.Persp2 == 1f &&
+                float.IsFinite(matrix.TransX) && float.IsFinite(matrix.TransY))
+            {
+                var offset = new Vector2(matrix.TransX, matrix.TransY);
+                _currentPoint += offset;
+                _contourStart += offset;
+            }
+            else
+            {
+                var current = matrix.MapPoint(_currentPoint.X, _currentPoint.Y);
+                var contourStart = matrix.MapPoint(_contourStart.X, _contourStart.Y);
+                _currentPoint = new Vector2(current.X, current.Y);
+                _contourStart = new Vector2(contourStart.X, contourStart.Y);
+            }
             return;
         }
 

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -1659,14 +1659,35 @@ public class SKRoundRect : SKObject
 
 public class SKRegion : SKObject
 {
-    private readonly List<SKRectI> _rects = new();
+    [ThreadStatic]
+    private static RegionNormalizationStorage? s_threadNormalizationStorage;
+    [ThreadStatic]
+    private static List<SKRectI>? s_threadRectStorage;
+
+    private readonly List<SKRectI> _rects = RentRectStorage();
+    private RegionNormalizationStorage? _normalizationStorage;
     private SKRectI _bounds;
+    private bool _rectsNormalized = true;
 
     public bool IsEmpty => _rects.Count == 0;
 
-    public bool IsRect => _rects.Count == 1;
+    public bool IsRect
+    {
+        get
+        {
+            EnsureNormalized();
+            return _rects.Count == 1;
+        }
+    }
 
-    public bool IsComplex => _rects.Count > 1;
+    public bool IsComplex
+    {
+        get
+        {
+            EnsureNormalized();
+            return _rects.Count > 1;
+        }
+    }
 
     public SKRectI Bounds => _bounds;
 
@@ -1701,10 +1722,23 @@ public class SKRegion : SKObject
         SetPath(path, clip);
     }
 
-    internal IReadOnlyList<SKRectI> Rects => _rects;
+    internal IReadOnlyList<SKRectI> Rects
+    {
+        get
+        {
+            EnsureNormalized();
+            return _rects;
+        }
+    }
 
     public bool Contains(int x, int y)
     {
+        if (!Contains(_bounds, x, y))
+        {
+            return false;
+        }
+
+        EnsureNormalized();
         foreach (var rect in _rects)
         {
             if (Contains(rect, x, y))
@@ -2050,9 +2084,11 @@ public class SKRegion : SKObject
             return !IsEmpty;
         }
 
+        region.EnsureNormalized();
         _rects.Clear();
         _rects.AddRange(region._rects);
         _bounds = region._bounds;
+        _rectsNormalized = true;
         return !IsEmpty;
     }
 
@@ -2074,11 +2110,19 @@ public class SKRegion : SKObject
                 unchecked(rect.Bottom + y));
         }
 
-        UpdateBounds();
+        if (!IsEmpty)
+        {
+            _bounds = new SKRectI(
+                unchecked(_bounds.Left + x),
+                unchecked(_bounds.Top + y),
+                unchecked(_bounds.Right + x),
+                unchecked(_bounds.Bottom + y));
+        }
     }
 
     public SKPath GetBoundaryPath()
     {
+        EnsureNormalized();
         var path = new SKPath();
         foreach (var rect in _rects)
         {
@@ -2090,6 +2134,11 @@ public class SKRegion : SKObject
 
     public bool Op(SKRectI rect, SKRegionOperation op)
     {
+        if (op is not SKRegionOperation.Replace and not SKRegionOperation.Union)
+        {
+            EnsureNormalized();
+        }
+
         switch (op)
         {
             case SKRegionOperation.Replace:
@@ -2099,8 +2148,22 @@ public class SKRegion : SKObject
                 IntersectWith(rect);
                 break;
             case SKRegionOperation.Union:
+                if (!IsValid(rect))
+                {
+                    return !IsEmpty;
+                }
+
+                foreach (var existing in _rects)
+                {
+                    if (Contains(existing, rect))
+                    {
+                        return true;
+                    }
+                }
+
                 AddRect(rect);
-                break;
+                UnionBounds(rect);
+                return true;
             case SKRegionOperation.Difference:
                 DifferenceWith(rect);
                 break;
@@ -2129,6 +2192,8 @@ public class SKRegion : SKObject
     public bool Op(SKRegion region, SKRegionOperation op)
     {
         ArgumentNullException.ThrowIfNull(region);
+        EnsureNormalized();
+        region.EnsureNormalized();
         using var leftSnapshot = new SKRegion(this);
         using var rightSnapshot = new SKRegion(region);
         switch (op)
@@ -2201,10 +2266,17 @@ public class SKRegion : SKObject
     {
         _rects.Clear();
         _bounds = SKRectI.Empty;
+        _rectsNormalized = true;
     }
 
     public bool Intersects(SKRectI rect)
     {
+        if (!IsValid(Intersect(_bounds, rect)))
+        {
+            return false;
+        }
+
+        EnsureNormalized();
         foreach (var existing in _rects)
         {
             if (IsValid(Intersect(existing, rect)))
@@ -2237,18 +2309,30 @@ public class SKRegion : SKObject
         return Intersects(region);
     }
 
-    public RectIterator CreateRectIterator() => new(_rects);
+    public RectIterator CreateRectIterator()
+    {
+        EnsureNormalized();
+        return new RectIterator(_rects);
+    }
 
-    public ClipIterator CreateClipIterator(SKRectI clip) => new(_rects, clip);
+    public ClipIterator CreateClipIterator(SKRectI clip)
+    {
+        EnsureNormalized();
+        return new ClipIterator(_rects, clip);
+    }
 
-    public SpanIterator CreateSpanIterator(int y, int left, int right) =>
-        new(_rects, y, left, right);
+    public SpanIterator CreateSpanIterator(int y, int left, int right)
+    {
+        EnsureNormalized();
+        return new SpanIterator(_rects, y, left, right);
+    }
 
     private void SetSingleRect(SKRectI rect)
     {
         _rects.Clear();
         AddRect(rect);
         UpdateBounds();
+        _rectsNormalized = true;
     }
 
     private void AddRect(SKRectI rect)
@@ -2259,6 +2343,7 @@ public class SKRegion : SKObject
         }
 
         _rects.Add(rect);
+        _rectsNormalized = false;
     }
 
     private void IntersectWith(SKRectI rect)
@@ -2373,12 +2458,20 @@ public class SKRegion : SKObject
 
     private void NormalizeRects()
     {
-        if (_rects.Count <= 1)
+        if (_rectsNormalized)
         {
             return;
         }
 
-        var yCoordinates = new SortedSet<int>();
+        if (_rects.Count <= 1)
+        {
+            _rectsNormalized = true;
+            return;
+        }
+
+        var storage = _normalizationStorage ??= RentNormalizationStorage();
+        var yCoordinates = storage.YCoordinates;
+        yCoordinates.Clear();
         foreach (var rect in _rects)
         {
             if (IsValid(rect))
@@ -2387,26 +2480,43 @@ public class SKRegion : SKObject
                 yCoordinates.Add(rect.Bottom);
             }
         }
+        yCoordinates.Sort();
+        var uniqueCount = 0;
+        for (var index = 0; index < yCoordinates.Count; index++)
+        {
+            if (uniqueCount == 0 || yCoordinates[index] != yCoordinates[uniqueCount - 1])
+            {
+                yCoordinates[uniqueCount++] = yCoordinates[index];
+            }
+        }
+        if (uniqueCount < yCoordinates.Count)
+        {
+            yCoordinates.RemoveRange(uniqueCount, yCoordinates.Count - uniqueCount);
+        }
         if (yCoordinates.Count < 2)
         {
             _rects.Clear();
+            _rectsNormalized = true;
             return;
         }
 
-        var ys = new int[yCoordinates.Count];
-        yCoordinates.CopyTo(ys);
-        var normalized = new List<SKRectI>();
-        var previousBand = new Dictionary<(int Left, int Right), int>();
-        for (var yIndex = 0; yIndex + 1 < ys.Length; yIndex++)
+        var normalized = storage.Rects;
+        normalized.Clear();
+        var previousBand = storage.BandA;
+        var currentBand = storage.BandB;
+        previousBand.Clear();
+        currentBand.Clear();
+        for (var yIndex = 0; yIndex + 1 < yCoordinates.Count; yIndex++)
         {
-            var top = ys[yIndex];
-            var bottom = ys[yIndex + 1];
+            var top = yCoordinates[yIndex];
+            var bottom = yCoordinates[yIndex + 1];
             if (bottom <= top)
             {
                 continue;
             }
 
-            var intervals = new List<(int Left, int Right)>();
+            var intervals = storage.Intervals;
+            intervals.Clear();
             foreach (var rect in _rects)
             {
                 if (IsValid(rect) && rect.Top <= top && rect.Bottom >= bottom)
@@ -2426,7 +2536,8 @@ public class SKRegion : SKObject
                 return comparison != 0 ? comparison : left.Right.CompareTo(right.Right);
             });
 
-            var merged = new List<(int Left, int Right)>();
+            var merged = storage.MergedIntervals;
+            merged.Clear();
             var current = intervals[0];
             for (var intervalIndex = 1; intervalIndex < intervals.Count; intervalIndex++)
             {
@@ -2443,7 +2554,7 @@ public class SKRegion : SKObject
             }
             merged.Add(current);
 
-            var currentBand = new Dictionary<(int Left, int Right), int>();
+            currentBand.Clear();
             foreach (var interval in merged)
             {
                 if (previousBand.TryGetValue(interval, out var rectIndex) &&
@@ -2465,11 +2576,53 @@ public class SKRegion : SKObject
                 currentBand[interval] = rectIndex;
             }
 
-            previousBand = currentBand;
+            (previousBand, currentBand) = (currentBand, previousBand);
         }
 
         _rects.Clear();
         _rects.AddRange(normalized);
+        _rectsNormalized = true;
+    }
+
+    private void EnsureNormalized() => NormalizeRects();
+
+    private static RegionNormalizationStorage RentNormalizationStorage()
+    {
+        var storage = s_threadNormalizationStorage;
+        if (storage is null)
+        {
+            return new RegionNormalizationStorage();
+        }
+
+        s_threadNormalizationStorage = null;
+        return storage;
+    }
+
+    private static List<SKRectI> RentRectStorage()
+    {
+        var rects = s_threadRectStorage;
+        if (rects is null)
+        {
+            return new List<SKRectI>();
+        }
+
+        s_threadRectStorage = null;
+        return rects;
+    }
+
+    private void UnionBounds(SKRectI rect)
+    {
+        if (_rects.Count == 1)
+        {
+            _bounds = rect;
+            return;
+        }
+
+        _bounds = new SKRectI(
+            Math.Min(_bounds.Left, rect.Left),
+            Math.Min(_bounds.Top, rect.Top),
+            Math.Max(_bounds.Right, rect.Right),
+            Math.Max(_bounds.Bottom, rect.Bottom));
     }
 
     private void UpdateBounds()
@@ -2508,9 +2661,67 @@ public class SKRegion : SKObject
         return x >= rect.Left && x < rect.Right && y >= rect.Top && y < rect.Bottom;
     }
 
+    private static bool Contains(SKRectI outer, SKRectI inner)
+    {
+        return IsValid(inner) &&
+               outer.Left <= inner.Left &&
+               outer.Top <= inner.Top &&
+               outer.Right >= inner.Right &&
+               outer.Bottom >= inner.Bottom;
+    }
+
     private static bool IsValid(SKRectI rect)
     {
         return rect.Width > 0 && rect.Height > 0;
+    }
+
+    protected override void DisposeManaged()
+    {
+        _rects.Clear();
+        if (s_threadRectStorage is null && _rects.Capacity <= 1_024)
+        {
+            s_threadRectStorage = _rects;
+        }
+
+        if (_normalizationStorage is { } storage)
+        {
+            _normalizationStorage = null;
+            storage.Clear();
+            if (s_threadNormalizationStorage is null && storage.CanRetain)
+            {
+                s_threadNormalizationStorage = storage;
+            }
+        }
+
+        base.DisposeManaged();
+    }
+
+    private sealed class RegionNormalizationStorage
+    {
+        public List<int> YCoordinates { get; } = new();
+        public List<(int Left, int Right)> Intervals { get; } = new();
+        public List<(int Left, int Right)> MergedIntervals { get; } = new();
+        public List<SKRectI> Rects { get; } = new();
+        public Dictionary<(int Left, int Right), int> BandA { get; } = new();
+        public Dictionary<(int Left, int Right), int> BandB { get; } = new();
+
+        public bool CanRetain =>
+            YCoordinates.Capacity <= 512 &&
+            Intervals.Capacity <= 1_024 &&
+            MergedIntervals.Capacity <= 1_024 &&
+            Rects.Capacity <= 1_024 &&
+            BandA.EnsureCapacity(0) <= 2_048 &&
+            BandB.EnsureCapacity(0) <= 2_048;
+
+        public void Clear()
+        {
+            YCoordinates.Clear();
+            Intervals.Clear();
+            MergedIntervals.Clear();
+            Rects.Clear();
+            BandA.Clear();
+            BandB.Clear();
+        }
     }
 
     private static bool TryGetSingleAxisAlignedRect(SKPath path, out SKRectI rect)

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -223,6 +223,29 @@ public partial class SKPath : SKObject
         return _geometry;
     }
 
+    internal void ReplaceWithOwned(SKPath source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (ReferenceEquals(this, source))
+        {
+            return;
+        }
+
+        _packedPathData?.Dispose();
+        _packedPathData = source._packedPathData;
+        _geometry = source._geometry;
+        _currentFigure = source._currentFigure;
+        _currentPoint = source._currentPoint;
+        _contourStart = source._contourStart;
+        _fillType = source._fillType;
+
+        source._packedPathData = null;
+        source._geometry = null;
+        source._currentFigure = null;
+        source.ResetCurrentState();
+        source._fillType = SKPathFillType.Winding;
+    }
+
     private void EnsureFigure()
     {
         if (_currentFigure is not null)

--- a/src/SkiaSharp/SKPathMeasure.cs
+++ b/src/SkiaSharp/SKPathMeasure.cs
@@ -14,10 +14,15 @@ public enum SKPathMeasureMatrixFlags
 public class SKPathMeasure : SKObject
 {
     private const float Epsilon = 0.00001f;
+    private const int MaximumRetainedContours = 64;
+    private const int MaximumRetainedSegments = 2_048;
+    private const int MaximumRetainedSamples = 8_192;
+
+    [ThreadStatic]
+    private static ContourStorage? s_threadStorage;
 
     private readonly int _curveSegmentCount;
-    private SKPath? _path;
-    private List<Contour> _contours = new();
+    private ContourStorage? _storage;
     private int _contourIndex;
     private Contour? _contour;
 
@@ -29,6 +34,7 @@ public class SKPathMeasure : SKObject
     public SKPathMeasure(SKPath? path, bool forceClosed = false, float resScale = 1f)
         : base(SKObjectHandle.Create(), owns: true)
     {
+        _storage = RentStorage();
         var normalizedScale = float.IsFinite(resScale) && resScale > 0f ? resScale : 1f;
         // Skia's precision grows sublinearly with resScale. The square-root schedule
         // tracks its contour lengths while bounding setup work for text-on-path use.
@@ -47,22 +53,27 @@ public class SKPathMeasure : SKObject
 
     public void SetPath(SKPath? path, bool forceClosed)
     {
-        _path?.Dispose();
-        _path = path is null ? null : new SKPath(path);
-        _contours = _path is null ? new List<Contour>() : BuildContours(_path, forceClosed);
+        var storage = _storage ?? throw new ObjectDisposedException(nameof(SKPathMeasure));
+        storage.Reset();
+        if (path is not null)
+        {
+            BuildContours(path, forceClosed, storage);
+        }
+
         _contourIndex = 0;
-        _contour = _contours.Count == 0 ? null : _contours[0];
+        _contour = storage.Count == 0 ? null : storage[0];
     }
 
     public bool NextContour()
     {
-        if (_contourIndex + 1 >= _contours.Count)
+        var storage = _storage;
+        if (storage is null || _contourIndex + 1 >= storage.Count)
         {
             _contour = null;
             return false;
         }
 
-        _contour = _contours[++_contourIndex];
+        _contour = storage[++_contourIndex];
         return true;
     }
 
@@ -244,11 +255,16 @@ public class SKPathMeasure : SKObject
         return tangent.LengthSquared() > Epsilon * Epsilon;
     }
 
-    private List<Contour> BuildContours(SKPath path, bool forceClosed)
+    private void BuildContours(SKPath path, bool forceClosed, ContourStorage storage)
     {
-        var contours = new List<Contour>();
+        if (path.PackedPathData is { } packed)
+        {
+            BuildPackedContours(packed.CommandSpan, forceClosed, storage);
+            return;
+        }
+
         using var iterator = path.CreateRawIterator();
-        var points = new SKPoint[4];
+        Span<SKPoint> points = stackalloc SKPoint[4];
         Contour? contour = null;
         SKPathVerb verb;
         while ((verb = iterator.Next(points)) != SKPathVerb.Done)
@@ -256,24 +272,24 @@ public class SKPathMeasure : SKObject
             switch (verb)
             {
                 case SKPathVerb.Move:
-                    FinalizeContour(contours, contour, forceClosed);
-                    contour = new Contour(ToVector(points[0]));
+                    FinalizeContour(contour, forceClosed);
+                    contour = storage.AddContour(ToVector(points[0]));
                     break;
 
                 case SKPathVerb.Line:
-                    contour ??= new Contour(ToVector(points[0]));
+                    contour ??= storage.AddContour(ToVector(points[0]));
                     contour.AddSegment(MeasuredSegment.Line(ToVector(points[0]), ToVector(points[1])), 1);
                     break;
 
                 case SKPathVerb.Quad:
-                    contour ??= new Contour(ToVector(points[0]));
+                    contour ??= storage.AddContour(ToVector(points[0]));
                     contour.AddSegment(
                         MeasuredSegment.Quad(ToVector(points[0]), ToVector(points[1]), ToVector(points[2])),
                         _curveSegmentCount);
                     break;
 
                 case SKPathVerb.Conic:
-                    contour ??= new Contour(ToVector(points[0]));
+                    contour ??= storage.AddContour(ToVector(points[0]));
                     contour.AddSegment(
                         MeasuredSegment.Conic(
                             ToVector(points[0]),
@@ -284,7 +300,7 @@ public class SKPathMeasure : SKObject
                     break;
 
                 case SKPathVerb.Cubic:
-                    contour ??= new Contour(ToVector(points[0]));
+                    contour ??= storage.AddContour(ToVector(points[0]));
                     contour.AddSegment(
                         MeasuredSegment.Cubic(
                             ToVector(points[0]),
@@ -303,11 +319,58 @@ public class SKPathMeasure : SKObject
             }
         }
 
-        FinalizeContour(contours, contour, forceClosed);
-        return contours;
+        FinalizeContour(contour, forceClosed);
     }
 
-    private static void FinalizeContour(List<Contour> contours, Contour? contour, bool forceClosed)
+    private void BuildPackedContours(
+        ReadOnlySpan<PackedPathCommand> commands,
+        bool forceClosed,
+        ContourStorage storage)
+    {
+        Contour? contour = null;
+        var current = Vector2.Zero;
+        foreach (ref readonly var command in commands)
+        {
+            switch (command.Kind)
+            {
+                case PackedPathCommandKind.Move:
+                    FinalizeContour(contour, forceClosed);
+                    current = command.Point0;
+                    contour = storage.AddContour(current);
+                    break;
+
+                case PackedPathCommandKind.Line:
+                    contour ??= storage.AddContour(current);
+                    contour.AddSegment(MeasuredSegment.Line(current, command.Point0), 1);
+                    current = command.Point0;
+                    break;
+
+                case PackedPathCommandKind.Quadratic:
+                    contour ??= storage.AddContour(current);
+                    contour.AddSegment(
+                        MeasuredSegment.Quad(current, command.Point0, command.Point1),
+                        _curveSegmentCount);
+                    current = command.Point1;
+                    break;
+
+                case PackedPathCommandKind.Cubic:
+                    contour ??= storage.AddContour(current);
+                    contour.AddSegment(
+                        MeasuredSegment.Cubic(current, command.Point0, command.Point1, command.Point2),
+                        _curveSegmentCount);
+                    current = command.Point2;
+                    break;
+
+                case PackedPathCommandKind.Close:
+                    contour?.Close();
+                    break;
+            }
+        }
+
+        FinalizeContour(contour, forceClosed);
+    }
+
+    private static void FinalizeContour(Contour? contour, bool forceClosed)
     {
         if (contour is null)
         {
@@ -319,15 +382,20 @@ public class SKPathMeasure : SKObject
             contour.Close();
         }
 
-        contours.Add(contour);
     }
 
     protected override void DisposeManaged()
     {
-        _path?.Dispose();
-        _path = null;
-        _contours.Clear();
         _contour = null;
+        if (_storage is { } storage)
+        {
+            _storage = null;
+            storage.Reset();
+            if (s_threadStorage is null && storage.CanRetain)
+            {
+                s_threadStorage = storage;
+            }
+        }
         base.DisposeManaged();
     }
 
@@ -345,6 +413,18 @@ public class SKPathMeasure : SKObject
 
     private static Vector2 ToVector(SKPoint value) => new(value.X, value.Y);
 
+    private static ContourStorage RentStorage()
+    {
+        var storage = s_threadStorage;
+        if (storage is null)
+        {
+            return new ContourStorage();
+        }
+
+        s_threadStorage = null;
+        return storage;
+    }
+
     private readonly record struct Sample(
         Vector2 Point,
         float Distance,
@@ -355,7 +435,7 @@ public class SKPathMeasure : SKObject
 
     private sealed class Contour
     {
-        private readonly Vector2 _start;
+        private Vector2 _start;
         private readonly List<Sample> _samples = new();
 
         public Contour(Vector2 start)
@@ -363,11 +443,23 @@ public class SKPathMeasure : SKObject
             _start = start;
         }
 
+        public int RetainedSegmentCapacity => Segments.Capacity;
+
+        public int RetainedSampleCapacity => _samples.Capacity;
+
         public List<MeasuredSegment> Segments { get; } = new();
 
         public bool IsClosed { get; private set; }
 
         public float Length => _samples.Count == 0 ? 0f : _samples[^1].Distance;
+
+        public void Reset(Vector2 start)
+        {
+            _start = start;
+            _samples.Clear();
+            Segments.Clear();
+            IsClosed = false;
+        }
 
         public void AddSegment(MeasuredSegment segment, int subdivisionCount)
         {
@@ -465,7 +557,66 @@ public class SKPathMeasure : SKObject
         }
     }
 
-    private sealed class MeasuredSegment
+    private sealed class ContourStorage
+    {
+        private readonly List<Contour> _contours = new(4);
+
+        public int Count { get; private set; }
+
+        public Contour this[int index] => _contours[index];
+
+        public bool CanRetain
+        {
+            get
+            {
+                if (_contours.Capacity > MaximumRetainedContours)
+                {
+                    return false;
+                }
+
+                var segments = 0;
+                var samples = 0;
+                foreach (var contour in _contours)
+                {
+                    segments += contour.RetainedSegmentCapacity;
+                    samples += contour.RetainedSampleCapacity;
+                }
+
+                return segments <= MaximumRetainedSegments &&
+                       samples <= MaximumRetainedSamples;
+            }
+        }
+
+        public Contour AddContour(Vector2 start)
+        {
+            Contour contour;
+            if (Count < _contours.Count)
+            {
+                contour = _contours[Count];
+                contour.Reset(start);
+            }
+            else
+            {
+                contour = new Contour(start);
+                _contours.Add(contour);
+            }
+
+            Count++;
+            return contour;
+        }
+
+        public void Reset()
+        {
+            for (var index = 0; index < Count; index++)
+            {
+                _contours[index].Reset(default);
+            }
+
+            Count = 0;
+        }
+    }
+
+    private readonly struct MeasuredSegment
     {
         private MeasuredSegment(
             SKPathVerb verb,

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -126,10 +126,10 @@ internal static class ProgramEntry
             new BenchmarkCase("avalonia-paint-reuse", 100_000, RunAvaloniaPaintReuse),
             new BenchmarkCase("avalonia-positioned-text-blob", 1_000, RunAvaloniaPositionedTextBlob),
             new BenchmarkCase("avalonia-stream-geometry", 1_000, RunAvaloniaStreamGeometry),
-            new BenchmarkCase("avalonia-path-measure-create", 1_000, RunAvaloniaPathMeasureCreate),
+            new BenchmarkCase("avalonia-path-measure-create", 10_000, RunAvaloniaPathMeasureCreate),
             new BenchmarkCase("avalonia-path-measure-query", 100_000, RunAvaloniaPathMeasureQuery),
-            new BenchmarkCase("avalonia-path-transform-copy", 1_000, RunAvaloniaPathTransformCopy),
-            new BenchmarkCase("avalonia-region-union-query", 1_000, RunAvaloniaRegionUnionQuery),
+            new BenchmarkCase("avalonia-path-transform-copy", 10_000, RunAvaloniaPathTransformCopy),
+            new BenchmarkCase("avalonia-region-union-query", 10_000, RunAvaloniaRegionUnionQuery),
             new BenchmarkCase("avalonia-stroke-expand", 1_000, RunAvaloniaStrokeExpand),
             new BenchmarkCase("avalonia-path-combine", 8, RunAvaloniaPathCombine),
             // Keep each sample above the sub-millisecond timer-noise floor and

--- a/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
+++ b/tools/ProGPU.SkiaSharp.Benchmarks/Program.cs
@@ -126,6 +126,12 @@ internal static class ProgramEntry
             new BenchmarkCase("avalonia-paint-reuse", 100_000, RunAvaloniaPaintReuse),
             new BenchmarkCase("avalonia-positioned-text-blob", 1_000, RunAvaloniaPositionedTextBlob),
             new BenchmarkCase("avalonia-stream-geometry", 1_000, RunAvaloniaStreamGeometry),
+            new BenchmarkCase("avalonia-path-measure-create", 1_000, RunAvaloniaPathMeasureCreate),
+            new BenchmarkCase("avalonia-path-measure-query", 100_000, RunAvaloniaPathMeasureQuery),
+            new BenchmarkCase("avalonia-path-transform-copy", 1_000, RunAvaloniaPathTransformCopy),
+            new BenchmarkCase("avalonia-region-union-query", 1_000, RunAvaloniaRegionUnionQuery),
+            new BenchmarkCase("avalonia-stroke-expand", 1_000, RunAvaloniaStrokeExpand),
+            new BenchmarkCase("avalonia-path-combine", 8, RunAvaloniaPathCombine),
             // Keep each sample above the sub-millisecond timer-noise floor and
             // warm the gradient factories through their final dynamic-PGO tier.
             new BenchmarkCase("shader-gradient-factories", 16_000, RunShaderGradientFactories),
@@ -934,6 +940,134 @@ internal static class ProgramEntry
         }
 
         return checksum;
+    }
+#pragma warning restore CS0618
+
+#pragma warning disable CS0618 // Avalonia.Skia 12 consumes these official legacy geometry APIs.
+    private static ulong RunAvaloniaPathMeasureCreate(int operations)
+    {
+        using var path = CreateAvaloniaGeometryPath();
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            using var measure = new SKPathMeasure(path, forceClosed: false, resScale: 1f);
+            checksum = Mix(checksum, measure.Length > 0f ? 1u : 0u);
+            checksum = Mix(checksum, measure.IsClosed ? 1u : 0u);
+        }
+
+        return checksum;
+    }
+
+    private static ulong RunAvaloniaPathMeasureQuery(int operations)
+    {
+        using var path = CreateAvaloniaGeometryPath();
+        using var measure = new SKPathMeasure(path, forceClosed: false, resScale: 1f);
+        var length = measure.Length;
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            var distance = length * ((index & 255) / 255f);
+            var success = measure.GetPositionAndTangent(distance, out var point, out var tangent);
+            checksum = Mix(checksum, success ? 1u : 0u);
+            checksum = Mix(checksum, float.IsFinite(point.X + point.Y + tangent.X + tangent.Y) ? 1u : 0u);
+        }
+
+        return checksum;
+    }
+
+    private static ulong RunAvaloniaPathTransformCopy(int operations)
+    {
+        using var source = CreateAvaloniaGeometryPath();
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            using var transformed = new SKPath(source);
+            var matrix = SKMatrix.CreateTranslation((index & 15) * 0.25f, (index & 7) * -0.125f);
+            transformed.Transform(matrix);
+            var bounds = transformed.TightBounds;
+            checksum = Mix(checksum, bounds.Width > 0f && bounds.Height > 0f ? 1u : 0u);
+        }
+
+        return checksum;
+    }
+
+    private static ulong RunAvaloniaRegionUnionQuery(int operations)
+    {
+        using var region = new SKRegion();
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            region.SetEmpty();
+            for (var rectIndex = 0; rectIndex < 24; rectIndex++)
+            {
+                var x = rectIndex * 3;
+                region.Op(x, rectIndex & 3, x + 12, (rectIndex & 3) + 10, SKRegionOperation.Union);
+            }
+
+            checksum = Mix(checksum, region.Contains(15, 5) ? 1u : 0u);
+            checksum = Mix(checksum, region.Intersects(new SKRectI(48, 2, 54, 8)) ? 1u : 0u);
+            checksum = Mix(checksum, (uint)region.Bounds.Width);
+        }
+
+        return checksum;
+    }
+
+    private static ulong RunAvaloniaStrokeExpand(int operations)
+    {
+        using var source = CreateAvaloniaGeometryPath();
+        using var paint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 3.5f,
+            StrokeCap = SKStrokeCap.Round,
+            StrokeJoin = SKStrokeJoin.Round,
+            StrokeMiter = 4f,
+        };
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            using var destination = new SKPath();
+            var success = paint.GetFillPath(source, destination, 1f);
+            checksum = Mix(checksum, success ? 1u : 0u);
+            checksum = Mix(checksum, destination.IsEmpty ? 0u : 1u);
+        }
+
+        return checksum;
+    }
+
+    private static ulong RunAvaloniaPathCombine(int operations)
+    {
+        using var surface = SKSurface.Create(
+            new SKImageInfo(1, 1, SKColorType.Rgba8888, SKAlphaType.Premul));
+        using var left = new SKPath();
+        using var right = new SKPath();
+        left.AddRoundRect(new SKRect(0f, 0f, 80f, 48f), 8f, 8f);
+        right.AddCircle(52f, 24f, 20f);
+        ulong checksum = 1469598103934665603UL;
+        for (var index = 0; index < operations; index++)
+        {
+            using var combined = left.Op(right, (index & 1) == 0 ? SKPathOp.Union : SKPathOp.Intersect);
+            checksum = Mix(checksum, combined.IsEmpty ? 0u : 1u);
+            checksum = Mix(checksum, combined.Bounds.Width > 0f ? 1u : 0u);
+        }
+
+        return checksum;
+    }
+
+    private static SKPath CreateAvaloniaGeometryPath()
+    {
+        var path = new SKPath { FillType = SKPathFillType.EvenOdd };
+        path.MoveTo(2f, 3f);
+        for (var segment = 0; segment < 12; segment++)
+        {
+            var x = segment * 6f;
+            var y = (segment & 1) == 0 ? 4f : 18f;
+            path.LineTo(x + 4f, y);
+            path.QuadTo(x + 6f, y - 8f, x + 8f, y + 2f);
+            path.CubicTo(x + 9f, y + 9f, x + 11f, y - 7f, x + 13f, y + 1f);
+        }
+        path.Close();
+        return path;
     }
 #pragma warning restore CS0618
 


### PR DESCRIPTION
## Summary

- optimize the Avalonia.Skia path-measure, transform, region, stroke, and boolean-operation workloads against official SkiaSharp 4.151
- retain copy-on-write packed path state with lazy `O(1)` translation and deferred dirty-region canonicalization
- adaptively flatten strokes, retain bounded command storage, and batch join/cap triangles into packed paths
- preserve collinear reversing-curve extrema and canonical region topology after direct mutations
- retain WebGPU path-operation shader/pipeline/layout resources per device and reconstruct mapped output without intermediate arrays
- preserve official API behavior, exact semantic checksums, WebGPU rendering, and clean-room implementation boundaries

## Measured evidence

| Avalonia-shaped workload | Official SkiaSharp | ProGPU | Official / ProGPU allocation |
| --- | ---: | ---: | ---: |
| path-measure construction | 2,052 ns | 516 ns | 80 / 56 B/op |
| path-measure query | 26.790 ns | 22.511 ns | 0 / 0 B/op |
| packed copy plus translation | 403.812 ns | 136.904 ns | 88 / 80 B/op |
| dirty-region unions plus queries | 2,424.975 ns | 1,156.994 ns | 0 / 0 B/op |
| reversal-safe stroke expansion | 25,977.708 ns | 22,603.645 ns | 168 / 83 B/op |

Synchronous non-trivial `SKPath.Op` improved from 5.37 ms / 6,710 B to 1.64 ms / 4,079 B, but remains slower than official SkiaSharp because the compatibility API currently requires a CPU-to-GPU-to-CPU round trip. This latency boundary remains explicitly documented; the implementation does not substitute a bounds-only result or CPU bitmap fallback.

## Clean-room research

The [research and profiling record](https://github.com/wieslawsoltes/ProGPU/blob/f31bd8ed/docs/AVALONIA_SKIA_GEOMETRY_RESOURCE_RESEARCH.md) compares the observable contracts and architecture of [Skia path measurement](https://api.skia.org/classSkPathMeasure.html), [Direct2D geometry realizations](https://learn.microsoft.com/en-us/windows/win32/direct2d/geometry-realizations-overview), [Win2D DPI/DIP behavior](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/dpi-and-dips), [WebRender](https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst), [Vello](https://github.com/linebender/vello), and the [HarfBuzz shaping/render boundary](https://harfbuzz.github.io/glyphs-and-rendering.html). ProGPU adopts retained compact geometry, bounded reuse, lazy observation, and device-owned WebGPU resources while keeping CPU-observable SkiaSharp contracts deterministic and independently implemented.

## Validation

- [x] 3,285 core and 225 headless tests
- [x] official SkiaSharp metadata: 4,222 matching, 0 missing
- [x] exact-checksum alternating official/ProGPU benchmarks
- [x] matched final-binary EventPipe and macOS Time Profiler, Allocations/VM Tracker, and Metal System Trace evidence
- [x] raw trace, Xcode scratch, temporary JSON, and baseline worktree cleanup
- [x] 37 portable packages, symbol packages, XAML consumer, CLI install, and XAML compile
- [x] review feedback addressed with zero unresolved threads
- [x] refreshed final-head GitHub Actions checks

