### PR TITLE
Optimize retained Avalonia.Skia picture, image, layer, and text hot paths

### DIFF
--- a/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
@@ -1,0 +1,89 @@
+# Avalonia.Skia retained command-stream research
+
+## Scope and observed framework contract
+
+This clean-room slice optimizes the SkiaSharp picture and immutable-image APIs
+used by Avalonia.Skia. At Avalonia commit
+[`fee9c561`](https://github.com/AvaloniaUI/Avalonia/tree/fee9c561ce036e8a3e8cee2397c75ca599b4790d),
+[`DrawingContextImpl`](https://github.com/AvaloniaUI/Avalonia/blob/fee9c561ce036e8a3e8cee2397c75ca599b4790d/src/Skia/Avalonia.Skia/DrawingContextImpl.cs)
+records ordered canvas state, clip, rectangle, path, glyph-run, and immutable
+image operations. `PictureRenderTarget`, `SurfaceRenderTarget`, and
+`WriteableBitmapImpl` retain or replay those operations. Those observable
+public calls, rather than any foreign implementation text or command encoding,
+define the benchmark and regression-test workloads.
+
+The previous ProGPU representation retained one full, wide `RenderCommand`
+record per operation, plus parallel side data. A repeated immutable-image
+picture consequently retained about 149 managed bytes per draw even though an
+ordinary image command needs only texture, source/destination rectangles,
+sampling, transform, and presentation state.
+
+## Primary-source comparison
+
+| Engine or specification | Relevant public or architectural contract | ProGPU clean-room decision |
+| --- | --- | --- |
+| [Skia `SkPicture`](https://api.skia.org/classSkPicture.html) and [`SkPictureRecorder`](https://api.skia.org/classSkPictureRecorder.html) | A picture is an immutable recording of ordered drawing, matrix, and clip operations. Finishing a recording invalidates the recording canvas for further recording. | Preserve exact command order and immutable replay. Use an original ProGPU token and typed-record layout; do not reproduce Skia opcodes, record structures, source organization, or implementation control flow. Clear picture-only image lookup state when recording finishes. |
+| [Direct2D command lists](https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1commandlist) and [Win2D `CanvasCommandList`](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasCommandList.htm) | A closed command list is an immutable device resource that can be drawn repeatedly; drawing state and resources remain associated with the device domain. | Retain typed resource references and shared transforms in the owning WebGPU context. Do not materialize a CPU bitmap or cross-device compatibility adapter during recording. |
+| [WebGPU command buffers](https://www.w3.org/TR/webgpu/#command-buffers) | Command buffers are immutable encodings submitted in order to a device queue. | Keep the CPU retained stream immutable and allocation-free to index, then expand it into the existing WebGPU compilation and submission path. CPU command packing does not replace GPU rasterization or composition. |
+| [WebRender rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html) | Retained display lists preserve ordered scene state while renderer-owned resources are reused across frames. | Separate compact scene intent from device resource ownership. Retain one texture lease per image/context and reuse it for consecutive picture draws instead of searching the retained-resource list per draw. |
+| [Vello scene encoding](https://github.com/linebender/vello/blob/main/vello_encoding/src/encoding.rs) and [Vello architecture](https://github.com/linebender/vello) | Compact scene encoding is separate from the `wgpu` device, queue, target, and GPU compute renderer. | Adopt that separation only at the architectural level. ProGPU uses original 32-bit ordered tokens, typed managed arrays, exact fallback records, and its existing WebGPU renderer. |
+| [SkParagraph](https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/README.md), [DirectWrite glyph runs](https://learn.microsoft.com/en-us/windows/win32/directwrite/glyphs-and-glyph-runs), [HarfBuzz shaping](https://harfbuzz.github.io/harfbuzz-hb-shape.html), and [Parley](https://docs.rs/parley/latest/parley/) | Shaping and layout produce reusable glyph IDs, positions, and runs before rasterization. | Preserve the existing shaped arrays and text records. This slice does not reshape during replay, move Unicode work to the GPU, or alter fallback, DPI, subpixel, atlas, or device-loss contracts. |
+
+Adopted concepts are immutable ordered replay, typed records for frequent
+operations, shared transforms, explicit device-resource ownership, and reusable
+CPU shaping results. Adapted concepts are implemented through ProGPU's own
+reflection-free command types and WebGPU compiler. Rejected alternatives are
+copying a foreign opcode layout, placing unmanaged allocations outside managed
+measurements, an eager CPU image mirror, a CPU raster fallback, dropping state
+operations, and unbounded per-draw resource lookup caches.
+
+## Resulting algorithm and bounds
+
+- Construction performs two linear passes over `C` commands. Transform
+  interning is `O(C)` average and `O(C²)` only under adversarial hash
+  collisions, with bounded `O(C)` pooled scratch.
+- Retained storage is `O(C + T + R)` for ordered 32-bit tokens, `T` unique
+  transforms, typed common records, and `R` referenced resources. Uncommon
+  commands retain an exact full-record fallback.
+- Indexing and replay expansion are allocation-free `O(1)` per command. The
+  command token selects a typed array and index; no scan or reflection occurs.
+- A consecutive whole-image picture draw reuses the already retained
+  image/context texture in `O(1)`. The recording context still owns the one
+  actual lease; the three-reference lookup cache is cleared at recording
+  completion and canvas disposal.
+- The focused storage gate permits at most 64 retained bytes per ordinary
+  texture draw, plus one shared transform. Exact clone tests cover texture,
+  rectangle, path, rectangle clip, geometry clip, and all pop-state records.
+
+## Validation protocol
+
+The benchmark runner uses matched Release binaries, three fresh ProGPU
+processes compared with three alternating official-SkiaSharp baseline
+processes, 32 warmup passes, and 24 samples per process. Semantic checksums must
+match exactly. Managed allocation is measured with
+`GC.GetAllocatedBytesForCurrentThread`; elapsed distributions report the
+combined median and p95 rather than a selected process.
+
+Focused tests require exact `RenderCommand` round trips, the 64-byte texture
+record bound, retained image lease sharing without a GPU copy, picture state
+semantics, and compositor regression coverage. Final integration will repeat
+the representative Avalonia application workload and matched Xcode
+Allocations, Time Profiler, and Metal System Trace captures. Raw `.trace`,
+`.nettrace`, Xcode scratch, and exported XML are temporary and will be deleted
+after compact summaries are retained.
+
+## First checkpoint measurement
+
+The exact Preview.46 release commit `d55d6657` is the clean baseline. The
+candidate differs by the retained token stream, typed common records, and
+consecutive picture-image lease lookup cache. Every checksum matched.
+
+| Avalonia-shaped workload | Baseline median | Candidate median | Change | Baseline p95 | Candidate p95 | Baseline allocation | Candidate allocation |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Immutable-image picture recording | 330.771 ns | 314.645 ns | -4.9% | 512.916 ns | 359.209 ns | 149 B/op | 65 B/op (-56.4%) |
+| Mixed picture recording | 3,773.844 ns | 3,533.693 ns | -6.4% | 4,660.480 ns | 4,150.555 ns | 1,627 B/op | 1,080 B/op (-33.6%) |
+
+Official SkiaSharp remains faster in both microbenchmarks at this checkpoint;
+these results establish a material improvement and memory floor for the next
+typed text/glyph and immutable-image slices, not completion of the broader
+performance goal.

--- a/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
@@ -23,6 +23,7 @@ sampling, transform, and presentation state.
 | Engine or specification | Relevant public or architectural contract | ProGPU clean-room decision |
 | --- | --- | --- |
 | [Skia `SkPicture`](https://api.skia.org/classSkPicture.html) and [`SkPictureRecorder`](https://api.skia.org/classSkPictureRecorder.html) | A picture is an immutable recording of ordered drawing, matrix, and clip operations. Finishing a recording invalidates the recording canvas for further recording. | Preserve exact command order and immutable replay. Use an original ProGPU token and typed-record layout; do not reproduce Skia opcodes, record structures, source organization, or implementation control flow. Clear picture-only image lookup state when recording finishes. |
+| [Skia `SkImage`](https://api.skia.org/classSkImage.html) | An image cannot be modified after creation. `kAllow_CachingHint` permits internally caching decoded/copied pixels; `kDisallow_CachingHint` forbids that cache. | Cache one immutable GPU readback only for `Allow`. For `Disallow`, copy a whole native-format texture directly into the caller's rows through the reusable WebGPU staging buffer, preserving row padding and avoiding a persistent copied-pixel cache. |
 | [Direct2D command lists](https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1commandlist) and [Win2D `CanvasCommandList`](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasCommandList.htm) | A closed command list is an immutable device resource that can be drawn repeatedly; drawing state and resources remain associated with the device domain. | Retain typed resource references and shared transforms in the owning WebGPU context. Do not materialize a CPU bitmap or cross-device compatibility adapter during recording. |
 | [WebGPU command buffers](https://www.w3.org/TR/webgpu/#command-buffers) | Command buffers are immutable encodings submitted in order to a device queue. | Keep the CPU retained stream immutable and allocation-free to index, then expand it into the existing WebGPU compilation and submission path. CPU command packing does not replace GPU rasterization or composition. |
 | [WebRender rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html) | Retained display lists preserve ordered scene state while renderer-owned resources are reused across frames. | Separate compact scene intent from device resource ownership. Retain one texture lease per image/context and reuse it for consecutive picture draws instead of searching the retained-resource list per draw. |
@@ -51,6 +52,14 @@ operations, and unbounded per-draw resource lookup caches.
   image/context texture in `O(1)`. The recording context still owns the one
   actual lease; the three-reference lookup cache is cleared at recording
   completion and canvas disposal.
+- A native-format whole-image `ReadPixels` with `Disallow` performs one
+  `O(P)` GPU-to-staging transfer and copies mapped rows directly to caller
+  storage. `Allow` may reuse one `O(P)` immutable readback array. Both paths
+  reuse one staging buffer and preserve the caller's row padding.
+- Synchronous map completion performs non-blocking WebGPU device polls and
+  cooperative thread yields until completion or the existing 30-second
+  timeout. It does not impose a one-millisecond sleep after every incomplete
+  poll, so latency remains proportional to actual queue completion.
 - The focused storage gate permits at most 64 retained bytes per ordinary
   texture draw, plus one shared transform. Exact clone tests cover texture,
   rectangle, path, rectangle clip, geometry clip, and all pop-state records.
@@ -87,3 +96,24 @@ Official SkiaSharp remains faster in both microbenchmarks at this checkpoint;
 these results establish a material improvement and memory floor for the next
 typed text/glyph and immutable-image slices, not completion of the broader
 performance goal.
+
+## Readback checkpoint measurement
+
+The readback checkpoint uses the same Release runner and three fresh processes
+per backend. The previous ProGPU source endpoint and Preview.46 have identical
+surface/readback product code; only package versions and documentation changed
+between them. Every checksum matched.
+
+| Avalonia-shaped workload | Previous ProGPU median | Candidate median | Change | Previous allocation | Candidate allocation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Immutable-image repeated readback (`Disallow`) | 2,799,313 ns | 230,266 ns | -91.8% | 1,104 B/op | 640 B/op (-42.0%) |
+| Direct surface readback | 2,901,513 ns | 431,690 ns | -85.1% | 1,135 B/op | 1,136 B/op |
+| Framebuffer conversion readback | 3,169,493 ns | 447,761 ns | -85.9% | 14,088 B/op | 14,089 B/op |
+| Reusable surface composition | 658,568 ns | 606,675 ns | -7.9% | 991 B/op | 992 B/op |
+
+The small one-byte allocation differences are integer division artifacts in
+the per-operation runner, not retained objects. Official SkiaSharp remains
+faster for synchronous GPU-to-CPU reads because its compared surface is a CPU
+raster surface. ProGPU intentionally keeps rendering and composition on
+WebGPU; this checkpoint removes avoidable waiting and copying without adding a
+CPU renderer or violating `Disallow` caching semantics.

--- a/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
@@ -76,11 +76,11 @@ combined median and p95 rather than a selected process.
 
 Focused tests require exact `RenderCommand` round trips, the 64-byte texture
 record bound, retained image lease sharing without a GPU copy, picture state
-semantics, and compositor regression coverage. Final integration will repeat
-the representative Avalonia application workload and matched Xcode
-Allocations, Time Profiler, and Metal System Trace captures. Raw `.trace`,
-`.nettrace`, Xcode scratch, and exported XML are temporary and will be deleted
-after compact summaries are retained.
+semantics, and compositor regression coverage. Final integration repeats the
+representative Avalonia application workload and matched Xcode Allocations,
+Time Profiler, and Metal System Trace captures. Raw `.trace`, `.nettrace`,
+`.etlx`, Xcode scratch, and exported XML are temporary and are deleted after
+compact summaries are retained.
 
 ## First checkpoint measurement
 
@@ -144,3 +144,48 @@ faster for synchronous GPU-to-CPU reads because its compared surface is a CPU
 raster surface. ProGPU intentionally keeps rendering and composition on
 WebGPU; this checkpoint removes avoidable waiting and copying without adding a
 CPU renderer or violating `Disallow` caching semantics.
+
+## Final broad-distribution and integration validation
+
+The final complete benchmark matrix ran three fresh official and three fresh
+ProGPU processes with the same 32/24 warmup/sample protocol. All cases retained
+their exact semantic checksums. Representative final ProGPU medians are
+155,793 ns for repeated immutable-image `Disallow` readback, 441,181 ns for
+direct surface readback, 460,935 ns for conversion readback, 2,854 ns and
+424 B/op for mixed picture recording, 3,512 ns and 8,180 B/op for layer
+recording, and 254 ns and 89 B/op for positioned text. Complete-distribution
+timings vary more than isolated alternating runs, especially for submicrosecond
+text construction; therefore the focused paired distributions above remain the
+claim evidence and no universal native-performance superiority is asserted.
+
+The exact final source passed these integration gates:
+
+- official SkiaSharp 4.151.0 metadata: 4,222 of 4,222 entries matched, zero
+  missing;
+- 3,305 `ProGPU.Tests` and 225 headless tests;
+- 28 pinned Avalonia retained-compositor tests;
+- 274 upstream Avalonia.Skia text tests plus 13 focused text tests, with five
+  documented platform/profile skips;
+- the full patched Avalonia 12.0.5 ControlCatalog source build against the
+  ProGPU SkiaSharp shim, with zero warnings and zero errors.
+
+## Matched macOS Instruments qualification
+
+The same Release `avalonia-surface-compose` workload and checksum
+`10859766936728445827` were captured before and after with Xcode Allocations
+plus VM Tracker, Time Profiler, and Metal System Trace. Managed allocation
+remained exactly 992 B/op. The instrumented medians were 733,859/701,778 ns
+before/after under Allocations, 579,267/616,824 ns under Time Profiler, and
+713,420/710,813 ns under Metal. The mixed directions are within the
+instrumented-run spread and do not support a throughput-regression or
+throughput-improvement claim for composition itself.
+
+Allocations reported 159,348,000 B before and 159,378,672 B after for
+persistent heap plus anonymous VM, a 30,672 B (0.019%) difference. Both Metal
+captures reported zero drawable waits, compiler spills, potential hangs, hang
+risks, and command-buffer errors. The first candidate Metal finalization hit an
+Instruments rules-engine failure; its incomplete 85 MB trace and 186 MB Xcode
+scratch were deleted, and an independent successful capture supplied the final
+Metal evidence. All final raw traces, EventPipe traces, `.etlx` files, Xcode
+scratch, and XML exports were removed after compact JSON/Markdown summaries and
+target logs were retained.

--- a/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
@@ -97,6 +97,14 @@ these results establish a material improvement and memory floor for the next
 typed text/glyph and immutable-image slices, not completion of the broader
 performance goal.
 
+The next packing checkpoint adds an at-most-96-byte common glyph-run record and
+an exact 8-byte scalar state record for opacity and blend pushes. On the same
+three-process mixed-picture workload, retained managed allocation falls again
+from 1,080 to 424 B/op (-60.7%, or -73.9% from Preview.46), while median time
+moves from 3,533.693 to 3,511.312 ns/op (-0.6%). Exact glyph arrays, positions,
+font transform, rendering/hinting modes, presentation dependencies, transform,
+and pop ordering round-trip through the compact stream.
+
 ## Readback checkpoint measurement
 
 The readback checkpoint uses the same Release runner and three fresh processes

--- a/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
@@ -114,6 +114,16 @@ improves from 3,412.750 to 3,367.188 ns/op (-1.3%) and from 9,311 to 8,180 B/op
 pool was measured and rejected: it increased allocation by 20 B/op and slowed
 the median, so no pooling code remains.
 
+The positioned-text checkpoint keeps the common one-run builder state in one
+typed field instead of adding and clearing a `List<T>` reference slot for every
+blob. Multi-run builders promote the first run to the existing list exactly
+once; immutable blob snapshots and the bounded pinned run lease are unchanged.
+Construction and disposal remain `O(1)` outside the caller's `O(G)` glyph and
+position copies. In three fresh matched processes, the Avalonia positioned-run
+workload is 268.375 ns/op and 89 B/op versus official SkiaSharp at 289.270
+ns/op and 136 B/op: ProGPU is 7.2% faster and allocates 34.6% less managed
+memory, with the exact checksum preserved.
+
 ## Readback checkpoint measurement
 
 The readback checkpoint uses the same Release runner and three fresh processes

--- a/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
+++ b/docs/AVALONIA_SKIA_RETAINED_COMMAND_STREAM_RESEARCH.md
@@ -24,6 +24,7 @@ sampling, transform, and presentation state.
 | --- | --- | --- |
 | [Skia `SkPicture`](https://api.skia.org/classSkPicture.html) and [`SkPictureRecorder`](https://api.skia.org/classSkPictureRecorder.html) | A picture is an immutable recording of ordered drawing, matrix, and clip operations. Finishing a recording invalidates the recording canvas for further recording. | Preserve exact command order and immutable replay. Use an original ProGPU token and typed-record layout; do not reproduce Skia opcodes, record structures, source organization, or implementation control flow. Clear picture-only image lookup state when recording finishes. |
 | [Skia `SkImage`](https://api.skia.org/classSkImage.html) | An image cannot be modified after creation. `kAllow_CachingHint` permits internally caching decoded/copied pixels; `kDisallow_CachingHint` forbids that cache. | Cache one immutable GPU readback only for `Allow`. For `Disallow`, copy a whole native-format texture directly into the caller's rows through the reusable WebGPU staging buffer, preserving row padding and avoiding a persistent copied-pixel cache. |
+| [Skia `SkRRect`](https://api.skia.org/classSkRRect.html) | Uniform rounded rectangles standardize bounds, scale oversized radii to fit, collapse invalid radii to rectangular corners, and clamp oval radii to half extents. | Apply the same public normalization directly in the scalar `DrawRoundRect(rect, rx, ry, paint)` fast path and record one analytic rounded-rectangle command. Complex corners and shader geometry continue through the existing retained-path fallback. |
 | [Direct2D command lists](https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1commandlist) and [Win2D `CanvasCommandList`](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasCommandList.htm) | A closed command list is an immutable device resource that can be drawn repeatedly; drawing state and resources remain associated with the device domain. | Retain typed resource references and shared transforms in the owning WebGPU context. Do not materialize a CPU bitmap or cross-device compatibility adapter during recording. |
 | [WebGPU command buffers](https://www.w3.org/TR/webgpu/#command-buffers) | Command buffers are immutable encodings submitted in order to a device queue. | Keep the CPU retained stream immutable and allocation-free to index, then expand it into the existing WebGPU compilation and submission path. CPU command packing does not replace GPU rasterization or composition. |
 | [WebRender rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html) | Retained display lists preserve ordered scene state while renderer-owned resources are reused across frames. | Separate compact scene intent from device resource ownership. Retain one texture lease per image/context and reuse it for consecutive picture draws instead of searching the retained-resource list per draw. |
@@ -104,6 +105,14 @@ from 1,080 to 424 B/op (-60.7%, or -73.9% from Preview.46), while median time
 moves from 3,533.693 to 3,511.312 ns/op (-0.6%). Exact glyph arrays, positions,
 font transform, rendering/hinting modes, presentation dependencies, transform,
 and pop ordering round-trip through the compact stream.
+
+The SaveLayer checkpoint adds at-most-80-byte analytic rounded-rectangle
+records and exact 16-byte retained-visual references. Its type-first classifier
+avoids rescanning those common wide commands. The three-process layer workload
+improves from 3,412.750 to 3,367.188 ns/op (-1.3%) and from 9,311 to 8,180 B/op
+(-12.1%, or -21.4% from Preview.46's 10,411 B/op). A canvas-local layer-context
+pool was measured and rejected: it increased allocation by 20 B/op and slowed
+the median, so no pooling code remains.
 
 ## Readback checkpoint measurement
 

--- a/src/ProGPU.Backend/GpuTextureReadbackBuffer.cs
+++ b/src/ProGPU.Backend/GpuTextureReadbackBuffer.cs
@@ -307,7 +307,10 @@ public unsafe sealed class GpuTextureReadbackBuffer : IDisposable
         while (!mapTask.IsCompleted)
         {
             _context.PollDevice(wait: false);
-            Thread.Sleep(1);
+            if (!mapTask.IsCompleted)
+            {
+                Thread.Yield();
+            }
             if (stopwatch.ElapsedMilliseconds > timeoutMilliseconds)
             {
                 LastMapTimedOut = true;

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -749,7 +749,9 @@ internal enum RetainedCommandDataKind : byte
     SimplePath,
     RectangleClip,
     GeometryClip,
-    NoData
+    NoData,
+    SimpleGlyphRun,
+    ScalarState
 }
 
 internal readonly struct RetainedTextCommandData
@@ -964,6 +966,16 @@ internal readonly struct RetainedRenderCommand
             return RetainedCommandDataKind.SimpleTexture;
         }
 
+        if (IsSimpleGlyphRun(in command, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.SimpleGlyphRun;
+        }
+
+        if (IsScalarState(in command, hasText, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.ScalarState;
+        }
+
         if (!hasText && !hasTexture && !hasOther)
         {
             return RetainedCommandDataKind.Basic;
@@ -1068,6 +1080,119 @@ internal readonly struct RetainedRenderCommand
         !command.IsPenThicknessLocal &&
         command.PathSampleGrid == 0 &&
         command.PathCoverageGamma == 0f;
+
+    private static bool IsSimpleGlyphRun(
+        in RenderCommand command,
+        bool hasTexture,
+        bool hasOther) =>
+        command.Type == RenderCommandType.DrawGlyphRun &&
+        !hasTexture &&
+        !hasOther &&
+        command.Text is null &&
+        command.TextShapingOptions is null &&
+        command.TextAlignment == default &&
+        command.Rotation == 0f &&
+        command.Rect == default &&
+        command.Pen is null &&
+        command.Path is null &&
+        command.GeometryCache is null &&
+        !command.IsPenThicknessLocal &&
+        command.PathSampleGrid == 0 &&
+        command.PathCoverageGamma == 0f;
+
+    private static bool IsScalarState(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture,
+        bool hasOther)
+    {
+        if (hasTexture ||
+            !HasDefaultCoreData(
+                in command,
+                allowBrush: false,
+                allowPen: false,
+                allowPath: false) ||
+            command.Rect != default ||
+            command.Transform != default)
+        {
+            return false;
+        }
+
+        return command.Type switch
+        {
+            RenderCommandType.PushOpacity =>
+                hasText &&
+                !hasOther &&
+                HasOnlyFontSizeTextData(in command),
+            RenderCommandType.PushBlendMode =>
+                !hasText &&
+                hasOther &&
+                HasOnlyIntParamOtherData(in command),
+            _ => false
+        };
+    }
+
+    private static bool HasOnlyFontSizeTextData(in RenderCommand command) =>
+        command.Text is null &&
+        command.Font is null &&
+        command.Position == default &&
+        !command.IsBold &&
+        !command.IsItalic &&
+        command.TextShapingOptions is null &&
+        command.TextAlignment == default &&
+        command.FontTransform == default &&
+        !command.HasFontTransform &&
+        command.Rotation == 0f &&
+        command.TextRenderingMode == default &&
+        command.TextHintingMode == default &&
+        !command.UseVectorGlyphRendering &&
+        !command.PreferGlyphAtlas &&
+        !command.UseLogicalGlyphAtlasResolution &&
+        command.GlyphIndices is null &&
+        command.GlyphPositions is null &&
+        command.GlyphRangeStart == 0 &&
+        command.GlyphRangeCount == 0;
+
+    private static bool HasOnlyIntParamOtherData(in RenderCommand command) =>
+        command.Position2 == default &&
+        command.Position3 == default &&
+        command.Position4 == default &&
+        command.RadiusX == 0f &&
+        command.RadiusY == 0f &&
+        command.CornerRadius == 0f &&
+        command.PolylinePoints is null &&
+        !command.IsClosed &&
+        command.SplineKnots is null &&
+        command.SplineWeights is null &&
+        command.SplineDegree == 0 &&
+        command.Position3D1 == default &&
+        command.Position3D2 == default &&
+        command.Edges3D is null &&
+        command.StaticBuffer is null &&
+        command.GpuPoints is null &&
+        command.GpuPointsCount == 0 &&
+        !command.UseGpuTransforms &&
+        command.CameraView == default &&
+        command.Scale == default &&
+        command.Translate == default &&
+        command.PointBufferOffset == 0 &&
+        command.PointBufferCount == 0 &&
+        command.DoubleBufferOffset == 0 &&
+        command.DoubleBufferCount == 0 &&
+        command.Line3DBufferOffset == 0 &&
+        command.Line3DBufferCount == 0 &&
+        command.WeightBufferOffset == 0 &&
+        command.WeightBufferCount == 0 &&
+        command.FloatBufferOffset == 0 &&
+        command.FloatBufferCount == 0 &&
+        command.SeriesCacheKey is null &&
+        command.Picture is null &&
+        command.Visual is null &&
+        command.VertexMesh is null &&
+        command.VertexColorBlendMode == default &&
+        command.ExtensionId == 0 &&
+        command.FloatParam == 0f &&
+        command.DataParam is null;
 
     private static bool HasDefaultCoreData(
         in RenderCommand command,
@@ -1391,6 +1516,118 @@ internal readonly struct RetainedGeometryClipCommand
         };
 }
 
+internal readonly struct RetainedSimpleGlyphRunCommand
+{
+    private const ushort BoldFlag = 1 << 0;
+    private const ushort ItalicFlag = 1 << 1;
+    private const ushort FontTransformFlag = 1 << 2;
+    private const ushort VectorRenderingFlag = 1 << 3;
+    private const ushort PreferAtlasFlag = 1 << 4;
+    private const ushort LogicalAtlasResolutionFlag = 1 << 5;
+    private const ushort EdgeAliasedFlag = 1 << 6;
+
+    private readonly Brush? _brush;
+    private readonly TtfFont? _font;
+    private readonly ushort[]? _glyphIndices;
+    private readonly Vector2[]? _glyphPositions;
+    private readonly Vector2 _position;
+    private readonly Vector2 _fontTransform;
+    private readonly float _fontSize;
+    private readonly int _glyphRangeStart;
+    private readonly int _glyphRangeCount;
+    private readonly int _hitTestId;
+    private readonly int _transformIndex;
+    private readonly RenderCommandPresentationDependencies _presentationDependencies;
+    private readonly ushort _flags;
+    private readonly byte _textRenderingMode;
+    private readonly byte _textHintingMode;
+
+    public RetainedSimpleGlyphRunCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _brush = command.Brush;
+        _font = command.Font;
+        _glyphIndices = command.GlyphIndices;
+        _glyphPositions = command.GlyphPositions;
+        _position = command.Position;
+        _fontTransform = command.FontTransform;
+        _fontSize = command.FontSize;
+        _glyphRangeStart = command.GlyphRangeStart;
+        _glyphRangeCount = command.GlyphRangeCount;
+        _hitTestId = command.HitTestId;
+        _transformIndex = transformIndex;
+        _presentationDependencies = command.PresentationDependencies;
+        _flags = (ushort)(
+            (command.IsBold ? BoldFlag : 0) |
+            (command.IsItalic ? ItalicFlag : 0) |
+            (command.HasFontTransform ? FontTransformFlag : 0) |
+            (command.UseVectorGlyphRendering ? VectorRenderingFlag : 0) |
+            (command.PreferGlyphAtlas ? PreferAtlasFlag : 0) |
+            (command.UseLogicalGlyphAtlasResolution
+                ? LogicalAtlasResolutionFlag
+                : 0) |
+            (command.IsEdgeAliased ? EdgeAliasedFlag : 0));
+        _textRenderingMode = checked((byte)command.TextRenderingMode);
+        _textHintingMode = checked((byte)command.TextHintingMode);
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.DrawGlyphRun,
+            HitTestId = _hitTestId,
+            Brush = _brush,
+            Font = _font,
+            FontSize = _fontSize,
+            Position = _position,
+            FontTransform = _fontTransform,
+            Transform = transforms[_transformIndex],
+            PresentationDependencies = _presentationDependencies,
+            IsBold = (_flags & BoldFlag) != 0,
+            IsItalic = (_flags & ItalicFlag) != 0,
+            HasFontTransform = (_flags & FontTransformFlag) != 0,
+            UseVectorGlyphRendering = (_flags & VectorRenderingFlag) != 0,
+            PreferGlyphAtlas = (_flags & PreferAtlasFlag) != 0,
+            UseLogicalGlyphAtlasResolution =
+                (_flags & LogicalAtlasResolutionFlag) != 0,
+            IsEdgeAliased = (_flags & EdgeAliasedFlag) != 0,
+            TextRenderingMode = (TextRenderingMode)_textRenderingMode,
+            TextHintingMode = (TextHintingMode)_textHintingMode,
+            GlyphIndices = _glyphIndices,
+            GlyphPositions = _glyphPositions,
+            GlyphRangeStart = _glyphRangeStart,
+            GlyphRangeCount = _glyphRangeCount
+        };
+}
+
+internal readonly struct RetainedScalarStateCommand
+{
+    private readonly RenderCommandType _type;
+    private readonly int _value;
+
+    public RetainedScalarStateCommand(in RenderCommand command)
+    {
+        _type = command.Type;
+        _value = command.Type == RenderCommandType.PushOpacity
+            ? BitConverter.SingleToInt32Bits(command.FontSize)
+            : command.IntParam;
+    }
+
+    public RenderCommand Expand() =>
+        _type == RenderCommandType.PushOpacity
+            ? new RenderCommand
+            {
+                Type = _type,
+                FontSize = BitConverter.Int32BitsToSingle(_value)
+            }
+            : new RenderCommand
+            {
+                Type = _type,
+                IntParam = _value
+            };
+}
+
 /// <summary>
 /// Immutable command snapshot with an ordered 32-bit token stream plus typed
 /// rectangle, path, clip, text, texture, transform, and uncommon-command
@@ -1413,6 +1650,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
     private readonly RetainedSimplePathCommand[] _simplePaths;
     private readonly RetainedRectangleClipCommand[] _rectangleClips;
     private readonly RetainedGeometryClipCommand[] _geometryClips;
+    private readonly RetainedSimpleGlyphRunCommand[] _simpleGlyphRuns;
+    private readonly RetainedScalarStateCommand[] _scalarStates;
     private readonly Matrix4x4[] _transforms;
     private readonly Visual[] _embeddedVisuals;
 
@@ -1430,6 +1669,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             _simplePaths = [];
             _rectangleClips = [];
             _geometryClips = [];
+            _simpleGlyphRuns = [];
+            _scalarStates = [];
             _transforms = [];
             _embeddedVisuals = [];
             return;
@@ -1444,6 +1685,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
         int simplePathCount = 0;
         int rectangleClipCount = 0;
         int geometryClipCount = 0;
+        int simpleGlyphRunCount = 0;
+        int scalarStateCount = 0;
         int embeddedVisualCount = 0;
         byte[] classifications =
             ArrayPool<byte>.Shared.Rent(commands.Length);
@@ -1500,6 +1743,12 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     case RetainedCommandDataKind.GeometryClip:
                         geometryClipCount++;
                         break;
+                    case RetainedCommandDataKind.SimpleGlyphRun:
+                        simpleGlyphRunCount++;
+                        break;
+                    case RetainedCommandDataKind.ScalarState:
+                        scalarStateCount++;
+                        break;
                 }
                 if (commands[index].Type == RenderCommandType.DrawVisual &&
                     commands[index].Visual != null)
@@ -1536,6 +1785,12 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             _geometryClips = geometryClipCount == 0
                 ? []
                 : new RetainedGeometryClipCommand[geometryClipCount];
+            _simpleGlyphRuns = simpleGlyphRunCount == 0
+                ? []
+                : new RetainedSimpleGlyphRunCommand[simpleGlyphRunCount];
+            _scalarStates = scalarStateCount == 0
+                ? []
+                : new RetainedScalarStateCommand[scalarStateCount];
             _transforms = new Matrix4x4[transformCount];
             _embeddedVisuals = embeddedVisualCount == 0
                 ? []
@@ -1550,6 +1805,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             int simplePathIndex = 0;
             int rectangleClipIndex = 0;
             int geometryClipIndex = 0;
+            int simpleGlyphRunIndex = 0;
+            int scalarStateIndex = 0;
             int embeddedVisualIndex = 0;
             for (int index = 0; index < commands.Length; index++)
             {
@@ -1623,6 +1880,18 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                                 in command,
                                 transformIndices[index]);
                         break;
+                    case RetainedCommandDataKind.SimpleGlyphRun:
+                        dataIndex = simpleGlyphRunIndex;
+                        _simpleGlyphRuns[simpleGlyphRunIndex++] =
+                            new RetainedSimpleGlyphRunCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.ScalarState:
+                        dataIndex = scalarStateIndex;
+                        _scalarStates[scalarStateIndex++] =
+                            new RetainedScalarStateCommand(in command);
+                        break;
                     case RetainedCommandDataKind.NoData:
                         dataIndex = (int)command.Type;
                         break;
@@ -1676,6 +1945,10 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     _rectangleClips[dataIndex].Expand(_transforms),
                 RetainedCommandDataKind.GeometryClip =>
                     _geometryClips[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.SimpleGlyphRun =>
+                    _simpleGlyphRuns[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.ScalarState =>
+                    _scalarStates[dataIndex].Expand(),
                 RetainedCommandDataKind.NoData => new RenderCommand
                 {
                     Type = (RenderCommandType)dataIndex
@@ -1706,6 +1979,10 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedRectangleClipCommand>() +
         (long)_geometryClips.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedGeometryClipCommand>() +
+        (long)_simpleGlyphRuns.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimpleGlyphRunCommand>() +
+        (long)_scalarStates.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedScalarStateCommand>() +
         (long)_transforms.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<Matrix4x4>() +
         (long)_embeddedVisuals.Length * IntPtr.Size;
@@ -1754,7 +2031,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
     private static bool RequiresTransform(
         RetainedCommandDataKind dataKind) =>
         dataKind is not RetainedCommandDataKind.Auxiliary and
-            not RetainedCommandDataKind.NoData;
+            not RetainedCommandDataKind.NoData and
+            not RetainedCommandDataKind.ScalarState;
 
     private static int GetTransformTableCapacity(int commandCount)
     {

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -740,10 +740,16 @@ public struct RenderCommand
 
 internal enum RetainedCommandDataKind : byte
 {
-    None,
+    Basic,
     Auxiliary,
     Text,
-    Texture
+    Texture,
+    SimpleTexture,
+    SimpleRectangle,
+    SimplePath,
+    RectangleClip,
+    GeometryClip,
+    NoData
 }
 
 internal readonly struct RetainedTextCommandData
@@ -881,13 +887,9 @@ internal readonly struct RetainedRenderCommand
     private readonly bool _isPenThicknessLocal;
     private readonly uint _pathSampleGrid;
     private readonly float _pathCoverageGamma;
-    private readonly int _dataIndex;
-    private readonly RetainedCommandDataKind _dataKind;
 
     public RetainedRenderCommand(
         in RenderCommand command,
-        RetainedCommandDataKind dataKind,
-        int dataIndex,
         int transformIndex)
     {
         _type = command.Type;
@@ -903,21 +905,10 @@ internal readonly struct RetainedRenderCommand
         _isPenThicknessLocal = command.IsPenThicknessLocal;
         _pathSampleGrid = command.PathSampleGrid;
         _pathCoverageGamma = command.PathCoverageGamma;
-        _dataIndex = dataIndex;
-        _dataKind = dataKind;
     }
 
-    public RenderCommand Expand(
-        RenderCommand[] auxiliary,
-        RetainedTextCommandData[] text,
-        RetainedTextureCommandData[] texture,
-        Matrix4x4[] transforms)
+    public RenderCommand Expand(Matrix4x4[] transforms)
     {
-        if (_dataKind == RetainedCommandDataKind.Auxiliary)
-        {
-            return auxiliary[_dataIndex];
-        }
-
         var command = new RenderCommand
         {
             Type = _type,
@@ -934,16 +925,6 @@ internal readonly struct RetainedRenderCommand
             PathSampleGrid = _pathSampleGrid,
             PathCoverageGamma = _pathCoverageGamma
         };
-
-        if (_dataKind == RetainedCommandDataKind.Text)
-        {
-            text[_dataIndex].Apply(ref command);
-        }
-        else if (_dataKind == RetainedCommandDataKind.Texture)
-        {
-            texture[_dataIndex].Apply(ref command);
-        }
-
         return command;
     }
 
@@ -952,9 +933,40 @@ internal readonly struct RetainedRenderCommand
         bool hasText = HasTextData(in command);
         bool hasTexture = HasTextureData(in command);
         bool hasOther = HasOtherData(in command);
+
+        if (IsNoDataCommand(in command, hasText, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.NoData;
+        }
+
+        if (IsSimpleRectangle(in command, hasText, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.SimpleRectangle;
+        }
+
+        if (IsSimplePath(in command, hasText, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.SimplePath;
+        }
+
+        if (IsRectangleClip(in command, hasText, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.RectangleClip;
+        }
+
+        if (IsGeometryClip(in command, hasText, hasTexture, hasOther))
+        {
+            return RetainedCommandDataKind.GeometryClip;
+        }
+
+        if (IsSimpleTexture(in command, hasText, hasOther))
+        {
+            return RetainedCommandDataKind.SimpleTexture;
+        }
+
         if (!hasText && !hasTexture && !hasOther)
         {
-            return RetainedCommandDataKind.None;
+            return RetainedCommandDataKind.Basic;
         }
 
         if (hasText && !hasTexture && !hasOther &&
@@ -972,6 +984,106 @@ internal readonly struct RetainedRenderCommand
 
         return RetainedCommandDataKind.Auxiliary;
     }
+
+    private static bool IsNoDataCommand(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture,
+        bool hasOther) =>
+        (command.Type is RenderCommandType.PopClip or
+            RenderCommandType.PopOpacity or
+            RenderCommandType.PopGeometryClip or
+            RenderCommandType.PopOpacityMask or
+            RenderCommandType.PopBlendMode) &&
+        !hasText &&
+        !hasTexture &&
+        !hasOther &&
+        HasDefaultCoreData(in command, allowBrush: false, allowPen: false, allowPath: false) &&
+        command.Rect == default &&
+        command.Transform == default;
+
+    private static bool IsSimpleRectangle(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture,
+        bool hasOther) =>
+        command.Type == RenderCommandType.DrawRect &&
+        !hasText &&
+        !hasTexture &&
+        !hasOther &&
+        command.Path is null &&
+        command.GeometryCache is null;
+
+    private static bool IsSimplePath(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture,
+        bool hasOther) =>
+        command.Type == RenderCommandType.DrawPath &&
+        !hasText &&
+        !hasTexture &&
+        !hasOther &&
+        command.Rect == default;
+
+    private static bool IsRectangleClip(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture,
+        bool hasOther) =>
+        command.Type == RenderCommandType.PushClip &&
+        !hasText &&
+        !hasTexture &&
+        !hasOther &&
+        HasDefaultCoreData(in command, allowBrush: false, allowPen: false, allowPath: false);
+
+    private static bool IsGeometryClip(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture,
+        bool hasOther) =>
+        command.Type == RenderCommandType.PushGeometryClip &&
+        !hasText &&
+        !hasTexture &&
+        !hasOther &&
+        command.Rect == default &&
+        HasDefaultCoreData(in command, allowBrush: false, allowPen: false, allowPath: true);
+
+    private static bool IsSimpleTexture(
+        in RenderCommand command,
+        bool hasText,
+        bool hasOther) =>
+        command.Type == RenderCommandType.DrawTexture &&
+        !hasText &&
+        !hasOther &&
+        command.Brush is null &&
+        command.Pen is null &&
+        command.Path is null &&
+        command.GeometryCache is null &&
+        command.TexturePatches is null &&
+        !command.HasTextureCubicCoefficients &&
+        !command.HasImageEffect &&
+        command.InlineImageEffectBox is null &&
+        command.ImageEffectBufferIndex == 0 &&
+        !command.HasBufferedImageEffect &&
+        !command.IsPenThicknessLocal &&
+        command.PathSampleGrid == 0 &&
+        command.PathCoverageGamma == 0f;
+
+    private static bool HasDefaultCoreData(
+        in RenderCommand command,
+        bool allowBrush,
+        bool allowPen,
+        bool allowPath) =>
+        (allowBrush || command.Brush is null) &&
+        (allowPen || command.Pen is null) &&
+        (allowPath || command.Path is null) &&
+        command.GeometryCache is null &&
+        command.HitTestId == 0 &&
+        command.PresentationDependencies == default &&
+        !command.IsEdgeAliased &&
+        !command.IsPenThicknessLocal &&
+        command.PathSampleGrid == 0 &&
+        command.PathCoverageGamma == 0f;
 
     private static bool HasTextData(in RenderCommand command) =>
         command.Text is not null ||
@@ -1052,18 +1164,255 @@ internal readonly struct RetainedRenderCommand
         command.DataParam is not null;
 }
 
+internal readonly struct RetainedTextRenderCommand
+{
+    private readonly RetainedRenderCommand _core;
+    private readonly RetainedTextCommandData _text;
+
+    public RetainedTextRenderCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _core = new RetainedRenderCommand(in command, transformIndex);
+        _text = new RetainedTextCommandData(in command);
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms)
+    {
+        RenderCommand command = _core.Expand(transforms);
+        _text.Apply(ref command);
+        return command;
+    }
+}
+
+internal readonly struct RetainedTextureRenderCommand
+{
+    private readonly RetainedRenderCommand _core;
+    private readonly RetainedTextureCommandData _texture;
+
+    public RetainedTextureRenderCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _core = new RetainedRenderCommand(in command, transformIndex);
+        _texture = new RetainedTextureCommandData(in command);
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms)
+    {
+        RenderCommand command = _core.Expand(transforms);
+        _texture.Apply(ref command);
+        return command;
+    }
+}
+
+internal readonly struct RetainedSimpleTextureCommand
+{
+    private readonly GpuTexture? _texture;
+    private readonly Rect _destination;
+    private readonly Rect _source;
+    private readonly int _hitTestId;
+    private readonly int _transformIndex;
+    private readonly RenderCommandPresentationDependencies _presentationDependencies;
+    private readonly byte _samplingMode;
+    private readonly byte _maxAnisotropy;
+    private readonly bool _snapToPixels;
+    private readonly bool _isEdgeAliased;
+
+    public RetainedSimpleTextureCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _texture = command.Texture;
+        _destination = command.Rect;
+        _source = command.SrcRect;
+        _hitTestId = command.HitTestId;
+        _transformIndex = transformIndex;
+        _presentationDependencies = command.PresentationDependencies;
+        _samplingMode = checked((byte)command.TextureSamplingMode);
+        _maxAnisotropy = command.TextureMaxAnisotropy;
+        _snapToPixels = command.SnapTextureToPixels;
+        _isEdgeAliased = command.IsEdgeAliased;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.DrawTexture,
+            HitTestId = _hitTestId,
+            Rect = _destination,
+            Texture = _texture,
+            SrcRect = _source,
+            Transform = transforms[_transformIndex],
+            PresentationDependencies = _presentationDependencies,
+            TextureSamplingMode = (TextureSamplingMode)_samplingMode,
+            TextureMaxAnisotropy = _maxAnisotropy,
+            SnapTextureToPixels = _snapToPixels,
+            IsEdgeAliased = _isEdgeAliased
+        };
+}
+
+internal readonly struct RetainedSimpleRectangleCommand
+{
+    private readonly int _hitTestId;
+    private readonly Rect _rectangle;
+    private readonly Brush? _brush;
+    private readonly Pen? _pen;
+    private readonly int _transformIndex;
+    private readonly RenderCommandPresentationDependencies _presentationDependencies;
+    private readonly bool _isEdgeAliased;
+    private readonly bool _isPenThicknessLocal;
+    private readonly uint _pathSampleGrid;
+    private readonly float _pathCoverageGamma;
+
+    public RetainedSimpleRectangleCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _hitTestId = command.HitTestId;
+        _rectangle = command.Rect;
+        _brush = command.Brush;
+        _pen = command.Pen;
+        _transformIndex = transformIndex;
+        _presentationDependencies = command.PresentationDependencies;
+        _isEdgeAliased = command.IsEdgeAliased;
+        _isPenThicknessLocal = command.IsPenThicknessLocal;
+        _pathSampleGrid = command.PathSampleGrid;
+        _pathCoverageGamma = command.PathCoverageGamma;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.DrawRect,
+            HitTestId = _hitTestId,
+            Rect = _rectangle,
+            Brush = _brush,
+            Pen = _pen,
+            Transform = transforms[_transformIndex],
+            PresentationDependencies = _presentationDependencies,
+            IsEdgeAliased = _isEdgeAliased,
+            IsPenThicknessLocal = _isPenThicknessLocal,
+            PathSampleGrid = _pathSampleGrid,
+            PathCoverageGamma = _pathCoverageGamma
+        };
+}
+
+internal readonly struct RetainedSimplePathCommand
+{
+    private readonly int _hitTestId;
+    private readonly Brush? _brush;
+    private readonly Pen? _pen;
+    private readonly PathGeometry? _path;
+    private readonly RenderCommandGeometryCache? _geometryCache;
+    private readonly int _transformIndex;
+    private readonly RenderCommandPresentationDependencies _presentationDependencies;
+    private readonly bool _isEdgeAliased;
+    private readonly bool _isPenThicknessLocal;
+    private readonly uint _pathSampleGrid;
+    private readonly float _pathCoverageGamma;
+
+    public RetainedSimplePathCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _hitTestId = command.HitTestId;
+        _brush = command.Brush;
+        _pen = command.Pen;
+        _path = command.Path;
+        _geometryCache = command.GeometryCache;
+        _transformIndex = transformIndex;
+        _presentationDependencies = command.PresentationDependencies;
+        _isEdgeAliased = command.IsEdgeAliased;
+        _isPenThicknessLocal = command.IsPenThicknessLocal;
+        _pathSampleGrid = command.PathSampleGrid;
+        _pathCoverageGamma = command.PathCoverageGamma;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = _hitTestId,
+            Brush = _brush,
+            Pen = _pen,
+            Path = _path,
+            GeometryCache = _geometryCache,
+            Transform = transforms[_transformIndex],
+            PresentationDependencies = _presentationDependencies,
+            IsEdgeAliased = _isEdgeAliased,
+            IsPenThicknessLocal = _isPenThicknessLocal,
+            PathSampleGrid = _pathSampleGrid,
+            PathCoverageGamma = _pathCoverageGamma
+        };
+}
+
+internal readonly struct RetainedRectangleClipCommand
+{
+    private readonly Rect _rectangle;
+    private readonly int _transformIndex;
+
+    public RetainedRectangleClipCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _rectangle = command.Rect;
+        _transformIndex = transformIndex;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.PushClip,
+            Rect = _rectangle,
+            Transform = transforms[_transformIndex]
+        };
+}
+
+internal readonly struct RetainedGeometryClipCommand
+{
+    private readonly PathGeometry? _path;
+    private readonly int _transformIndex;
+
+    public RetainedGeometryClipCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _path = command.Path;
+        _transformIndex = transformIndex;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.PushGeometryClip,
+            Path = _path,
+            Transform = transforms[_transformIndex]
+        };
+}
+
 /// <summary>
-/// Immutable command snapshot with compact core, text, texture, transform, and
-/// uncommon-command storage. Construction is O(C) average and O(C²) only for
+/// Immutable command snapshot with an ordered 32-bit token stream plus typed
+/// rectangle, path, clip, text, texture, transform, and uncommon-command
+/// storage. Construction is O(C) average and O(C²) only for
 /// adversarial transform-hash collisions, with O(C) bounded scratch and retained
 /// storage for C commands. Indexing and replay expansion are allocation-free O(1).
 /// </summary>
 internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
 {
-    private readonly RetainedRenderCommand[] _commands;
+    private const int TokenKindShift = 28;
+    private const uint TokenIndexMask = (1u << TokenKindShift) - 1u;
+
+    private readonly uint[] _order;
+    private readonly RetainedRenderCommand[] _basic;
     private readonly RenderCommand[] _auxiliary;
-    private readonly RetainedTextCommandData[] _text;
-    private readonly RetainedTextureCommandData[] _texture;
+    private readonly RetainedTextRenderCommand[] _text;
+    private readonly RetainedTextureRenderCommand[] _texture;
+    private readonly RetainedSimpleTextureCommand[] _simpleTextures;
+    private readonly RetainedSimpleRectangleCommand[] _simpleRectangles;
+    private readonly RetainedSimplePathCommand[] _simplePaths;
+    private readonly RetainedRectangleClipCommand[] _rectangleClips;
+    private readonly RetainedGeometryClipCommand[] _geometryClips;
     private readonly Matrix4x4[] _transforms;
     private readonly Visual[] _embeddedVisuals;
 
@@ -1071,18 +1420,30 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
     {
         if (commands.IsEmpty)
         {
-            _commands = [];
+            _order = [];
+            _basic = [];
             _auxiliary = [];
             _text = [];
             _texture = [];
+            _simpleTextures = [];
+            _simpleRectangles = [];
+            _simplePaths = [];
+            _rectangleClips = [];
+            _geometryClips = [];
             _transforms = [];
             _embeddedVisuals = [];
             return;
         }
 
+        int basicCount = 0;
         int auxiliaryCount = 0;
         int textCount = 0;
         int textureCount = 0;
+        int simpleTextureCount = 0;
+        int simpleRectangleCount = 0;
+        int simplePathCount = 0;
+        int rectangleClipCount = 0;
+        int geometryClipCount = 0;
         int embeddedVisualCount = 0;
         byte[] classifications =
             ArrayPool<byte>.Shared.Rent(commands.Length);
@@ -1102,14 +1463,19 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                 RetainedCommandDataKind dataKind =
                     RetainedRenderCommand.Classify(in commands[index]);
                 classifications[index] = (byte)dataKind;
-                transformIndices[index] = GetOrAddTransform(
-                    in commands[index].Transform,
-                    transformScratch,
-                    transformTable,
-                    transformTableCapacity - 1,
-                    ref transformCount);
+                transformIndices[index] = RequiresTransform(dataKind)
+                    ? GetOrAddTransform(
+                        in commands[index].Transform,
+                        transformScratch,
+                        transformTable,
+                        transformTableCapacity - 1,
+                        ref transformCount)
+                    : -1;
                 switch (dataKind)
                 {
+                    case RetainedCommandDataKind.Basic:
+                        basicCount++;
+                        break;
                     case RetainedCommandDataKind.Auxiliary:
                         auxiliaryCount++;
                         break;
@@ -1119,6 +1485,21 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     case RetainedCommandDataKind.Texture:
                         textureCount++;
                         break;
+                    case RetainedCommandDataKind.SimpleTexture:
+                        simpleTextureCount++;
+                        break;
+                    case RetainedCommandDataKind.SimpleRectangle:
+                        simpleRectangleCount++;
+                        break;
+                    case RetainedCommandDataKind.SimplePath:
+                        simplePathCount++;
+                        break;
+                    case RetainedCommandDataKind.RectangleClip:
+                        rectangleClipCount++;
+                        break;
+                    case RetainedCommandDataKind.GeometryClip:
+                        geometryClipCount++;
+                        break;
                 }
                 if (commands[index].Type == RenderCommandType.DrawVisual &&
                     commands[index].Visual != null)
@@ -1127,24 +1508,48 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                 }
             }
 
-            _commands = new RetainedRenderCommand[commands.Length];
+            _order = new uint[commands.Length];
+            _basic = basicCount == 0
+                ? []
+                : new RetainedRenderCommand[basicCount];
             _auxiliary = auxiliaryCount == 0
                 ? []
                 : new RenderCommand[auxiliaryCount];
             _text = textCount == 0
                 ? []
-                : new RetainedTextCommandData[textCount];
+                : new RetainedTextRenderCommand[textCount];
             _texture = textureCount == 0
                 ? []
-                : new RetainedTextureCommandData[textureCount];
+                : new RetainedTextureRenderCommand[textureCount];
+            _simpleTextures = simpleTextureCount == 0
+                ? []
+                : new RetainedSimpleTextureCommand[simpleTextureCount];
+            _simpleRectangles = simpleRectangleCount == 0
+                ? []
+                : new RetainedSimpleRectangleCommand[simpleRectangleCount];
+            _simplePaths = simplePathCount == 0
+                ? []
+                : new RetainedSimplePathCommand[simplePathCount];
+            _rectangleClips = rectangleClipCount == 0
+                ? []
+                : new RetainedRectangleClipCommand[rectangleClipCount];
+            _geometryClips = geometryClipCount == 0
+                ? []
+                : new RetainedGeometryClipCommand[geometryClipCount];
             _transforms = new Matrix4x4[transformCount];
             _embeddedVisuals = embeddedVisualCount == 0
                 ? []
                 : new Visual[embeddedVisualCount];
             transformScratch.AsSpan(0, transformCount).CopyTo(_transforms);
+            int basicIndex = 0;
             int auxiliaryIndex = 0;
             int textIndex = 0;
             int textureIndex = 0;
+            int simpleTextureIndex = 0;
+            int simpleRectangleIndex = 0;
+            int simplePathIndex = 0;
+            int rectangleClipIndex = 0;
+            int geometryClipIndex = 0;
             int embeddedVisualIndex = 0;
             for (int index = 0; index < commands.Length; index++)
             {
@@ -1159,6 +1564,12 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                 int dataIndex = -1;
                 switch (dataKind)
                 {
+                    case RetainedCommandDataKind.Basic:
+                        dataIndex = basicIndex;
+                        _basic[basicIndex++] = new RetainedRenderCommand(
+                            in command,
+                            transformIndices[index]);
+                        break;
                     case RetainedCommandDataKind.Auxiliary:
                         dataIndex = auxiliaryIndex;
                         _auxiliary[auxiliaryIndex++] = command;
@@ -1166,20 +1577,58 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     case RetainedCommandDataKind.Text:
                         dataIndex = textIndex;
                         _text[textIndex++] =
-                            new RetainedTextCommandData(in command);
+                            new RetainedTextRenderCommand(
+                                in command,
+                                transformIndices[index]);
                         break;
                     case RetainedCommandDataKind.Texture:
                         dataIndex = textureIndex;
                         _texture[textureIndex++] =
-                            new RetainedTextureCommandData(in command);
+                            new RetainedTextureRenderCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.SimpleTexture:
+                        dataIndex = simpleTextureIndex;
+                        _simpleTextures[simpleTextureIndex++] =
+                            new RetainedSimpleTextureCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.SimpleRectangle:
+                        dataIndex = simpleRectangleIndex;
+                        _simpleRectangles[simpleRectangleIndex++] =
+                            new RetainedSimpleRectangleCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.SimplePath:
+                        dataIndex = simplePathIndex;
+                        _simplePaths[simplePathIndex++] =
+                            new RetainedSimplePathCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.RectangleClip:
+                        dataIndex = rectangleClipIndex;
+                        _rectangleClips[rectangleClipIndex++] =
+                            new RetainedRectangleClipCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.GeometryClip:
+                        dataIndex = geometryClipIndex;
+                        _geometryClips[geometryClipIndex++] =
+                            new RetainedGeometryClipCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.NoData:
+                        dataIndex = (int)command.Type;
                         break;
                 }
 
-                _commands[index] = new RetainedRenderCommand(
-                    in command,
-                    dataKind,
-                    dataIndex,
-                    transformIndices[index]);
+                _order[index] = PackToken(dataKind, dataIndex);
             }
         }
         finally
@@ -1191,40 +1640,84 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
         }
     }
 
-    public int Count => _commands.Length;
+    public int Count => _order.Length;
 
-    public int Length => _commands.Length;
+    public int Length => _order.Length;
 
     internal ReadOnlySpan<Visual> EmbeddedVisuals => _embeddedVisuals;
 
-    public RenderCommand this[int index] =>
-        _commands[index].Expand(
-            _auxiliary,
-            _text,
-            _texture,
-            _transforms);
+    public RenderCommand this[int index]
+    {
+        get
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(
+                (uint)index,
+                (uint)_order.Length,
+                nameof(index));
+            uint token = _order[index];
+            var dataKind = (RetainedCommandDataKind)(token >> TokenKindShift);
+            int dataIndex = (int)(token & TokenIndexMask);
+            return dataKind switch
+            {
+                RetainedCommandDataKind.Basic =>
+                    _basic[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.Auxiliary => _auxiliary[dataIndex],
+                RetainedCommandDataKind.Text =>
+                    _text[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.Texture =>
+                    _texture[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.SimpleTexture =>
+                    _simpleTextures[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.SimpleRectangle =>
+                    _simpleRectangles[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.SimplePath =>
+                    _simplePaths[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.RectangleClip =>
+                    _rectangleClips[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.GeometryClip =>
+                    _geometryClips[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.NoData => new RenderCommand
+                {
+                    Type = (RenderCommandType)dataIndex
+                },
+                _ => throw new InvalidOperationException(
+                    $"Unknown retained command data kind: {dataKind}.")
+            };
+        }
+    }
 
     internal long ApproximateStorageBytes =>
-        (long)_commands.Length *
+        (long)_order.Length * sizeof(uint) +
+        (long)_basic.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedRenderCommand>() +
         (long)_auxiliary.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<RenderCommand>() +
         (long)_text.Length *
-            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedTextCommandData>() +
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedTextRenderCommand>() +
         (long)_texture.Length *
-            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedTextureCommandData>() +
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedTextureRenderCommand>() +
+        (long)_simpleTextures.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimpleTextureCommand>() +
+        (long)_simpleRectangles.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimpleRectangleCommand>() +
+        (long)_simplePaths.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimplePathCommand>() +
+        (long)_rectangleClips.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedRectangleClipCommand>() +
+        (long)_geometryClips.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedGeometryClipCommand>() +
         (long)_transforms.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<Matrix4x4>() +
         (long)_embeddedVisuals.Length * IntPtr.Size;
 
     internal RenderCommand[] Clone()
     {
-        if (_commands.Length == 0)
+        if (_order.Length == 0)
         {
             return [];
         }
 
-        var result = new RenderCommand[_commands.Length];
+        var result = new RenderCommand[_order.Length];
         for (int index = 0; index < result.Length; index++)
         {
             result[index] = this[index];
@@ -1239,6 +1732,29 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
         GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private static uint PackToken(
+        RetainedCommandDataKind dataKind,
+        int dataIndex)
+    {
+        if ((uint)dataKind >= (1u << (32 - TokenKindShift)))
+        {
+            throw new InvalidOperationException(
+                $"Retained command data kind {dataKind} exceeds the token format.");
+        }
+        if ((uint)dataIndex > TokenIndexMask)
+        {
+            throw new InvalidOperationException(
+                "Retained command data exceeds the 28-bit token index capacity.");
+        }
+
+        return ((uint)dataKind << TokenKindShift) | (uint)dataIndex;
+    }
+
+    private static bool RequiresTransform(
+        RetainedCommandDataKind dataKind) =>
+        dataKind is not RetainedCommandDataKind.Auxiliary and
+            not RetainedCommandDataKind.NoData;
 
     private static int GetTransformTableCapacity(int commandCount)
     {

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -751,7 +751,9 @@ internal enum RetainedCommandDataKind : byte
     GeometryClip,
     NoData,
     SimpleGlyphRun,
-    ScalarState
+    ScalarState,
+    SimpleRoundedRectangle,
+    SimpleVisual
 }
 
 internal readonly struct RetainedTextCommandData
@@ -932,6 +934,46 @@ internal readonly struct RetainedRenderCommand
 
     public static RetainedCommandDataKind Classify(in RenderCommand command)
     {
+        switch (command.Type)
+        {
+            case RenderCommandType.DrawTexture:
+                if (IsSimpleTexture(
+                    in command,
+                    HasTextData(in command),
+                    HasOtherData(in command)))
+                {
+                    return RetainedCommandDataKind.SimpleTexture;
+                }
+                break;
+            case RenderCommandType.DrawGlyphRun:
+                if (IsSimpleGlyphRun(
+                    in command,
+                    HasTextureData(in command),
+                    HasOtherData(in command)))
+                {
+                    return RetainedCommandDataKind.SimpleGlyphRun;
+                }
+                break;
+            case RenderCommandType.DrawRoundedRect:
+                if (IsSimpleRoundedRectangle(
+                    in command,
+                    HasTextData(in command),
+                    HasTextureData(in command)))
+                {
+                    return RetainedCommandDataKind.SimpleRoundedRectangle;
+                }
+                break;
+            case RenderCommandType.DrawVisual:
+                if (IsSimpleVisual(
+                    in command,
+                    HasTextData(in command),
+                    HasTextureData(in command)))
+                {
+                    return RetainedCommandDataKind.SimpleVisual;
+                }
+                break;
+        }
+
         bool hasText = HasTextData(in command);
         bool hasTexture = HasTextureData(in command);
         bool hasOther = HasOtherData(in command);
@@ -959,16 +1001,6 @@ internal readonly struct RetainedRenderCommand
         if (IsGeometryClip(in command, hasText, hasTexture, hasOther))
         {
             return RetainedCommandDataKind.GeometryClip;
-        }
-
-        if (IsSimpleTexture(in command, hasText, hasOther))
-        {
-            return RetainedCommandDataKind.SimpleTexture;
-        }
-
-        if (IsSimpleGlyphRun(in command, hasTexture, hasOther))
-        {
-            return RetainedCommandDataKind.SimpleGlyphRun;
         }
 
         if (IsScalarState(in command, hasText, hasTexture, hasOther))
@@ -1154,45 +1186,33 @@ internal readonly struct RetainedRenderCommand
         command.GlyphRangeCount == 0;
 
     private static bool HasOnlyIntParamOtherData(in RenderCommand command) =>
-        command.Position2 == default &&
-        command.Position3 == default &&
-        command.Position4 == default &&
-        command.RadiusX == 0f &&
-        command.RadiusY == 0f &&
-        command.CornerRadius == 0f &&
-        command.PolylinePoints is null &&
-        !command.IsClosed &&
-        command.SplineKnots is null &&
-        command.SplineWeights is null &&
-        command.SplineDegree == 0 &&
-        command.Position3D1 == default &&
-        command.Position3D2 == default &&
-        command.Edges3D is null &&
-        command.StaticBuffer is null &&
-        command.GpuPoints is null &&
-        command.GpuPointsCount == 0 &&
-        !command.UseGpuTransforms &&
-        command.CameraView == default &&
-        command.Scale == default &&
-        command.Translate == default &&
-        command.PointBufferOffset == 0 &&
-        command.PointBufferCount == 0 &&
-        command.DoubleBufferOffset == 0 &&
-        command.DoubleBufferCount == 0 &&
-        command.Line3DBufferOffset == 0 &&
-        command.Line3DBufferCount == 0 &&
-        command.WeightBufferOffset == 0 &&
-        command.WeightBufferCount == 0 &&
-        command.FloatBufferOffset == 0 &&
-        command.FloatBufferCount == 0 &&
-        command.SeriesCacheKey is null &&
-        command.Picture is null &&
-        command.Visual is null &&
-        command.VertexMesh is null &&
-        command.VertexColorBlendMode == default &&
-        command.ExtensionId == 0 &&
-        command.FloatParam == 0f &&
-        command.DataParam is null;
+        !HasOtherData(in command, allowIntParam: true);
+
+    private static bool IsSimpleRoundedRectangle(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture) =>
+        command.Type == RenderCommandType.DrawRoundedRect &&
+        !hasText &&
+        !hasTexture &&
+        !HasOtherData(in command, allowRadii: true) &&
+        command.Path is null &&
+        command.GeometryCache is null;
+
+    private static bool IsSimpleVisual(
+        in RenderCommand command,
+        bool hasText,
+        bool hasTexture) =>
+        command.Type == RenderCommandType.DrawVisual &&
+        !hasText &&
+        !hasTexture &&
+        !HasOtherData(in command, allowVisual: true) &&
+        command.Rect == default &&
+        HasDefaultCoreData(
+            in command,
+            allowBrush: false,
+            allowPen: false,
+            allowPath: false);
 
     private static bool HasDefaultCoreData(
         in RenderCommand command,
@@ -1246,12 +1266,16 @@ internal readonly struct RetainedRenderCommand
         command.ImageEffectBufferIndex != 0 ||
         command.HasBufferedImageEffect;
 
-    private static bool HasOtherData(in RenderCommand command) =>
+    private static bool HasOtherData(
+        in RenderCommand command,
+        bool allowRadii = false,
+        bool allowVisual = false,
+        bool allowIntParam = false) =>
         command.Position2 != default ||
         command.Position3 != default ||
         command.Position4 != default ||
-        command.RadiusX != 0f ||
-        command.RadiusY != 0f ||
+        (!allowRadii &&
+            (command.RadiusX != 0f || command.RadiusY != 0f)) ||
         command.CornerRadius != 0f ||
         command.PolylinePoints is not null ||
         command.IsClosed ||
@@ -1280,11 +1304,11 @@ internal readonly struct RetainedRenderCommand
         command.FloatBufferCount != 0 ||
         command.SeriesCacheKey is not null ||
         command.Picture is not null ||
-        command.Visual is not null ||
+        (!allowVisual && command.Visual is not null) ||
         command.VertexMesh is not null ||
         command.VertexColorBlendMode != default ||
         command.ExtensionId != 0 ||
-        command.IntParam != 0 ||
+        (!allowIntParam && command.IntParam != 0) ||
         command.FloatParam != 0f ||
         command.DataParam is not null;
 }
@@ -1628,6 +1652,80 @@ internal readonly struct RetainedScalarStateCommand
             };
 }
 
+internal readonly struct RetainedSimpleRoundedRectangleCommand
+{
+    private readonly Rect _rectangle;
+    private readonly Brush? _brush;
+    private readonly Pen? _pen;
+    private readonly float _radiusX;
+    private readonly float _radiusY;
+    private readonly int _hitTestId;
+    private readonly int _transformIndex;
+    private readonly RenderCommandPresentationDependencies _presentationDependencies;
+    private readonly bool _isEdgeAliased;
+    private readonly bool _isPenThicknessLocal;
+    private readonly uint _pathSampleGrid;
+    private readonly float _pathCoverageGamma;
+
+    public RetainedSimpleRoundedRectangleCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _rectangle = command.Rect;
+        _brush = command.Brush;
+        _pen = command.Pen;
+        _radiusX = command.RadiusX;
+        _radiusY = command.RadiusY;
+        _hitTestId = command.HitTestId;
+        _transformIndex = transformIndex;
+        _presentationDependencies = command.PresentationDependencies;
+        _isEdgeAliased = command.IsEdgeAliased;
+        _isPenThicknessLocal = command.IsPenThicknessLocal;
+        _pathSampleGrid = command.PathSampleGrid;
+        _pathCoverageGamma = command.PathCoverageGamma;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.DrawRoundedRect,
+            HitTestId = _hitTestId,
+            Rect = _rectangle,
+            Brush = _brush,
+            Pen = _pen,
+            RadiusX = _radiusX,
+            RadiusY = _radiusY,
+            Transform = transforms[_transformIndex],
+            PresentationDependencies = _presentationDependencies,
+            IsEdgeAliased = _isEdgeAliased,
+            IsPenThicknessLocal = _isPenThicknessLocal,
+            PathSampleGrid = _pathSampleGrid,
+            PathCoverageGamma = _pathCoverageGamma
+        };
+}
+
+internal readonly struct RetainedSimpleVisualCommand
+{
+    private readonly Visual? _visual;
+    private readonly int _transformIndex;
+
+    public RetainedSimpleVisualCommand(
+        in RenderCommand command,
+        int transformIndex)
+    {
+        _visual = command.Visual;
+        _transformIndex = transformIndex;
+    }
+
+    public RenderCommand Expand(Matrix4x4[] transforms) =>
+        new()
+        {
+            Type = RenderCommandType.DrawVisual,
+            Visual = _visual,
+            Transform = transforms[_transformIndex]
+        };
+}
+
 /// <summary>
 /// Immutable command snapshot with an ordered 32-bit token stream plus typed
 /// rectangle, path, clip, text, texture, transform, and uncommon-command
@@ -1652,6 +1750,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
     private readonly RetainedGeometryClipCommand[] _geometryClips;
     private readonly RetainedSimpleGlyphRunCommand[] _simpleGlyphRuns;
     private readonly RetainedScalarStateCommand[] _scalarStates;
+    private readonly RetainedSimpleRoundedRectangleCommand[] _simpleRoundedRectangles;
+    private readonly RetainedSimpleVisualCommand[] _simpleVisuals;
     private readonly Matrix4x4[] _transforms;
     private readonly Visual[] _embeddedVisuals;
 
@@ -1671,6 +1771,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             _geometryClips = [];
             _simpleGlyphRuns = [];
             _scalarStates = [];
+            _simpleRoundedRectangles = [];
+            _simpleVisuals = [];
             _transforms = [];
             _embeddedVisuals = [];
             return;
@@ -1687,6 +1789,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
         int geometryClipCount = 0;
         int simpleGlyphRunCount = 0;
         int scalarStateCount = 0;
+        int simpleRoundedRectangleCount = 0;
+        int simpleVisualCount = 0;
         int embeddedVisualCount = 0;
         byte[] classifications =
             ArrayPool<byte>.Shared.Rent(commands.Length);
@@ -1749,6 +1853,12 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     case RetainedCommandDataKind.ScalarState:
                         scalarStateCount++;
                         break;
+                    case RetainedCommandDataKind.SimpleRoundedRectangle:
+                        simpleRoundedRectangleCount++;
+                        break;
+                    case RetainedCommandDataKind.SimpleVisual:
+                        simpleVisualCount++;
+                        break;
                 }
                 if (commands[index].Type == RenderCommandType.DrawVisual &&
                     commands[index].Visual != null)
@@ -1791,6 +1901,12 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             _scalarStates = scalarStateCount == 0
                 ? []
                 : new RetainedScalarStateCommand[scalarStateCount];
+            _simpleRoundedRectangles = simpleRoundedRectangleCount == 0
+                ? []
+                : new RetainedSimpleRoundedRectangleCommand[simpleRoundedRectangleCount];
+            _simpleVisuals = simpleVisualCount == 0
+                ? []
+                : new RetainedSimpleVisualCommand[simpleVisualCount];
             _transforms = new Matrix4x4[transformCount];
             _embeddedVisuals = embeddedVisualCount == 0
                 ? []
@@ -1807,6 +1923,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             int geometryClipIndex = 0;
             int simpleGlyphRunIndex = 0;
             int scalarStateIndex = 0;
+            int simpleRoundedRectangleIndex = 0;
+            int simpleVisualIndex = 0;
             int embeddedVisualIndex = 0;
             for (int index = 0; index < commands.Length; index++)
             {
@@ -1892,6 +2010,20 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                         _scalarStates[scalarStateIndex++] =
                             new RetainedScalarStateCommand(in command);
                         break;
+                    case RetainedCommandDataKind.SimpleRoundedRectangle:
+                        dataIndex = simpleRoundedRectangleIndex;
+                        _simpleRoundedRectangles[simpleRoundedRectangleIndex++] =
+                            new RetainedSimpleRoundedRectangleCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
+                    case RetainedCommandDataKind.SimpleVisual:
+                        dataIndex = simpleVisualIndex;
+                        _simpleVisuals[simpleVisualIndex++] =
+                            new RetainedSimpleVisualCommand(
+                                in command,
+                                transformIndices[index]);
+                        break;
                     case RetainedCommandDataKind.NoData:
                         dataIndex = (int)command.Type;
                         break;
@@ -1949,6 +2081,10 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     _simpleGlyphRuns[dataIndex].Expand(_transforms),
                 RetainedCommandDataKind.ScalarState =>
                     _scalarStates[dataIndex].Expand(),
+                RetainedCommandDataKind.SimpleRoundedRectangle =>
+                    _simpleRoundedRectangles[dataIndex].Expand(_transforms),
+                RetainedCommandDataKind.SimpleVisual =>
+                    _simpleVisuals[dataIndex].Expand(_transforms),
                 RetainedCommandDataKind.NoData => new RenderCommand
                 {
                     Type = (RenderCommandType)dataIndex
@@ -1983,6 +2119,10 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimpleGlyphRunCommand>() +
         (long)_scalarStates.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedScalarStateCommand>() +
+        (long)_simpleRoundedRectangles.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimpleRoundedRectangleCommand>() +
+        (long)_simpleVisuals.Length *
+            System.Runtime.CompilerServices.Unsafe.SizeOf<RetainedSimpleVisualCommand>() +
         (long)_transforms.Length *
             System.Runtime.CompilerServices.Unsafe.SizeOf<Matrix4x4>() +
         (long)_embeddedVisuals.Length * IntPtr.Size;

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -340,6 +340,7 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
             new Vector2(2f, 3f),
             new Vector2(9f, 11f));
         var transform = Matrix4x4.CreateTranslation(4f, 5f, 0f);
+        var visual = new ContainerVisual();
         ushort[] glyphIndices = [7, 9];
         Vector2[] glyphPositions = [new(0f, 0f), new(8f, 0f)];
         RenderCommand[] source =
@@ -374,6 +375,24 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                 IsEdgeAliased = true,
                 PathSampleGrid = 8,
                 PathCoverageGamma = 1.25f
+            },
+            new()
+            {
+                Type = RenderCommandType.DrawRoundedRect,
+                HitTestId = 10,
+                Rect = new Rect(5f, 7f, 20f, 22f),
+                RadiusX = 4f,
+                RadiusY = 6f,
+                Brush = brush,
+                Transform = transform,
+                IsEdgeAliased = true,
+                IsPenThicknessLocal = true
+            },
+            new()
+            {
+                Type = RenderCommandType.DrawVisual,
+                Visual = visual,
+                Transform = transform
             },
             new()
             {
@@ -433,6 +452,8 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
         Assert.Equal(source, picture.RetainedCommands.Clone());
         Assert.True(Unsafe.SizeOf<RetainedSimpleGlyphRunCommand>() <= 96);
         Assert.Equal(8, Unsafe.SizeOf<RetainedScalarStateCommand>());
+        Assert.True(Unsafe.SizeOf<RetainedSimpleRoundedRectangleCommand>() <= 80);
+        Assert.Equal(16, Unsafe.SizeOf<RetainedSimpleVisualCommand>());
         Assert.True(
             picture.CommandStorageBytes < source.Length * 96L,
             $"Expected packed Avalonia command storage, actual={picture.CommandStorageBytes} bytes.");

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -340,6 +340,8 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
             new Vector2(2f, 3f),
             new Vector2(9f, 11f));
         var transform = Matrix4x4.CreateTranslation(4f, 5f, 0f);
+        ushort[] glyphIndices = [7, 9];
+        Vector2[] glyphPositions = [new(0f, 0f), new(8f, 0f)];
         RenderCommand[] source =
         [
             new()
@@ -385,6 +387,40 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                 Path = path,
                 Transform = transform
             },
+            new()
+            {
+                Type = RenderCommandType.DrawGlyphRun,
+                HitTestId = 9,
+                Brush = brush,
+                FontSize = 14f,
+                Position = new Vector2(3f, 5f),
+                FontTransform = new Vector2(1.25f, 0.125f),
+                HasFontTransform = true,
+                Transform = transform,
+                PresentationDependencies =
+                    RenderCommandPresentationDependencies.TextRendering |
+                    RenderCommandPresentationDependencies.TextHinting,
+                IsBold = true,
+                TextRenderingMode = TextRenderingMode.ClearType,
+                TextHintingMode = TextHintingMode.Fixed,
+                UseVectorGlyphRendering = true,
+                PreferGlyphAtlas = true,
+                IsEdgeAliased = true,
+                GlyphIndices = glyphIndices,
+                GlyphPositions = glyphPositions,
+                GlyphRangeStart = 1,
+                GlyphRangeCount = 1
+            },
+            new()
+            {
+                Type = RenderCommandType.PushOpacity,
+                FontSize = 0.625f
+            },
+            new()
+            {
+                Type = RenderCommandType.PushBlendMode,
+                IntParam = (int)GpuBlendMode.Multiply
+            },
             new() { Type = RenderCommandType.PopGeometryClip },
             new() { Type = RenderCommandType.PopClip },
             new() { Type = RenderCommandType.PopOpacity },
@@ -395,6 +431,8 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
         using var picture = new GpuPicture(source, [], [], [], []);
 
         Assert.Equal(source, picture.RetainedCommands.Clone());
+        Assert.True(Unsafe.SizeOf<RetainedSimpleGlyphRunCommand>() <= 96);
+        Assert.Equal(8, Unsafe.SizeOf<RetainedScalarStateCommand>());
         Assert.True(
             picture.CommandStorageBytes < source.Length * 96L,
             $"Expected packed Avalonia command storage, actual={picture.CommandStorageBytes} bytes.");

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -333,6 +333,102 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void RetainedPictureAvaloniaCommandStreamUsesTypedPackedRecords()
+    {
+        var brush = new SolidColorBrush(new Vector4(0.1f, 0.3f, 0.7f, 1f));
+        var path = RenderCommandGeometryCache.CreateLinePath(
+            new Vector2(2f, 3f),
+            new Vector2(9f, 11f));
+        var transform = Matrix4x4.CreateTranslation(4f, 5f, 0f);
+        RenderCommand[] source =
+        [
+            new()
+            {
+                Type = RenderCommandType.DrawTexture,
+                Rect = new Rect(1f, 2f, 30f, 40f),
+                SrcRect = new Rect(3f, 4f, 10f, 12f),
+                Transform = transform,
+                TextureSamplingMode = TextureSamplingMode.Nearest,
+                TextureMaxAnisotropy = 4,
+                SnapTextureToPixels = true,
+                IsEdgeAliased = true
+            },
+            new()
+            {
+                Type = RenderCommandType.DrawRect,
+                HitTestId = 7,
+                Rect = new Rect(6f, 8f, 12f, 16f),
+                Brush = brush,
+                Transform = transform,
+                IsPenThicknessLocal = true
+            },
+            new()
+            {
+                Type = RenderCommandType.DrawPath,
+                HitTestId = 8,
+                Brush = brush,
+                Path = path,
+                Transform = transform,
+                IsEdgeAliased = true,
+                PathSampleGrid = 8,
+                PathCoverageGamma = 1.25f
+            },
+            new()
+            {
+                Type = RenderCommandType.PushClip,
+                Rect = new Rect(0f, 0f, 64f, 64f),
+                Transform = transform
+            },
+            new()
+            {
+                Type = RenderCommandType.PushGeometryClip,
+                Path = path,
+                Transform = transform
+            },
+            new() { Type = RenderCommandType.PopGeometryClip },
+            new() { Type = RenderCommandType.PopClip },
+            new() { Type = RenderCommandType.PopOpacity },
+            new() { Type = RenderCommandType.PopOpacityMask },
+            new() { Type = RenderCommandType.PopBlendMode }
+        ];
+
+        using var picture = new GpuPicture(source, [], [], [], []);
+
+        Assert.Equal(source, picture.RetainedCommands.Clone());
+        Assert.True(
+            picture.CommandStorageBytes < source.Length * 96L,
+            $"Expected packed Avalonia command storage, actual={picture.CommandStorageBytes} bytes.");
+    }
+
+    [Fact]
+    public void RetainedPictureSimpleTextureStorageStaysBelowSixtyFourBytesPerDraw()
+    {
+        const int commandCount = 1_024;
+        var commands = new RenderCommand[commandCount];
+        var transform = Matrix4x4.CreateScale(1.25f);
+        for (var index = 0; index < commands.Length; index++)
+        {
+            commands[index] = new RenderCommand
+            {
+                Type = RenderCommandType.DrawTexture,
+                Rect = new Rect(index & 7, index & 3, 16f, 16f),
+                SrcRect = new Rect(0f, 0f, 16f, 16f),
+                Transform = transform,
+                TextureSamplingMode = TextureSamplingMode.Linear,
+                TextureMaxAnisotropy = 1
+            };
+        }
+
+        using var picture = new GpuPicture(commands, [], [], [], []);
+
+        Assert.True(
+            picture.CommandStorageBytes <= commandCount * 64L +
+                Unsafe.SizeOf<Matrix4x4>(),
+            $"Expected at most 64 retained bytes per simple texture draw, actual={picture.CommandStorageBytes} bytes.");
+        Assert.Equal(commands, picture.RetainedCommands.Clone());
+    }
+
+    [Fact]
     public void SkRectUnionIncludesEmptyOriginInCoordinateEnvelope()
     {
         var bounds = SKRect.Empty;

--- a/src/ProGPU.Tests/SkImageBitmapTests.cs
+++ b/src/ProGPU.Tests/SkImageBitmapTests.cs
@@ -148,6 +148,45 @@ public sealed class SkImageBitmapTests
     }
 
     [Fact]
+    public void ImmutableTextureDisallowReadbackPreservesDestinationRowPadding()
+    {
+        var info = new SKImageInfo(
+            2,
+            2,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul);
+        using var surface = SKSurface.Create(
+            info,
+            new SKSurfaceProperties(SKPixelGeometry.RgbHorizontal));
+        surface.Canvas.Clear(new SKColor(10, 20, 30, 255));
+        surface.Flush();
+        using var image = surface.Snapshot();
+        var destination = Marshal.AllocHGlobal(24);
+        try
+        {
+            WriteBytes(destination, Enumerable.Repeat((byte)99, 24).ToArray());
+
+            Assert.True(image.ReadPixels(
+                info,
+                destination,
+                dstRowBytes: 12,
+                srcX: 0,
+                srcY: 0,
+                SKImageCachingHint.Disallow));
+
+            Assert.Equal(new byte[]
+            {
+                10, 20, 30, 255, 10, 20, 30, 255, 99, 99, 99, 99,
+                10, 20, 30, 255, 10, 20, 30, 255, 99, 99, 99, 99
+            }, ReadBytes(destination, 24));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(destination);
+        }
+    }
+
+    [Fact]
     public void FromBitmapMarksUnpremultipliedUploadsAsStraightAlpha()
     {
         using var bitmap = new SKBitmap(new SKImageInfo(1, 1, SKColorType.Rgba8888, SKAlphaType.Unpremul));

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -4082,6 +4082,16 @@ public class SKCanvas : SKObject
             return;
         }
 
+        DrawUniformRoundRect(rect.Rect, radiusX, radiusY, paint);
+    }
+
+    private void DrawUniformRoundRect(
+        SKRect rect,
+        float radiusX,
+        float radiusY,
+        SKPaint paint)
+    {
+
         var pushedBlendMode = PushPaintBlendMode(paint);
         try
         {
@@ -4090,7 +4100,7 @@ public class SKCanvas : SKObject
             _context.Commands.Add(new RenderCommand
             {
                 Type = RenderCommandType.DrawRoundedRect,
-                Rect = new Rect(rect.Rect.Left, rect.Rect.Top, rect.Rect.Width, rect.Rect.Height),
+                Rect = new Rect(rect.Left, rect.Top, rect.Width, rect.Height),
                 RadiusX = radiusX,
                 RadiusY = radiusY,
                 Brush = brush,
@@ -4108,7 +4118,18 @@ public class SKCanvas : SKObject
 
     public void DrawRoundRect(SKRect rect, float rx, float ry, SKPaint paint)
     {
-        DrawRoundRect(new SKRoundRect(rect, rx, ry), paint);
+        if (HasSpecialShader(paint.Shader) ||
+            !TryNormalizeUniformRoundRect(
+                ref rect,
+                ref rx,
+                ref ry))
+        {
+            using var roundRect = new SKRoundRect(rect, rx, ry);
+            DrawRoundRect(roundRect, paint);
+            return;
+        }
+
+        DrawUniformRoundRect(rect, rx, ry, paint);
     }
 
     public void DrawRoundRect(float x, float y, float w, float h, float rx, float ry, SKPaint paint) =>
@@ -4116,6 +4137,56 @@ public class SKCanvas : SKObject
 
     public void DrawRoundRect(SKRect rect, SKSize r, SKPaint paint) =>
         DrawRoundRect(rect, r.Width, r.Height, paint);
+
+    private static bool TryNormalizeUniformRoundRect(
+        ref SKRect rect,
+        ref float radiusX,
+        ref float radiusY)
+    {
+        if (!float.IsFinite(rect.Left) ||
+            !float.IsFinite(rect.Top) ||
+            !float.IsFinite(rect.Right) ||
+            !float.IsFinite(rect.Bottom))
+        {
+            return false;
+        }
+
+        rect = rect.Standardized;
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return false;
+        }
+
+        if (!float.IsFinite(radiusX) || !float.IsFinite(radiusY))
+        {
+            radiusX = 0f;
+            radiusY = 0f;
+        }
+
+        if (rect.Width < radiusX + radiusX ||
+            rect.Height < radiusY + radiusY)
+        {
+            var scale = MathF.Min(
+                rect.Width / (radiusX + radiusX),
+                rect.Height / (radiusY + radiusY));
+            radiusX *= scale;
+            radiusY *= scale;
+        }
+
+        if (radiusX <= 0f || radiusY <= 0f)
+        {
+            radiusX = 0f;
+            radiusY = 0f;
+        }
+        else if (radiusX >= rect.Width * 0.5f &&
+            radiusY >= rect.Height * 0.5f)
+        {
+            radiusX = rect.Width * 0.5f;
+            radiusY = rect.Height * 0.5f;
+        }
+
+        return true;
+    }
 
     private static bool TryGetUniformRadii(SKRoundRect rect, out float radiusX, out float radiusY)
     {
@@ -6600,6 +6671,7 @@ public class SKCanvas : SKObject
             layer.PreviousContext?.Clear();
             layer.Paint?.Dispose();
         }
+
     }
 
     protected override void Dispose(bool disposing)

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -124,6 +124,9 @@ public class SKCanvas : SKObject
     private readonly Func<int, bool> _commandInterceptor;
     private SKSurface? _surface;
     private GRRecordingContext? _recordingContext;
+    private IProGpuContextTextureLeaseSource? _lastPictureTextureSource;
+    private WgpuContext? _lastPictureTextureContext;
+    private GpuTexture? _lastPictureTexture;
     private SKMatrix _currentMatrix = SKMatrix.Identity;
     private float _currentOpacity = 1f;
     private ClipState _clipState;
@@ -542,6 +545,13 @@ public class SKCanvas : SKObject
     internal void AttachRecordingContext(GRRecordingContext? recordingContext)
     {
         _recordingContext = recordingContext;
+    }
+
+    internal void CompletePictureRecording()
+    {
+        _lastPictureTextureSource = null;
+        _lastPictureTextureContext = null;
+        _lastPictureTexture = null;
     }
 
     internal void DetachSurface(SKSurface surface)
@@ -6054,12 +6064,24 @@ public class SKCanvas : SKObject
 
     private GpuTexture RetainImageTexture(SKImage image, bool generateMipmaps = false)
     {
+        ObjectDisposedException.ThrowIf(image.IsDisposed, image);
         var currentContext = WgpuContext.Current;
         var targetContext = _gpuContext != null && !_gpuContext.IsDisposed
             ? _gpuContext
             : currentContext != null && !currentContext.IsDisposed
                 ? currentContext
                 : image.Texture.Context;
+        IProGpuContextTextureLeaseSource textureSource =
+            image.TextureLeaseSource;
+
+        if (_isPictureRecording &&
+            !generateMipmaps &&
+            ReferenceEquals(textureSource, _lastPictureTextureSource) &&
+            ReferenceEquals(targetContext, _lastPictureTextureContext) &&
+            _lastPictureTexture is { IsDisposed: false } cachedTexture)
+        {
+            return cachedTexture;
+        }
 
         // Whole immutable images already own a texture in the target device.
         // Retain that ownership through the drawing context instead of making
@@ -6069,7 +6091,7 @@ public class SKCanvas : SKObject
         if (!generateMipmaps &&
             image.IsWholeTexture &&
             _context.TryRetainTexture(
-                image.TextureLeaseSource,
+                textureSource,
                 targetContext,
                 out var leasedTexture))
         {
@@ -6078,6 +6100,12 @@ public class SKCanvas : SKObject
                 s_textureColorSpaces.AddOrUpdate(
                     leasedTexture,
                     new TextureColorSpace(leasedColorSpace));
+            }
+            if (_isPictureRecording)
+            {
+                _lastPictureTextureSource = textureSource;
+                _lastPictureTextureContext = targetContext;
+                _lastPictureTexture = leasedTexture;
             }
             return leasedTexture;
         }
@@ -6588,6 +6616,7 @@ public class SKCanvas : SKObject
         }
         finally
         {
+            CompletePictureRecording();
             _context.ClearCommandInterceptor(_commandInterceptor);
             _bitmap?.DetachCanvas(this);
             ReleaseUnrestoredLayers();

--- a/src/SkiaSharp/SKImage.cs
+++ b/src/SkiaSharp/SKImage.cs
@@ -37,6 +37,7 @@ public partial class SKImage : SKObject
         private readonly object _readbackLock = new();
         private GpuTextureReadbackBuffer? _readbackBuffer;
         private byte[]? _readbackPixels;
+        private bool _hasCachedReadbackPixels;
 
         public TextureStorage(
             GpuTexture texture,
@@ -69,7 +70,7 @@ public partial class SKImage : SKObject
 
         public object ReadbackLock => _readbackLock;
 
-        public byte[] ReadTexturePixels()
+        public byte[] ReadTexturePixels(bool allowCaching)
         {
             var byteCount = checked(
                 (int)(Texture.Width * Texture.Height * 4));
@@ -80,10 +81,16 @@ public partial class SKImage : SKObject
                     GC.AllocateUninitializedArray<byte>(byteCount);
             }
 
+            if (allowCaching && _hasCachedReadbackPixels)
+            {
+                return _readbackPixels;
+            }
+
             _readbackBuffer ??= new GpuTextureReadbackBuffer(Texture.Context);
             try
             {
                 Texture.ReadPixels(_readbackPixels, _readbackBuffer);
+                _hasCachedReadbackPixels = allowCaching;
             }
             finally
             {
@@ -91,6 +98,32 @@ public partial class SKImage : SKObject
             }
 
             return _readbackPixels;
+        }
+
+        public unsafe bool TryReadTexturePixels(
+            IntPtr destination,
+            int destinationRowBytes)
+        {
+            if (destination == IntPtr.Zero ||
+                destinationRowBytes < checked((int)Texture.Width * 4))
+            {
+                return false;
+            }
+
+            _readbackBuffer ??= new GpuTextureReadbackBuffer(Texture.Context);
+            try
+            {
+                return _readbackBuffer.TryReadTextureRows(
+                    Texture,
+                    Texture.Width,
+                    Texture.Height,
+                    destination.ToPointer(),
+                    checked((uint)destinationRowBytes));
+            }
+            finally
+            {
+                Texture.Context.CleanupPendingResources();
+            }
         }
 
         bool IProGpuTextureSource.TryGetGpuTexture(out GpuTexture texture) =>
@@ -225,6 +258,7 @@ public partial class SKImage : SKObject
                 _readbackBuffer?.Dispose();
                 _readbackBuffer = null;
                 _readbackPixels = null;
+                _hasCachedReadbackPixels = false;
             }
 
             _releaseProc?.Invoke(_releaseContext!);
@@ -858,13 +892,25 @@ public partial class SKImage : SKObject
 
         lock (_textureStorage.ReadbackLock)
         {
-            byte[] pixels = _textureStorage.ReadTexturePixels();
+            var nativeInfo = CreateNativeTextureReadbackInfo();
+            if (cachingHint == SKImageCachingHint.Disallow &&
+                IsWholeTexture &&
+                srcX == 0 &&
+                srcY == 0 &&
+                dstInfo == nativeInfo &&
+                _textureStorage.TryReadTexturePixels(dstPixels, dstRowBytes))
+            {
+                return true;
+            }
+
+            byte[] pixels = _textureStorage.ReadTexturePixels(
+                cachingHint == SKImageCachingHint.Allow);
             fixed (byte* sourcePixels = pixels)
             {
                 var sourceOffset = checked(
                     (_originY * (int)Texture.Width + _originX) * 4);
                 using var source = new SKPixmap(
-                    CreateNativeTextureReadbackInfo(),
+                    nativeInfo,
                     (IntPtr)(sourcePixels + sourceOffset),
                     checked((int)Texture.Width * 4));
                 return source.ReadPixels(

--- a/src/SkiaSharp/SKPicture.cs
+++ b/src/SkiaSharp/SKPicture.cs
@@ -222,6 +222,7 @@ public class SKPictureRecorder : SKObject
     public SKPicture EndRecording()
     {
         var recorder = _recorder ?? throw new InvalidOperationException("No picture recording is active.");
+        _canvas?.CompletePictureRecording();
         var gpuPicture = recorder.EndRecording();
         var cullRect = gpuPicture.RetainedCommands.Length == 0 ? SKRect.Empty : _cullRect;
         var picture = new SKPicture(gpuPicture, cullRect);

--- a/src/SkiaSharp/SKTextBlobBuilder.cs
+++ b/src/SkiaSharp/SKTextBlobBuilder.cs
@@ -418,7 +418,9 @@ public class SKTextBlobBuilder : SKObject
 {
     internal const int MaximumReusablePositionedGlyphs = 1_024;
     private readonly List<SKTextBlobBuilderRun> _runs = new();
-    private SKTextBlobBuilderRun? _singleRun;
+#nullable disable
+    private SKTextBlobBuilderRun _singleRun;
+#nullable restore
     internal SKTextBlobBuilderScratch Scratch;
     internal bool IsDisposedForScratch;
 

--- a/src/SkiaSharp/SKTextBlobBuilder.cs
+++ b/src/SkiaSharp/SKTextBlobBuilder.cs
@@ -418,6 +418,7 @@ public class SKTextBlobBuilder : SKObject
 {
     internal const int MaximumReusablePositionedGlyphs = 1_024;
     private readonly List<SKTextBlobBuilderRun> _runs = new();
+    private SKTextBlobBuilderRun? _singleRun;
     internal SKTextBlobBuilderScratch Scratch;
     internal bool IsDisposedForScratch;
 
@@ -533,7 +534,8 @@ public class SKTextBlobBuilder : SKObject
             points[index] = new SKPoint(matrices[index].TX, matrices[index].TY);
         }
 
-        _runs.Add(new SKTextBlobBuilderRun(new SKTextBlobRun(font, visibleGlyphs, points, matrices)));
+        AddRun(new SKTextBlobBuilderRun(
+            new SKTextBlobRun(font, visibleGlyphs, points, matrices)));
     }
 
     public SKRunBuffer AllocateRun(
@@ -620,7 +622,7 @@ public class SKTextBlobBuilder : SKObject
     {
         var run = AllocatePositionedRunCore(font, count, textByteCount: 0, bounds);
         run.MarkSnapshotLeaseable();
-        if (_runs.Count != 1)
+        if (_singleRun is null)
         {
             return new SKPositionedRunBuffer(run);
         }
@@ -699,26 +701,34 @@ public class SKTextBlobBuilder : SKObject
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SKTextBlob? Build()
     {
-        if (_runs.Count == 0)
+        if (_singleRun is null && _runs.Count == 0)
         {
             return null;
         }
 
-        if (_runs.Count == 1 &&
-            _runs[0].CanLeaseSnapshot &&
-            _runs[0].CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs))
+        if (_singleRun is { } singleRun &&
+            singleRun.CanLeaseSnapshot &&
+            singleRun.CanCacheAsPositionedScratch(MaximumReusablePositionedGlyphs))
         {
             // Typed run buffers are builder-owned and invalid after Build. Lease
             // their pinned storage to the immutable blob, redirect the public
             // wrapper to a bounded shadow, and reclaim both on blob disposal.
-            var leasedRun = _runs[0];
+            var leasedRun = singleRun;
             var leasedSnapshots = Scratch.SingleRunSnapshots ?? new SKTextBlobRun[1];
             Scratch.SingleRunSnapshots = null;
             leasedSnapshots[0] = leasedRun.BorrowPositionedSnapshot();
-            _runs.Clear();
+            _singleRun = null;
             Scratch.DetachPositionedBuffer(leasedRun);
             leasedRun.LeaseTo(this, leasedSnapshots);
             return new SKTextBlob(leasedSnapshots, leasedRun);
+        }
+
+        if (_singleRun is { } detachedSingleRun)
+        {
+            _singleRun = null;
+            return new SKTextBlob([
+                detachedSingleRun.Snapshot()
+            ]);
         }
 
         var snapshots = new SKTextBlobRun[_runs.Count];
@@ -736,6 +746,7 @@ public class SKTextBlobBuilder : SKObject
         if (disposing)
         {
             IsDisposedForScratch = true;
+            _singleRun = null;
             _runs.Clear();
             Scratch = default;
         }
@@ -783,7 +794,7 @@ public class SKTextBlobBuilder : SKObject
             scratch.TryResetPositioned(font, count))
         {
             Scratch.PositionedRun = null;
-            _runs.Add(scratch);
+            AddRun(scratch);
             return scratch;
         }
 
@@ -817,7 +828,25 @@ public class SKTextBlobBuilder : SKObject
         ArgumentOutOfRangeException.ThrowIfNegative(textByteCount);
         _ = bounds;
         var run = new SKTextBlobBuilderRun(font, count, placement, x, y, textByteCount);
-        _runs.Add(run);
+        AddRun(run);
         return run;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddRun(SKTextBlobBuilderRun run)
+    {
+        if (_singleRun is null && _runs.Count == 0)
+        {
+            _singleRun = run;
+            return;
+        }
+
+        if (_singleRun is { } singleRun)
+        {
+            _runs.Add(singleRun);
+            _singleRun = null;
+        }
+
+        _runs.Add(run);
     }
 }


### PR DESCRIPTION
## What changed

This clean-room Avalonia.Skia-first performance tranche keeps rendering on the existing retained WebGPU path while reducing CPU-side recording and readback overhead:

- packs frequent picture operations into an ordered 32-bit token stream plus typed records, preserving exact fallback records for uncommon commands;
- compacts common texture, rectangle, path, clip, glyph, scalar state, rounded-rectangle, and retained-visual records;
- reuses the already-owned immutable image/context texture for consecutive picture draws;
- removes the fixed 1 ms synchronous map-poll sleep and copies native-format `Disallow` readbacks directly from the reusable WebGPU staging buffer into caller rows;
- specializes the common single-run text-blob builder without changing multi-run or bounded lease ownership;
- adds exact round-trip, ownership, padding, and storage-bound regressions;
- records the clean-room engine research, rejected experiments, complexity, benchmarks, and macOS profiling evidence.

No CPU renderer, eager CPU image mirror, reflection bridge, external dependency, or foreign command encoding was added.

## Clean-room sources

The design record links the public/architectural contracts consulted: SkPicture/Recorder, SkImage, SkRRect, Direct2D command lists, Win2D CanvasCommandList, WebGPU command buffers, WebRender, Vello, SkParagraph, DirectWrite glyph runs, HarfBuzz, and Parley. The implementation and record layout are original ProGPU code.

## Performance evidence

Matched Release runs use three fresh processes per backend, 32 warmups, 24 samples, and exact semantic checksums.

- mixed picture recording: 1,627 -> 424 B/op (-73.9% from Preview.46);
- layer recording: 9,311 -> 8,180 B/op (-12.1% from the immediate checkpoint, -21.4% from Preview.46);
- repeated immutable-image `Disallow` readback: 2,799,313 -> 230,266 ns/op (-91.8%) and 1,104 -> 640 B/op;
- direct surface readback: 2,901,513 -> 431,690 ns/op (-85.1%);
- conversion readback: 3,169,493 -> 447,761 ns/op (-85.9%);
- focused positioned text: ProGPU 268.375 ns/op and 89 B/op versus official 289.270 ns/op and 136 B/op.

Official CPU-raster surfaces remain faster than synchronous WebGPU-to-CPU readback. This PR removes avoidable waiting/copying and makes no universal superiority claim.

Matched Xcode Allocations, Time Profiler, and Metal System Trace preserve the composition checksum and 992 B/op. Persistent heap plus anonymous VM differs by 0.019%; Metal reports no drawable waits, spills, hangs, or command-buffer errors. Raw trace, ETLX, export, and Xcode scratch artifacts were deleted after compact evidence was retained.

## Validation

- SkiaSharp 4.151.0 metadata: 4,222/4,222 exact matches, 0 missing
- ProGPU.Tests: 3,305 passed
- ProGPU.Tests.Headless: 225 passed
- pinned Avalonia retained compositor: 28 passed
- upstream Avalonia.Skia text: 274 passed, 5 documented skips; focused text: 13 passed
- patched Avalonia 12.0.5 ControlCatalog source build: 0 warnings, 0 errors
- full fresh benchmark matrix: all semantic checksums exact

## Primary references

- https://api.skia.org/classSkPicture.html
- https://api.skia.org/classSkPictureRecorder.html
- https://api.skia.org/classSkImage.html
- https://api.skia.org/classSkRRect.html
- https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1commandlist
- https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasCommandList.htm
- https://www.w3.org/TR/webgpu/#command-buffers
- https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html
- https://github.com/linebender/vello
- https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/README.md
- https://learn.microsoft.com/en-us/windows/win32/directwrite/glyphs-and-glyph-runs
- https://harfbuzz.github.io/harfbuzz-hb-shape.html
- https://docs.rs/parley/latest/parley/
