### PR TITLE
fix(scene): scale stroke thickness by the visual transform

### DIFF
--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -9466,6 +9466,33 @@ SceneStateUploadComplete:
         }
     }
 
+    /// <summary>
+    /// Returns a stroked command's pen thickness in the same space as its transformed geometry.
+    /// </summary>
+    /// <remarks>
+    /// Thickness reaches the compositor already scaled by the command's own transform - the drawing
+    /// context bridges apply their current stroke scale when they emit the command - but not by the
+    /// visual-tree transform that gets composed into <paramref name="activeTransform"/> here. The
+    /// vertices below are emitted post-transform, so recovering just that missing factor keeps a
+    /// stroke proportional to its geometry under a Viewbox or RenderTransform while leaving a
+    /// DrawingContext PushTransform, which was already accounted for, untouched.
+    /// </remarks>
+    private static float ResolveDeviceStrokeThickness(in RenderCommand cmd, Matrix4x4 activeTransform)
+    {
+        var thickness = cmd.Pen!.Thickness;
+        var activeScale = TransformMetrics.GetStrokeScale(activeTransform);
+        var commandScale = cmd.Transform == default
+            ? 1f
+            : TransformMetrics.GetStrokeScale(cmd.Transform);
+
+        if (!float.IsFinite(activeScale) || !float.IsFinite(commandScale) || commandScale <= 0f)
+        {
+            return thickness;
+        }
+
+        return thickness * (activeScale / commandScale);
+    }
+
     private void CompileLineCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         SwitchBatch(BatchType.Vector);
@@ -9490,7 +9517,7 @@ SceneStateUploadComplete:
 
         var p0_pos = Vector2.Transform(cmd.Position, transform);
         var p1_pos = Vector2.Transform(cmd.Position2, transform);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
         var lineShapeType = EncodeShapeType(cmd, 3f);
 
         uint idxStart = (uint)startIndex;
@@ -9545,7 +9572,7 @@ SceneStateUploadComplete:
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
 
         var p0_trans = Vector2.Transform(cmd.Position, transform);
         var p1_trans = Vector2.Transform(cmd.Position2, transform);
@@ -9602,7 +9629,7 @@ SceneStateUploadComplete:
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
 
         var p0_trans = Vector2.Transform(cmd.Position, transform);
         var p1_trans = Vector2.Transform(cmd.Position2, transform);

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -879,6 +879,35 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
         Assert.InRange(window.Compositor.CachedTextLayoutGlyphCount, visibleRows * 2, 32_768);
     }
 
+    [Theory]
+    [InlineData(1f, 12f)]
+    [InlineData(0.5f, 6f)]
+    [InlineData(0.25f, 3f)]
+    public void VisualTransformScalesStrokeThicknessWithItsGeometry(float scale, float expectedDeviceThickness)
+    {
+        // A visual-tree transform is composed into the compositor's active transform rather than
+        // into the command's own transform, so the pen thickness that reaches CompileLineCommand is
+        // still in local units. Leaving it there kept strokes at their unscaled width while the
+        // geometry shrank, which made adjacent edges of a lopsided Border overlap into a solid block.
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new ScaledStrokeVisual(scale);
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        int paintedRows = 0;
+        for (var y = 0; y < 64; y++)
+        {
+            // The line is drawn across the middle of the window; sample a column inside its span.
+            if (pixels[(y * 64 + 32) * 4 + 2] > 128)
+            {
+                paintedRows++;
+            }
+        }
+
+        Assert.InRange(paintedRows, expectedDeviceThickness - 1.5f, expectedDeviceThickness + 1.5f);
+    }
+
     [Fact]
     public void SolidRectangleFillAndStrokeUseSpecializedBatchAndComposeOpacity()
     {
@@ -9271,6 +9300,29 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                 null,
                 path,
                 Matrix4x4.Identity);
+        }
+    }
+
+    private sealed class ScaledStrokeVisual : FrameworkElement
+    {
+        private readonly float _scale;
+
+        public ScaledStrokeVisual(float scale)
+        {
+            _scale = scale;
+            Width = 64f;
+            Height = 64f;
+            // Scale about the window centre so the stroke stays in view at every scale factor.
+            Transform =
+                Matrix4x4.CreateTranslation(-32f, -32f, 0f) *
+                Matrix4x4.CreateScale(scale, scale, 1f) *
+                Matrix4x4.CreateTranslation(32f, 32f, 0f);
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var stroke = new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f));
+            context.DrawLine(new Pen(stroke, 12f), new Vector2(0f, 32f), new Vector2(64f, 32f));
         }
     }
 


### PR DESCRIPTION
## Problem

Stroked render commands arrive at the compositor with their pen thickness **already scaled by the command's own transform** — the drawing-context bridges multiply by their current stroke scale when they emit the command (`PresentationCore/System/Windows/Media/DrawingContext.cs`, pinned by `WpfDrawingContextStrokeTransformTests`). They are **not** scaled by the visual-tree transform, which is composed into the active transform later:

```csharp
activeTransform = command.Transform == default ? activeTransform : command.Transform * activeTransform;
```

`CompileLineCommand`, `CompileBezierCommand` and `CompileCubicBezierCommand` transform their points by `activeTransform` and then expanded the stroke by the untouched local thickness:

```csharp
var p0_pos = Vector2.Transform(cmd.Position, transform);
var p1_pos = Vector2.Transform(cmd.Position2, transform);
float thickness = cmd.Pen.Thickness;   // still local
```

So a stroke under a `Viewbox` or a visual `RenderTransform` keeps its unscaled width while the geometry shrinks. It is invisible for thin uniform strokes and severe once a shape's stroke is a large fraction of its own extent — adjacent edges overlap and fill the interior.

## Reproduction

A WPF `Border` renders a non-uniform `BorderThickness` by stroking each edge with a `Pen`, so it exercises this path directly. A 50x80 Border with `BorderThickness="20,5,5,5"` should be a hollow frame with a 25x70 interior:

| case | before | after |
|---|---|---|
| natural size, `20,5,5,5` | correct | correct |
| natural size, uniform `5` | correct | correct |
| inside a `Viewbox` (→ 40x40) | **solid block** | correct |
| under `ScaleTransform(0.5)` | **solid block** | correct |

At 0.5 scale the box narrows to ~25px while the strokes stay 20px and 5px, so the interior collapses to zero. The two unscaled cases are unchanged, which rules out a regression in the ordinary path.

## Fix

Recover **only** the factor the command did not already account for:

```csharp
thickness * (GetStrokeScale(activeTransform) / GetStrokeScale(cmd.Transform))
```

- pure visual transform (`cmdScale == 1`) → scales by the visual factor, fixing the bug
- pure `DrawingContext.PushTransform` → ratio is 1, so the pre-scaled thickness is left exactly as-is and is never double-scaled
- both → resolves to just the visual factor

A naive `thickness * GetStrokeScale(activeTransform)` would double-scale the `PushTransform` case that the existing bridge tests pin; this formulation does not. `TransformMetrics.GetStrokeScale` is the established stroke-scale convention in this file (~12 existing call sites), so no new policy is introduced.

## Tests

Added `VisualTransformScalesStrokeThicknessWithItsGeometry` to `CompositorReviewRegressionTests`, a pixel-sampling theory over scale factors 1 / 0.5 / 0.25 that measures the painted band against the clear colour. It **fails on both scaled cases without this change** and passes at identity either way, so it pins the defect rather than the implementation.

```
dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release
  Passed! - Failed: 0, Passed: 3308, Skipped: 0, Total: 3308

dotnet test src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj -c Release
  Passed! - Failed: 0, Passed: 225, Skipped: 0, Total: 225
```

Also verified end to end in a real WPF application: a docking-compass overlay whose drop-target glyphs are `Viewbox`-scaled Borders rendered as solid blobs before and as correct hollow frames after.

> Note: `AGENTS.md` records a baseline of 1,756 renderer / 177 headless tests; the suites now report 3,308 / 225 on `main` before this change, so I have left that line alone rather than adjust it here.
