### PR TITLE
fix(rendering): make transformed strokes exact across retained paths

### DIFF
--- a/docs/SKIASHARP_API_PARITY.md
+++ b/docs/SKIASHARP_API_PARITY.md
@@ -718,12 +718,12 @@ System Trace exported zero target command-buffer, device-allocation, and Metal
 resource-allocation rows for both CPU-only binaries.
 
 The pinned Svg.Skia `03f64b67badfca9fca216dc25896d0c0ee04e7b7`
-validation remained stable after the preceding variable-font slice: native W3C
-reported 530 passed and 3 skipped; the ProGPU raw lane reported 485 passed, 45
-reviewed known differences, and 3 skipped; the resvg lane reported 927 passed
-and 37 intentional skips; and the remaining suite passed 1,147 of 1,147 tests.
-The repository's parity verifier accepted the complete reviewed-difference
-inventory.
+validation improved with the transformed-stroke slice: native W3C reported 530
+passed and 3 skipped; the ProGPU raw lane reported 486 passed, 44 reviewed known
+differences, and 3 skipped after `filters-overview-02-b` reached native image
+parity; the resvg lane reported 927 passed and 37 intentional skips; and the
+remaining suite passed 1,147 of 1,147 tests. The repository's parity verifier
+accepted the complete reviewed-difference inventory.
 
 ### Typeface arguments and path-builder metadata checkpoint
 

--- a/docs/STROKE_TRANSFORM_RESEARCH.md
+++ b/docs/STROKE_TRANSFORM_RESEARCH.md
@@ -1,0 +1,221 @@
+# Stroke-transform provenance and rendering research
+
+## Scope and clean-room boundary
+
+This record defines how a retained two-dimensional pen width composes with a
+command transform, picture or visual replay transform, a late-bound static or
+GPU transform, and the final render transform. It covers solid and dashed
+rectangles, ellipses, rounded rectangles, paths, lines, quadratic and cubic
+curves, polylines, splines, opacity masks, hit-test geometry, and Skia's
+explicit one-device-pixel hairline. Text shaping, font selection, and
+three-dimensional line width are outside this change.
+
+The implementation is clean-room. The primary sources below informed only
+observable contracts, coordinate-space separation, retained-scene
+architecture, and validation cases. No foreign implementation text, helper
+structure, shader, data layout, naming, or control flow was copied, translated,
+or adapted.
+
+## Primary-source comparison
+
+| Engine or specification | Public or architectural contract examined | ProGPU decision |
+| --- | --- | --- |
+| [Skia `SkCanvas`](https://api.skia.org/classSkCanvas.html) and [`SkPaint`](https://api.skia.org/classSkPaint.html) | Canvas draw calls apply the current matrix to geometry and use paint for stroke width. A zero-width Skia stroke is an explicit one-device-pixel hairline whose width does not scale. | Retain ordinary width in the command's source coordinate space and compose it with the complete transform exactly once. Keep hairline behavior separate; do not infer a non-scaling stroke from an ordinary positive width. |
+| [Direct2D transforms](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview) and [`D2D1_STROKE_TRANSFORM_TYPE`](https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/ne-d2d1_1-d2d1_stroke_transform_type) | A render-target world transform generally affects both fill and stroke. Geometry transforms happen before stroking, while fixed and hairline transform types are explicit exceptions. | Preserve whether retained width is local or was already changed by a legacy recorder. Normal visual transforms scale the pen; a future fixed-width feature must be an explicit mode, not an inverse-scale accident. |
+| [Win2D `CanvasDrawingSession`](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasDrawingSession.htm) and [`DrawLine`](https://microsoft.github.io/Win2D/WinUI2/html/M_Microsoft_Graphics_Canvas_CanvasDrawingSession_DrawLine_2.htm) | A drawing session applies its `Transform` to subsequent operations, while each draw supplies an independent stroke width and style. | Keep transform and pen as separate typed retained state. Bridges record provenance rather than destructively rewriting the width during picture replay. |
+| [WebRender rendering overview](https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst) | A retained display list becomes a scene and then a culled frame. A spatial tree preserves local-to-world and world-to-device transforms, and non-simple transforms form distinct coordinate systems. | Retain one source command and compose coordinate transforms at compilation. Do not create scale-specific picture copies or make width identity depend on replay position. |
+| [Vello](https://github.com/linebender/vello) and its [`Scene`](https://github.com/linebender/vello/blob/main/vello/src/scene.rs) | A retained scene records path, stroke style, brush, and affine state, then performs parallel vector work on a WebGPU-capable renderer. | Preserve the same separation at ProGPU's typed boundary and use GPU expansion only where it is mathematically equivalent. ProGPU's provenance flag and affine outline path are original designs rather than ports of Vello encoding. |
+| [SkParagraph](https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/) | Shaping and paragraph layout are reusable CPU results consumed later by rendering. | Examined because text is a mandatory rendering-research boundary, but rejected as an implementation model for primitive pen transforms. This change does not reshape, relayout, or re-key glyphs. |
+| [DirectWrite glyph-run analysis](https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nn-dwrite-idwriteglyphrunanalysis) | DirectWrite derives device-pixel coverage from a reusable positioned glyph run and an explicit transform at the rendering boundary. | Preserve ProGPU's existing separation between retained text layout and transformed coverage. No pen-transform state is added to text or glyph caches. |
+| [Parley](https://docs.rs/parley/latest/parley/) | Shared font and layout contexts produce reusable positioned glyph runs; rendering is a later concern. | Rejected for stroke implementation. Its separation reinforces that a primitive-stroke correction must not invalidate or rebuild text layout. |
+| [HarfBuzz glyph rendering boundary](https://harfbuzz.github.io/glyphs-and-rendering.html) | HarfBuzz primarily returns positioned glyphs; outline extraction and rasterization follow shaping. | Rejected for stroke implementation. Unicode/OpenType shaping, fallback, glyph IDs, and variation state remain unchanged. |
+| [SVG 2 painting and vector effects](https://www.w3.org/TR/SVG2/painting.html#VectorEffects) | Normal positive-width strokes participate in transforms. `non-scaling-stroke` is a distinct opt-in vector effect. | Ordinary ProGPU pens scale with their visual. A non-scaling pen must become an explicit public contract; it must not be simulated by ambiguously pre-scaling every retained width. |
+| [WGSL derivative built-ins](https://www.w3.org/TR/WGSL/#derivative-builtin-functions) | Screen-space derivatives, including the Manhattan-width `fwidth`, are defined only in fragment stages and must be evaluated in uniform control flow. | Late affine stroke modes compute coordinate derivatives at fragment entry, then select the winning edge or distance gradient without placing derivative calls in divergent primitive branches. |
+
+## Retained provenance contract
+
+Let `C` be a command-local transform, `V` the enclosing visual or picture
+transform, and `F = C * V` the complete row-vector transform used by
+`System.Numerics`. A retained command has one of two width representations:
+
+- `IsPenThicknessLocal == true` means `Pen.Thickness` is the source-space
+  width. All new Scene transform overloads and bridges that retain a raw pen
+  must set this state.
+- `IsPenThicknessLocal == false` is the compatibility representation used by
+  older or external recorders that pre-scaled the width by `C`. The compiler
+  recovers the source width by dividing by the same finite, positive matrix
+  metric that recorder used. Current WPF, System.Drawing, Avalonia, Skia, and
+  Scene transform overloads all retain the raw width and mark it local, so
+  anisotropic and sheared geometry never has to reconstruct a lost direction.
+
+Picture replay may transform brush coordinates, but it must not multiply pen
+width, mutate a dash array, or change dash offset. Replaying one retained
+picture beneath scales `s1`, `s2`, ... must compile each instance from the same
+source width. In particular, a scale `s` must produce `s`, never `s^2`, width
+composition. Solid brushes reuse their existing pen object when no brush-space
+rewrite is required.
+
+Dash lengths, offsets, caps, joins, and miter limits are resolved from the same
+source-space thickness. A dashed command lowered to an undashed outline records
+that derived pen as local, preventing the compatibility recovery from running a
+second time. Open dashed contours retain the source start and end caps only
+when the first or last painted interval reaches that endpoint; interior dash
+intervals use the dash cap. A painted interval that crosses a closed contour's
+seam is merged into one cyclic run, so it receives a join instead of two
+coincident caps. These per-figure decisions are retained typed metadata and are
+part of clone, transform, path-operation, font-outline, and picture archive
+ownership. Opacity-mask compilation and CPU/GPU hit testing use the same
+provenance and cap resolver as visible rendering.
+
+Non-finite, zero, collapsed, or non-invertible width state fails closed for the
+stroke. A valid fill on the same command remains renderable. The compatibility
+path is bounded to known legacy commands; it is not a general inference that a
+pen with an arbitrary transform has already been scaled.
+
+## Conformal fast path and affine fallback
+
+For the linear two-by-two part `A = [[a,b],[c,d]]`, the existing matrix metric
+is its largest singular value:
+
+`scale(A) = sqrt((q + sqrt(q^2 - 4 det(A)^2)) / 2)`, where
+`q = a^2 + b^2 + c^2 + d^2`.
+
+The calculation is fixed `O(1)` work and allocation-free. For a conformal
+transform--orthogonal basis vectors of equal length--this scalar is the exact
+uniform scale. Lines and analytic curves whose centerlines are already in
+render space may therefore use
+`deviceThickness = localThickness * scale(F)` without changing their existing
+constant-size GPU records.
+
+No scalar is exact for an anisotropic scale or shear: the transformed width
+depends on the local tangent. Those transforms use the affine fallback. ProGPU
+constructs the stroked outline in source space using the source thickness,
+dash, cap, join, and miter state, then transforms the resulting geometry by
+`F`. Rectangles, ellipses, and rounded rectangles whose shader distance fields
+already interpolate local coordinates likewise keep local thickness. Applying
+the largest singular value as a universal width is rejected because it makes
+some orientations too thick and cannot reproduce a sheared outline.
+
+The conformal classification compares the lengths and dot product of the two
+basis vectors using a small scale-relative tolerance. Rotation, reflection,
+translation, and uniform scale stay on the scalar path. Non-uniform scale and
+shear take the outline path. Perspective and invalid transforms are not
+silently approximated as affine strokes.
+
+## Static and late-bound GPU transforms
+
+Static buffers and commands with `UseGpuTransforms` retain source-space width;
+their final matrix is intentionally applied after CPU scene compilation. A
+conformal late-bound matrix may supply its exact scalar to the vector vertex
+shader. A static viewport may cache that `O(1)` metric in reserved uniform
+storage without changing the shared 224-byte `GpuUniforms` ABI; a dynamic view
+derives it from the current matrix.
+
+The explicit multiplication is scoped only to direct two-dimensional stroke
+primitives whose centerline is transformed before screen-space expansion.
+Local-coordinate distance-field shapes already inherit scale from their
+coordinates, and an explicit hairline stays one device pixel. Text, textures,
+three-dimensional lines, and unrelated vector payloads must not consume the
+stroke scale.
+
+A non-conformal late-bound matrix must preserve the same affine-outline result
+as normal scene compilation. It must either transform source-space outline
+offsets in the GPU path or materialize the local outline before the late-bound
+draw. A singular-value-only shader fallback for anisotropic scale or shear is
+not acceptable. Static and dynamic GPU paths are required to match the CPU
+path's orientation-sensitive result. For quadratic and cubic commands,
+"exact" here means the exact affine transform of ProGPU's existing bounded
+24-section ribbon approximation; it does not claim an analytic nearest-distance
+solution for an arbitrary cubic curve.
+
+Retained hairline caps and joins use fixed vector ABI shape types `22` and
+`23`, with one quad per adornment. The vertex stage reconstructs transformed
+directions, turns, and miter intersections in framebuffer space; the fragment
+stage evaluates only the exterior signed-distance region while the adjoining
+stroke bodies own their shared seams. This preserves exact one-device-pixel
+behavior under scale, reflection, anisotropy, and shear without a CPU-baked
+classifier or per-frame outline allocation.
+
+The experimental Wavefront engine currently supports only a narrow subset of
+opaque, nonzero-winding, closed solid fills. Because it composites one compute
+layer after the ordered Atlas pass, mixing a Wavefront instance with a stroke,
+mask, text run, image, gradient, effect, or other Atlas command would reorder
+content. ProGPU therefore makes one transactional engine choice per frame: a
+pure supported-fill frame remains Wavefront, while any unsupported or mixed
+content retries the complete frame through Atlas. Per-command stroke fallback
+was rejected because it cannot preserve z order, and mask/offscreen work stays
+on Atlas until Wavefront gains ordered render-target batches. The current
+64-instance frame bound also prevents the fixed per-cell Wavefront index table
+from silently dropping overlapping shapes; larger fill scenes retry Atlas.
+Wavefront's current signed-distance conversion uses one transform-axis length,
+so its eligibility gate also rejects anisotropic scale and shear. Those
+non-conformal fills use Atlas until Wavefront evaluates distance with the full
+inverse-transpose/Jacobian rather than a scalar approximation.
+
+## Complexity, ownership, and performance contract
+
+- Provenance recovery, conformal classification, and matrix-scale resolution
+  are allocation-free `O(1)` operations per stroke command.
+- A conformal line retains constant vertex and index counts. A conformal curve
+  retains its existing bounded sampling cost; only one scalar multiplication is
+  added per applicable GPU vertex.
+- Affine outline construction is `O(S + D)` time and storage for generated
+  stroke segments `S` and dash boundaries `D`. Scratch buffers are reserved or
+  pooled and must not allocate per source segment after warmup.
+- Picture replay is `O(C)` for retained commands `C`. Stable solid-color replay
+  does not clone pens or dash arrays and does not create variants keyed by
+  visual scale. Append translation and portable picture deserialization rebuild
+  direct-primitive centerline caches once; unchanged replay and composed
+  transforms retain cache identity. Opaque transform-backed payloads (pictures,
+  visuals, hatches, dot grids, 3D lines, ACIS, and static DXF) compose the
+  translation without rewriting shared retained geometry or GPU buffers.
+  Extension compilation receives that already-composed transform exactly once;
+  static hatch/3D-line vertices bake it, while transform-consuming retained DXF
+  draw calls carry it to rendering without a second multiplication.
+- A warmed dashed-stroke cache compares the bounded dash interval list in
+  `O(D)` time and performs no geometry or paint allocation. Geometry identity
+  includes width, offset, interval values, and all endpoint/dash caps; derived
+  paint identity additionally includes brush reference, join, and miter state.
+- Static conformal scale is computed once per viewport-uniform update, not once
+  per command. Late-bound affine expansion remains linear in emitted outline
+  vertices and does not require CPU readback.
+- Wavefront eligibility is checked only when that experimental engine is
+  selected. A supported path scan is `O(S)` for retained segments `S`; an
+  unsupported or mixed frame performs one bounded transactional recompilation
+  through Atlas and never interleaves incorrectly ordered engine output.
+- Width provenance is scalar typed state on `RenderCommand`; it introduces no
+  reflection, object dictionary, native dependency, or per-frame adapter.
+
+Correctness is not traded for a lower command count. An optimization that
+restores the old width by skipping visual invalidation, dropping caps or dashes,
+using a conservative scalar for affine geometry, or turning an ordinary stroke
+into a hairline is a regression.
+
+## Validation contract
+
+The focused tests and existing rendering suites jointly exercise:
+
+- raw-local Scene, Avalonia, WPF, System.Drawing, and Skia commands plus
+  synthetic legacy pre-scaled compatibility commands;
+- nested visual and picture scales below and above one, proving exactly one
+  width composition and immutable picture metadata;
+- rectangles, ellipses, rounded rectangles, paths, lines, quadratic and cubic
+  curves, polylines, splines, dashes, open and closed dash seams, every cap and
+  join family, masks, and hit-test bounds;
+- horizontal, vertical, diagonal, rotated, reflected, anisotropically scaled,
+  and sheared strokes, comparing the conformal path with transformed local
+  outline expectations;
+- static-buffer and dynamic GPU-transform output for both conformal and
+  non-conformal matrices, with explicit one-device-pixel hairline coverage;
+- invalid and collapsed render and hit-test transforms, ensuring a bad stroke
+  emits no invalid vertices or ghost hit while an independent fill survives;
+- fixed `GpuUniforms` layout, scoped vector-shader use, retained-scene reuse,
+  and zero managed allocation in the warmed provenance/solid-picture hot path.
+
+Release qualification runs the focused pixel and provenance tests, the full
+Release core and headless suites, Avalonia contract tests, static/GPU rendering
+tests, `ShaderResourceTests`, documentation gates, and package builds on all CI
+platforms. Any performance claim requires matched Release workloads and
+correlated EventPipe plus macOS Time Profiler, Allocations/VM Tracker, and Metal
+System Trace evidence. Raw profiling traces and temporary launch artifacts are
+removed after retaining compact measurements and exact reproduction metadata.

--- a/docs/STROKE_TRANSFORM_RESEARCH.md
+++ b/docs/STROKE_TRANSFORM_RESEARCH.md
@@ -172,10 +172,18 @@ inverse-transpose/Jacobian rather than a scalar approximation.
   Extension compilation receives that already-composed transform exactly once;
   static hatch/3D-line vertices bake it, while transform-consuming retained DXF
   draw calls carry it to rendering without a second multiplication.
+  Static image, ShaderToy, WPF shader-effect, and backdrop quads likewise bake
+  their active transform once; deferred-transform extensions keep their
+  render-time transform contract.
 - A warmed dashed-stroke cache compares the bounded dash interval list in
   `O(D)` time and performs no geometry or paint allocation. Geometry identity
   includes width, offset, interval values, and all endpoint/dash caps; derived
   paint identity additionally includes brush reference, join, and miter state.
+  Rectangles, ellipses, circles, and rounded rectangles retain their analytic
+  fill quad, but route a dashed outline through the same cached path for visible
+  rendering and GPU hit testing. Replay, append, and picture archives preserve
+  or rebuild that source path once; solid analytic primitives keep the compact
+  allocation-free recorder path.
 - Static conformal scale is computed once per viewport-uniform update, not once
   per command. Late-bound affine expansion remains linear in emitted outline
   vertices and does not require CPU readback.

--- a/docs/STROKE_TRANSFORM_RESEARCH.md
+++ b/docs/STROKE_TRANSFORM_RESEARCH.md
@@ -124,10 +124,11 @@ as normal scene compilation. It must either transform source-space outline
 offsets in the GPU path or materialize the local outline before the late-bound
 draw. A singular-value-only shader fallback for anisotropic scale or shear is
 not acceptable. Static and dynamic GPU paths are required to match the CPU
-path's orientation-sensitive result. For quadratic and cubic commands,
-"exact" here means the exact affine transform of ProGPU's existing bounded
-24-section ribbon approximation; it does not claim an analytic nearest-distance
-solution for an arbitrary cubic curve.
+path's orientation-sensitive result. For quadratic and cubic commands, the
+affine ribbon uses at least 24 sections and increases the bounded section count
+from transformed second-difference curvature until its conservative chord
+error is at most 0.25 device pixel (capped at 1,024 sections). It does not claim
+an analytic nearest-distance solution for an arbitrary cubic curve.
 
 Retained hairline caps and joins use fixed vector ABI shape types `22` and
 `23`, with one quad per adornment. The vertex stage reconstructs transformed
@@ -180,6 +181,11 @@ inverse-transpose/Jacobian rather than a scalar approximation.
 - Affine outline construction is `O(S + D)` time and storage for generated
   stroke segments `S` and dash boundaries `D`. Scratch buffers are reserved or
   pooled and must not allocate per source segment after warmup.
+- Device-hairline arc hit geometry selects its chord count from transformed
+  ellipse radius and sweep with at most 0.25-pixel sagitta error, retaining a
+  32-section floor and a 4,096-section safety bound. The bound covers radii far
+  beyond supported framebuffer dimensions without allowing adversarial paths
+  to request unbounded CPU memory.
 - Picture replay is `O(C)` for retained commands `C`. Stable solid-color replay
   does not clone pens or dash arrays and does not create variants keyed by
   visual scale. Span-based polyline and spline recording, append translation,

--- a/docs/STROKE_TRANSFORM_RESEARCH.md
+++ b/docs/STROKE_TRANSFORM_RESEARCH.md
@@ -21,7 +21,7 @@ or adapted.
 | Engine or specification | Public or architectural contract examined | ProGPU decision |
 | --- | --- | --- |
 | [Skia `SkCanvas`](https://api.skia.org/classSkCanvas.html) and [`SkPaint`](https://api.skia.org/classSkPaint.html) | Canvas draw calls apply the current matrix to geometry and use paint for stroke width. A zero-width Skia stroke is an explicit one-device-pixel hairline whose width does not scale. | Retain ordinary width in the command's source coordinate space and compose it with the complete transform exactly once. Keep hairline behavior separate; do not infer a non-scaling stroke from an ordinary positive width. |
-| [Direct2D transforms](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview) and [`D2D1_STROKE_TRANSFORM_TYPE`](https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/ne-d2d1_1-d2d1_stroke_transform_type) | A render-target world transform generally affects both fill and stroke. Geometry transforms happen before stroking, while fixed and hairline transform types are explicit exceptions. | Preserve whether retained width is local or was already changed by a legacy recorder. Normal visual transforms scale the pen; a future fixed-width feature must be an explicit mode, not an inverse-scale accident. |
+| [Direct2D transforms](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview) and [`D2D1_STROKE_TRANSFORM_TYPE`](https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/ne-d2d1_1-d2d1_stroke_transform_type) | A render-target world transform generally affects both fill and stroke. Geometry transforms happen before stroking, while fixed and hairline transform types are explicit exceptions. | Preserve whether retained width is local or was already changed by a legacy recorder. Normal visual transforms scale the pen; WinUI's fixed-width contract is lowered explicitly in device space, not simulated by an inverse scalar. |
 | [Win2D `CanvasDrawingSession`](https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasDrawingSession.htm) and [`DrawLine`](https://microsoft.github.io/Win2D/WinUI2/html/M_Microsoft_Graphics_Canvas_CanvasDrawingSession_DrawLine_2.htm) | A drawing session applies its `Transform` to subsequent operations, while each draw supplies an independent stroke width and style. | Keep transform and pen as separate typed retained state. Bridges record provenance rather than destructively rewriting the width during picture replay. |
 | [WebRender rendering overview](https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst) | A retained display list becomes a scene and then a culled frame. A spatial tree preserves local-to-world and world-to-device transforms, and non-simple transforms form distinct coordinate systems. | Retain one source command and compose coordinate transforms at compilation. Do not create scale-specific picture copies or make width identity depend on replay position. |
 | [Vello](https://github.com/linebender/vello) and its [`Scene`](https://github.com/linebender/vello/blob/main/vello/src/scene.rs) | A retained scene records path, stroke style, brush, and affine state, then performs parallel vector work on a WebGPU-capable renderer. | Preserve the same separation at ProGPU's typed boundary and use GPU expansion only where it is mathematically equivalent. ProGPU's provenance flag and affine outline path are original designs rather than ports of Vello encoding. |
@@ -30,6 +30,7 @@ or adapted.
 | [Parley](https://docs.rs/parley/latest/parley/) | Shared font and layout contexts produce reusable positioned glyph runs; rendering is a later concern. | Rejected for stroke implementation. Its separation reinforces that a primitive-stroke correction must not invalidate or rebuild text layout. |
 | [HarfBuzz glyph rendering boundary](https://harfbuzz.github.io/glyphs-and-rendering.html) | HarfBuzz primarily returns positioned glyphs; outline extraction and rasterization follow shaping. | Rejected for stroke implementation. Unicode/OpenType shaping, fallback, glyph IDs, and variation state remain unchanged. |
 | [SVG 2 painting and vector effects](https://www.w3.org/TR/SVG2/painting.html#VectorEffects) | Normal positive-width strokes participate in transforms. `non-scaling-stroke` is a distinct opt-in vector effect. | Ordinary ProGPU pens scale with their visual. A non-scaling pen must become an explicit public contract; it must not be simulated by ambiguously pre-scaling every retained width. |
+| [WinUI `CompositionSpriteShape.IsStrokeNonScaling`](https://learn.microsoft.com/en-us/uwp/api/windows.ui.composition.compositionspriteshape.isstrokenonscaling) | Enabling the property keeps the shape outline from scaling with the shape transform. | Lower the retained centerline through the complete Composition transform once, cache that transformed path, and apply the original width, dash distances, caps, and joins in device space. A scalar inverse is rejected because it cannot be exact for anisotropic scale or shear. |
 | [WGSL derivative built-ins](https://www.w3.org/TR/WGSL/#derivative-builtin-functions) | Screen-space derivatives, including the Manhattan-width `fwidth`, are defined only in fragment stages and must be evaluated in uniform control flow. | Late affine stroke modes compute coordinate derivatives at fragment entry, then select the winning edge or distance gradient without placing derivative calls in divergent primitive branches. |
 
 ## Retained provenance contract
@@ -136,6 +137,23 @@ stroke bodies own their shared seams. This preserves exact one-device-pixel
 behavior under scale, reflection, anisotropy, and shear without a CPU-baked
 classifier or per-frame outline allocation.
 
+WinUI's explicit positive-width non-scaling stroke is lowered at the retained
+Composition boundary. The source centerline is transformed once and cached by
+source-path identity and the complete affine matrix; the unchanged positive
+width is then stroked with an identity command transform. This makes width,
+dash arc length, caps, joins, visible rendering, opacity masks, and GPU hit
+testing share one exact device-space representation. Geometry or transform
+changes replace the bounded cache; steady replay performs no path conversion.
+This is deliberately separate from Skia's zero-width hairline sentinel.
+
+Special Skia picture, image, composed, and color-filter shader strokes use the
+same retained hairline contract. A zero-width Stroke records a typed path
+opacity mask carrying the complete canvas transform, cap/join state, and dash
+state, then shades a tightly bounded fill through that mask. StrokeAndFill
+records its fill and its one-device-pixel outline as two ordered operations.
+Materializing a local fill outline is rejected because a device hairline has no
+transform-independent local outline.
+
 The experimental Wavefront engine currently supports only a narrow subset of
 opaque, nonzero-winding, closed solid fills. Because it composites one compute
 layer after the ordered Atlas pass, mixing a Wavefront instance with a stroke,
@@ -164,9 +182,12 @@ inverse-transpose/Jacobian rather than a scalar approximation.
   pooled and must not allocate per source segment after warmup.
 - Picture replay is `O(C)` for retained commands `C`. Stable solid-color replay
   does not clone pens or dash arrays and does not create variants keyed by
-  visual scale. Append translation and portable picture deserialization rebuild
-  direct-primitive centerline caches once; unchanged replay and composed
-  transforms retain cache identity. Opaque transform-backed payloads (pictures,
+  visual scale. Span-based polyline and spline recording, append translation,
+  and portable picture deserialization do not materialize managed path graphs.
+  Connected solid polylines compile directly into pre-reserved bounded vertex
+  and index spans. Splines use a transform-adaptive 10/25/50/100-segment stack
+  sample at compilation rather than an unconditional 100-segment retained
+  graph. Opaque transform-backed payloads (pictures,
   visuals, hatches, dot grids, 3D lines, ACIS, and static DXF) compose the
   translation without rewriting shared retained geometry or GPU buffers.
   Extension compilation receives that already-composed transform exactly once;
@@ -193,6 +214,11 @@ inverse-transpose/Jacobian rather than a scalar approximation.
   through Atlas and never interleaves incorrectly ordered engine output.
 - Width provenance is scalar typed state on `RenderCommand`; it introduces no
   reflection, object dictionary, native dependency, or per-frame adapter.
+- A WinUI non-scaling shape path is rebuilt in `O(S)` time and storage for `S`
+  source segments only when its source geometry or complete transform changes;
+  steady recording and replay reuse the cached transformed path. Special-shader
+  hairlines add one bounded opacity-mask pass and retain one-device-pixel width
+  under every finite invertible affine transform.
 
 Correctness is not traded for a lower command count. An optimization that
 restores the old width by skipping visual invalidation, dropping caps or dashes,
@@ -219,6 +245,8 @@ The focused tests and existing rendering suites jointly exercise:
   emits no invalid vertices or ghost hit while an independent fill survives;
 - fixed `GpuUniforms` layout, scoped vector-shader use, retained-scene reuse,
   and zero managed allocation in the warmed provenance/solid-picture hot path.
+- WinUI positive non-scaling strokes under anisotropic scale and Skia special-
+  shader hairlines under non-uniform transforms, including StrokeAndFill.
 
 Release qualification runs the focused pixel and provenance tests, the full
 Release core and headless suites, Avalonia contract tests, static/GPU rendering

--- a/docs/STROKE_TRANSFORM_RESEARCH.md
+++ b/docs/STROKE_TRANSFORM_RESEARCH.md
@@ -10,6 +10,12 @@ curves, polylines, splines, opacity masks, hit-test geometry, and Skia's
 explicit one-device-pixel hairline. Text shaping, font selection, and
 three-dimensional line width are outside this change.
 
+The follow-up DXF correction also covers an explicit positive fixed-device
+width. DXF linework opts into that mode because its cached 1.0/1.2/1.5 widths
+are cosmetic screen widths: zoom transforms the retained CAD centerline but
+must not magnify those widths. Ordinary positive-width pens remain in normal
+source-space mode.
+
 The implementation is clean-room. The primary sources below informed only
 observable contracts, coordinate-space separation, retained-scene
 architecture, and validation cases. No foreign implementation text, helper
@@ -55,6 +61,15 @@ picture beneath scales `s1`, `s2`, ... must compile each instance from the same
 source width. In particular, a scale `s` must produce `s`, never `s^2`, width
 composition. Solid brushes reuse their existing pen object when no brush-space
 rewrite is required.
+
+`PenStrokeTransformMode.Fixed` is a distinct positive-width contract. It
+retains the requested width in typed pen state, transforms the centerline by
+the complete affine matrix, and expands the body, caps, and joins in device
+space. The mode is preserved through pen clones, geometry caches, append and
+picture replay, and the versioned picture archive. It is not represented as a
+hairline, an inverse zoom scalar, or a scale-keyed CPU geometry copy. DXF uses
+this mode for every cached entity pen and for its specialized uncached
+outlines.
 
 Dash lengths, offsets, caps, joins, and miter limits are resolved from the same
 source-space thickness. A dashed command lowered to an undashed outline records
@@ -138,6 +153,17 @@ stroke bodies own their shared seams. This preserves exact one-device-pixel
 behavior under scale, reflection, anisotropy, and shear without a CPU-baked
 classifier or per-frame outline allocation.
 
+Arbitrary positive fixed-device widths reuse the same constant-size GPU
+centerline records and cap/join descriptors. A reserved negative vertex-width
+encoding distinguishes the positive fixed width from the `-1` hairline
+sentinel; the vertex shader decodes it only for analytic and direct-stroke
+shape types. Direct line, quadratic, cubic, and arc bodies expand by the
+decoded width after the late transform. Analytic rectangle, ellipse, rounded
+rectangle, and circle distance fields convert that device width into local
+distance units from fragment derivatives evaluated in uniform control flow.
+This keeps DXF static-buffer zoom entirely on WebGPU and adds no per-frame CPU
+geometry rebuild, managed allocation, or GPU readback.
+
 WinUI's explicit positive-width non-scaling stroke is lowered at the retained
 Composition boundary. The source centerline is transformed once and cached by
 source-path identity and the complete affine matrix; the unchanged positive
@@ -214,6 +240,10 @@ inverse-transpose/Jacobian rather than a scalar approximation.
 - Static conformal scale is computed once per viewport-uniform update, not once
   per command. Late-bound affine expansion remains linear in emitted outline
   vertices and does not require CPU readback.
+- Fixed-device positive strokes retain the normal constant vertex/index count.
+  Their late zoom path adds only bounded matrix, direction, and derivative
+  arithmetic per existing vertex or fragment; steady DXF zoom neither
+  recompiles the static buffer nor allocates scale-specific pen/geometry state.
 - Wavefront eligibility is checked only when that experimental engine is
   selected. A supported path scan is `O(S)` for retained segments `S`; an
   unsupported or mixed frame performs one bounded transactional recompilation
@@ -246,7 +276,11 @@ The focused tests and existing rendering suites jointly exercise:
   and sheared strokes, comparing the conformal path with transformed local
   outline expectations;
 - static-buffer and dynamic GPU-transform output for both conformal and
-  non-conformal matrices, with explicit one-device-pixel hairline coverage;
+  non-conformal matrices, with explicit one-device-pixel hairline and positive
+  fixed-device-width coverage;
+- a DXF-rendered static line plus analytic fixed-width rectangle, ellipse, and
+  rounded rectangle at zoom factors below and above one, proving unchanged
+  framebuffer thickness without static-buffer recompilation;
 - invalid and collapsed render and hit-test transforms, ensuring a bad stroke
   emits no invalid vertices or ghost hit while an independent fill survives;
 - fixed `GpuUniforms` layout, scoped vector-shader use, retained-scene reuse,

--- a/eng/progpu-verify-svg-skia-results.ps1
+++ b/eng/progpu-verify-svg-skia-results.ps1
@@ -71,6 +71,6 @@ if ($difference.Count -ne 0) {
 }
 
 Assert-Counts $native 533 530 0 3 'Native W3C'
-Assert-Counts $progpu 533 485 45 3 'ProGPU W3C'
+Assert-Counts $progpu 533 486 44 3 'ProGPU W3C'
 
-Write-Host "Svg.Skia W3C parity inventory verified: native 530/533 with 3 skips; ProGPU 485/533 with 45 reviewed differences and 3 skips."
+Write-Host "Svg.Skia W3C parity inventory verified: native 530/533 with 3 skips; ProGPU 486/533 with 44 reviewed differences and 3 skips."

--- a/eng/svg-skia-progpu-ci.patch
+++ b/eng/svg-skia-progpu-ci.patch
@@ -10,3 +10,18 @@ index 9ed632c..48c41d0 100644
          svg.Settings.EnableSvgFonts = false;
          svg.Settings.EnableTextReferences = false;
          svg.Settings.StandaloneViewport = SkiaSharp.SKRect.Create(0f, 0f, 480f, 360f);
+diff --git a/tests/Svg.Skia.UnitTests/W3CTestSuiteTests.cs b/tests/Svg.Skia.UnitTests/W3CTestSuiteTests.cs
+--- a/tests/Svg.Skia.UnitTests/W3CTestSuiteTests.cs
++++ b/tests/Svg.Skia.UnitTests/W3CTestSuiteTests.cs
+@@ -564,7 +564,9 @@ public class W3CTestSuiteTests
+             "masking-path-06-b" => 0.095,
+             "masking-path-07-b" => 0.042,
+             // The animated dash/linecap/linejoin/miter states align with Chrome at the sampled
+             // SMIL frame; the residual delta is Skia stroke rasterization on the dense path samples.
++            // ProGPU's transform-adaptive cubic subdivision raises the anisotropic curve from 24
++            // to 29 sections to keep chord error below 0.25 device pixel.
+-            "animate-elem-35-t" => 0.1,
++            "animate-elem-35-t" => 0.1002,
+             // These two W3C rows intentionally stay on the legacy W3C pass images because current
+             // Chrome snapshots do not match the W3C discrete class/to-only non-interpolable states.
+             // The animated shape pixels match; the residual delta is text and frame rasterization.

--- a/eng/svg-skia-w3c-known-differences.txt
+++ b/eng/svg-skia-w3c-known-differences.txt
@@ -10,7 +10,6 @@ filters-composite-02-b
 filters-comptran-01-b
 filters-conv-04-f
 filters-morph-01-f
-filters-overview-02-b
 fonts-elem-02-t
 fonts-glyph-02-t
 linking-uri-01-b

--- a/src/PresentationCore/System/Windows/Media/DrawingContext.cs
+++ b/src/PresentationCore/System/Windows/Media/DrawingContext.cs
@@ -58,8 +58,6 @@ public class DrawingContext :
 
     private Matrix4x4 CurrentTransform => _transformStack.Peek();
     private float CurrentOpacity => _opacityStack.Peek();
-    private float CurrentStrokeScale => ProGPU.Vector.TransformMetrics.GetStrokeScale(CurrentTransform);
-
     private void ApplyContextStateToLastCommands(int startCount)
     {
         int endCount = _nativeContext.Commands.Count;
@@ -77,6 +75,16 @@ public class DrawingContext :
                 cmd.Transform = cmd.Transform * CurrentTransform;
             }
 
+            // WPF pens remain in drawing-local coordinates. Keeping the raw
+            // width lets the compositor stroke before applying the complete
+            // geometry + DrawingContext transform, which is exact for
+            // anisotropic scale and shear and avoids reconstructing a scale
+            // from an already modified width.
+            if (cmd.Pen is not null)
+            {
+                cmd.IsPenThicknessLocal = true;
+            }
+
             _nativeContext.Commands[i] = cmd;
         }
     }
@@ -84,7 +92,7 @@ public class DrawingContext :
     public void DrawLine(Pen? pen, Point point0, Point point1)
     {
         if (pen == null) return;
-        var nativePen = pen.ToNative(new Rect(point0, point1), CurrentStrokeScale);
+        var nativePen = pen.ToNative(new Rect(point0, point1));
         if (nativePen == null) return;
         var p0 = new Vector2((float)point0.X, (float)point0.Y);
         var p1 = new Vector2((float)point1.X, (float)point1.Y);
@@ -97,7 +105,7 @@ public class DrawingContext :
     public void DrawRectangle(Brush? brush, Pen? pen, Rect rectangle)
     {
         var nativeBrush = brush?.ToNative(rectangle);
-        var nativePen = pen?.ToNative(rectangle, CurrentStrokeScale);
+        var nativePen = pen?.ToNative(rectangle);
         var nativeRect = new ProGPU.Scene.Rect((float)rectangle.X, (float)rectangle.Y, (float)rectangle.Width, (float)rectangle.Height);
 
         int start = _nativeContext.Commands.Count;
@@ -108,7 +116,7 @@ public class DrawingContext :
     public void DrawRoundedRectangle(Brush? brush, Pen? pen, Rect rectangle, double radiusX, double radiusY)
     {
         var nativeBrush = brush?.ToNative(rectangle);
-        var nativePen = pen?.ToNative(rectangle, CurrentStrokeScale);
+        var nativePen = pen?.ToNative(rectangle);
         var nativeRect = new ProGPU.Scene.Rect((float)rectangle.X, (float)rectangle.Y, (float)rectangle.Width, (float)rectangle.Height);
 
         int start = _nativeContext.Commands.Count;
@@ -120,7 +128,7 @@ public class DrawingContext :
     {
         var bounds = new Rect(center.X - radiusX, center.Y - radiusY, radiusX * 2.0, radiusY * 2.0);
         var nativeBrush = brush?.ToNative(bounds);
-        var nativePen = pen?.ToNative(bounds, CurrentStrokeScale);
+        var nativePen = pen?.ToNative(bounds);
         var c = new Vector2((float)center.X, (float)center.Y);
 
         int start = _nativeContext.Commands.Count;
@@ -133,7 +141,7 @@ public class DrawingContext :
         if (geometry == null) return;
         var bounds = geometry.Bounds;
         var nativeBrush = brush?.ToNative(bounds);
-        var nativePen = pen?.ToNative(bounds, CurrentStrokeScale);
+        var nativePen = pen?.ToNative(bounds);
 
         int start = _nativeContext.Commands.Count;
         geometry.Draw(_nativeContext, nativeBrush, nativePen);

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
@@ -297,8 +297,8 @@ internal partial class DrawingContextImpl :
         DrawingContext.DrawLine(
             translated,
             ToVector(p1),
-            ToVector(p2));
-        ApplyTransformToLastCommand();
+            ToVector(p2),
+            ToProGpuMatrix(CommandTransform));
     }
 
     public void DrawGeometry(
@@ -833,16 +833,6 @@ internal partial class DrawingContextImpl :
     {
         source.EnsureGpuTexture();
         return source.Texture;
-    }
-
-    private void ApplyTransformToLastCommand()
-    {
-        int index = DrawingContext.Commands.Count - 1;
-        if (index < 0)
-            return;
-        RenderCommand command = DrawingContext.Commands[index];
-        command.Transform = ToProGpuMatrix(CommandTransform);
-        DrawingContext.Commands[index] = command;
     }
 
     private static TextureFormat GetFramebufferFormat(

--- a/src/ProGPU.Backend/Shaders/Vector.wgsl
+++ b/src/ProGPU.Backend/Shaders/Vector.wgsl
@@ -1,5 +1,5 @@
-// Algorithm: Expand and transform batched vector primitives and meshes, evaluate analytic curves, arcs, and quarter-pixel-snapped periodic dot grids, use exact single-evaluation box/rounded-box distance gradients for anti-aliasing, then shade fills, strokes, gradients, vertex-color blends, and edges; dedicated solid-rectangle and adaptively selected circular-rounded-rectangle entry points avoid the general material/path program for dense UI chrome.
-// Time complexity: O(1) per vertex or fragment under the shader's fixed primitive and gradient limits.
+// Algorithm: Expand and transform batched vector primitives and meshes; direct 2D strokes use a scalar screen-space fast path for conformal transforms and an exact transformed local-outline path with derivative anti-aliasing for anisotropic or sheared transforms; the reserved Skia hairline sentinel derives an invariant one-framebuffer-pixel width from screen-space expansion or analytic-distance derivatives, while one fixed quad regenerates each cap or join from transformed centerline directions and evaluates its exterior analytically with hard-owned body seams; evaluate analytic curves, arcs, and quarter-pixel-snapped periodic dot grids; use exact single-evaluation box/rounded-box distance gradients; then shade fills, strokes, gradients, vertex-color blends, and edges. Dedicated solid-rectangle and adaptively selected circular-rounded-rectangle entry points avoid the general material/path program for dense UI chrome.
+// Time complexity: O(1) per vertex or fragment under the shader's fixed primitive and gradient limits; static draws reuse CPU-cached maximum/minimum singular values, dynamic GPU-transformed direct strokes and hairline bounds add fixed 2x2 matrix arithmetic and two square roots per vertex, non-conformal arc quads test four analytic extrema per vertex, hairline caps/joins use one fixed quad with bounded line-intersection and at most four signed-edge evaluations, and non-conformal or analytic-hairline stroke fragments add fixed derivative/gradient arithmetic.
 // Space complexity: O(1) local storage and bounded uniform/storage reads; texture masks add one sample per fragment while analytic rounded and uniform-opacity masks add fixed derivative arithmetic and no texture bandwidth.
 struct Brush {
     brushType: u32,
@@ -143,6 +143,8 @@ struct VertexOutput {
     @location(5) strokeThickness: f32,
     @location(6) shapeType: f32,
     @location(7) gridIndex: f32,
+    @location(8) @interpolate(flat) localStrokeMode: f32,
+    @location(9) brushCoord: vec2<f32>,
 };
 
 fn apply_gradient_spread(t: f32, spreadMethod: u32) -> f32 {
@@ -506,6 +508,10 @@ fn safe_normalize(value: vec2<f32>) -> vec2<f32> {
     return vec2<f32>(0.0, 0.0);
 }
 
+fn cross_2d(left: vec2<f32>, right: vec2<f32>) -> f32 {
+    return left.x * right.y - left.y * right.x;
+}
+
 fn nearest_ellipse_theta(point: vec2<f32>, center: vec2<f32>, axisX: vec2<f32>, axisY: vec2<f32>) -> f32 {
     let p = point - center;
     let det = axisX.x * axisY.y - axisX.y * axisY.x;
@@ -545,6 +551,93 @@ fn is_angle_inside_arc(theta: f32, theta1: f32, deltaTheta: f32) -> bool {
     return along <= span + 0.001;
 }
 
+fn arc_bounds_center(
+    center: vec2<f32>,
+    axisX: vec2<f32>,
+    axisY: vec2<f32>,
+    theta1: f32,
+    deltaTheta: f32) -> vec2<f32> {
+    let start = arc_eval(center, axisX, axisY, theta1);
+    let end = arc_eval(center, axisX, axisY, theta1 + deltaTheta);
+    var boundsMin = min(start, end);
+    var boundsMax = max(start, end);
+
+    let xMinimumTheta = atan2(axisY.x, axisX.x);
+    if (is_angle_inside_arc(xMinimumTheta, theta1, deltaTheta)) {
+        let point = arc_eval(center, axisX, axisY, xMinimumTheta);
+        boundsMin = min(boundsMin, point);
+        boundsMax = max(boundsMax, point);
+    }
+    let xMaximumTheta = xMinimumTheta + PROGPU_TWO_PI * 0.5;
+    if (is_angle_inside_arc(xMaximumTheta, theta1, deltaTheta)) {
+        let point = arc_eval(center, axisX, axisY, xMaximumTheta);
+        boundsMin = min(boundsMin, point);
+        boundsMax = max(boundsMax, point);
+    }
+
+    let yMinimumTheta = atan2(axisY.y, axisX.y);
+    if (is_angle_inside_arc(yMinimumTheta, theta1, deltaTheta)) {
+        let point = arc_eval(center, axisX, axisY, yMinimumTheta);
+        boundsMin = min(boundsMin, point);
+        boundsMax = max(boundsMax, point);
+    }
+    let yMaximumTheta = yMinimumTheta + PROGPU_TWO_PI * 0.5;
+    if (is_angle_inside_arc(yMaximumTheta, theta1, deltaTheta)) {
+        let point = arc_eval(center, axisX, axisY, yMaximumTheta);
+        boundsMin = min(boundsMin, point);
+        boundsMax = max(boundsMax, point);
+    }
+
+    return (boundsMin + boundsMax) * 0.5;
+}
+
+fn affine_stroke_scales(transform: mat4x4<f32>) -> vec2<f32> {
+    // Match TransformMetrics.TryGetStrokeScale for sigma_max and derive
+    // sigma_min from |determinant| / sigma_max. Matrix indexing returns columns
+    // in WGSL, matching the uploaded System.Numerics basis vectors.
+    let axisX = transform[0].xy;
+    let axisY = transform[1].xy;
+    let sum = dot(axisX, axisX) + dot(axisY, axisY);
+    let determinant = axisX.x * axisY.y - axisX.y * axisY.x;
+    let discriminant = max(
+        0.0,
+        sum * sum - 4.0 * determinant * determinant);
+    let maximumScale = sqrt(max(0.0, (sum + sqrt(discriminant)) * 0.5));
+    // NaN fails both comparisons. Infinity fails the upper bound. Invalid
+    // transforms fail closed through the zero pair.
+    if (!(maximumScale > 0.0 && maximumScale <= 3.402823e38)) {
+        return vec2<f32>(0.0);
+    }
+
+    let minimumScale = abs(determinant) / maximumScale;
+    if (!(minimumScale >= 0.0 && minimumScale <= 3.402823e38)) {
+        return vec2<f32>(maximumScale);
+    }
+    return vec2<f32>(maximumScale, minimumScale);
+}
+
+fn direct_2d_stroke_scales(isStatic: bool, useGpuTransforms: bool) -> vec2<f32> {
+    if (isStatic) {
+        // pad1.xy is precomputed by DxfStaticBuffer. Fall back to the matrix so
+        // buffers produced by older/custom writers preserve the same result.
+        let cachedScales = uniforms.pad1;
+        if (cachedScales.x > 0.0 && cachedScales.x <= 3.402823e38 &&
+            cachedScales.y > 0.0 && cachedScales.y <= cachedScales.x) {
+            return cachedScales;
+        }
+        return affine_stroke_scales(uniforms.mvp);
+    }
+    if (useGpuTransforms) {
+        return affine_stroke_scales(uniforms.view);
+    }
+    return vec2<f32>(1.0);
+}
+
+fn is_conformal_stroke_transform(scales: vec2<f32>) -> bool {
+    let tolerance = max(1.0, scales.x) * 0.0001;
+    return abs(scales.x - scales.y) <= tolerance;
+}
+
 @vertex
 fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
     var output: VertexOutput;
@@ -573,20 +666,155 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
     var inShapeSize = input.shapeSize;
     var inColor = input.color;
 
+    // Rectangles/ellipses keep their stroke width in local SDF coordinates and
+    // therefore scale through interpolation. Hairlines intentionally stay one
+    // device pixel. Direct strokes retain the screen-space scalar fast path for
+    // conformal transforms and transform their expanded local outline exactly
+    // for anisotropic or sheared transforms.
+    let isAnalyticSdf = sType < 3u;
+    let isHairlineAdornment = sType == 22u || sType == 23u;
+    let isDirect2DStroke =
+        sType == 3u || sType == 5u || sType == 6u || sType == 12u ||
+        isHairlineAdornment;
+    let isLocalPolygonSdf = sType >= 13u && sType <= 17u;
+    // strokeThickness is overloaded as quadrilateral p3.y for types 14-17;
+    // only analytic/direct primitives own it as an actual stroke width.
+    let isHairlineStroke =
+        (isAnalyticSdf || isDirect2DStroke) &&
+        input.strokeThickness == -1.0;
+    let hasLateAffineTransform = isStatic || useGpuTransforms;
+    var directStrokeScales = vec2<f32>(1.0);
+    if ((isAnalyticSdf || isDirect2DStroke || isLocalPolygonSdf) && hasLateAffineTransform) {
+        directStrokeScales = direct_2d_stroke_scales(isStatic, useGpuTransforms);
+    }
+    let hasValidLateAffineTransform =
+        directStrokeScales.x > 0.000001 &&
+        directStrokeScales.y > 0.000001;
+    let discardLateAffineShape =
+        (isAnalyticSdf || isDirect2DStroke || isLocalPolygonSdf) &&
+        hasLateAffineTransform &&
+        !hasValidLateAffineTransform;
+    let useLocalStrokeOutline =
+        isDirect2DStroke &&
+        !isHairlineStroke &&
+        hasLateAffineTransform &&
+        hasValidLateAffineTransform &&
+        !is_conformal_stroke_transform(directStrokeScales);
+    var outputStrokeThickness = select(
+        input.strokeThickness,
+        1.0,
+        isHairlineStroke);
+    if (isDirect2DStroke &&
+        !isHairlineStroke &&
+        hasLateAffineTransform &&
+        hasValidLateAffineTransform &&
+        !useLocalStrokeOutline) {
+        outputStrokeThickness = outputStrokeThickness * directStrokeScales.x;
+    }
+    let strokeExpansionPadding = select(
+        1.5,
+        1.5 / max(directStrokeScales.y, 0.000001),
+        useLocalStrokeOutline);
+
+    if (isAnalyticSdf &&
+        isHairlineStroke &&
+        hasLateAffineTransform &&
+        hasValidLateAffineTransform) {
+        // CPU recording reserves a two-local-unit halo for a device hairline
+        // (half a pixel of stroke plus the 1.5-pixel AA fringe). A late
+        // downscale needs a larger local quad so that the same two framebuffer
+        // pixels remain covered after interpolation. The SDF itself derives
+        // its exact one-pixel width from fragment derivatives below.
+        let extraPadding = max(
+            0.0,
+            2.0 / directStrokeScales.y - 2.0);
+        let quadrant = select(
+            vec2<f32>(-1.0),
+            vec2<f32>(1.0),
+            input.texCoord >= vec2<f32>(0.0));
+        inPos = inPos + quadrant * extraPadding;
+        inTexCoord = inTexCoord + quadrant * extraPadding;
+    }
+
+    if (sType == 12u &&
+        isHairlineStroke &&
+        hasLateAffineTransform &&
+        hasValidLateAffineTransform) {
+        // Arc stroke quads are recorded with a two-local-unit halo. Enlarge
+        // that halo before applying a late affine transform so its support in
+        // every device-space direction remains at least two pixels:
+        // (0.5 hairline width + 1.5 antialias fringe). Since every vector is
+        // scaled by at least sigma_min, 2 / sigma_min is conservative under
+        // anisotropic scale and shear.
+        let extraPadding = max(
+            0.0,
+            2.0 / directStrokeScales.y - 2.0);
+        let boundsCenter = arc_bounds_center(
+            inColor.xy,
+            inTexCoord,
+            inShapeSize,
+            inColor.z,
+            inColor.w);
+        let quadrant = select(
+            vec2<f32>(-1.0),
+            vec2<f32>(1.0),
+            inPos >= boundsCenter);
+        inPos = inPos + quadrant * extraPadding;
+    }
+
+    if (isLocalPolygonSdf && hasLateAffineTransform && hasValidLateAffineTransform) {
+        // Polygon SDF payload stays in its pre-late-transform coordinate space;
+        // interpolation then provides the inverse affine map in the fragment.
+        // When Position and texCoord share that space (all quadrilateral stroke
+        // bodies and stroke triangles), conservatively enlarge their retained
+        // 1.5-unit raster pad for downscaled late transforms. Direct-fill
+        // triangles with a previously baked command transform intentionally do
+        // not satisfy this equality and retain their existing CPU-sized quad.
+        let sharedPositionCoordinates =
+            distance(input.position, input.texCoord) <= 0.0001;
+        if (sharedPositionCoordinates) {
+            let extraPadding = max(
+                0.0,
+                1.5 / directStrokeScales.y - 1.5);
+            var payloadMin = min(input.color.xy, input.color.zw);
+            var payloadMax = max(input.color.xy, input.color.zw);
+            payloadMin = min(payloadMin, input.shapeSize);
+            payloadMax = max(payloadMax, input.shapeSize);
+            if (sType >= 14u) {
+                let fourthPoint = vec2<f32>(
+                    input.cornerRadius,
+                    input.strokeThickness);
+                payloadMin = min(payloadMin, fourthPoint);
+                payloadMax = max(payloadMax, fourthPoint);
+            }
+            let payloadCenter = (payloadMin + payloadMax) * 0.5;
+            let quadrant = select(
+                vec2<f32>(-1.0),
+                vec2<f32>(1.0),
+                input.texCoord >= payloadCenter);
+            inPos = inPos + quadrant * extraPadding;
+            inTexCoord = inTexCoord + quadrant * extraPadding;
+        }
+    }
+
     if ((isStatic || useGpuTransforms) && sType != 8u) {
         if (useGpuTransforms) {
-            inPos = (uniforms.view * vec4<f32>(input.position, 0.0, 1.0)).xy;
-            if (sType == 12u) {
-                inTexCoord = (uniforms.view * vec4<f32>(input.texCoord, 0.0, 0.0)).xy;
-                inShapeSize = (uniforms.view * vec4<f32>(input.shapeSize, 0.0, 0.0)).xy;
-                inColor = vec4<f32>((uniforms.view * vec4<f32>(input.color.xy, 0.0, 1.0)).xy, input.color.z, input.color.w);
-            } else if (sType == 3u || sType == 5u || sType == 6u) {
-                inTexCoord = (uniforms.view * vec4<f32>(input.texCoord, 0.0, 1.0)).xy;
-                inShapeSize = (uniforms.view * vec4<f32>(input.shapeSize, 0.0, 1.0)).xy;
-                if (sType == 6u) {
-                    inColor = vec4<f32>((uniforms.view * vec4<f32>(input.color.rg, 0.0, 1.0)).xy, input.color.b, input.color.a);
+            if (!(useLocalStrokeOutline && isDirect2DStroke) &&
+                !isHairlineAdornment) {
+                inPos = (uniforms.view * vec4<f32>(inPos, 0.0, 1.0)).xy;
+                if (sType == 12u) {
+                    inTexCoord = (uniforms.view * vec4<f32>(input.texCoord, 0.0, 0.0)).xy;
+                    inShapeSize = (uniforms.view * vec4<f32>(input.shapeSize, 0.0, 0.0)).xy;
+                    inColor = vec4<f32>((uniforms.view * vec4<f32>(input.color.xy, 0.0, 1.0)).xy, input.color.z, input.color.w);
+                } else if (sType == 3u || sType == 5u || sType == 6u) {
+                    inTexCoord = (uniforms.view * vec4<f32>(input.texCoord, 0.0, 1.0)).xy;
+                    inShapeSize = (uniforms.view * vec4<f32>(input.shapeSize, 0.0, 1.0)).xy;
+                    if (sType == 6u) {
+                        inColor = vec4<f32>((uniforms.view * vec4<f32>(input.color.rg, 0.0, 1.0)).xy, input.color.b, input.color.a);
+                    }
                 }
-            } else if (sType < 3u || sType == 19u || sType == 20u) {
+            }
+            if (sType < 3u || sType == 19u || sType == 20u) {
                 let bIdx = u32(round(input.brushIndex));
                 let brush = brushes[bIdx];
                 if (brush.brushType > 0u) {
@@ -594,18 +822,22 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
                 }
             }
         } else {
-            inPos = (uniforms.mvp * vec4<f32>(input.position, 0.0, 1.0)).xy;
-            if (sType == 12u) {
-                inTexCoord = (uniforms.mvp * vec4<f32>(input.texCoord, 0.0, 0.0)).xy;
-                inShapeSize = (uniforms.mvp * vec4<f32>(input.shapeSize, 0.0, 0.0)).xy;
-                inColor = vec4<f32>((uniforms.mvp * vec4<f32>(input.color.xy, 0.0, 1.0)).xy, input.color.z, input.color.w);
-            } else if (sType == 3u || sType == 5u || sType == 6u) {
-                inTexCoord = (uniforms.mvp * vec4<f32>(input.texCoord, 0.0, 1.0)).xy;
-                inShapeSize = (uniforms.mvp * vec4<f32>(input.shapeSize, 0.0, 1.0)).xy;
-                if (sType == 6u) {
-                    inColor = vec4<f32>((uniforms.mvp * vec4<f32>(input.color.rg, 0.0, 1.0)).xy, input.color.b, input.color.a);
+            if (!(useLocalStrokeOutline && isDirect2DStroke) &&
+                !isHairlineAdornment) {
+                inPos = (uniforms.mvp * vec4<f32>(inPos, 0.0, 1.0)).xy;
+                if (sType == 12u) {
+                    inTexCoord = (uniforms.mvp * vec4<f32>(input.texCoord, 0.0, 0.0)).xy;
+                    inShapeSize = (uniforms.mvp * vec4<f32>(input.shapeSize, 0.0, 0.0)).xy;
+                    inColor = vec4<f32>((uniforms.mvp * vec4<f32>(input.color.xy, 0.0, 1.0)).xy, input.color.z, input.color.w);
+                } else if (sType == 3u || sType == 5u || sType == 6u) {
+                    inTexCoord = (uniforms.mvp * vec4<f32>(input.texCoord, 0.0, 1.0)).xy;
+                    inShapeSize = (uniforms.mvp * vec4<f32>(input.shapeSize, 0.0, 1.0)).xy;
+                    if (sType == 6u) {
+                        inColor = vec4<f32>((uniforms.mvp * vec4<f32>(input.color.rg, 0.0, 1.0)).xy, input.color.b, input.color.a);
+                    }
                 }
-            } else if (sType < 3u || sType == 19u || sType == 20u) {
+            }
+            if (sType < 3u || sType == 19u || sType == 20u) {
                 let bIdx = u32(round(input.brushIndex));
                 let brush = brushes[bIdx];
                 if (brush.brushType > 0u) {
@@ -620,8 +852,125 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
     var gridIndex = 0.0;
     var outputCornerRadius = input.cornerRadius;
     var outputShapeType = sType;
+    var discardGeneratedHairlineAdornment = false;
 
-    if (sType == 19u || sType == 20u) {
+    if (sType == 22u) {
+        // A cap descriptor stores a centerline endpoint and direction. Apply
+        // any retained late transform to those values first, normalize in
+        // framebuffer space, then expand one fixed quad around the exact
+        // one-pixel cap. color.x is PenLineCap, color.y isStart, color.z is a
+        // full-cap flag for degenerate paths, and shapeSize.x is vertex start.
+        var center = inPos;
+        var direction = inTexCoord;
+        if (useGpuTransforms) {
+            center = (uniforms.view * vec4<f32>(center, 0.0, 1.0)).xy;
+            direction = (uniforms.view * vec4<f32>(direction, 0.0, 0.0)).xy;
+        } else if (isStatic) {
+            center = (uniforms.mvp * vec4<f32>(center, 0.0, 1.0)).xy;
+            direction = (uniforms.mvp * vec4<f32>(direction, 0.0, 0.0)).xy;
+        }
+        direction = safe_normalize(direction);
+        if (length(direction) <= 0.0001) {
+            discardGeneratedHairlineAdornment = true;
+        }
+
+        let isStart = input.color.y > 0.5;
+        let outward = select(direction, -direction, isStart);
+        let normal = vec2<f32>(-direction.y, direction.x);
+        let localIndex = vertexIndex - u32(round(input.shapeSize.x));
+        var capCoordinate = vec2<f32>(-2.0, -2.0);
+        if (localIndex == 1u) {
+            capCoordinate = vec2<f32>(2.0, -2.0);
+        } else if (localIndex == 2u) {
+            capCoordinate = vec2<f32>(2.0, 2.0);
+        } else if (localIndex == 3u) {
+            capCoordinate = vec2<f32>(-2.0, 2.0);
+        }
+        worldPos = center + outward * capCoordinate.x +
+            normal * capCoordinate.y;
+        texCoord = capCoordinate;
+        inShapeSize = vec2<f32>(0.0);
+        outputCornerRadius = input.color.x;
+        outputStrokeThickness = input.color.z;
+        outputShapeType = 22u;
+        gridIndex = 0.0;
+    } else if (sType == 23u) {
+        // A join descriptor stores the center and its two centerline
+        // directions. Resolve the outer side, transformed angle, and miter
+        // limit in framebuffer space. One AABB quad then evaluates the bevel,
+        // miter, or round exterior analytically in the fragment shader.
+        var center = inPos;
+        var incoming = inTexCoord;
+        var outgoing = inShapeSize;
+        if (useGpuTransforms) {
+            center = (uniforms.view * vec4<f32>(center, 0.0, 1.0)).xy;
+            incoming = (uniforms.view * vec4<f32>(incoming, 0.0, 0.0)).xy;
+            outgoing = (uniforms.view * vec4<f32>(outgoing, 0.0, 0.0)).xy;
+        } else if (isStatic) {
+            center = (uniforms.mvp * vec4<f32>(center, 0.0, 1.0)).xy;
+            incoming = (uniforms.mvp * vec4<f32>(incoming, 0.0, 0.0)).xy;
+            outgoing = (uniforms.mvp * vec4<f32>(outgoing, 0.0, 0.0)).xy;
+        }
+        incoming = safe_normalize(incoming);
+        outgoing = safe_normalize(outgoing);
+        let turn = cross_2d(incoming, outgoing);
+        if (length(incoming) <= 0.0001 ||
+            length(outgoing) <= 0.0001 ||
+            abs(turn) <= 0.0001) {
+            discardGeneratedHairlineAdornment = true;
+        }
+
+        let outerSign = select(1.0, -1.0, turn > 0.0);
+        let previousOuter =
+            vec2<f32>(-incoming.y, incoming.x) * outerSign * 0.5;
+        let nextOuter =
+            vec2<f32>(-outgoing.y, outgoing.x) * outerSign * 0.5;
+        let denominator = cross_2d(incoming, outgoing);
+        var miterPoint = vec2<f32>(0.0);
+        var hasMiter = false;
+        if (abs(denominator) > 0.0001) {
+            let intersectionDistance =
+                cross_2d(nextOuter - previousOuter, outgoing) /
+                denominator;
+            let candidate = previousOuter + incoming * intersectionDistance;
+            let miterLimit = max(input.color.y, 1.0);
+            if (length(candidate) <= 0.5 * miterLimit + 0.0001) {
+                miterPoint = candidate;
+                hasMiter = true;
+            }
+        }
+
+        let joinKind = u32(round(input.color.x));
+        var boundsMin = min(vec2<f32>(0.0), min(previousOuter, nextOuter));
+        var boundsMax = max(vec2<f32>(0.0), max(previousOuter, nextOuter));
+        if (joinKind == 2u) {
+            boundsMin = vec2<f32>(-0.5);
+            boundsMax = vec2<f32>(0.5);
+        } else if (joinKind == 0u && hasMiter) {
+            boundsMin = min(boundsMin, miterPoint);
+            boundsMax = max(boundsMax, miterPoint);
+        }
+        boundsMin = boundsMin - vec2<f32>(1.5);
+        boundsMax = boundsMax + vec2<f32>(1.5);
+
+        let localIndex = vertexIndex - u32(round(input.color.z));
+        var joinCoordinate = boundsMin;
+        if (localIndex == 1u) {
+            joinCoordinate = vec2<f32>(boundsMax.x, boundsMin.y);
+        } else if (localIndex == 2u) {
+            joinCoordinate = boundsMax;
+        } else if (localIndex == 3u) {
+            joinCoordinate = vec2<f32>(boundsMin.x, boundsMax.y);
+        }
+        worldPos = center + joinCoordinate;
+        texCoord = joinCoordinate;
+        inColor = vec4<f32>(previousOuter, nextOuter);
+        inShapeSize = miterPoint;
+        outputCornerRadius = input.color.x;
+        outputStrokeThickness = select(0.0, 1.0, hasMiter);
+        outputShapeType = 23u;
+        gridIndex = select(-1.0, 1.0, turn > 0.0);
+    } else if (sType == 19u || sType == 20u) {
         // Algorithm: expand a retained point center by the encoded corner offset
         // after static/GPU transforms so a zero-width Skia hairline stays one
         // device pixel. Time and local-space complexity are O(1) per vertex.
@@ -662,8 +1011,8 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
             miterN = normalize(n1 + n2);
             miterScale = clamp(1.0 / max(dot(miterN, n1), 0.0001), 0.5, 4.0);
         }
-        let halfThickness = input.strokeThickness * 0.5;
-        let expandedDistance = halfThickness * miterScale + 1.5;
+        let halfThickness = outputStrokeThickness * 0.5;
+        let expandedDistance = halfThickness * miterScale + strokeExpansionPadding;
         let signVal = select(-1.0, 1.0, input.cornerRadius > 0.0);
         let offset = miterN * expandedDistance * signVal;
         worldPos = worldPos + offset;
@@ -692,8 +1041,8 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         if (len > 0.0001) {
             normal = vec2<f32>(-tangent.y, tangent.x) / len;
         }
-        let halfThickness = input.strokeThickness * 0.5;
-        let expandedDistance = halfThickness + 1.5;
+        let halfThickness = outputStrokeThickness * 0.5;
+        let expandedDistance = halfThickness + strokeExpansionPadding;
         let offset = normal * expandedDistance * signVal;
         worldPos = pos + offset;
         texCoord = pos;
@@ -733,22 +1082,45 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         if (len > 0.0001) {
             normal = vec2<f32>(-tangent.y, tangent.x) / len;
         }
-        let halfThickness = input.strokeThickness * 0.5;
-        let expandedDistance = halfThickness + 1.5;
+        let halfThickness = outputStrokeThickness * 0.5;
+        let expandedDistance = halfThickness + strokeExpansionPadding;
         let offset = normal * expandedDistance * signVal;
         worldPos = pos + offset;
         texCoord = pos;
         gridIndex = signVal * expandedDistance;
     } else if (sType == 12u) {
         // Fixed-quad native arc stroke. The fragment shader evaluates the
-        // transformed ellipse and WPF/SVG sweep directly, so the CPU does not
-        // tessellate valid arcs into a line strip.
+        // transformed ellipse for conformal transforms and the original local
+        // ellipse for non-conformal transforms, so the CPU does not tessellate
+        // valid arcs into a line strip.
         worldPos = inPos;
+        if (useLocalStrokeOutline) {
+            // The retained quad includes two local units of padding. Derive the
+            // tight partial-arc bounds from four fixed analytic extrema before
+            // extending its corners, rather than comparing against the ellipse
+            // center (a partial arc can lie wholly within one quadrant).
+            let extraPadding = max(0.0, strokeExpansionPadding - 2.0);
+            let boundsCenter = arc_bounds_center(
+                inColor.xy,
+                inTexCoord,
+                inShapeSize,
+                inColor.z,
+                inColor.w);
+            let quadrant = select(
+                vec2<f32>(-1.0),
+                vec2<f32>(1.0),
+                worldPos >= boundsCenter);
+            worldPos = worldPos + quadrant * extraPadding;
+        }
         texCoord = worldPos;
         outputCornerRadius = inTexCoord.x;
         gridIndex = inTexCoord.y;
     }
 
+    var brushCoord = texCoord;
+    if (isHairlineAdornment) {
+        brushCoord = worldPos;
+    }
     if (sType == 8u) {
         let local3D = vec3<f32>(inPos, inTexCoord.x);
         var pos3D = local3D;
@@ -760,24 +1132,41 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         output.position = uniforms.projection * vec4<f32>(pos3D, 1.0);
     } else {
         var pos = worldPos;
-        if (useGpuTransforms) {
-            // Since we pre-transformed inPos/inTexCoord/inShapeSize by uniforms.view,
-            // worldPos is already in screen-space. Do not transform it again!
-            pos = worldPos;
+        if (useLocalStrokeOutline) {
+            if (useGpuTransforms) {
+                pos = (uniforms.view * vec4<f32>(worldPos, 0.0, 1.0)).xy;
+                brushCoord = (uniforms.view * vec4<f32>(texCoord, 0.0, 1.0)).xy;
+            } else {
+                pos = (uniforms.mvp * vec4<f32>(worldPos, 0.0, 1.0)).xy;
+                brushCoord = (uniforms.mvp * vec4<f32>(texCoord, 0.0, 1.0)).xy;
+            }
         }
         output.position = uniforms.projection * vec4<f32>(pos, 0.0, 1.0);
+    }
+    if (discardLateAffineShape || discardGeneratedHairlineAdornment) {
+        // Collapse invalid/singular late-transformed primitives outside clip
+        // space. The fragment sentinel below is a second fail-closed guard.
+        output.position = vec4<f32>(2.0, 2.0, 0.0, 1.0);
     }
     output.color = inColor;
     output.texCoord = texCoord;
     output.brushIndex = input.brushIndex;
     output.shapeSize = inShapeSize;
     output.cornerRadius = outputCornerRadius;
-    output.strokeThickness = input.strokeThickness;
+    output.strokeThickness = outputStrokeThickness;
     output.shapeType = select(
         f32(outputShapeType),
         f32(outputShapeType) + 1000.0,
         aliasedEdge);
     output.gridIndex = gridIndex;
+    output.localStrokeMode = select(
+        select(
+            select(0.0, 1.0, useLocalStrokeOutline),
+            2.0,
+            isHairlineStroke),
+        -1.0,
+        discardLateAffineShape || discardGeneratedHairlineAdornment);
+    output.brushCoord = brushCoord;
     return output;
 }
 
@@ -810,6 +1199,8 @@ fn vs_solid_rect(input: VertexInput) -> VertexOutput {
     output.strokeThickness = input.strokeThickness;
     output.shapeType = select(0.0, 1000.0, aliasedEdge);
     output.gridIndex = 0.0;
+    output.localStrokeMode = 0.0;
+    output.brushCoord = input.texCoord;
     return output;
 }
 
@@ -933,6 +1324,8 @@ fn vs_solid_rounded(input: VertexInput) -> VertexOutput {
     output.strokeThickness = input.strokeThickness;
     output.shapeType = select(2.0, 1002.0, aliasedEdge);
     output.gridIndex = 0.0;
+    output.localStrokeMode = 0.0;
+    output.brushCoord = input.texCoord;
     return output;
 }
 
@@ -1249,6 +1642,8 @@ fn box_distance_gradient(
 fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
     let atlasCoordDx = dpdx(input.texCoord);
     let atlasCoordDy = dpdy(input.texCoord);
+    let strokeDistanceDx = dpdx(input.gridIndex);
+    let strokeDistanceDy = dpdy(input.gridIndex);
     var encodedShapeType = input.shapeType;
     let aliasedEdge = encodedShapeType >= 1000.0;
     if (aliasedEdge) {
@@ -1257,7 +1652,11 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
 
     let sType = u32(round(encodedShapeType));
 
-    var evalCoord = input.texCoord;
+    if (input.localStrokeMode < -0.5) {
+        discard;
+    }
+
+    var evalCoord = input.brushCoord;
     if (sType < 3u) {
         evalCoord = input.color.xy + input.texCoord;
     } else if (sType == 4u) {
@@ -1323,6 +1722,13 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
                         input.shapeSize,
                         input.cornerRadius)) / (2.0 * gradientStep);
         }
+        // Transform the local SDF gradient with derivatives obtained before
+        // non-uniform branching. Device hairlines use exactly one framebuffer
+        // pixel of width expressed in these local-distance units.
+        let fw = max(
+            abs(dot(gradient, atlasCoordDx)) + abs(dot(gradient, atlasCoordDy)),
+            0.0001);
+        let isHairline = input.localStrokeMode > 1.5;
         var d_shape: f32 = 0.0;
         if (input.strokeThickness > 0.0) {
             var strokeDistance = d;
@@ -1333,23 +1739,30 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
                 0.0,
                 0.0625,
                 !aliasedEdge && input.strokeThickness <= 1.0001);
-            d_shape = abs(strokeDistance) -
-                max(input.strokeThickness * 0.5 - thinStrokeInset, 0.0);
+            let ordinaryHalfWidth = max(
+                input.strokeThickness * 0.5 - thinStrokeInset,
+                0.0);
+            let hairlineHalfWidth = max(
+                fw * select(0.5, 0.4375, !aliasedEdge),
+                0.0);
+            d_shape = abs(strokeDistance) - select(
+                ordinaryHalfWidth,
+                hairlineHalfWidth,
+                isHairline);
         } else {
             d_shape = d;
         }
-        // Transform the local SDF gradient with derivatives obtained before
-        // non-uniform branching.
-        let fw = max(
-            abs(dot(gradient, atlasCoordDx)) + abs(dot(gradient, atlasCoordDy)),
-            0.0001);
         let antialiasedAlpha = 1.0 - smoothstep(-0.5 * fw, 0.5 * fw, d_shape);
         let aliasedAlpha = select(0.0, 1.0, d_shape <= 0.0);
         shapeAlpha = select(antialiasedAlpha, aliasedAlpha, aliasedEdge);
     } else if (sType == 12u) {
-        // Fixed-quad elliptical arc stroke SDF. color.xy carries the center,
-        // color.zw carries theta1/deltaTheta, cornerRadius/gridIndex carries
-        // axisX, shapeSize carries axisY, and texCoord is the pixel position.
+        // Fixed-quad elliptical arc stroke SDF. Under non-conformal transforms
+        // every value remains in command-local coordinates and only the quad
+        // positions are transformed. The distance gradient and interpolated
+        // local-coordinate derivatives convert AA back to framebuffer pixels.
+        // Conformal transforms retain the equivalent screen-space fast path.
+        // color.xy carries the center, color.zw theta1/deltaTheta,
+        // cornerRadius/gridIndex axisX, shapeSize axisY, and texCoord the point.
         let center = input.color.xy;
         let theta1 = input.color.z;
         let deltaTheta = input.color.w;
@@ -1358,23 +1771,43 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         let point = input.texCoord;
         let theta = nearest_ellipse_theta(point, center, axisX, axisY);
         let nearest = arc_eval(center, axisX, axisY, theta);
+        var distanceGradient = safe_normalize(point - nearest);
+        let initialDerivativeWidth = max(
+            abs(dot(distanceGradient, atlasCoordDx)) +
+                abs(dot(distanceGradient, atlasCoordDy)),
+            0.0001);
+        let initialFilterWidth = select(
+            1.0,
+            initialDerivativeWidth,
+            input.localStrokeMode > 0.5);
+        let effectiveStrokeThickness = select(
+            input.strokeThickness,
+            initialFilterWidth,
+            input.localStrokeMode > 1.5);
+        let deviceStrokeThickness =
+            effectiveStrokeThickness / initialFilterWidth;
         let thinStrokeInset = select(
             0.0,
-            0.0625,
-            !aliasedEdge && input.strokeThickness <= 1.0001);
+            0.0625 * initialFilterWidth,
+            !aliasedEdge && deviceStrokeThickness <= 1.0001);
         let effectiveHalfWidth = max(
-            input.strokeThickness * 0.5 - thinStrokeInset,
+            effectiveStrokeThickness * 0.5 - thinStrokeInset,
             0.0);
         var d_shape = length(point - nearest) - effectiveHalfWidth;
         let radiusX = length(axisX);
         let radiusY = length(axisY);
         if (abs(radiusX - radiusY) <= 0.0001) {
             let signedDistance = length(point - center) - radiusX;
+            let radialGradient = safe_normalize(point - center);
             if (aliasedEdge) {
                 d_shape = abs(signedDistance + 0.08) -
-                    input.strokeThickness * 0.5;
+                    effectiveStrokeThickness * 0.5;
+                distanceGradient = radialGradient *
+                    select(-1.0, 1.0, signedDistance + 0.08 >= 0.0);
             } else {
                 d_shape = abs(signedDistance) - effectiveHalfWidth;
+                distanceGradient = radialGradient *
+                    select(-1.0, 1.0, signedDistance >= 0.0);
             }
         }
 
@@ -1386,18 +1819,32 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
             let startCap = -dot(point - startPoint, startTangent);
             let endCap = dot(point - endPoint, endTangent);
             let capDistance = max(startCap, endCap);
+            let capGradient = select(
+                -startTangent,
+                endTangent,
+                endCap >= startCap);
             let insideSweep = is_angle_inside_arc(theta, theta1, deltaTheta);
-            d_shape = select(max(d_shape, capDistance), d_shape, insideSweep);
+            if (!insideSweep && capDistance > d_shape) {
+                d_shape = capDistance;
+                distanceGradient = capGradient;
+            }
         }
 
-        // Arc distance is evaluated in framebuffer pixels and has unit gradient.
-        let fw = 1.0;
+        let derivativeWidth = max(
+            abs(dot(distanceGradient, atlasCoordDx)) +
+                abs(dot(distanceGradient, atlasCoordDy)),
+            0.0001);
+        let fw = select(
+            1.0,
+            derivativeWidth,
+            input.localStrokeMode > 0.5);
         let antialiasedAlpha = 1.0 - smoothstep(-0.5 * fw, 0.5 * fw, d_shape);
         let aliasedAlpha = select(0.0, 1.0, d_shape <= 0.0);
         shapeAlpha = select(antialiasedAlpha, aliasedAlpha, aliasedEdge);
     } else if (sType == 13u) {
         // Antialiased stroke join/cap triangle. color.xy/color.zw/shapeSize
-        // carry its three screen-space points and texCoord carries the pixel.
+        // carry its three pre-late-transform points and texCoord carries the
+        // point in that same coordinate space.
         let p0 = input.color.xy;
         let p1 = input.color.zw;
         let p2 = input.shapeSize;
@@ -1416,6 +1863,24 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         let distance2 = -orientation *
             (edge2.x * (point.y - p2.y) - edge2.y * (point.x - p2.x)) /
             max(length(edge2), 0.0001);
+        let gradient0 = orientation *
+            vec2<f32>(edge0.y, -edge0.x) / max(length(edge0), 0.0001);
+        let gradient1 = orientation *
+            vec2<f32>(edge1.y, -edge1.x) / max(length(edge1), 0.0001);
+        let gradient2 = orientation *
+            vec2<f32>(edge2.y, -edge2.x) / max(length(edge2), 0.0001);
+        let width0 = max(
+            abs(dot(gradient0, atlasCoordDx)) +
+                abs(dot(gradient0, atlasCoordDy)),
+            0.0001);
+        let width1 = max(
+            abs(dot(gradient1, atlasCoordDx)) +
+                abs(dot(gradient1, atlasCoordDy)),
+            0.0001);
+        let width2 = max(
+            abs(dot(gradient2, atlasCoordDx)) +
+                abs(dot(gradient2, atlasCoordDy)),
+            0.0001);
         let allDistance = max(distance0, max(distance1, distance2));
         let edgeMask = u32(round(input.cornerRadius));
         let ownedInternalEdgeMask = u32(round(input.strokeThickness));
@@ -1433,14 +1898,20 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
                 select(distance2 < -internalEdgeTolerance, distance2 <= internalEdgeTolerance, (ownedInternalEdgeMask & 4u) != 0u),
                 true,
                 (edgeMask & 4u) != 0u);
-        let exteriorDistance = max(
-            select(-1000000.0, distance0, (edgeMask & 1u) != 0u),
-            max(
-                select(-1000000.0, distance1, (edgeMask & 2u) != 0u),
-                select(-1000000.0, distance2, (edgeMask & 4u) != 0u)));
-        // The edge equations and fragment position are both in framebuffer pixels,
-        // so a one-pixel filter width is exact and avoids branch-local derivatives.
-        let fw = 1.0;
+        var exteriorDistance = -1000000.0;
+        var fw = 1.0;
+        if ((edgeMask & 1u) != 0u && distance0 > exteriorDistance) {
+            exteriorDistance = distance0;
+            fw = width0;
+        }
+        if ((edgeMask & 2u) != 0u && distance1 > exteriorDistance) {
+            exteriorDistance = distance1;
+            fw = width1;
+        }
+        if ((edgeMask & 4u) != 0u && distance2 > exteriorDistance) {
+            exteriorDistance = distance2;
+            fw = width2;
+        }
         let antialiasedAlpha = select(
             0.0,
             1.0 - smoothstep(-0.5 * fw, 0.5 * fw, exteriorDistance),
@@ -1449,7 +1920,8 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         shapeAlpha = select(antialiasedAlpha, aliasedAlpha, aliasedEdge);
     } else if (sType >= 14u && sType <= 17u) {
         // Antialiased affine stroke segment. color.xy/color.zw/shapeSize and
-        // cornerRadius/strokeThickness carry its four screen-space corners.
+        // cornerRadius/strokeThickness carry its four pre-late-transform
+        // corners; texCoord remains in the same space.
         // Types 15-17 keep shared curve cross-sections hard-owned so adjacent
         // sections do not introduce antialiased seams.
         let p0 = input.color.xy;
@@ -1475,6 +1947,30 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         let distance3 = -orientation *
             (edge3.x * (point.y - p3.y) - edge3.y * (point.x - p3.x)) /
             max(length(edge3), 0.0001);
+        let gradient0 = orientation *
+            vec2<f32>(edge0.y, -edge0.x) / max(length(edge0), 0.0001);
+        let gradient1 = orientation *
+            vec2<f32>(edge1.y, -edge1.x) / max(length(edge1), 0.0001);
+        let gradient2 = orientation *
+            vec2<f32>(edge2.y, -edge2.x) / max(length(edge2), 0.0001);
+        let gradient3 = orientation *
+            vec2<f32>(edge3.y, -edge3.x) / max(length(edge3), 0.0001);
+        let width0 = max(
+            abs(dot(gradient0, atlasCoordDx)) +
+                abs(dot(gradient0, atlasCoordDy)),
+            0.0001);
+        let width1 = max(
+            abs(dot(gradient1, atlasCoordDx)) +
+                abs(dot(gradient1, atlasCoordDy)),
+            0.0001);
+        let width2 = max(
+            abs(dot(gradient2, atlasCoordDx)) +
+                abs(dot(gradient2, atlasCoordDy)),
+            0.0001);
+        let width3 = max(
+            abs(dot(gradient3, atlasCoordDx)) +
+                abs(dot(gradient3, atlasCoordDy)),
+            0.0001);
         let allDistance = max(max(distance0, distance1), max(distance2, distance3));
         var exteriorEdgeMask = 15u;
         if (sType == 15u) {
@@ -1489,16 +1985,24 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
             ((exteriorEdgeMask & 2u) != 0u || distance1 <= 0.0) &&
             ((exteriorEdgeMask & 4u) != 0u || distance2 <= 0.0) &&
             ((exteriorEdgeMask & 8u) != 0u || distance3 <= 0.0);
-        let exteriorDistance = max(
-            max(
-                select(-1000000.0, distance0, (exteriorEdgeMask & 1u) != 0u),
-                select(-1000000.0, distance1, (exteriorEdgeMask & 2u) != 0u)),
-            max(
-                select(-1000000.0, distance2, (exteriorEdgeMask & 4u) != 0u),
-                select(-1000000.0, distance3, (exteriorEdgeMask & 8u) != 0u)));
-        // The edge equations and fragment position are both in framebuffer pixels,
-        // so a one-pixel filter width is exact and avoids branch-local derivatives.
-        let fw = 1.0;
+        var exteriorDistance = -1000000.0;
+        var fw = 1.0;
+        if ((exteriorEdgeMask & 1u) != 0u && distance0 > exteriorDistance) {
+            exteriorDistance = distance0;
+            fw = width0;
+        }
+        if ((exteriorEdgeMask & 2u) != 0u && distance1 > exteriorDistance) {
+            exteriorDistance = distance1;
+            fw = width1;
+        }
+        if ((exteriorEdgeMask & 4u) != 0u && distance2 > exteriorDistance) {
+            exteriorDistance = distance2;
+            fw = width2;
+        }
+        if ((exteriorEdgeMask & 8u) != 0u && distance3 > exteriorDistance) {
+            exteriorDistance = distance3;
+            fw = width3;
+        }
         let antialiasedAlpha = select(
             0.0,
             1.0 - smoothstep(-0.5 * fw, 0.5 * fw, exteriorDistance),
@@ -1506,15 +2010,25 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         let aliasedAlpha = select(0.0, 1.0, allDistance <= 0.0);
         shapeAlpha = select(antialiasedAlpha, aliasedAlpha, aliasedEdge);
     } else if (sType == 3u || sType == 5u || sType == 6u) {
-        // Line, Quadratic, and Cubic Bezier stroke anti-aliasing via signed pixel distance
-        let d_pixels = abs(input.gridIndex);
+        // Conformal strokes use signed pixel distance. Non-conformal strokes
+        // interpolate signed local distance across the transformed outline and
+        // use derivatives to express the AA ramp in framebuffer pixels.
+        let derivativeWidth = max(
+            abs(strokeDistanceDx) + abs(strokeDistanceDy),
+            0.0001);
+        let filterWidth = select(
+            1.0,
+            derivativeWidth,
+            input.localStrokeMode > 0.5);
+        let deviceStrokeThickness = input.strokeThickness / filterWidth;
+        let d_stroke = abs(input.gridIndex);
         let thinStrokeInset = select(
             0.0,
-            0.0625,
-            !aliasedEdge && input.strokeThickness <= 1.0001);
-        let d_shape = d_pixels -
+            0.0625 * filterWidth,
+            !aliasedEdge && deviceStrokeThickness <= 1.0001);
+        let d_shape = d_stroke -
             max(input.strokeThickness * 0.5 - thinStrokeInset, 0.0);
-        let antialiasHalfWidth = 0.5;
+        let antialiasHalfWidth = 0.5 * filterWidth;
         let linearAntialiasedAlpha = 1.0 - smoothstep(
             -antialiasHalfWidth,
             antialiasHalfWidth,
@@ -1569,6 +2083,196 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
             0.0001);
         shapeAlpha = 1.0 -
             smoothstep(-0.5 * filterWidth, 0.5 * filterWidth, dotDistance);
+    } else if (sType == 22u) {
+        // Analytic one-device-pixel path cap. The cap/body interface is a
+        // hard-owned internal seam; only the round, square, or triangular
+        // exterior contributes antialias coverage. Work and storage are O(1).
+        let point = input.texCoord;
+        let capKind = u32(round(input.cornerRadius));
+        let isFullCap = input.strokeThickness > 0.5;
+        var exteriorDistance = 0.0;
+        var exteriorGradient = vec2<f32>(1.0, 0.0);
+        var internalInside = true;
+        var allDistance = 0.0;
+        if (capKind == 2u) {
+            exteriorDistance = length(point) - 0.5;
+            exteriorGradient = safe_normalize(point);
+            internalInside = isFullCap || point.x >= -0.001;
+            allDistance = exteriorDistance;
+        } else if (capKind == 1u) {
+            if (isFullCap) {
+                let distanceGradient = box_distance_gradient(
+                    point,
+                    vec2<f32>(0.5),
+                    0.0);
+                exteriorDistance = distanceGradient.x;
+                exteriorGradient = distanceGradient.yz;
+                allDistance = exteriorDistance;
+            } else {
+                let forwardDistance = point.x - 0.5;
+                let sideDistance = abs(point.y) - 0.5;
+                exteriorDistance = max(forwardDistance, sideDistance);
+                exteriorGradient = select(
+                    vec2<f32>(0.0, select(-1.0, 1.0, point.y >= 0.0)),
+                    vec2<f32>(1.0, 0.0),
+                    forwardDistance >= sideDistance);
+                internalInside = point.x >= -0.001;
+                allDistance = max(exteriorDistance, -point.x);
+            }
+        } else {
+            let p0 = vec2<f32>(0.0, -0.5);
+            let p1 = vec2<f32>(0.5, 0.0);
+            let p2 = vec2<f32>(0.0, 0.5);
+            let edge0 = p1 - p0;
+            let edge1 = p2 - p1;
+            let edge2 = p0 - p2;
+            let distance0 = -cross_2d(edge0, point - p0) /
+                max(length(edge0), 0.0001);
+            let distance1 = -cross_2d(edge1, point - p1) /
+                max(length(edge1), 0.0001);
+            let distance2 = -cross_2d(edge2, point - p2) /
+                max(length(edge2), 0.0001);
+            let gradient0 = vec2<f32>(edge0.y, -edge0.x) /
+                max(length(edge0), 0.0001);
+            let gradient1 = vec2<f32>(edge1.y, -edge1.x) /
+                max(length(edge1), 0.0001);
+            exteriorDistance = max(distance0, distance1);
+            exteriorGradient = select(
+                gradient1,
+                gradient0,
+                distance0 >= distance1);
+            internalInside = distance2 <= 0.001;
+            allDistance = max(exteriorDistance, distance2);
+        }
+
+        let filterWidth = max(
+            abs(dot(exteriorGradient, atlasCoordDx)) +
+                abs(dot(exteriorGradient, atlasCoordDy)),
+            0.0001);
+        let antialiasedAlpha = select(
+            0.0,
+            1.0 - smoothstep(
+                -0.5 * filterWidth,
+                0.5 * filterWidth,
+                exteriorDistance),
+            internalInside);
+        let aliasedAlpha = select(
+            0.0,
+            1.0,
+            internalInside && allDistance <= 0.0);
+        shapeAlpha = select(antialiasedAlpha, aliasedAlpha, aliasedEdge);
+    } else if (sType == 23u) {
+        // Analytic one-device-pixel path join. color stores the two outer
+        // offsets, shapeSize stores a valid miter intersection, cornerRadius
+        // selects miter/bevel/round, and gridIndex preserves turn direction.
+        // Body-facing radial edges are hard-owned to prevent overlap seams.
+        let point = input.texCoord;
+        let previousOuter = input.color.xy;
+        let nextOuter = input.color.zw;
+        let miterPoint = input.shapeSize;
+        let joinKind = u32(round(input.cornerRadius));
+        var exteriorDistance = 0.0;
+        var exteriorGradient = vec2<f32>(1.0, 0.0);
+        var internalInside = true;
+        var allDistance = 0.0;
+
+        if (joinKind == 2u) {
+            let startAngle = atan2(previousOuter.y, previousOuter.x);
+            let endAngle = atan2(nextOuter.y, nextOuter.x);
+            var sweep = endAngle - startAngle;
+            if (input.gridIndex > 0.0 && sweep < 0.0) {
+                sweep = sweep + PROGPU_TWO_PI;
+            } else if (input.gridIndex < 0.0 && sweep > 0.0) {
+                sweep = sweep - PROGPU_TWO_PI;
+            }
+            let pointAngle = atan2(point.y, point.x);
+            internalInside = is_angle_inside_arc(
+                pointAngle,
+                startAngle,
+                sweep);
+            exteriorDistance = length(point) - 0.5;
+            exteriorGradient = safe_normalize(point);
+            allDistance = exteriorDistance;
+        } else if (joinKind == 0u && input.strokeThickness > 0.5) {
+            // Convex miter polygon order: previous outer, intersection, next
+            // outer, center. Only the first two edges are exterior.
+            let p0 = previousOuter;
+            let p1 = miterPoint;
+            let p2 = nextOuter;
+            let p3 = vec2<f32>(0.0);
+            let edge0 = p1 - p0;
+            let edge1 = p2 - p1;
+            let edge2 = p3 - p2;
+            let edge3 = p0 - p3;
+            let orientation = select(
+                -1.0,
+                1.0,
+                cross_2d(edge0, p2 - p0) >= 0.0);
+            let distance0 = -orientation * cross_2d(edge0, point - p0) /
+                max(length(edge0), 0.0001);
+            let distance1 = -orientation * cross_2d(edge1, point - p1) /
+                max(length(edge1), 0.0001);
+            let distance2 = -orientation * cross_2d(edge2, point - p2) /
+                max(length(edge2), 0.0001);
+            let distance3 = -orientation * cross_2d(edge3, point - p3) /
+                max(length(edge3), 0.0001);
+            let gradient0 = orientation *
+                vec2<f32>(edge0.y, -edge0.x) /
+                max(length(edge0), 0.0001);
+            let gradient1 = orientation *
+                vec2<f32>(edge1.y, -edge1.x) /
+                max(length(edge1), 0.0001);
+            exteriorDistance = max(distance0, distance1);
+            exteriorGradient = select(
+                gradient1,
+                gradient0,
+                distance0 >= distance1);
+            internalInside = distance2 <= 0.001 && distance3 <= 0.001;
+            allDistance = max(
+                max(distance0, distance1),
+                max(distance2, distance3));
+        } else {
+            // Bevel, including a miter that exceeds its transformed limit.
+            let p0 = previousOuter;
+            let p1 = vec2<f32>(0.0);
+            let p2 = nextOuter;
+            let edge0 = p1 - p0;
+            let edge1 = p2 - p1;
+            let edge2 = p0 - p2;
+            let orientation = select(
+                -1.0,
+                1.0,
+                cross_2d(edge0, p2 - p0) >= 0.0);
+            let distance0 = -orientation * cross_2d(edge0, point - p0) /
+                max(length(edge0), 0.0001);
+            let distance1 = -orientation * cross_2d(edge1, point - p1) /
+                max(length(edge1), 0.0001);
+            let distance2 = -orientation * cross_2d(edge2, point - p2) /
+                max(length(edge2), 0.0001);
+            exteriorGradient = orientation *
+                vec2<f32>(edge2.y, -edge2.x) /
+                max(length(edge2), 0.0001);
+            exteriorDistance = distance2;
+            internalInside = distance0 <= 0.001 && distance1 <= 0.001;
+            allDistance = max(distance2, max(distance0, distance1));
+        }
+
+        let filterWidth = max(
+            abs(dot(exteriorGradient, atlasCoordDx)) +
+                abs(dot(exteriorGradient, atlasCoordDy)),
+            0.0001);
+        let antialiasedAlpha = select(
+            0.0,
+            1.0 - smoothstep(
+                -0.5 * filterWidth,
+                0.5 * filterWidth,
+                exteriorDistance),
+            internalInside);
+        let aliasedAlpha = select(
+            0.0,
+            1.0,
+            internalInside && allDistance <= 0.0);
+        shapeAlpha = select(antialiasedAlpha, aliasedAlpha, aliasedEdge);
     }
 
     if (shapeAlpha <= 0.0) {
@@ -1581,7 +2285,9 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
 
     var finalColor = input.color;
     if (brush.brushType == 0u) {
-        if (sType == 5u || sType == 6u || (sType >= 12u && sType <= 18u)) {
+        if (sType == 5u || sType == 6u ||
+            (sType >= 12u && sType <= 18u) ||
+            sType == 22u || sType == 23u) {
             finalColor = vec4<f32>(brush.stopColors0.rgb, brush.stopColors0.a * brush.opacity);
         } else {
             finalColor = vec4<f32>(input.color.rgb, input.color.a * brush.opacity);

--- a/src/ProGPU.Backend/Shaders/Vector.wgsl
+++ b/src/ProGPU.Backend/Shaders/Vector.wgsl
@@ -1,5 +1,5 @@
-// Algorithm: Expand and transform batched vector primitives and meshes; direct 2D strokes use a scalar screen-space fast path for conformal transforms and an exact transformed local-outline path with derivative anti-aliasing for anisotropic or sheared transforms; the reserved Skia hairline sentinel derives an invariant one-framebuffer-pixel width from screen-space expansion or analytic-distance derivatives, while one fixed quad regenerates each cap or join from transformed centerline directions and evaluates its exterior analytically with hard-owned body seams; evaluate analytic curves, arcs, and quarter-pixel-snapped periodic dot grids; use exact single-evaluation box/rounded-box distance gradients; then shade fills, strokes, gradients, vertex-color blends, and edges. Dedicated solid-rectangle and adaptively selected circular-rounded-rectangle entry points avoid the general material/path program for dense UI chrome.
-// Time complexity: O(1) per vertex or fragment under the shader's fixed primitive and gradient limits; static draws reuse CPU-cached maximum/minimum singular values, dynamic GPU-transformed direct strokes and hairline bounds add fixed 2x2 matrix arithmetic and two square roots per vertex, non-conformal arc quads test four analytic extrema per vertex, hairline caps/joins use one fixed quad with bounded line-intersection and at most four signed-edge evaluations, and non-conformal or analytic-hairline stroke fragments add fixed derivative/gradient arithmetic.
+// Algorithm: Expand and transform batched vector primitives and meshes; direct 2D strokes use a scalar screen-space fast path for conformal transforms and an exact transformed local-outline path with derivative anti-aliasing for anisotropic or sheared transforms; reserved negative width encodings select either the Skia one-framebuffer-pixel hairline or an arbitrary positive fixed-device width, both expanded after the late transform, while one fixed quad regenerates each cap or join from transformed centerline directions and evaluates its exterior analytically with hard-owned body seams; evaluate analytic curves, arcs, and quarter-pixel-snapped periodic dot grids; use exact single-evaluation box/rounded-box distance gradients; then shade fills, strokes, gradients, vertex-color blends, and edges. Dedicated solid-rectangle and adaptively selected circular-rounded-rectangle entry points avoid the general material/path program for dense UI chrome.
+// Time complexity: O(1) per vertex or fragment under the shader's fixed primitive and gradient limits; static draws reuse CPU-cached maximum/minimum singular values, dynamic GPU-transformed direct strokes and fixed-device bounds add fixed 2x2 matrix arithmetic and two square roots per vertex, non-conformal arc quads test four analytic extrema per vertex, fixed-device caps/joins use one fixed quad with bounded line-intersection and at most four signed-edge evaluations, and non-conformal or analytic fixed-device stroke fragments add fixed derivative/gradient arithmetic.
 // Space complexity: O(1) local storage and bounded uniform/storage reads; texture masks add one sample per fragment while analytic rounded and uniform-opacity masks add fixed derivative arithmetic and no texture bandwidth.
 struct Brush {
     brushType: u32,
@@ -682,6 +682,12 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
     let isHairlineStroke =
         (isAnalyticSdf || isDirect2DStroke) &&
         input.strokeThickness == -1.0;
+    let isFixedDeviceStroke =
+        (isAnalyticSdf || isDirect2DStroke) &&
+        input.strokeThickness < -1.0;
+    let fixedDeviceStrokeThickness = max(
+        -input.strokeThickness - 1.0,
+        0.0);
     let hasLateAffineTransform = isStatic || useGpuTransforms;
     var directStrokeScales = vec2<f32>(1.0);
     if ((isAnalyticSdf || isDirect2DStroke || isLocalPolygonSdf) && hasLateAffineTransform) {
@@ -697,6 +703,7 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
     let useLocalStrokeOutline =
         isDirect2DStroke &&
         !isHairlineStroke &&
+        !isFixedDeviceStroke &&
         hasLateAffineTransform &&
         hasValidLateAffineTransform &&
         !is_conformal_stroke_transform(directStrokeScales);
@@ -704,8 +711,13 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         input.strokeThickness,
         1.0,
         isHairlineStroke);
+    outputStrokeThickness = select(
+        outputStrokeThickness,
+        fixedDeviceStrokeThickness,
+        isFixedDeviceStroke);
     if (isDirect2DStroke &&
         !isHairlineStroke &&
+        !isFixedDeviceStroke &&
         hasLateAffineTransform &&
         hasValidLateAffineTransform &&
         !useLocalStrokeOutline) {
@@ -717,7 +729,7 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         useLocalStrokeOutline);
 
     if (isAnalyticSdf &&
-        isHairlineStroke &&
+        (isHairlineStroke || isFixedDeviceStroke) &&
         hasLateAffineTransform &&
         hasValidLateAffineTransform) {
         // CPU recording reserves a two-local-unit halo for a device hairline
@@ -725,9 +737,13 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         // downscale needs a larger local quad so that the same two framebuffer
         // pixels remain covered after interpolation. The SDF itself derives
         // its exact one-pixel width from fragment derivatives below.
+        let retainedPadding = select(
+            2.0,
+            fixedDeviceStrokeThickness * 0.5 + 1.5,
+            isFixedDeviceStroke);
         let extraPadding = max(
             0.0,
-            2.0 / directStrokeScales.y - 2.0);
+            retainedPadding / directStrokeScales.y - retainedPadding);
         let quadrant = select(
             vec2<f32>(-1.0),
             vec2<f32>(1.0),
@@ -737,7 +753,7 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
     }
 
     if (sType == 12u &&
-        isHairlineStroke &&
+        (isHairlineStroke || isFixedDeviceStroke) &&
         hasLateAffineTransform &&
         hasValidLateAffineTransform) {
         // Arc stroke quads are recorded with a two-local-unit halo. Enlarge
@@ -746,9 +762,13 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         // (0.5 hairline width + 1.5 antialias fringe). Since every vector is
         // scaled by at least sigma_min, 2 / sigma_min is conservative under
         // anisotropic scale and shear.
+        let retainedPadding = select(
+            2.0,
+            fixedDeviceStrokeThickness * 0.5 + 1.5,
+            isFixedDeviceStroke);
         let extraPadding = max(
             0.0,
-            2.0 / directStrokeScales.y - 2.0);
+            retainedPadding / directStrokeScales.y - retainedPadding);
         let boundsCenter = arc_bounds_center(
             inColor.xy,
             inTexCoord,
@@ -877,19 +897,24 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         let isStart = input.color.y > 0.5;
         let outward = select(direction, -direction, isStart);
         let normal = vec2<f32>(-direction.y, direction.x);
+        let deviceStrokeThickness = select(
+            1.0,
+            fixedDeviceStrokeThickness,
+            isFixedDeviceStroke);
+        let capExtent = deviceStrokeThickness * 0.5 + 1.5;
         let localIndex = vertexIndex - u32(round(input.shapeSize.x));
-        var capCoordinate = vec2<f32>(-2.0, -2.0);
+        var capCoordinate = vec2<f32>(-capExtent, -capExtent);
         if (localIndex == 1u) {
-            capCoordinate = vec2<f32>(2.0, -2.0);
+            capCoordinate = vec2<f32>(capExtent, -capExtent);
         } else if (localIndex == 2u) {
-            capCoordinate = vec2<f32>(2.0, 2.0);
+            capCoordinate = vec2<f32>(capExtent, capExtent);
         } else if (localIndex == 3u) {
-            capCoordinate = vec2<f32>(-2.0, 2.0);
+            capCoordinate = vec2<f32>(-capExtent, capExtent);
         }
         worldPos = center + outward * capCoordinate.x +
             normal * capCoordinate.y;
         texCoord = capCoordinate;
-        inShapeSize = vec2<f32>(0.0);
+        inShapeSize = vec2<f32>(deviceStrokeThickness, 0.0);
         outputCornerRadius = input.color.x;
         outputStrokeThickness = input.color.z;
         outputShapeType = 22u;
@@ -921,10 +946,15 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         }
 
         let outerSign = select(1.0, -1.0, turn > 0.0);
+        let deviceStrokeThickness = select(
+            1.0,
+            fixedDeviceStrokeThickness,
+            isFixedDeviceStroke);
+        let halfStrokeThickness = deviceStrokeThickness * 0.5;
         let previousOuter =
-            vec2<f32>(-incoming.y, incoming.x) * outerSign * 0.5;
+            vec2<f32>(-incoming.y, incoming.x) * outerSign * halfStrokeThickness;
         let nextOuter =
-            vec2<f32>(-outgoing.y, outgoing.x) * outerSign * 0.5;
+            vec2<f32>(-outgoing.y, outgoing.x) * outerSign * halfStrokeThickness;
         let denominator = cross_2d(incoming, outgoing);
         var miterPoint = vec2<f32>(0.0);
         var hasMiter = false;
@@ -934,7 +964,7 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
                 denominator;
             let candidate = previousOuter + incoming * intersectionDistance;
             let miterLimit = max(input.color.y, 1.0);
-            if (length(candidate) <= 0.5 * miterLimit + 0.0001) {
+            if (length(candidate) <= halfStrokeThickness * miterLimit + 0.0001) {
                 miterPoint = candidate;
                 hasMiter = true;
             }
@@ -944,8 +974,8 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
         var boundsMin = min(vec2<f32>(0.0), min(previousOuter, nextOuter));
         var boundsMax = max(vec2<f32>(0.0), max(previousOuter, nextOuter));
         if (joinKind == 2u) {
-            boundsMin = vec2<f32>(-0.5);
-            boundsMax = vec2<f32>(0.5);
+            boundsMin = vec2<f32>(-halfStrokeThickness);
+            boundsMax = vec2<f32>(halfStrokeThickness);
         } else if (joinKind == 0u && hasMiter) {
             boundsMin = min(boundsMin, miterPoint);
             boundsMax = max(boundsMax, miterPoint);
@@ -1161,7 +1191,10 @@ fn vs_main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> Verte
     output.gridIndex = gridIndex;
     output.localStrokeMode = select(
         select(
-            select(0.0, 1.0, useLocalStrokeOutline),
+            select(
+                select(0.0, 1.0, useLocalStrokeOutline),
+                3.0,
+                isFixedDeviceStroke),
             2.0,
             isHairlineStroke),
         -1.0,
@@ -1728,7 +1761,9 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         let fw = max(
             abs(dot(gradient, atlasCoordDx)) + abs(dot(gradient, atlasCoordDy)),
             0.0001);
-        let isHairline = input.localStrokeMode > 1.5;
+        let isHairline =
+            input.localStrokeMode > 1.5 &&
+            input.localStrokeMode < 2.5;
         var d_shape: f32 = 0.0;
         if (input.strokeThickness > 0.0) {
             var strokeDistance = d;
@@ -1737,10 +1772,15 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
             }
             let thinStrokeInset = select(
                 0.0,
-                0.0625,
+                0.0625 * select(
+                    1.0,
+                    fw,
+                    input.localStrokeMode > 2.5),
                 !aliasedEdge && input.strokeThickness <= 1.0001);
             let ordinaryHalfWidth = max(
-                input.strokeThickness * 0.5 - thinStrokeInset,
+                input.strokeThickness *
+                    select(1.0, fw, input.localStrokeMode > 2.5) *
+                    0.5 - thinStrokeInset,
                 0.0);
             let hairlineHalfWidth = max(
                 fw * select(0.5, 0.4375, !aliasedEdge),
@@ -1780,10 +1820,14 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
             1.0,
             initialDerivativeWidth,
             input.localStrokeMode > 0.5);
-        let effectiveStrokeThickness = select(
+        var effectiveStrokeThickness = select(
             input.strokeThickness,
             initialFilterWidth,
             input.localStrokeMode > 1.5);
+        effectiveStrokeThickness = select(
+            effectiveStrokeThickness,
+            input.strokeThickness * initialFilterWidth,
+            input.localStrokeMode > 2.5);
         let deviceStrokeThickness =
             effectiveStrokeThickness / initialFilterWidth;
         let thinStrokeInset = select(
@@ -2090,12 +2134,13 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
         let point = input.texCoord;
         let capKind = u32(round(input.cornerRadius));
         let isFullCap = input.strokeThickness > 0.5;
+        let halfStrokeThickness = input.shapeSize.x * 0.5;
         var exteriorDistance = 0.0;
         var exteriorGradient = vec2<f32>(1.0, 0.0);
         var internalInside = true;
         var allDistance = 0.0;
         if (capKind == 2u) {
-            exteriorDistance = length(point) - 0.5;
+            exteriorDistance = length(point) - halfStrokeThickness;
             exteriorGradient = safe_normalize(point);
             internalInside = isFullCap || point.x >= -0.001;
             allDistance = exteriorDistance;
@@ -2103,14 +2148,14 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
             if (isFullCap) {
                 let distanceGradient = box_distance_gradient(
                     point,
-                    vec2<f32>(0.5),
+                    vec2<f32>(halfStrokeThickness),
                     0.0);
                 exteriorDistance = distanceGradient.x;
                 exteriorGradient = distanceGradient.yz;
                 allDistance = exteriorDistance;
             } else {
-                let forwardDistance = point.x - 0.5;
-                let sideDistance = abs(point.y) - 0.5;
+                let forwardDistance = point.x - halfStrokeThickness;
+                let sideDistance = abs(point.y) - halfStrokeThickness;
                 exteriorDistance = max(forwardDistance, sideDistance);
                 exteriorGradient = select(
                     vec2<f32>(0.0, select(-1.0, 1.0, point.y >= 0.0)),
@@ -2120,9 +2165,9 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
                 allDistance = max(exteriorDistance, -point.x);
             }
         } else {
-            let p0 = vec2<f32>(0.0, -0.5);
-            let p1 = vec2<f32>(0.5, 0.0);
-            let p2 = vec2<f32>(0.0, 0.5);
+            let p0 = vec2<f32>(0.0, -halfStrokeThickness);
+            let p1 = vec2<f32>(halfStrokeThickness, 0.0);
+            let p2 = vec2<f32>(0.0, halfStrokeThickness);
             let edge0 = p1 - p0;
             let edge1 = p2 - p1;
             let edge2 = p0 - p2;
@@ -2190,7 +2235,7 @@ fn vector_fs_main(input: VertexOutput, maskAlpha: f32) -> vec4<f32> {
                 pointAngle,
                 startAngle,
                 sweep);
-            exteriorDistance = length(point) - 0.5;
+            exteriorDistance = length(point) - length(previousOuter);
             exteriorGradient = safe_normalize(point);
             allDistance = exteriorDistance;
         } else if (joinKind == 0u && input.strokeThickness > 0.5) {

--- a/src/ProGPU.Dxf/DxfDocumentRenderer.cs
+++ b/src/ProGPU.Dxf/DxfDocumentRenderer.cs
@@ -139,7 +139,10 @@ public static class DxfDocumentRenderer
                     color = lColor;
                 }
                 var brush = new SolidColorBrush(color);
-                var pen = new ProGPU.Vector.Pen(brush, 1.0f);
+                var pen = new ProGPU.Vector.Pen(
+                    brush,
+                    1.0f,
+                    strokeTransformMode: PenStrokeTransformMode.Fixed);
 
                 foreach (var edge in solid.Edges)
                 {
@@ -174,7 +177,10 @@ public static class DxfDocumentRenderer
                     color = lColor;
                 }
                 var brush = new SolidColorBrush(color);
-                var pen = new ProGPU.Vector.Pen(brush, 1.5f);
+                var pen = new ProGPU.Vector.Pen(
+                    brush,
+                    1.5f,
+                    strokeTransformMode: PenStrokeTransformMode.Fixed);
 
                 // 1. Draw leader line segments
                 foreach (var line in mleader.LeaderLines)

--- a/src/ProGPU.Dxf/DxfEntityRenderers.cs
+++ b/src/ProGPU.Dxf/DxfEntityRenderers.cs
@@ -1136,7 +1136,10 @@ public class DxfViewportRenderer : IDxfEntityRenderer
                         color = lColor;
                     }
                     var brush = new SolidColorBrush(color);
-                    var pen = new ProGPU.Vector.Pen(brush, 1.0f);
+                    var pen = new ProGPU.Vector.Pen(
+                        brush,
+                        1.0f,
+                        strokeTransformMode: PenStrokeTransformMode.Fixed);
 
                     foreach (var edge in solid.Edges)
                     {
@@ -1168,7 +1171,10 @@ public class DxfViewportRenderer : IDxfEntityRenderer
                         color = lColor;
                     }
                     var brush = new SolidColorBrush(color);
-                    var pen = new ProGPU.Vector.Pen(brush, 1.5f);
+                    var pen = new ProGPU.Vector.Pen(
+                        brush,
+                        1.5f,
+                        strokeTransformMode: PenStrokeTransformMode.Fixed);
 
                     // 1. Draw leader line segments
                     foreach (var line in mleader.LeaderLines)
@@ -1305,7 +1311,10 @@ public class DxfImageRenderer : IDxfEntityRenderer
         dc.DrawRectangle(bgBrush, null, rect);
 
         // 2. Draw border
-        var borderPen = new Pen(new SolidColorBrush(new Vector4(0.4f, 0.4f, 0.45f, 0.5f)), 1f);
+        var borderPen = new Pen(
+            new SolidColorBrush(new Vector4(0.4f, 0.4f, 0.45f, 0.5f)),
+            1f,
+            strokeTransformMode: PenStrokeTransformMode.Fixed);
         dc.DrawRectangle(null, borderPen, rect);
 
         // 3. Draw a centered diagonal cross/hatch to look like standard architectural "missing image" box

--- a/src/ProGPU.Dxf/DxfRenderContext.cs
+++ b/src/ProGPU.Dxf/DxfRenderContext.cs
@@ -221,7 +221,13 @@ public class DxfRenderContext
         var key = (entity.Layer.Name, color.X, color.Y, color.Z, color.W, thickness);
         if (!_penCache.TryGetValue(key, out var pen))
         {
-            pen = new Pen(brush, thickness);
+            // CAD linework uses cosmetic positive widths: camera and visual
+            // transforms move the centerline, while zoom must not magnify the
+            // requested screen-space thickness.
+            pen = new Pen(
+                brush,
+                thickness,
+                strokeTransformMode: PenStrokeTransformMode.Fixed);
             _penCache[key] = pen;
         }
         return pen;

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -6137,11 +6137,12 @@ SceneStateUploadComplete:
 
         bool hasFill = cmd.Brush != null;
         var stroke = ResolveStrokeCompileState(cmd, transform);
-        bool hasStroke = stroke.IsValid;
+        bool hasDashedStroke = stroke.IsValid && cmd.Pen!.HasDashPattern;
+        bool hasStroke = stroke.IsValid && !hasDashedStroke;
         bool useSolidRectPipeline = ActiveCompilationContext == null &&
             (!hasFill || cmd.Brush is SolidColorBrush) &&
             (!hasStroke || cmd.Pen!.Brush is SolidColorBrush) &&
-            !stroke.IsHairline;
+            (!hasStroke || !stroke.IsHairline);
         SwitchBatch(useSolidRectPipeline ? BatchType.SolidRect : BatchType.Vector);
         int startIndex = _vectorVerticesList.Count;
         var r = cmd.Rect;
@@ -6238,6 +6239,16 @@ SceneStateUploadComplete:
                 vertices[i] = v;
             }
         }
+
+        if (hasDashedStroke)
+        {
+            var strokePath = cmd.GeometryCache?.StrokePath ??
+                RenderCommandGeometryCache.CreatePrimitiveStrokePath(cmd);
+            if (strokePath != null)
+            {
+                CompileRetainedStrokePath(cmd, strokePath, stroke, transform);
+            }
+        }
     }
 
     private void CompileTextureBrushRectangle(
@@ -6327,6 +6338,7 @@ SceneStateUploadComplete:
             // picture-shader pixels. Reuse the quad only when it is the final
             // coverage evaluation, avoiding atlas residency for ordinary UI.
             RenderCommand rectangleCommand = command;
+            rectangleCommand.Pen = null;
             rectangleCommand.Rect = new Rect(
                 outer.Left,
                 outer.Top,
@@ -7306,6 +7318,15 @@ SceneStateUploadComplete:
 
         if (IsRenderableStroke(cmd.Pen))
         {
+            // A canonical sharp-rectangle fill may have been emitted through
+            // the specialized SolidRect pipeline. Path strokes use the vector
+            // vertex contract, so restore that batch before appending their
+            // geometry instead of associating it with the fill pipeline.
+            if (compiledDirectRoundedFill)
+            {
+                SwitchBatch(BatchType.Vector);
+            }
+
             var stroke = ResolveStrokeCompileState(cmd, transform);
             if (!stroke.IsValid)
             {
@@ -11053,6 +11074,7 @@ SceneStateUploadComplete:
     {
         SwitchBatch(BatchType.Vector);
         var stroke = ResolveStrokeCompileState(cmd, transform);
+        var hasDashedStroke = stroke.IsValid && cmd.Pen!.HasDashPattern;
         int startIndex = _vectorVerticesList.Count;
         var center = cmd.Position2;
         var rx = cmd.RadiusX;
@@ -11095,7 +11117,7 @@ SceneStateUploadComplete:
             indexSpan[5] = idxStart + 3;
         }
 
-        if (stroke.IsValid)
+        if (stroke.IsValid && !hasDashedStroke)
         {
             var pen = cmd.Pen!;
             float pad = stroke.LocalBoundsThickness / 2f + antialiasPadding;
@@ -11140,6 +11162,16 @@ SceneStateUploadComplete:
                 vertices[i] = v;
             }
         }
+
+        if (hasDashedStroke)
+        {
+            var strokePath = cmd.GeometryCache?.StrokePath ??
+                RenderCommandGeometryCache.CreatePrimitiveStrokePath(cmd);
+            if (strokePath != null)
+            {
+                CompileRetainedStrokePath(cmd, strokePath, stroke, transform);
+            }
+        }
     }
 
     private void CompileCircleCommand(RenderCommand cmd, Matrix4x4 transform)
@@ -11165,7 +11197,8 @@ SceneStateUploadComplete:
         {
             var pathCommand = cmd;
             pathCommand.Type = RenderCommandType.DrawPath;
-            pathCommand.Path = GetOrCreateRoundedRectanglePath(r, radiusX, radiusY);
+            pathCommand.Path = cmd.GeometryCache?.StrokePath ??
+                GetOrCreateRoundedRectanglePath(r, radiusX, radiusY);
             pathCommand.Transform = default;
             if (stroke.IsValid)
             {
@@ -11177,12 +11210,13 @@ SceneStateUploadComplete:
         }
 
         bool hasFill = cmd.Brush != null;
-        bool hasStroke = stroke.IsValid;
+        bool hasDashedStroke = stroke.IsValid && cmd.Pen!.HasDashPattern;
+        bool hasStroke = stroke.IsValid && !hasDashedStroke;
         bool isSolidRoundedCandidate = ActiveCompilationContext == null &&
             (hasFill || hasStroke) &&
             (!hasFill || cmd.Brush is SolidColorBrush) &&
             (!hasStroke || cmd.Pen!.Brush is SolidColorBrush) &&
-            !stroke.IsHairline;
+            (!hasStroke || !stroke.IsHairline);
         if (isSolidRoundedCandidate)
         {
             _currentSolidRoundedPrimitiveCount++;
@@ -11284,6 +11318,16 @@ SceneStateUploadComplete:
                 var v = vertices[i];
                 v.Position = ClampToClip(v.Position);
                 vertices[i] = v;
+            }
+        }
+
+        if (hasDashedStroke)
+        {
+            var strokePath = cmd.GeometryCache?.StrokePath ??
+                RenderCommandGeometryCache.CreatePrimitiveStrokePath(cmd);
+            if (strokePath != null)
+            {
+                CompileRetainedStrokePath(cmd, strokePath, stroke, transform);
             }
         }
     }
@@ -16637,14 +16681,10 @@ SceneStateUploadComplete:
                             {
                                 CommitStaticDrawCalls();
                                 var localCmd = cmd;
-                                var compileTransform = localCmd.ExtensionId switch
-                                {
-                                    CompositorBuiltInExtensions.AcisSolid => localCmd.Transform,
-                                    CompositorBuiltInExtensions.Spline or
-                                    CompositorBuiltInExtensions.Hatch or
-                                    CompositorBuiltInExtensions.Line3D => activeTransform,
-                                    _ => Matrix4x4.Identity
-                                };
+                                var compileTransform = ResolveStaticExtensionCompileTransform(
+                                    localCmd.ExtensionId,
+                                    activeTransform,
+                                    localCmd.Transform);
                                 pipeline.Compile(this, null, compileTransform, ref localCmd);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
@@ -17095,14 +17135,10 @@ SceneStateUploadComplete:
                             {
                                 CommitStaticDrawCalls();
                                 var localCmd = cmd;
-                                var compileTransform = localCmd.ExtensionId switch
-                                {
-                                    CompositorBuiltInExtensions.AcisSolid => localCmd.Transform,
-                                    CompositorBuiltInExtensions.Spline or
-                                    CompositorBuiltInExtensions.Hatch or
-                                    CompositorBuiltInExtensions.Line3D => activeTransform,
-                                    _ => Matrix4x4.Identity
-                                };
+                                var compileTransform = ResolveStaticExtensionCompileTransform(
+                                    localCmd.ExtensionId,
+                                    activeTransform,
+                                    localCmd.Transform);
                                 pipeline.Compile(this, context, compileTransform, ref localCmd);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
@@ -17395,6 +17431,32 @@ SceneStateUploadComplete:
             ReturnListSnapshot(savedTextVertices, savedTextVerticesCount);
             ReturnListSnapshot(savedDrawCalls, savedDrawCallsCount);
         }
+    }
+
+    private static Matrix4x4 ResolveStaticExtensionCompileTransform(
+        int extensionId,
+        in Matrix4x4 activeTransform,
+        in Matrix4x4 commandTransform)
+    {
+        return extensionId switch
+        {
+            // ACIS owns a model transform as part of its typed payload.
+            CompositorBuiltInExtensions.AcisSolid => commandTransform == default
+                ? Matrix4x4.Identity
+                : commandTransform,
+            // These pipelines bake the supplied transform into generated vertices;
+            // their render methods do not consume CompositorDrawCall.Transform.
+            CompositorBuiltInExtensions.Spline or
+            CompositorBuiltInExtensions.Hatch or
+            CompositorBuiltInExtensions.Line3D or
+            CompositorBuiltInExtensions.ImageEffect or
+            CompositorBuiltInExtensions.ShaderToy or
+            CompositorBuiltInExtensions.WpfShaderEffect or
+            CompositorBuiltInExtensions.BackdropMaterial => activeTransform,
+            // StaticDxf and GPU series defer transforms to rendering. Unknown
+            // extensions retain the established identity compile contract.
+            _ => Matrix4x4.Identity
+        };
     }
 
     internal unsafe void DrawStaticDxfBuffer(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -9466,6 +9466,33 @@ SceneStateUploadComplete:
         }
     }
 
+    /// <summary>
+    /// Returns a stroked command's pen thickness in the same space as its transformed geometry.
+    /// </summary>
+    /// <remarks>
+    /// Thickness reaches the compositor already scaled by the command's own transform - the drawing
+    /// context bridges apply their current stroke scale when they emit the command - but not by the
+    /// visual-tree transform that gets composed into <paramref name="activeTransform"/> here. The
+    /// vertices below are emitted post-transform, so recovering just that missing factor keeps a
+    /// stroke proportional to its geometry under a Viewbox or RenderTransform while leaving a
+    /// DrawingContext PushTransform, which was already accounted for, untouched.
+    /// </remarks>
+    private static float ResolveDeviceStrokeThickness(in RenderCommand cmd, Matrix4x4 activeTransform)
+    {
+        var thickness = cmd.Pen!.Thickness;
+        var activeScale = TransformMetrics.GetStrokeScale(activeTransform);
+        var commandScale = cmd.Transform == default
+            ? 1f
+            : TransformMetrics.GetStrokeScale(cmd.Transform);
+
+        if (!float.IsFinite(activeScale) || !float.IsFinite(commandScale) || commandScale <= 0f)
+        {
+            return thickness;
+        }
+
+        return thickness * (activeScale / commandScale);
+    }
+
     private void CompileLineCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         SwitchBatch(BatchType.Vector);
@@ -9490,7 +9517,7 @@ SceneStateUploadComplete:
 
         var p0_pos = Vector2.Transform(cmd.Position, transform);
         var p1_pos = Vector2.Transform(cmd.Position2, transform);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
         var lineShapeType = EncodeShapeType(cmd, 3f);
 
         uint idxStart = (uint)startIndex;
@@ -9545,7 +9572,7 @@ SceneStateUploadComplete:
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
 
         var p0_trans = Vector2.Transform(cmd.Position, transform);
         var p1_trans = Vector2.Transform(cmd.Position2, transform);
@@ -9602,7 +9629,7 @@ SceneStateUploadComplete:
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
 
         var p0_trans = Vector2.Transform(cmd.Position, transform);
         var p1_trans = Vector2.Transform(cmd.Position2, transform);

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1658,43 +1658,62 @@ public unsafe partial class Compositor : IDisposable
             return;
         }
 
-        var stroke = ResolveStrokeCompileState(cmd, transform);
-        if (!stroke.IsValid)
-        {
-            return;
-        }
-
-        if (cmd.GeometryCache?.StrokePath is { } retainedPath)
-        {
-            CompileRetainedStrokePath(cmd, retainedPath, stroke, transform);
-            return;
-        }
-
-        ReadOnlySpan<Vector2> controlPoints = provider != null
-            ? provider.GetPoints(cmd.PointBufferOffset, cmd.PointBufferCount)
-            : cmd.PolylinePoints;
-        ReadOnlySpan<double> knots = provider != null
-            ? provider.GetDoubles(cmd.DoubleBufferOffset, cmd.DoubleBufferCount)
-            : cmd.SplineKnots;
-        ReadOnlySpan<double> weights = provider != null && cmd.WeightBufferCount > 0
-            ? provider.GetDoubles(cmd.WeightBufferOffset, cmd.WeightBufferCount)
-            : cmd.SplineWeights;
+        ReadOnlySpan<Vector2> controlPoints =
+            cmd.PolylinePoints is { Length: > 0 } inlinePoints
+                ? inlinePoints
+                : provider != null && cmd.PointBufferCount > 0
+                    ? provider.GetPoints(cmd.PointBufferOffset, cmd.PointBufferCount)
+                    : ReadOnlySpan<Vector2>.Empty;
+        ReadOnlySpan<double> knots =
+            cmd.SplineKnots is { Length: > 0 } inlineKnots
+                ? inlineKnots
+                : provider != null && cmd.DoubleBufferCount > 0
+                    ? provider.GetDoubles(cmd.DoubleBufferOffset, cmd.DoubleBufferCount)
+                    : ReadOnlySpan<double>.Empty;
+        ReadOnlySpan<double> weights =
+            cmd.SplineWeights is { Length: > 0 } inlineWeights
+                ? inlineWeights
+                : provider != null && cmd.WeightBufferCount > 0
+                    ? provider.GetDoubles(cmd.WeightBufferOffset, cmd.WeightBufferCount)
+                    : ReadOnlySpan<double>.Empty;
 
         if (controlPoints.Length < 2 || knots.IsEmpty)
         {
             return;
         }
 
-        // Legacy/archive commands may predate the retained geometry cache. Build
-        // the same local centerline as the recorder so caps, joins, dashes, and
-        // affine transforms still share the exact path-stroke implementation.
-        var fallbackPath = SplineGeometry.CreatePath(
+        if (!SplineGeometry.TryGetDomain(
+                controlPoints,
+                knots,
+                cmd.SplineDegree,
+                out _,
+                out _))
+        {
+            CompilePolylinePoints(controlPoints, cmd, transform);
+            return;
+        }
+
+        int segmentCount = SplineGeometry.GetScreenSegmentCount(
             controlPoints,
-            knots,
-            weights,
-            cmd.SplineDegree,
-            cmd.IsClosed);
-        CompileRetainedStrokePath(cmd, fallbackPath, stroke, transform);
+            transform);
+        if (segmentCount == 0)
+        {
+            return;
+        }
+
+        Span<Vector2> sampledPoints = stackalloc Vector2[segmentCount + 1];
+        if (!SplineGeometry.TryEvaluatePoints(
+                cmd.SplineDegree,
+                controlPoints,
+                knots,
+                weights,
+                Matrix4x4.Identity,
+                sampledPoints))
+        {
+            return;
+        }
+
+        CompilePolylinePoints(sampledPoints, cmd, transform);
     }
     public int VectorIndexCount => _vectorIndicesList.Count;
     public int TextVertexCount => _textVerticesList.Count * 6;
@@ -9299,23 +9318,27 @@ SceneStateUploadComplete:
         bool isEdgeAliased,
         bool isSmoothJoin)
     {
-        var localTriangles = StrokeJoinGeometry.CreateDirectionalJoin(
+        Span<StrokeJoinTriangle> localTriangles =
+            stackalloc StrokeJoinTriangle[StrokeJoinGeometry.MaxTrianglesPerJoin];
+        int localTriangleCount = StrokeJoinGeometry.WriteLineJoin(
+            localTriangles,
             pen.LineJoin,
             localThickness,
             pen.MiterLimit,
+            localJoinPoint - localIncomingDirection,
             localJoinPoint,
-            localIncomingDirection,
-            localOutgoingDirection,
+            localJoinPoint + localOutgoingDirection,
             isSmoothJoin);
 
-        for (var triangleIndex = 0; triangleIndex < localTriangles.Length; triangleIndex++)
+        var generatedTriangles = localTriangles[..localTriangleCount];
+        for (var triangleIndex = 0; triangleIndex < generatedTriangles.Length; triangleIndex++)
         {
-            var localTriangle = localTriangles[triangleIndex];
+            var localTriangle = generatedTriangles[triangleIndex];
             var transformedTriangle = new StrokeJoinTriangle(
                 Vector2.Transform(localTriangle.P0, transform),
                 Vector2.Transform(localTriangle.P1, transform),
                 Vector2.Transform(localTriangle.P2, transform));
-            var edgeMasks = GetStrokeTriangleEdgeMasks(localTriangles, triangleIndex);
+            var edgeMasks = GetStrokeTriangleEdgeMasks(generatedTriangles, triangleIndex);
             AppendStrokeTriangleVertices(
                 verticesSpan,
                 indicesSpan,
@@ -9546,23 +9569,33 @@ SceneStateUploadComplete:
             return;
         }
 
-        var localTriangles = StrokeCapGeometry.CreateDirectionalCap(
+        Span<StrokeJoinTriangle> localTriangles =
+            stackalloc StrokeJoinTriangle[StrokeCapGeometry.MaxTrianglesPerCap];
+        Vector2 lineStart = isStart
+            ? localCenter
+            : localCenter - localDirectionAlongPath;
+        Vector2 lineEnd = isStart
+            ? localCenter + localDirectionAlongPath
+            : localCenter;
+        int localTriangleCount = StrokeCapGeometry.WriteLineCap(
+            localTriangles,
             lineCap,
             localThickness,
-            localCenter,
-            localDirectionAlongPath,
+            lineStart,
+            lineEnd,
             isStart);
         var normalizedLocalDirection = localDirectionAlongPath / directionLength;
 
-        for (var triangleIndex = 0; triangleIndex < localTriangles.Length; triangleIndex++)
+        var generatedTriangles = localTriangles[..localTriangleCount];
+        for (var triangleIndex = 0; triangleIndex < generatedTriangles.Length; triangleIndex++)
         {
-            var localTriangle = localTriangles[triangleIndex];
+            var localTriangle = generatedTriangles[triangleIndex];
             var transformedTriangle = new StrokeJoinTriangle(
                 Vector2.Transform(localTriangle.P0, transform),
                 Vector2.Transform(localTriangle.P1, transform),
                 Vector2.Transform(localTriangle.P2, transform));
             var edgeMasks = GetStrokeCapTriangleEdgeMasks(
-                localTriangles,
+                generatedTriangles,
                 triangleIndex,
                 localCenter,
                 normalizedLocalDirection);
@@ -9594,25 +9627,29 @@ SceneStateUploadComplete:
         bool isEdgeAliased,
         bool isSmoothJoin)
     {
-        var triangles = StrokeJoinGeometry.CreateDirectionalJoin(
+        Span<StrokeJoinTriangle> triangles =
+            stackalloc StrokeJoinTriangle[StrokeJoinGeometry.MaxTrianglesPerJoin];
+        int triangleCount = StrokeJoinGeometry.WriteLineJoin(
+            triangles,
             pen.LineJoin,
             thickness,
             pen.MiterLimit,
+            joinPoint - incomingDirection,
             joinPoint,
-            incomingDirection,
-            outgoingDirection,
+            joinPoint + outgoingDirection,
             isSmoothJoin);
 
-        for (var triangleIndex = 0; triangleIndex < triangles.Length; triangleIndex++)
+        var generatedTriangles = triangles[..triangleCount];
+        for (var triangleIndex = 0; triangleIndex < generatedTriangles.Length; triangleIndex++)
         {
-            var edgeMasks = GetStrokeTriangleEdgeMasks(triangles, triangleIndex);
+            var edgeMasks = GetStrokeTriangleEdgeMasks(generatedTriangles, triangleIndex);
             AppendStrokeTriangleVertices(
                 verticesSpan,
                 indicesSpan,
                 ref currentVertexCount,
                 ref currentIndexCount,
                 penBrushIdx,
-                triangles[triangleIndex],
+                generatedTriangles[triangleIndex],
                 edgeMasks.Exterior,
                 edgeMasks.OwnedInternal,
                 isEdgeAliased);
@@ -9662,18 +9699,28 @@ SceneStateUploadComplete:
         bool isEdgeAliased,
         bool isStart)
     {
-        var triangles = StrokeCapGeometry.CreateDirectionalCap(
+        Span<StrokeJoinTriangle> triangles =
+            stackalloc StrokeJoinTriangle[StrokeCapGeometry.MaxTrianglesPerCap];
+        Vector2 lineStart = isStart
+            ? center
+            : center - directionAlongPath;
+        Vector2 lineEnd = isStart
+            ? center + directionAlongPath
+            : center;
+        int triangleCount = StrokeCapGeometry.WriteLineCap(
+            triangles,
             lineCap,
             thickness,
-            center,
-            directionAlongPath,
+            lineStart,
+            lineEnd,
             isStart);
         var normalizedDirection = Vector2.Normalize(directionAlongPath);
 
-        for (var triangleIndex = 0; triangleIndex < triangles.Length; triangleIndex++)
+        var generatedTriangles = triangles[..triangleCount];
+        for (var triangleIndex = 0; triangleIndex < generatedTriangles.Length; triangleIndex++)
         {
             var edgeMasks = GetStrokeCapTriangleEdgeMasks(
-                triangles,
+                generatedTriangles,
                 triangleIndex,
                 center,
                 normalizedDirection);
@@ -9683,7 +9730,7 @@ SceneStateUploadComplete:
                 ref currentVertexCount,
                 ref currentIndexCount,
                 penBrushIdx,
-                triangles[triangleIndex],
+                generatedTriangles[triangleIndex],
                 edgeMasks.Exterior,
                 edgeMasks.OwnedInternal,
                 isEdgeAliased);
@@ -9691,7 +9738,7 @@ SceneStateUploadComplete:
     }
 
     private static (uint Exterior, uint OwnedInternal) GetStrokeCapTriangleEdgeMasks(
-        StrokeJoinTriangle[] triangles,
+        ReadOnlySpan<StrokeJoinTriangle> triangles,
         int triangleIndex,
         Vector2 capCenter,
         Vector2 directionAlongPath)
@@ -9715,7 +9762,7 @@ SceneStateUploadComplete:
     }
 
     private static (uint Exterior, uint OwnedInternal) GetStrokeTriangleEdgeMasks(
-        StrokeJoinTriangle[] triangles,
+        ReadOnlySpan<StrokeJoinTriangle> triangles,
         int triangleIndex,
         bool hasCapBodyInterface = false,
         Vector2 capCenter = default,
@@ -9724,38 +9771,78 @@ SceneStateUploadComplete:
         var triangle = triangles[triangleIndex];
         uint exteriorMask = 0;
         uint ownedInternalMask = 0;
-        ClassifyStrokeTriangleEdge(triangle.P0, triangle.P1, 1u);
-        ClassifyStrokeTriangleEdge(triangle.P1, triangle.P2, 2u);
-        ClassifyStrokeTriangleEdge(triangle.P2, triangle.P0, 4u);
+        ClassifyStrokeTriangleEdge(
+            triangles,
+            triangleIndex,
+            triangle.P0,
+            triangle.P1,
+            1u,
+            hasCapBodyInterface,
+            capCenter,
+            capDirection,
+            ref exteriorMask,
+            ref ownedInternalMask);
+        ClassifyStrokeTriangleEdge(
+            triangles,
+            triangleIndex,
+            triangle.P1,
+            triangle.P2,
+            2u,
+            hasCapBodyInterface,
+            capCenter,
+            capDirection,
+            ref exteriorMask,
+            ref ownedInternalMask);
+        ClassifyStrokeTriangleEdge(
+            triangles,
+            triangleIndex,
+            triangle.P2,
+            triangle.P0,
+            4u,
+            hasCapBodyInterface,
+            capCenter,
+            capDirection,
+            ref exteriorMask,
+            ref ownedInternalMask);
         return (exteriorMask, ownedInternalMask);
+    }
 
-        void ClassifyStrokeTriangleEdge(Vector2 edgeStart, Vector2 edgeEnd, uint bit)
+    private static void ClassifyStrokeTriangleEdge(
+        ReadOnlySpan<StrokeJoinTriangle> triangles,
+        int triangleIndex,
+        Vector2 edgeStart,
+        Vector2 edgeEnd,
+        uint bit,
+        bool hasCapBodyInterface,
+        Vector2 capCenter,
+        Vector2 capDirection,
+        ref uint exteriorMask,
+        ref uint ownedInternalMask)
+    {
+        if (hasCapBodyInterface &&
+            IsPointOnStrokeCapBodyInterface(edgeStart, capCenter, capDirection) &&
+            IsPointOnStrokeCapBodyInterface(edgeEnd, capCenter, capDirection))
         {
-            if (hasCapBodyInterface &&
-                IsPointOnStrokeCapBodyInterface(edgeStart, capCenter, capDirection) &&
-                IsPointOnStrokeCapBodyInterface(edgeEnd, capCenter, capDirection))
-            {
-                return;
-            }
+            return;
+        }
 
-            var sharedTriangleIndex = FindSharedStrokeTriangleEdge(
-                triangles,
-                triangleIndex,
-                edgeStart,
-                edgeEnd);
-            if (sharedTriangleIndex < 0)
-            {
-                exteriorMask |= bit;
-            }
-            else if (triangleIndex < sharedTriangleIndex)
-            {
-                ownedInternalMask |= bit;
-            }
+        var sharedTriangleIndex = FindSharedStrokeTriangleEdge(
+            triangles,
+            triangleIndex,
+            edgeStart,
+            edgeEnd);
+        if (sharedTriangleIndex < 0)
+        {
+            exteriorMask |= bit;
+        }
+        else if (triangleIndex < sharedTriangleIndex)
+        {
+            ownedInternalMask |= bit;
         }
     }
 
     private static int FindSharedStrokeTriangleEdge(
-        StrokeJoinTriangle[] triangles,
+        ReadOnlySpan<StrokeJoinTriangle> triangles,
         int triangleIndex,
         Vector2 edgeStart,
         Vector2 edgeEnd)
@@ -10643,10 +10730,7 @@ SceneStateUploadComplete:
         int count = pointsSpan.Length;
         if (count < 2) return;
 
-        if (cmd.Pen!.HasDashPattern ||
-            cmd.IsClosed ||
-            count > 2 ||
-            RequiresEndpointCapGeometry(cmd.Pen))
+        if (cmd.Pen!.HasDashPattern)
         {
             var path = cmd.GeometryCache?.StrokePath ??
                 RenderCommandGeometryCache.CreatePolylinePath(
@@ -10660,74 +10744,301 @@ SceneStateUploadComplete:
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
         float thickness = stroke.EncodedThickness;
-        var lineShapeType = EncodeShapeType(cmd, 3f);
+        bool useAffineStrokeGeometry = stroke.RequiresAffineGeometry;
+        int segmentBudget = cmd.IsClosed ? count : count - 1;
+        int joinBudget = cmd.IsClosed ? count : Math.Max(0, count - 2);
+        int capBudget = cmd.IsClosed ? 0 : 2;
+        int maxAdornmentTriangles = checked(
+            joinBudget * StrokeJoinGeometry.MaxTrianglesPerJoin +
+            capBudget * StrokeCapGeometry.MaxTrianglesPerCap);
+        int maxVertices = checked(segmentBudget * 4 + maxAdornmentTriangles * 4);
+        int maxIndices = checked(segmentBudget * 6 + maxAdornmentTriangles * 6);
 
-        int segmentCount = count - 1;
-        if (cmd.IsClosed) segmentCount++;
+        int vertexStart = _vectorVerticesList.Count;
+        int indexStart = _vectorIndicesList.Count;
+        CollectionsMarshal.SetCount(
+            _vectorVerticesList,
+            checked(vertexStart + maxVertices));
+        CollectionsMarshal.SetCount(
+            _vectorIndicesList,
+            checked(indexStart + maxIndices));
 
-        // We will append 4 vertices and 6 indices for each segment
-        int totalVerticesToAdd = segmentCount * 4;
-        int totalIndicesToAdd = segmentCount * 6;
+        var verticesSpan = CollectionsMarshal.AsSpan(_vectorVerticesList);
+        var indicesSpan = CollectionsMarshal.AsSpan(_vectorIndicesList);
+        int currentVertexCount = vertexStart;
+        int currentIndexCount = indexStart;
+        var firstSegmentStartDirection = default(Vector2);
+        var previousSegmentEndDirection = default(Vector2);
+        var lastCapCenter = default(Vector2);
+        var lastCapDirection = default(Vector2);
+        var degenerateStrokeCenter = pointsSpan[0];
+        bool hasFirstSegmentStartDirection = false;
+        bool hasPreviousSegmentEndDirection = false;
+        bool hasLastCapCandidate = false;
+        bool hasDegenerateStrokeCandidate = false;
+        bool isFirstSegment = true;
 
-        int originalVertexCount = _vectorVerticesList.Count;
-        CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + totalVerticesToAdd);
-        var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, totalVerticesToAdd);
-
-        int originalIndexCount = _vectorIndicesList.Count;
-        CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + totalIndicesToAdd);
-        var indexSpan = CollectionsMarshal.AsSpan(_vectorIndicesList).Slice(originalIndexCount, totalIndicesToAdd);
-
-        if (stroke.RequiresAffineGeometry)
+        for (int segmentIndex = 0; segmentIndex < count - 1; segmentIndex++)
         {
-            var affineVertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
-            var affineIndices = CollectionsMarshal.AsSpan(_vectorIndicesList);
-            var currentVertexCount = originalVertexCount;
-            var currentIndexCount = originalIndexCount;
-            for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+            var segmentStart = pointsSpan[segmentIndex];
+            var segmentEnd = pointsSpan[segmentIndex + 1];
+            var directionCandidate = segmentEnd - segmentStart;
+            bool hasDirection = TrySelectDirection(
+                out var direction,
+                directionCandidate);
+            if (!hasDirection)
             {
-                AppendAffineStrokeLineVertices(
-                    affineVertices,
-                    affineIndices,
+                if (Vector2.DistanceSquared(segmentStart, segmentEnd) <=
+                    StrokeEpsilon * StrokeEpsilon)
+                {
+                    if (isFirstSegment)
+                    {
+                        hasDegenerateStrokeCandidate = true;
+                        degenerateStrokeCenter = segmentEnd;
+                    }
+
+                    continue;
+                }
+
+                hasDegenerateStrokeCandidate = false;
+                hasPreviousSegmentEndDirection = false;
+                hasLastCapCandidate = false;
+                isFirstSegment = false;
+                continue;
+            }
+
+            hasDegenerateStrokeCandidate = false;
+            if (isFirstSegment)
+            {
+                firstSegmentStartDirection = direction;
+                hasFirstSegmentStartDirection = true;
+                if (!cmd.IsClosed)
+                {
+                    AppendPathStrokeSegmentCapTriangles(
+                        verticesSpan,
+                        indicesSpan,
+                        ref currentVertexCount,
+                        ref currentIndexCount,
+                        penSolidColor,
+                        penBrushIdx,
+                        stroke.LocalGeometryThickness,
+                        segmentStart,
+                        direction,
+                        transform,
+                        useAffineStrokeGeometry,
+                        stroke.IsHairline,
+                        cmd.IsEdgeAliased,
+                        isStart: true,
+                        lineCap: cmd.Pen.StartLineCap);
+                }
+            }
+            else if (hasPreviousSegmentEndDirection)
+            {
+                AppendPathStrokeSegmentJoinTriangles(
+                    verticesSpan,
+                    indicesSpan,
                     ref currentVertexCount,
                     ref currentIndexCount,
+                    cmd.Pen,
                     penSolidColor,
                     penBrushIdx,
                     stroke.LocalGeometryThickness,
-                    pointsSpan[segmentIndex % count],
-                    pointsSpan[(segmentIndex + 1) % count],
+                    segmentStart,
+                    previousSegmentEndDirection,
+                    direction,
                     transform,
-                    cmd.IsEdgeAliased);
+                    useAffineStrokeGeometry,
+                    cmd.IsEdgeAliased,
+                    isSmoothJoin: false);
             }
 
-            CollectionsMarshal.SetCount(_vectorVerticesList, currentVertexCount);
-            CollectionsMarshal.SetCount(_vectorIndicesList, currentIndexCount);
-            ClampVectorVerticesToActiveClip(startIndex);
+            AppendPolylineStrokeLine(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penSolidColor,
+                penBrushIdx,
+                thickness,
+                stroke.LocalGeometryThickness,
+                segmentStart,
+                segmentEnd,
+                transform,
+                useAffineStrokeGeometry,
+                cmd.IsEdgeAliased);
+
+            previousSegmentEndDirection = direction;
+            hasPreviousSegmentEndDirection = true;
+            lastCapCenter = segmentEnd;
+            lastCapDirection = direction;
+            hasLastCapCandidate = true;
+            isFirstSegment = false;
+        }
+
+        if (!cmd.IsClosed && hasLastCapCandidate)
+        {
+            AppendPathStrokeSegmentCapTriangles(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penSolidColor,
+                penBrushIdx,
+                stroke.LocalGeometryThickness,
+                lastCapCenter,
+                lastCapDirection,
+                transform,
+                useAffineStrokeGeometry,
+                stroke.IsHairline,
+                cmd.IsEdgeAliased,
+                isStart: false,
+                lineCap: cmd.Pen.EndLineCap);
+        }
+        else if (!cmd.IsClosed && hasDegenerateStrokeCandidate)
+        {
+            AppendDegenerateStrokeCapVertices(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                cmd.Pen,
+                penSolidColor,
+                penBrushIdx,
+                stroke.DeviceThickness,
+                degenerateStrokeCenter,
+                transform,
+                cmd.IsEdgeAliased);
+        }
+        else if (cmd.IsClosed && pointsSpan[^1] != pointsSpan[0])
+        {
+            var closeLineStart = pointsSpan[^1];
+            var closeLineEnd = pointsSpan[0];
+            var closeLineDirection = closeLineEnd - closeLineStart;
+            if (hasPreviousSegmentEndDirection)
+            {
+                AppendPathStrokeSegmentJoinTriangles(
+                    verticesSpan,
+                    indicesSpan,
+                    ref currentVertexCount,
+                    ref currentIndexCount,
+                    cmd.Pen,
+                    penSolidColor,
+                    penBrushIdx,
+                    stroke.LocalGeometryThickness,
+                    closeLineStart,
+                    previousSegmentEndDirection,
+                    closeLineDirection,
+                    transform,
+                    useAffineStrokeGeometry,
+                    cmd.IsEdgeAliased,
+                    isSmoothJoin: false);
+            }
+
+            AppendPolylineStrokeLine(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penSolidColor,
+                penBrushIdx,
+                thickness,
+                stroke.LocalGeometryThickness,
+                closeLineStart,
+                closeLineEnd,
+                transform,
+                useAffineStrokeGeometry,
+                cmd.IsEdgeAliased);
+
+            if (hasFirstSegmentStartDirection)
+            {
+                AppendPathStrokeSegmentJoinTriangles(
+                    verticesSpan,
+                    indicesSpan,
+                    ref currentVertexCount,
+                    ref currentIndexCount,
+                    cmd.Pen,
+                    penSolidColor,
+                    penBrushIdx,
+                    stroke.LocalGeometryThickness,
+                    closeLineEnd,
+                    closeLineDirection,
+                    firstSegmentStartDirection,
+                    transform,
+                    useAffineStrokeGeometry,
+                    cmd.IsEdgeAliased,
+                    isSmoothJoin: false);
+            }
+        }
+        else if (cmd.IsClosed &&
+                 hasPreviousSegmentEndDirection &&
+                 hasFirstSegmentStartDirection)
+        {
+            AppendPathStrokeSegmentJoinTriangles(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                cmd.Pen,
+                penSolidColor,
+                penBrushIdx,
+                stroke.LocalGeometryThickness,
+                pointsSpan[0],
+                previousSegmentEndDirection,
+                firstSegmentStartDirection,
+                transform,
+                useAffineStrokeGeometry,
+                cmd.IsEdgeAliased,
+                isSmoothJoin: false);
+        }
+
+        CollectionsMarshal.SetCount(_vectorVerticesList, currentVertexCount);
+        CollectionsMarshal.SetCount(_vectorIndicesList, currentIndexCount);
+        ClampVectorVerticesToActiveClip(startIndex);
+    }
+
+    private static void AppendPolylineStrokeLine(
+        Span<VectorVertex> verticesSpan,
+        Span<uint> indicesSpan,
+        ref int currentVertexCount,
+        ref int currentIndexCount,
+        Vector4 penSolidColor,
+        float penBrushIdx,
+        float thickness,
+        float localThickness,
+        Vector2 localStart,
+        Vector2 localEnd,
+        Matrix4x4 transform,
+        bool useAffineStrokeGeometry,
+        bool isEdgeAliased)
+    {
+        if (useAffineStrokeGeometry)
+        {
+            AppendAffineStrokeLineVertices(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penSolidColor,
+                penBrushIdx,
+                localThickness,
+                localStart,
+                localEnd,
+                transform,
+                isEdgeAliased);
             return;
         }
 
-        for (int i = 0; i < segmentCount; i++)
-        {
-            var p0_pos = Vector2.Transform(pointsSpan[i % count], transform);
-            var p1_pos = Vector2.Transform(pointsSpan[(i + 1) % count], transform);
-
-            uint idxStart = (uint)(originalVertexCount + i * 4);
-
-            int vIdx = i * 4;
-            vertexSpan[vIdx] = new VectorVertex(p0_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, 1f, thickness, lineShapeType);
-            vertexSpan[vIdx + 1] = new VectorVertex(p0_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, -1f, thickness, lineShapeType);
-            vertexSpan[vIdx + 2] = new VectorVertex(p1_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, 2f, thickness, lineShapeType);
-            vertexSpan[vIdx + 3] = new VectorVertex(p1_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, -2f, thickness, lineShapeType);
-
-            int iIdx = i * 6;
-            indexSpan[iIdx] = idxStart;
-            indexSpan[iIdx + 1] = idxStart + 1;
-            indexSpan[iIdx + 2] = idxStart + 2;
-            indexSpan[iIdx + 3] = idxStart + 1;
-            indexSpan[iIdx + 4] = idxStart + 3;
-            indexSpan[iIdx + 5] = idxStart + 2;
-        }
-
-        ClampVectorVerticesToActiveClip(startIndex);
+        AppendStrokeLineVertices(
+            verticesSpan,
+            indicesSpan,
+            ref currentVertexCount,
+            ref currentIndexCount,
+            penSolidColor,
+            penBrushIdx,
+            thickness,
+            Vector2.Transform(localStart, transform),
+            Vector2.Transform(localEnd, transform),
+            isEdgeAliased);
     }
 
     private void CompileSplineCommand(IRenderDataProvider? provider, RenderCommand cmd, Matrix4x4 transform)

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -371,6 +371,8 @@ public unsafe partial class Compositor : IDisposable
     private GpuBuffer? _wavefrontQuadIndexBuffer;
     private BindGroup* _wavefrontTextureBindGroup;
     private uint _wavefrontTextureBindGroupGeneration;
+    private bool _wavefrontFrameEnabled;
+    private int _wavefrontFramePathCount;
 
     public VectorRenderingEngine VectorEngine
     {
@@ -393,6 +395,16 @@ public unsafe partial class Compositor : IDisposable
 
         private PathAtlasCapacityExceededException()
             : base("PathAtlas compilation transaction requires a bounded retry.")
+        {
+        }
+    }
+
+    private sealed class WavefrontFrameFallbackException : InvalidOperationException
+    {
+        public static WavefrontFrameFallbackException Instance { get; } = new();
+
+        private WavefrontFrameFallbackException()
+            : base("The experimental Wavefront engine requires an Atlas frame fallback for this command stream.")
         {
         }
     }
@@ -429,10 +441,13 @@ public unsafe partial class Compositor : IDisposable
     private const float SquarePointHairlineShapeType = 19f;
     private const float RoundPointHairlineShapeType = 20f;
     private const float DotGridShapeType = 21f;
+    private const float HairlineCapShapeType = 22f;
+    private const float HairlineJoinShapeType = 23f;
     private const int DirectRoundedMinimumCornerSegmentCount = 8;
     private const int DirectRoundedMaximumCornerSegmentCount = 128;
     private const float DirectRoundedMaximumDeviceChordError = 0.25f;
     private const float AffineStrokeArcMaxAngleRadians = MathF.PI / 24f;
+    private const float AnalyticPrimitiveAntialiasPaddingPixels = 1.5f;
     // Matches Skia grayscale edge weight for axis-aligned vector glyphs rasterized at 8x8 coverage.
     private const float SmallTextPathCoverageGamma = 0.72f;
     private const float LargeTextPathCoverageGamma = 0.5f;
@@ -452,6 +467,33 @@ public unsafe partial class Compositor : IDisposable
     {
         public float Width => Right - Left;
         public float Height => Bottom - Top;
+    }
+
+    private readonly record struct StrokeCompileState(
+        float LocalThickness,
+        float LocalGeometryThickness,
+        float LocalBoundsThickness,
+        float DeviceThickness,
+        bool RequiresAffineGeometry,
+        bool IsHairline)
+    {
+        public float EncodedThickness => IsHairline
+            ? Pen.HairlineThickness
+            : DeviceThickness;
+
+        public float RetainedThickness => IsHairline
+            ? Pen.HairlineThickness
+            : LocalThickness;
+
+        public bool IsValid =>
+            float.IsFinite(LocalThickness) &&
+            LocalThickness > 0f &&
+            float.IsFinite(LocalGeometryThickness) &&
+            LocalGeometryThickness > 0f &&
+            float.IsFinite(LocalBoundsThickness) &&
+            LocalBoundsThickness > 0f &&
+            float.IsFinite(DeviceThickness) &&
+            DeviceThickness > 0f;
     }
 
     private readonly record struct VectorGlyphPathCacheKey(
@@ -753,6 +795,12 @@ public unsafe partial class Compositor : IDisposable
             return;
         }
 
+        // The compositor has already folded CameraView and the enclosing
+        // visual/picture transform into the hit-test transform. Clear only the
+        // late-render routing marker so the cache builder accepts the resolved
+        // command without attempting to interpret GPU state a second time.
+        command.UseGpuTransforms = false;
+        command.CameraView = default;
         _hitTestCacheBuilder.AddCommand(command, transform);
     }
 
@@ -765,6 +813,8 @@ public unsafe partial class Compositor : IDisposable
             return;
         }
 
+        command.UseGpuTransforms = false;
+        command.CameraView = default;
         _hitTestCacheBuilder.AddCommand(command, transform);
     }
 
@@ -777,6 +827,8 @@ public unsafe partial class Compositor : IDisposable
             return;
         }
 
+        command.UseGpuTransforms = false;
+        command.CameraView = default;
         _hitTestCacheBuilder.AddCommand(command, transform, provider);
     }
 
@@ -788,7 +840,9 @@ public unsafe partial class Compositor : IDisposable
             RenderCommandType.PushGeometryClip or
             RenderCommandType.PopGeometryClip or
             RenderCommandType.PushOpacity or
-            RenderCommandType.PopOpacity;
+            RenderCommandType.PopOpacity or
+            RenderCommandType.PushOpacityMask or
+            RenderCommandType.PopOpacityMask;
     }
 
     private void EnsurePathHitTestCompilation(PathGeometry path)
@@ -1596,6 +1650,52 @@ public unsafe partial class Compositor : IDisposable
     internal ulong FrameNumber => _frameNumber;
 
     internal void CompilePolyline(IRenderDataProvider? provider, RenderCommand cmd, in Matrix4x4 transform) => CompilePolylineCommand(provider, cmd, transform);
+
+    internal void CompileSpline(IRenderDataProvider? provider, RenderCommand cmd, in Matrix4x4 transform)
+    {
+        if (!IsRenderableStroke(cmd.Pen))
+        {
+            return;
+        }
+
+        var stroke = ResolveStrokeCompileState(cmd, transform);
+        if (!stroke.IsValid)
+        {
+            return;
+        }
+
+        if (cmd.GeometryCache?.StrokePath is { } retainedPath)
+        {
+            CompileRetainedStrokePath(cmd, retainedPath, stroke, transform);
+            return;
+        }
+
+        ReadOnlySpan<Vector2> controlPoints = provider != null
+            ? provider.GetPoints(cmd.PointBufferOffset, cmd.PointBufferCount)
+            : cmd.PolylinePoints;
+        ReadOnlySpan<double> knots = provider != null
+            ? provider.GetDoubles(cmd.DoubleBufferOffset, cmd.DoubleBufferCount)
+            : cmd.SplineKnots;
+        ReadOnlySpan<double> weights = provider != null && cmd.WeightBufferCount > 0
+            ? provider.GetDoubles(cmd.WeightBufferOffset, cmd.WeightBufferCount)
+            : cmd.SplineWeights;
+
+        if (controlPoints.Length < 2 || knots.IsEmpty)
+        {
+            return;
+        }
+
+        // Legacy/archive commands may predate the retained geometry cache. Build
+        // the same local centerline as the recorder so caps, joins, dashes, and
+        // affine transforms still share the exact path-stroke implementation.
+        var fallbackPath = SplineGeometry.CreatePath(
+            controlPoints,
+            knots,
+            weights,
+            cmd.SplineDegree,
+            cmd.IsClosed);
+        CompileRetainedStrokePath(cmd, fallbackPath, stroke, transform);
+    }
     public int VectorIndexCount => _vectorIndicesList.Count;
     public int TextVertexCount => _textVerticesList.Count * 6;
     public int TextIndexCount => _textVerticesList.Count * 6;
@@ -2649,12 +2749,30 @@ public unsafe partial class Compositor : IDisposable
     public void RenderScene(Visual root, uint width, uint height, TextureView* targetView)
     {
         var retriedAfterPathAtlasReset = false;
+        var retriedWithAtlas = false;
         while (true)
         {
+            _wavefrontFrameEnabled =
+                VectorEngine == VectorRenderingEngine.Wavefront &&
+                !retriedWithAtlas;
             try
             {
                 RenderSceneCore(root, width, height, targetView);
                 return;
+            }
+            catch (WavefrontFrameFallbackException)
+            {
+                if (retriedWithAtlas)
+                {
+                    throw;
+                }
+
+                retriedWithAtlas = true;
+                retriedAfterPathAtlasReset = false;
+                _compiledSceneReusable = false;
+                ReturnPendingMaskTexturesToPool();
+                ProGpuSceneDiagnostics.WriteLine(
+                    "[Compositor] Retrying the experimental Wavefront frame with the ordered Atlas renderer because the scene uses unsupported or mixed content.");
             }
             catch (PathAtlasCapacityExceededException)
             {
@@ -2672,6 +2790,7 @@ public unsafe partial class Compositor : IDisposable
             }
             finally
             {
+                _wavefrontFrameEnabled = false;
                 ReleaseFrameRetainedResources();
             }
         }
@@ -2696,9 +2815,10 @@ public unsafe partial class Compositor : IDisposable
 
         _context.CleanupPendingResources();
 
-        var wavefrontEnabled = VectorEngine == VectorRenderingEngine.Wavefront;
+        var wavefrontEnabled = _wavefrontFrameEnabled;
         if (wavefrontEnabled)
         {
+            _wavefrontFramePathCount = 0;
             (_wavefrontEngine ??= new WavefrontVectorEngine(_context)).BeginFrame();
         }
 
@@ -2930,7 +3050,13 @@ public unsafe partial class Compositor : IDisposable
                 for (var commandIndex = 0; commandIndex < diagnosticCommandCount; commandIndex++)
                 {
                     var cmd = diagnosticCommands[commandIndex];
-                    var activeTransform = Matrix4x4.Identity;
+                    // Match normal visual compilation: path compilation composes its
+                    // recorded transform internally, while every other command expects
+                    // the complete active transform from its caller.
+                    var activeTransform = cmd.Type != RenderCommandType.DrawPath &&
+                        cmd.Transform != default
+                            ? cmd.Transform
+                            : Matrix4x4.Identity;
                     switch (cmd.Type)
                     {
                         case RenderCommandType.DrawRect:
@@ -3050,6 +3176,21 @@ SceneCompilationComplete:
         {
             glyphBatchActive = false;
             _atlas.EndBatch();
+        }
+
+        // Wavefront currently composites one frame-wide compute layer after the
+        // ordered Atlas pass. Mixing the two would reorder content. Retry the
+        // complete frame transaction through Atlas whenever compilation emitted
+        // any ordinary draw or mask work; pure supported Wavefront fills keep the
+        // experimental fast path.
+        if (wavefrontEnabled &&
+            (_vectorIndicesList.Count > 0 ||
+             _textVerticesList.Count > 0 ||
+             _textureIndicesList.Count > 0 ||
+             _drawCalls.Count > 0 ||
+             _maskRenderPasses.Count > 0))
+        {
+            throw WavefrontFrameFallbackException.Instance;
         }
 
         if (_pathAtlas.CapacityExceeded ||
@@ -3461,6 +3602,18 @@ SceneStateUploadComplete:
                             {
                                 _context.Api.RenderPassEncoderSetBindGroup(pass, 1, *pPathAtlas, 0, null);
                             }
+                            _context.Api.RenderPassEncoderSetVertexBuffer(
+                                pass,
+                                0,
+                                _vectorVertexBuffer.BufferPtr,
+                                0,
+                                _vectorVertexBuffer.Size);
+                            _context.Api.RenderPassEncoderSetIndexBuffer(
+                                pass,
+                                _vectorIndexBuffer.BufferPtr,
+                                IndexFormat.Uint32,
+                                0,
+                                _vectorIndexBuffer.Size);
                             currentType = DrawCallType.Vector;
                             currentBlendMode = dc.BlendMode;
                             currentPipelineHasMask = hasMask;
@@ -5109,6 +5262,10 @@ SceneStateUploadComplete:
                 ? activeTransform
                 : command.Transform * activeTransform;
         }
+        Matrix4x4 hitTestTransform = ResolveHitTestTransform(
+            command,
+            globalTransform,
+            activeTransform);
 
         bool savedUseGpuTransformsActive = _useGpuTransformsActive;
         Matrix4x4 savedCameraViewMatrix = _cameraViewMatrix;
@@ -5122,7 +5279,7 @@ SceneStateUploadComplete:
                 _gpuTransformsCameraView = command.CameraView * globalTransform;
             }
 
-            AddHitTestStateCommand(command, activeTransform);
+            AddHitTestStateCommand(command, hitTestTransform);
 
             switch (command.Type)
             {
@@ -5168,7 +5325,10 @@ SceneStateUploadComplete:
                             command.Path,
                             command.Pen,
                             command.Rect,
-                            activeTransform);
+                            activeTransform,
+                            command.IsPenThicknessLocal,
+                            command.Transform,
+                            command.GeometryCache);
                     }
                     else if (command.Brush != null)
                     {
@@ -5282,7 +5442,10 @@ SceneStateUploadComplete:
                         activeTransform);
                     break;
                 case RenderCommandType.DrawPicture:
-                    CompilePicture(command.Picture, activeTransform);
+                    CompilePicture(
+                        command.Picture,
+                        activeTransform,
+                        hitTestTransform);
                     break;
                 case RenderCommandType.DrawVisual:
                     CompileEmbeddedVisual(command.Visual, activeTransform);
@@ -5292,7 +5455,7 @@ SceneStateUploadComplete:
                     break;
             }
 
-            AddHitTestDrawCommand(command, activeTransform, context);
+            AddHitTestDrawCommand(command, hitTestTransform, context);
 
             if (command.UseGpuTransforms)
             {
@@ -5323,6 +5486,23 @@ SceneStateUploadComplete:
         }
     }
 
+    private static Matrix4x4 ResolveHitTestTransform(
+        in RenderCommand command,
+        in Matrix4x4 globalTransform,
+        in Matrix4x4 activeTransform)
+    {
+        if (!command.UseGpuTransforms)
+        {
+            return activeTransform;
+        }
+
+        var lateTransform = command.CameraView * globalTransform;
+        return command.Type != RenderCommandType.DrawPath &&
+            command.Transform != default
+                ? command.Transform * lateTransform
+                : lateTransform;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void CompileExtensionCommand(
         DrawingContext context,
@@ -5340,10 +5520,6 @@ SceneStateUploadComplete:
             context,
             activeTransform,
             ref localCommand);
-        Matrix4x4 commandTransform = localCommand.Transform;
-        if (commandTransform == default)
-            commandTransform = Matrix4x4.Identity;
-
         _drawCalls.Add(new CompositorDrawCall
         {
             Type = DrawCallType.Extension,
@@ -5368,7 +5544,10 @@ SceneStateUploadComplete:
             Brush = localCommand.Brush,
             Pen = localCommand.Pen,
             Path = localCommand.Path,
-            Transform = activeTransform * commandTransform,
+            // The command transform was already composed into activeTransform
+            // before the extension compiled. Retaining it again here would make
+            // transform-consuming render pipelines (notably StaticDxf) apply it twice.
+            Transform = activeTransform,
             LineThicknessOrRadius = localCommand.RadiusX,
             Scale = localCommand.Scale,
             Translate = localCommand.Translate,
@@ -5436,6 +5615,36 @@ SceneStateUploadComplete:
                MathF.Abs(transform.M44 - 1f) <= epsilon;
     }
 
+    private static bool IsFiniteInvertibleAffine2D(Matrix4x4 transform)
+    {
+        if (!IsFiniteAffine2D(transform))
+        {
+            return false;
+        }
+
+        var determinant = transform.M11 * transform.M22 -
+            transform.M12 * transform.M21;
+        return float.IsFinite(determinant) && determinant != 0f;
+    }
+
+    private static float GetAnalyticPrimitiveLocalAntialiasPadding(Matrix4x4 transform)
+    {
+        if (!TransformMetrics.TryGetStrokeScales(
+                transform,
+                out _,
+                out var minimumScale))
+        {
+            // Retain the established fill behavior for invalid or collapsed
+            // transforms. Stroke validation remains independently fail-closed.
+            return AnalyticPrimitiveAntialiasPaddingPixels;
+        }
+
+        var localPadding = AnalyticPrimitiveAntialiasPaddingPixels / minimumScale;
+        return float.IsFinite(localPadding) && localPadding > 0f
+            ? localPadding
+            : AnalyticPrimitiveAntialiasPaddingPixels;
+    }
+
     private static bool IsFiniteRect(Rect rect) =>
         float.IsFinite(rect.X) &&
         float.IsFinite(rect.Y) &&
@@ -5465,10 +5674,13 @@ SceneStateUploadComplete:
             node.HitTestId);
     }
 
-    private void CompilePicture(GpuPicture? picture, Matrix4x4 globalTransform)
+    private void CompilePicture(
+        GpuPicture? picture,
+        Matrix4x4 globalTransform,
+        Matrix4x4? hitTestGlobalTransform = null)
     {
         if (picture == null) return;
-        var pictureStrokeScale = TransformMetrics.GetStrokeScale(globalTransform);
+        var retainedHitTestTransform = hitTestGlobalTransform ?? globalTransform;
         var commands = picture.RetainedCommands;
         PreparePictureLayerCaches(commands);
         for (var commandIndex = 0; commandIndex < commands.Length; commandIndex++)
@@ -5476,22 +5688,32 @@ SceneStateUploadComplete:
             var cmd = commands[commandIndex];
             int vectorStart = _vectorVerticesList.Count;
             int textStart = _textVerticesList.Count;
-            var activeTransform = cmd.UseGpuTransforms ? Matrix4x4.Identity : globalTransform;
+            var activeTransform = cmd.UseGpuTransforms
+                ? Matrix4x4.Identity
+                : globalTransform;
             if (cmd.Type != RenderCommandType.DrawPath)
             {
                 activeTransform = (cmd.Transform == default) ? activeTransform : cmd.Transform * activeTransform;
             }
+            var hitTestTransform = cmd.UseGpuTransforms
+                ? ResolveHitTestTransform(
+                    cmd,
+                    globalTransform,
+                    activeTransform)
+                : cmd.Type != RenderCommandType.DrawPath &&
+                    cmd.Transform != default
+                        ? cmd.Transform * retainedHitTestTransform
+                        : retainedHitTestTransform;
 
             var brushTransform = cmd.Type == RenderCommandType.DrawPath && cmd.Transform != default
                 ? cmd.Transform * activeTransform
                 : activeTransform;
             if (!UsesLocalBrushCoordinates(cmd.Type))
             {
-                TransformCommandBrushes(ref cmd, brushTransform, pictureStrokeScale);
+                TransformCommandBrushes(ref cmd, brushTransform);
             }
             else
             {
-                ScaleCommandPen(ref cmd, pictureStrokeScale);
                 if (cmd.Type == RenderCommandType.DrawPath)
                 {
                     TransformCommandPenBrush(ref cmd, brushTransform);
@@ -5509,7 +5731,7 @@ SceneStateUploadComplete:
                 _gpuTransformsCameraView = cmd.CameraView * globalTransform;
             }
 
-            AddHitTestStateCommand(cmd, activeTransform);
+            AddHitTestStateCommand(cmd, hitTestTransform);
 
             switch (cmd.Type)
             {
@@ -5545,7 +5767,10 @@ SceneStateUploadComplete:
                             cmd.Path,
                             cmd.Pen,
                             cmd.Rect,
-                            activeTransform);
+                            activeTransform,
+                            cmd.IsPenThicknessLocal,
+                            cmd.Transform,
+                            cmd.GeometryCache);
                     else if (cmd.Brush != null)
                         PushOpacityMaskValue(cmd.Brush, cmd.Rect, activeTransform);
                     break;
@@ -5624,11 +5849,6 @@ SceneStateUploadComplete:
                             CommitPendingDrawCalls();
                             var localCmd = cmd;
                             pipeline.Compile(this, picture, activeTransform, ref localCmd);
-                            var cmdTransform = localCmd.Transform;
-                            if (cmdTransform == default || cmdTransform == new Matrix4x4())
-                            {
-                                cmdTransform = Matrix4x4.Identity;
-                            }
                             _drawCalls.Add(new CompositorDrawCall
                             {
                                 Type = DrawCallType.Extension,
@@ -5652,7 +5872,8 @@ SceneStateUploadComplete:
                                 Brush = localCmd.Brush,
                                 Pen = localCmd.Pen,
                                 Path = localCmd.Path,
-                                Transform = activeTransform * cmdTransform,
+                                // activeTransform already includes cmd.Transform.
+                                Transform = activeTransform,
                                 LineThicknessOrRadius = localCmd.RadiusX,
                                 Scale = localCmd.Scale,
                                 Translate = localCmd.Translate,
@@ -5674,7 +5895,10 @@ SceneStateUploadComplete:
                     CompileGpuScatterSeriesCommand(picture, cmd, activeTransform);
                     break;
                 case RenderCommandType.DrawPicture:
-                    CompilePicture(cmd.Picture, activeTransform);
+                    CompilePicture(
+                        cmd.Picture,
+                        activeTransform,
+                        hitTestTransform);
                     break;
                 case RenderCommandType.DrawVisual:
                     CompileEmbeddedVisual(cmd.Visual, activeTransform);
@@ -5684,7 +5908,7 @@ SceneStateUploadComplete:
                     break;
             }
 
-            AddHitTestDrawCommand(cmd, activeTransform, picture);
+            AddHitTestDrawCommand(cmd, hitTestTransform, picture);
 
             if (cmd.UseGpuTransforms)
             {
@@ -5777,8 +6001,7 @@ SceneStateUploadComplete:
 
     private static void TransformCommandBrushes(
         ref RenderCommand command,
-        Matrix4x4 commandTransform,
-        float strokeScale)
+        Matrix4x4 commandTransform)
     {
         if (!Matrix4x4.Invert(commandTransform, out var inverseCommandTransform))
         {
@@ -5788,18 +6011,22 @@ SceneStateUploadComplete:
         command.Brush = TransformCommandBrush(command.Brush, inverseCommandTransform);
         if (command.Pen != null)
         {
-            var penScale = command.IsPenThicknessLocal ? 1f : strokeScale;
-            var penThickness = command.Pen.Thickness * penScale;
+            var transformedPenBrush = TransformCommandBrush(command.Pen.Brush, inverseCommandTransform);
+            if (ReferenceEquals(transformedPenBrush, command.Pen.Brush))
+            {
+                return;
+            }
+
             command.Pen = new Pen(
-                TransformCommandBrush(command.Pen.Brush, inverseCommandTransform)!,
-                penThickness,
+                transformedPenBrush!,
+                command.Pen.Thickness,
                 command.Pen.LineJoin,
                 command.Pen.MiterLimit,
                 command.Pen.StartLineCap,
                 command.Pen.EndLineCap,
                 command.Pen.DashCap,
-                ScaleRelativeDashArray(command.Pen.DashArray, penScale),
-                command.Pen.DashOffset / penScale);
+                command.Pen.DashArray,
+                command.Pen.DashOffset);
         }
     }
 
@@ -5815,40 +6042,6 @@ SceneStateUploadComplete:
             RenderCommandType.DrawPointBatch;
     }
 
-    private static void ScaleCommandPen(ref RenderCommand command, float strokeScale)
-    {
-        if (command.Pen == null || command.IsPenThicknessLocal)
-        {
-            return;
-        }
-
-        command.Pen = new Pen(
-            command.Pen.Brush,
-            command.Pen.Thickness * strokeScale,
-            command.Pen.LineJoin,
-            command.Pen.MiterLimit,
-            command.Pen.StartLineCap,
-            command.Pen.EndLineCap,
-            command.Pen.DashCap,
-            ScaleRelativeDashArray(command.Pen.DashArray, strokeScale),
-            command.Pen.DashOffset / strokeScale);
-    }
-
-    private static double[]? ScaleRelativeDashArray(double[]? dashArray, float strokeScale)
-    {
-        if (dashArray == null || strokeScale == 1f)
-        {
-            return dashArray;
-        }
-
-        for (var i = 0; i < dashArray.Length; i++)
-        {
-            dashArray[i] /= strokeScale;
-        }
-
-        return dashArray;
-    }
-
     private static void TransformCommandPenBrush(ref RenderCommand command, Matrix4x4 commandTransform)
     {
         if (command.Pen == null || !Matrix4x4.Invert(commandTransform, out var inverseCommandTransform))
@@ -5856,8 +6049,14 @@ SceneStateUploadComplete:
             return;
         }
 
+        var transformedPenBrush = TransformCommandBrush(command.Pen.Brush, inverseCommandTransform);
+        if (ReferenceEquals(transformedPenBrush, command.Pen.Brush))
+        {
+            return;
+        }
+
         command.Pen = new Pen(
-            TransformCommandBrush(command.Pen.Brush, inverseCommandTransform)!,
+            transformedPenBrush!,
             command.Pen.Thickness,
             command.Pen.LineJoin,
             command.Pen.MiterLimit,
@@ -5931,16 +6130,18 @@ SceneStateUploadComplete:
         if (cmd.Brush is GpuTextureBrush textureBrush)
         {
             CompileTextureBrushRectangle(textureBrush, cmd.Rect, transform);
-            if (cmd.Pen is null || cmd.Pen.Thickness <= 0f)
+            if (!IsRenderableStroke(cmd.Pen))
                 return;
             cmd.Brush = null;
         }
 
         bool hasFill = cmd.Brush != null;
-        bool hasStroke = cmd.Pen != null && cmd.Pen.Thickness > 0f;
+        var stroke = ResolveStrokeCompileState(cmd, transform);
+        bool hasStroke = stroke.IsValid;
         bool useSolidRectPipeline = ActiveCompilationContext == null &&
             (!hasFill || cmd.Brush is SolidColorBrush) &&
-            (!hasStroke || cmd.Pen!.Brush is SolidColorBrush);
+            (!hasStroke || cmd.Pen!.Brush is SolidColorBrush) &&
+            !stroke.IsHairline;
         SwitchBatch(useSolidRectPipeline ? BatchType.SolidRect : BatchType.Vector);
         int startIndex = _vectorVerticesList.Count;
         var r = cmd.Rect;
@@ -5948,10 +6149,11 @@ SceneStateUploadComplete:
         float hHalf = r.Height / 2f;
         var shapeSize = new Vector2(r.Width, r.Height);
         var rectShapeType = EncodeShapeType(cmd, 0f);
+        var antialiasPadding = GetAnalyticPrimitiveLocalAntialiasPadding(transform);
 
         if (cmd.Brush != null)
         {
-            float pad = 1.5f;
+            float pad = antialiasPadding;
             var f0_pos = Vector2.Transform(new Vector2(r.X - pad, r.Y - pad), transform);
             var f1_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y - pad), transform);
             var f2_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y + r.Height + pad), transform);
@@ -5987,19 +6189,20 @@ SceneStateUploadComplete:
             indexSpan[5] = idxStart + 3;
         }
 
-        if (cmd.Pen != null && cmd.Pen.Thickness > 0f)
+        if (hasStroke)
         {
-            float pad = cmd.Pen.Thickness / 2f + 1.5f;
+            var pen = cmd.Pen!;
+            float pad = stroke.LocalBoundsThickness / 2f + antialiasPadding;
             var p0_pos = Vector2.Transform(new Vector2(r.X - pad, r.Y - pad), transform);
             var p1_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y - pad), transform);
             var p2_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y + r.Height + pad), transform);
             var p3_pos = Vector2.Transform(new Vector2(r.X - pad, r.Y + r.Height + pad), transform);
 
-            float penBrushIdx = useSolidRectPipeline ? 0f : RegisterBrush(cmd.Pen.Brush);
-            var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solidPen) ? solidPen.Color : new Vector4(r.X + wHalf, r.Y + hHalf, 0f, 0f);
+            float penBrushIdx = useSolidRectPipeline ? 0f : RegisterBrush(pen.Brush);
+            var penSolidColor = (pen.Brush is SolidColorBrush solidPen) ? solidPen.Color : new Vector4(r.X + wHalf, r.Y + hHalf, 0f, 0f);
             if (useSolidRectPipeline)
             {
-                penSolidColor.W *= cmd.Pen.Brush.Opacity * _activeOpacity;
+                penSolidColor.W *= pen.Brush.Opacity * _activeOpacity;
             }
 
             uint idxStart = (uint)_vectorVerticesList.Count;
@@ -6008,10 +6211,10 @@ SceneStateUploadComplete:
             CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + 4);
             var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, 4);
 
-            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, rectShapeType);
-            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, rectShapeType);
-            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, rectShapeType);
-            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, rectShapeType);
+            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
+            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
+            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
+            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
 
             int originalIndexCount = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + 6);
@@ -6949,13 +7152,26 @@ SceneStateUploadComplete:
         SwitchBatch(BatchType.Vector);
         if (cmd.Path == null) return;
 
-        if (VectorEngine == VectorRenderingEngine.Wavefront)
+        if (_wavefrontFrameEnabled)
         {
             var activeTransform = cmd.Transform == default ? transform : cmd.Transform * transform;
+            if (!CanCompileWavefrontPath(cmd, activeTransform))
+            {
+                throw WavefrontFrameFallbackException.Instance;
+            }
+
+            // The current compute grid stores at most 64 instances per cell.
+            // A frame-wide instance bound guarantees no cell can silently drop
+            // an otherwise eligible path; larger scenes use the Atlas retry.
+            if (++_wavefrontFramePathCount > 64)
+            {
+                throw WavefrontFrameFallbackException.Instance;
+            }
+
             (_wavefrontEngine ??= new WavefrontVectorEngine(_context)).DrawPath(
                 cmd.Path,
                 activeTransform,
-                cmd.Brush ?? new SolidColorBrush(Vector4.One));
+                cmd.Brush!);
             return;
         }
 
@@ -7088,20 +7304,34 @@ SceneStateUploadComplete:
             }
         }
 
-        if (cmd.Pen != null && cmd.Pen.Thickness > 0f)
+        if (IsRenderableStroke(cmd.Pen))
         {
-            if (cmd.Pen.HasDashPattern)
+            var stroke = ResolveStrokeCompileState(cmd, transform);
+            if (!stroke.IsValid)
+            {
+                return;
+            }
+
+            if (cmd.Pen!.HasDashPattern)
             {
                 PathGeometry dashedPath;
                 Pen undashedPen;
-                if (cmd.GeometryCache?.TryGetDashedStrokePath(cmd.Pen, out dashedPath, out undashedPen) != true)
+                if (cmd.GeometryCache?.TryGetDashedStrokePath(
+                        cmd.Pen,
+                        stroke.LocalThickness,
+                        out dashedPath,
+                        out undashedPen) != true)
                 {
-                    if (!TryCreateDashedStrokePath(cmd.Path, cmd.Pen, out dashedPath))
+                    if (!TryCreateDashedStrokePath(
+                            cmd.Path,
+                            cmd.Pen,
+                            stroke.LocalThickness,
+                            out dashedPath))
                     {
                         throw new NotSupportedException("Dashed strokes are not supported for this path geometry.");
                     }
 
-                    undashedPen = CreateUndashedPen(cmd.Pen);
+                    undashedPen = CreateUndashedPen(cmd.Pen, stroke.LocalThickness);
                 }
 
                 var dashedCmd = cmd;
@@ -7109,6 +7339,7 @@ SceneStateUploadComplete:
                 dashedCmd.Path = dashedPath;
                 dashedCmd.Pen = undashedPen;
                 dashedCmd.Transform = default;
+                dashedCmd.IsPenThicknessLocal = true;
                 if (_activeClipRect.HasValue)
                 {
                     var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
@@ -7131,11 +7362,9 @@ SceneStateUploadComplete:
 
             float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
             var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-            float thickness = cmd.Pen.Thickness;
-            var useAffineStrokeGeometry = RequiresAffineStrokeGeometry(transform);
-            var localAffineThickness = useAffineStrokeGeometry
-                ? thickness / TransformMetrics.GetStrokeScale(transform)
-                : thickness;
+            float thickness = stroke.EncodedThickness;
+            var useAffineStrokeGeometry = stroke.RequiresAffineGeometry;
+            var localAffineThickness = stroke.LocalGeometryThickness;
 
             int maxVertices = 0;
             int maxIndices = 0;
@@ -7143,11 +7372,13 @@ SceneStateUploadComplete:
             for (int figureIndex = 0; figureIndex < pathFigures.Count; figureIndex++)
             {
                 var figure = pathFigures[figureIndex];
+                var startLineCap = figure.StrokeStartLineCap ?? cmd.Pen.StartLineCap;
+                var endLineCap = figure.StrokeEndLineCap ?? cmd.Pen.EndLineCap;
                 int maxJoinTriangles = CountStrokeSegmentJoinTriangleBudget(figure);
                 maxVertices += maxJoinTriangles * 4;
                 maxIndices += maxJoinTriangles * 6;
 
-                int maxCapTriangles = CountStrokeSegmentCapTriangleBudget(figure, cmd.Pen.StartLineCap, cmd.Pen.EndLineCap);
+                int maxCapTriangles = CountStrokeSegmentCapTriangleBudget(figure, startLineCap, endLineCap);
                 maxVertices += maxCapTriangles * 4;
                 maxIndices += maxCapTriangles * 6;
 
@@ -7229,6 +7460,8 @@ SceneStateUploadComplete:
             for (int figureIndex = 0; figureIndex < pathFigures.Count; figureIndex++)
             {
                 var figure = pathFigures[figureIndex];
+                var startLineCap = figure.StrokeStartLineCap ?? cmd.Pen.StartLineCap;
+                var endLineCap = figure.StrokeEndLineCap ?? cmd.Pen.EndLineCap;
                 var currentPoint = figure.StartPoint;
                 var firstSegmentStartDirection = default(Vector2);
                 var previousSegmentEndDirection = default(Vector2);
@@ -7256,7 +7489,6 @@ SceneStateUploadComplete:
                                 indicesSpan,
                                 ref currentVertexCount,
                                 ref currentIndexCount,
-                                cmd.Pen,
                                 penSolidColor,
                                 penBrushIdx,
                                 localAffineThickness,
@@ -7264,8 +7496,10 @@ SceneStateUploadComplete:
                                 lastCapDirection,
                                 transform,
                                 useAffineStrokeGeometry,
+                                stroke.IsHairline,
                                 cmd.IsEdgeAliased,
-                                isStart: false);
+                                isStart: false,
+                                lineCap: endLineCap);
                         }
                         else if (!figure.IsClosed && hasDegenerateStrokeCandidate)
                         {
@@ -7277,7 +7511,7 @@ SceneStateUploadComplete:
                                 cmd.Pen,
                                 penSolidColor,
                                 penBrushIdx,
-                                thickness,
+                                stroke.DeviceThickness,
                                 degenerateStrokeCenter,
                                 transform,
                                 cmd.IsEdgeAliased);
@@ -7336,7 +7570,6 @@ SceneStateUploadComplete:
                             indicesSpan,
                             ref currentVertexCount,
                             ref currentIndexCount,
-                            cmd.Pen,
                             penSolidColor,
                             penBrushIdx,
                             localAffineThickness,
@@ -7344,8 +7577,10 @@ SceneStateUploadComplete:
                             segmentStartDirection,
                             transform,
                             useAffineStrokeGeometry,
+                            stroke.IsHairline,
                             cmd.IsEdgeAliased,
-                            isStart: true);
+                            isStart: true,
+                            lineCap: startLineCap);
                     }
 
                     if (!isFirstSegment &&
@@ -7425,7 +7660,8 @@ SceneStateUploadComplete:
                                 penBrushIdx,
                                 localAffineThickness,
                                 segmentStart,
-                                quad,
+                                quad.ControlPoint,
+                                quad.Point,
                                 transform,
                                 cmd.IsEdgeAliased);
                         }
@@ -7480,7 +7716,9 @@ SceneStateUploadComplete:
                                 penBrushIdx,
                                 localAffineThickness,
                                 segmentStart,
-                                cubic,
+                                cubic.ControlPoint1,
+                                cubic.ControlPoint2,
+                                cubic.Point,
                                 transform,
                                 cmd.IsEdgeAliased);
                         }
@@ -7617,7 +7855,6 @@ SceneStateUploadComplete:
                         indicesSpan,
                         ref currentVertexCount,
                         ref currentIndexCount,
-                        cmd.Pen,
                         penSolidColor,
                         penBrushIdx,
                         localAffineThickness,
@@ -7625,8 +7862,10 @@ SceneStateUploadComplete:
                         lastCapDirection,
                         transform,
                         useAffineStrokeGeometry,
+                        stroke.IsHairline,
                         cmd.IsEdgeAliased,
-                        isStart: false);
+                        isStart: false,
+                        lineCap: endLineCap);
                 }
                 else if (!figure.IsClosed && hasDegenerateStrokeCandidate)
                 {
@@ -7638,7 +7877,7 @@ SceneStateUploadComplete:
                         cmd.Pen,
                         penSolidColor,
                         penBrushIdx,
-                        thickness,
+                        stroke.DeviceThickness,
                         degenerateStrokeCenter,
                         transform,
                         cmd.IsEdgeAliased);
@@ -7759,7 +7998,80 @@ SceneStateUploadComplete:
         }
     }
 
+    private bool CanCompileWavefrontPath(
+        in RenderCommand cmd,
+        in Matrix4x4 activeTransform)
+    {
+        if (cmd.Path == null ||
+            cmd.Path.IsCombined ||
+            cmd.Path.FillRule != FillRule.Nonzero ||
+            cmd.Brush is not SolidColorBrush solid ||
+            IsRenderableStroke(cmd.Pen) ||
+            cmd.UseVectorGlyphRendering ||
+            cmd.IsEdgeAliased ||
+            solid.Opacity != 1f ||
+            solid.Color.W != 1f ||
+            !IsFiniteVector4(solid.Color) ||
+            _activeOpacity != 1f ||
+            _activeClipRect.HasValue ||
+            _maskStack.Count != 0 ||
+            _activeBlendMode != GpuBlendMode.SrcOver ||
+            _offscreenRenderDepth != 0 ||
+            _suspendHitTestCacheWrites ||
+            _useGpuTransformsActive ||
+            !IsFiniteInvertibleAffine2D(activeTransform) ||
+            RequiresAffineStrokeGeometry(activeTransform))
+        {
+            return false;
+        }
+
+        var hasSegment = false;
+        var figures = cmd.Path.Figures;
+        for (var figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            var figure = figures[figureIndex];
+            if (!figure.IsFilled || !figure.IsClosed)
+            {
+                return false;
+            }
+
+            var segments = figure.Segments;
+            for (var segmentIndex = 0; segmentIndex < segments.Count; segmentIndex++)
+            {
+                if (segments[segmentIndex] is not LineSegment and
+                    not QuadraticBezierSegment and
+                    not CubicBezierSegment)
+                {
+                    return false;
+                }
+
+                hasSegment = true;
+            }
+        }
+
+        return hasSegment;
+    }
+
+    private static bool IsFiniteVector4(in Vector4 value) =>
+        float.IsFinite(value.X) &&
+        float.IsFinite(value.Y) &&
+        float.IsFinite(value.Z) &&
+        float.IsFinite(value.W);
+
     internal static bool TryCreateDashedStrokePath(PathGeometry source, Pen pen, out PathGeometry dashedPath)
+    {
+        return TryCreateDashedStrokePath(
+            source,
+            pen,
+            pen.IsHairline ? 1f : pen.Thickness,
+            out dashedPath);
+    }
+
+    internal static bool TryCreateDashedStrokePath(
+        PathGeometry source,
+        Pen pen,
+        float localThickness,
+        out PathGeometry dashedPath)
     {
         dashedPath = new PathGeometry
         {
@@ -7772,8 +8084,9 @@ SceneStateUploadComplete:
         }
 
         var dashArray = pen.DashArray;
+        var dashThickness = pen.IsHairline ? 1f : localThickness;
         if (dashArray is not { Length: > 0 } ||
-            !DashPattern.TryCreate(dashArray, pen.DashOffset, pen.Thickness, out var pattern))
+            !DashPattern.TryCreate(dashArray, pen.DashOffset, dashThickness, out var pattern))
         {
             return false;
         }
@@ -7782,6 +8095,7 @@ SceneStateUploadComplete:
         for (int figureIndex = 0; figureIndex < sourceFigures.Count; figureIndex++)
         {
             var figure = sourceFigures[figureIndex];
+            var dashedFigureStartIndex = dashedPath.Figures.Count;
             var patternIndex = pattern.InitialIndex;
             var distanceInPattern = pattern.InitialDistance;
             PathFigure? activeDashFigure = null;
@@ -7917,9 +8231,110 @@ SceneStateUploadComplete:
                     ref activeDashFigure,
                     ref activeDashEnd);
             }
+
+            if (figure.IsClosed)
+            {
+                MergeClosedDashSeam(dashedPath, dashedFigureStartIndex, figure.StartPoint);
+            }
+            else
+            {
+                ApplyOpenDashEndpointCaps(
+                    dashedPath,
+                    dashedFigureStartIndex,
+                    figure.StartPoint,
+                    currentPoint,
+                    pen.StartLineCap,
+                    pen.EndLineCap,
+                    pen.DashCap);
+            }
         }
 
         return true;
+    }
+
+    private static void ApplyOpenDashEndpointCaps(
+        PathGeometry dashedPath,
+        int firstFigureIndex,
+        Vector2 sourceStart,
+        Vector2 sourceEnd,
+        PenLineCap startLineCap,
+        PenLineCap endLineCap,
+        PenLineCap dashCap)
+    {
+        var figures = dashedPath.Figures;
+        if ((uint)firstFigureIndex >= (uint)figures.Count)
+        {
+            return;
+        }
+
+        var firstFigure = figures[firstFigureIndex];
+        if (startLineCap != dashCap &&
+            Vector2.DistanceSquared(firstFigure.StartPoint, sourceStart) <= StrokeEpsilon * StrokeEpsilon)
+        {
+            firstFigure.StrokeStartLineCap = startLineCap;
+        }
+
+        var lastFigure = figures[^1];
+        if (endLineCap != dashCap &&
+            TryGetPathFigureEndPoint(lastFigure, out var lastEnd) &&
+            Vector2.DistanceSquared(lastEnd, sourceEnd) <= StrokeEpsilon * StrokeEpsilon)
+        {
+            lastFigure.StrokeEndLineCap = endLineCap;
+        }
+    }
+
+    private static void MergeClosedDashSeam(
+        PathGeometry dashedPath,
+        int firstFigureIndex,
+        Vector2 seam)
+    {
+        var figures = dashedPath.Figures;
+        if ((uint)firstFigureIndex >= (uint)figures.Count)
+        {
+            return;
+        }
+
+        var firstFigure = figures[firstFigureIndex];
+        var lastFigure = figures[^1];
+        if (Vector2.DistanceSquared(firstFigure.StartPoint, seam) > StrokeEpsilon * StrokeEpsilon ||
+            !TryGetPathFigureEndPoint(lastFigure, out var lastEnd) ||
+            Vector2.DistanceSquared(lastEnd, seam) > StrokeEpsilon * StrokeEpsilon)
+        {
+            return;
+        }
+
+        if (ReferenceEquals(firstFigure, lastFigure))
+        {
+            // The drawn interval covers the complete contour. Closing the retained figure
+            // produces the source seam join without synthesizing two coincident dash caps.
+            firstFigure.IsClosed = true;
+            firstFigure.StrokeStartLineCap = null;
+            firstFigure.StrokeEndLineCap = null;
+            return;
+        }
+
+        // The final and initial drawn intervals are one cyclic run. Reuse both retained
+        // segment lists and move the initial span behind the final span, preserving O(S)
+        // construction while keeping cache hits allocation- and traversal-free.
+        lastFigure.Segments.AddRange(firstFigure.Segments);
+        lastFigure.StrokeStartLineCap = null;
+        lastFigure.StrokeEndLineCap = null;
+        figures.RemoveAt(firstFigureIndex);
+    }
+
+    private static bool TryGetPathFigureEndPoint(PathFigure figure, out Vector2 endPoint)
+    {
+        endPoint = figure.StartPoint;
+        var segments = figure.Segments;
+        for (int segmentIndex = 0; segmentIndex < segments.Count; segmentIndex++)
+        {
+            if (TryGetPathSegmentEndPoint(segments[segmentIndex], out var segmentEnd))
+            {
+                endPoint = segmentEnd;
+            }
+        }
+
+        return segments.Count > 0;
     }
 
     private static void AddDashedLineFigures(
@@ -8014,14 +8429,33 @@ SceneStateUploadComplete:
 
     internal static Pen CreateUndashedPen(Pen pen)
     {
+        return CreateUndashedPen(pen, pen.Thickness);
+    }
+
+    internal static Pen CreateUndashedPen(Pen pen, float localThickness)
+    {
         return new Pen(
             pen.Brush,
-            pen.Thickness,
+            pen.IsHairline ? Pen.HairlineThickness : localThickness,
+            pen.LineJoin,
+            pen.MiterLimit,
+            pen.DashCap,
+            pen.DashCap,
+            pen.DashCap);
+    }
+
+    private static Pen CreatePenWithThickness(Pen pen, float localThickness)
+    {
+        return new Pen(
+            pen.Brush,
+            localThickness,
             pen.LineJoin,
             pen.MiterLimit,
             pen.StartLineCap,
             pen.EndLineCap,
-            pen.DashCap);
+            pen.DashCap,
+            pen.DashArray,
+            pen.DashOffset);
     }
 
     private static int CountStrokeSegmentJoinTriangleBudget(PathFigure figure)
@@ -8290,19 +8724,20 @@ SceneStateUploadComplete:
         float penBrushIdx,
         float localThickness,
         Vector2 start,
-        QuadraticBezierSegment segment,
+        Vector2 control,
+        Vector2 end,
         Matrix4x4 transform,
         bool isEdgeAliased)
     {
         const int segmentCount = 24;
         var previousPoint = start;
-        var previousTangent = GetQuadraticTangent(start, segment.ControlPoint, segment.Point, 0f);
+        var previousTangent = GetQuadraticTangent(start, control, end, 0f);
 
         for (var i = 1; i <= segmentCount; i++)
         {
             var t = (float)i / segmentCount;
-            var point = BezierSegmentGeometry.EvaluateQuadratic(start, segment.ControlPoint, segment.Point, t);
-            var tangent = GetQuadraticTangent(start, segment.ControlPoint, segment.Point, t);
+            var point = BezierSegmentGeometry.EvaluateQuadratic(start, control, end, t);
+            var tangent = GetQuadraticTangent(start, control, end, t);
             AppendAffineStrokeCurveSection(
                 verticesSpan,
                 indicesSpan,
@@ -8331,19 +8766,21 @@ SceneStateUploadComplete:
         float penBrushIdx,
         float localThickness,
         Vector2 start,
-        CubicBezierSegment segment,
+        Vector2 control1,
+        Vector2 control2,
+        Vector2 end,
         Matrix4x4 transform,
         bool isEdgeAliased)
     {
         const int segmentCount = 24;
         var previousPoint = start;
-        var previousTangent = GetCubicTangent(start, segment.ControlPoint1, segment.ControlPoint2, segment.Point, 0f);
+        var previousTangent = GetCubicTangent(start, control1, control2, end, 0f);
 
         for (var i = 1; i <= segmentCount; i++)
         {
             var t = (float)i / segmentCount;
-            var point = BezierSegmentGeometry.EvaluateCubic(start, segment.ControlPoint1, segment.ControlPoint2, segment.Point, t);
-            var tangent = GetCubicTangent(start, segment.ControlPoint1, segment.ControlPoint2, segment.Point, t);
+            var point = BezierSegmentGeometry.EvaluateCubic(start, control1, control2, end, t);
+            var tangent = GetCubicTangent(start, control1, control2, end, t);
             AppendAffineStrokeCurveSection(
                 verticesSpan,
                 indicesSpan,
@@ -8636,7 +9073,14 @@ SceneStateUploadComplete:
             return false;
         }
 
-        float pad = thickness * 0.5f + 2.0f;
+        // A Skia zero-width stroke is encoded as a negative sentinel, but its
+        // raster footprint is one framebuffer pixel. Keep the retained arc
+        // quad large enough for half that pixel plus the calibrated 1.5-pixel
+        // antialias fringe. Late affine transforms conservatively enlarge this
+        // two-unit local halo in Vector.wgsl using sigma_min.
+        float pad = thickness == Pen.HairlineThickness
+            ? 2.0f
+            : thickness * 0.5f + 2.0f;
         if (!TryGetTransformedArcBounds(segmentStart, arc, transform, pad, out Vector2 min, out Vector2 max))
         {
             Vector2 extent = new(
@@ -8765,6 +9209,25 @@ SceneStateUploadComplete:
         bool isEdgeAliased,
         bool isSmoothJoin)
     {
+        if (pen.IsHairline)
+        {
+            AppendHairlineJoinVertices(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penBrushIdx,
+                pen.LineJoin,
+                pen.MiterLimit,
+                localJoinPoint,
+                localIncomingDirection,
+                localOutgoingDirection,
+                transform,
+                isEdgeAliased,
+                isSmoothJoin);
+            return;
+        }
+
         if (useAffineStrokeGeometry)
         {
             AppendAffineStrokeSegmentJoinTriangles(
@@ -8790,6 +9253,7 @@ SceneStateUploadComplete:
             ref currentVertexCount,
             ref currentIndexCount,
             pen,
+            localThickness * TransformMetrics.GetStrokeScale(transform),
             penSolidColor,
             penBrushIdx,
             Vector2.Transform(localJoinPoint, transform),
@@ -8849,7 +9313,6 @@ SceneStateUploadComplete:
         Span<uint> indicesSpan,
         ref int currentVertexCount,
         ref int currentIndexCount,
-        Pen pen,
         Vector4 penSolidColor,
         float penBrushIdx,
         float localThickness,
@@ -8857,9 +9320,29 @@ SceneStateUploadComplete:
         Vector2 localDirectionAlongPath,
         Matrix4x4 transform,
         bool useAffineStrokeGeometry,
+        bool isHairline,
         bool isEdgeAliased,
-        bool isStart)
+        bool isStart,
+        PenLineCap lineCap)
     {
+        if (isHairline)
+        {
+            AppendHairlineCapVertices(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penBrushIdx,
+                lineCap,
+                localCenter,
+                localDirectionAlongPath,
+                transform,
+                isEdgeAliased,
+                isStart,
+                isFullCap: false);
+            return;
+        }
+
         if (useAffineStrokeGeometry)
         {
             AppendAffineStrokeSegmentCapTriangles(
@@ -8867,7 +9350,7 @@ SceneStateUploadComplete:
                 indicesSpan,
                 ref currentVertexCount,
                 ref currentIndexCount,
-                pen,
+                lineCap,
                 penBrushIdx,
                 localThickness,
                 localCenter,
@@ -8883,7 +9366,8 @@ SceneStateUploadComplete:
             indicesSpan,
             ref currentVertexCount,
             ref currentIndexCount,
-            pen,
+            lineCap,
+            localThickness * TransformMetrics.GetStrokeScale(transform),
             penSolidColor,
             penBrushIdx,
             Vector2.Transform(localCenter, transform),
@@ -8892,12 +9376,141 @@ SceneStateUploadComplete:
             isStart);
     }
 
+    private static void AppendHairlineCapVertices(
+        Span<VectorVertex> verticesSpan,
+        Span<uint> indicesSpan,
+        ref int currentVertexCount,
+        ref int currentIndexCount,
+        float penBrushIdx,
+        PenLineCap lineCap,
+        Vector2 localCenter,
+        Vector2 localDirectionAlongPath,
+        Matrix4x4 transform,
+        bool isEdgeAliased,
+        bool isStart,
+        bool isFullCap)
+    {
+        if (lineCap is not (
+            PenLineCap.Square or
+            PenLineCap.Round or
+            PenLineCap.Triangle))
+        {
+            return;
+        }
+
+        var center = Vector2.Transform(localCenter, transform);
+        var direction = TransformDirection(localDirectionAlongPath, transform);
+        if (!IsFinite(center) ||
+            !IsFinite(direction) ||
+            direction.LengthSquared() <= StrokeEpsilon * StrokeEpsilon)
+        {
+            return;
+        }
+
+        var index = (uint)currentVertexCount;
+        var descriptor = new VectorVertex(
+            center,
+            new Vector4(
+                (float)lineCap,
+                isStart ? 1f : 0f,
+                isFullCap ? 1f : 0f,
+                0f),
+            direction,
+            penBrushIdx,
+            new Vector2(index, 0f),
+            0f,
+            Pen.HairlineThickness,
+            EncodeShapeType(isEdgeAliased, HairlineCapShapeType));
+        verticesSpan.Slice(currentVertexCount, 4).Fill(descriptor);
+        currentVertexCount += 4;
+        AppendHairlineAdornmentIndices(
+            indicesSpan,
+            ref currentIndexCount,
+            index);
+    }
+
+    private static void AppendHairlineJoinVertices(
+        Span<VectorVertex> verticesSpan,
+        Span<uint> indicesSpan,
+        ref int currentVertexCount,
+        ref int currentIndexCount,
+        float penBrushIdx,
+        PenLineJoin lineJoin,
+        float miterLimit,
+        Vector2 localJoinPoint,
+        Vector2 localIncomingDirection,
+        Vector2 localOutgoingDirection,
+        Matrix4x4 transform,
+        bool isEdgeAliased,
+        bool isSmoothJoin)
+    {
+        if (isSmoothJoin)
+        {
+            return;
+        }
+
+        var joinPoint = Vector2.Transform(localJoinPoint, transform);
+        var incomingDirection = TransformDirection(localIncomingDirection, transform);
+        var outgoingDirection = TransformDirection(localOutgoingDirection, transform);
+        if (!IsFinite(joinPoint) ||
+            !IsFinite(incomingDirection) ||
+            !IsFinite(outgoingDirection) ||
+            incomingDirection.LengthSquared() <= StrokeEpsilon * StrokeEpsilon ||
+            outgoingDirection.LengthSquared() <= StrokeEpsilon * StrokeEpsilon)
+        {
+            return;
+        }
+
+        var index = (uint)currentVertexCount;
+        var resolvedJoin = lineJoin switch
+        {
+            PenLineJoin.Bevel => PenLineJoin.Bevel,
+            PenLineJoin.Round => PenLineJoin.Round,
+            _ => PenLineJoin.Miter
+        };
+        var resolvedMiterLimit = float.IsFinite(miterLimit) && miterLimit >= 1f
+            ? miterLimit
+            : 1f;
+        var descriptor = new VectorVertex(
+            joinPoint,
+            new Vector4(
+                (float)resolvedJoin,
+                resolvedMiterLimit,
+                index,
+                0f),
+            incomingDirection,
+            penBrushIdx,
+            outgoingDirection,
+            0f,
+            Pen.HairlineThickness,
+            EncodeShapeType(isEdgeAliased, HairlineJoinShapeType));
+        verticesSpan.Slice(currentVertexCount, 4).Fill(descriptor);
+        currentVertexCount += 4;
+        AppendHairlineAdornmentIndices(
+            indicesSpan,
+            ref currentIndexCount,
+            index);
+    }
+
+    private static void AppendHairlineAdornmentIndices(
+        Span<uint> indicesSpan,
+        ref int currentIndexCount,
+        uint index)
+    {
+        indicesSpan[currentIndexCount++] = index;
+        indicesSpan[currentIndexCount++] = index + 1;
+        indicesSpan[currentIndexCount++] = index + 2;
+        indicesSpan[currentIndexCount++] = index;
+        indicesSpan[currentIndexCount++] = index + 2;
+        indicesSpan[currentIndexCount++] = index + 3;
+    }
+
     private static void AppendAffineStrokeSegmentCapTriangles(
         Span<VectorVertex> verticesSpan,
         Span<uint> indicesSpan,
         ref int currentVertexCount,
         ref int currentIndexCount,
-        Pen pen,
+        PenLineCap lineCap,
         float penBrushIdx,
         float localThickness,
         Vector2 localCenter,
@@ -8913,7 +9526,7 @@ SceneStateUploadComplete:
         }
 
         var localTriangles = StrokeCapGeometry.CreateDirectionalCap(
-            isStart ? pen.StartLineCap : pen.EndLineCap,
+            lineCap,
             localThickness,
             localCenter,
             localDirectionAlongPath,
@@ -8951,6 +9564,7 @@ SceneStateUploadComplete:
         ref int currentVertexCount,
         ref int currentIndexCount,
         Pen pen,
+        float thickness,
         Vector4 penSolidColor,
         float penBrushIdx,
         Vector2 joinPoint,
@@ -8961,7 +9575,7 @@ SceneStateUploadComplete:
     {
         var triangles = StrokeJoinGeometry.CreateDirectionalJoin(
             pen.LineJoin,
-            pen.Thickness,
+            thickness,
             pen.MiterLimit,
             joinPoint,
             incomingDirection,
@@ -8990,6 +9604,36 @@ SceneStateUploadComplete:
         ref int currentVertexCount,
         ref int currentIndexCount,
         Pen pen,
+        float thickness,
+        Vector4 penSolidColor,
+        float penBrushIdx,
+        Vector2 center,
+        Vector2 directionAlongPath,
+        bool isEdgeAliased,
+        bool isStart)
+    {
+        AppendStrokeSegmentCapTriangles(
+            verticesSpan,
+            indicesSpan,
+            ref currentVertexCount,
+            ref currentIndexCount,
+            isStart ? pen.StartLineCap : pen.EndLineCap,
+            thickness,
+            penSolidColor,
+            penBrushIdx,
+            center,
+            directionAlongPath,
+            isEdgeAliased,
+            isStart);
+    }
+
+    private static void AppendStrokeSegmentCapTriangles(
+        Span<VectorVertex> verticesSpan,
+        Span<uint> indicesSpan,
+        ref int currentVertexCount,
+        ref int currentIndexCount,
+        PenLineCap lineCap,
+        float thickness,
         Vector4 penSolidColor,
         float penBrushIdx,
         Vector2 center,
@@ -8998,8 +9642,8 @@ SceneStateUploadComplete:
         bool isStart)
     {
         var triangles = StrokeCapGeometry.CreateDirectionalCap(
-            isStart ? pen.StartLineCap : pen.EndLineCap,
-            pen.Thickness,
+            lineCap,
+            thickness,
             center,
             directionAlongPath,
             isStart);
@@ -9195,6 +9839,56 @@ SceneStateUploadComplete:
             return;
         }
 
+        if (pen.IsHairline)
+        {
+            if (pen.StartLineCap == pen.EndLineCap &&
+                pen.StartLineCap is PenLineCap.Round or PenLineCap.Square)
+            {
+                AppendHairlineCapVertices(
+                    verticesSpan,
+                    indicesSpan,
+                    ref currentVertexCount,
+                    ref currentIndexCount,
+                    penBrushIdx,
+                    pen.StartLineCap,
+                    localCenter,
+                    Vector2.UnitX,
+                    transform,
+                    isEdgeAliased,
+                    isStart: false,
+                    isFullCap: true);
+                return;
+            }
+
+            AppendHairlineCapVertices(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penBrushIdx,
+                pen.StartLineCap,
+                localCenter,
+                Vector2.UnitX,
+                transform,
+                isEdgeAliased,
+                isStart: true,
+                isFullCap: false);
+            AppendHairlineCapVertices(
+                verticesSpan,
+                indicesSpan,
+                ref currentVertexCount,
+                ref currentIndexCount,
+                penBrushIdx,
+                pen.EndLineCap,
+                localCenter,
+                Vector2.UnitX,
+                transform,
+                isEdgeAliased,
+                isStart: false,
+                isFullCap: false);
+            return;
+        }
+
         if (pen.StartLineCap == pen.EndLineCap && pen.StartLineCap is PenLineCap.Round or PenLineCap.Square)
         {
             var strokeScale = TransformMetrics.GetStrokeScale(transform);
@@ -9255,6 +9949,7 @@ SceneStateUploadComplete:
             ref currentVertexCount,
             ref currentIndexCount,
             pen,
+            thickness,
             penSolidColor,
             penBrushIdx,
             centerPoint,
@@ -9267,6 +9962,7 @@ SceneStateUploadComplete:
             ref currentVertexCount,
             ref currentIndexCount,
             pen,
+            thickness,
             penSolidColor,
             penBrushIdx,
             centerPoint,
@@ -9467,47 +10163,184 @@ SceneStateUploadComplete:
     }
 
     /// <summary>
-    /// Returns a stroked command's pen thickness in the same space as its transformed geometry.
+    /// Resolves the local and device-space widths for a retained stroke without allocating.
     /// </summary>
     /// <remarks>
-    /// Thickness reaches the compositor already scaled by the command's own transform - the drawing
-    /// context bridges apply their current stroke scale when they emit the command - but not by the
-    /// visual-tree transform that gets composed into <paramref name="activeTransform"/> here. The
-    /// vertices below are emitted post-transform, so recovering just that missing factor keeps a
-    /// stroke proportional to its geometry under a Viewbox or RenderTransform while leaving a
-    /// DrawingContext PushTransform, which was already accounted for, untouched.
+    /// New commands retain their source-space width and set <see cref="RenderCommand.IsPenThicknessLocal"/>.
+    /// Older bridge commands may store a width pre-scaled by <see cref="RenderCommand.Transform"/>;
+    /// dividing by that command scale recovers the source width before the complete visual transform is
+    /// applied. A conformal transform can use the scalar device width directly. A non-conformal affine
+    /// transform must instead expand the source outline and transform that geometry, preserving directional
+    /// width under anisotropic scale and shear.
     /// </remarks>
-    private static float ResolveDeviceStrokeThickness(in RenderCommand cmd, Matrix4x4 activeTransform)
+    private static StrokeCompileState ResolveStrokeCompileState(
+        in RenderCommand cmd,
+        Matrix4x4 fullTransform)
     {
-        var thickness = cmd.Pen!.Thickness;
-        var activeScale = TransformMetrics.GetStrokeScale(activeTransform);
-        var commandScale = cmd.Transform == default
-            ? 1f
-            : TransformMetrics.GetStrokeScale(cmd.Transform);
-
-        if (!float.IsFinite(activeScale) || !float.IsFinite(commandScale) || commandScale <= 0f)
+        if (!IsFiniteInvertibleAffine2D(fullTransform) ||
+            !TryResolveLocalStrokeThickness(cmd, out var localThickness) ||
+            !TransformMetrics.TryGetStrokeScales(
+                fullTransform,
+                out var maximumScale,
+                out var minimumScale))
         {
-            return thickness;
+            return default;
         }
 
-        return thickness * (activeScale / commandScale);
+        var isHairline = cmd.Pen!.IsHairline;
+        if (isHairline)
+        {
+            // The retained sentinel means "one framebuffer pixel", not zero
+            // local units. Centerline geometry is transformed normally while
+            // direct stroke expansion remains in device space. Separate
+            // conservative local widths keep CPU-generated caps/joins and SDF
+            // raster bounds valid without changing dash distances (basis 1).
+            return new StrokeCompileState(
+                localThickness,
+                1f / maximumScale,
+                1f / minimumScale,
+                1f,
+                RequiresAffineGeometry: false,
+                IsHairline: true);
+        }
+
+        return new StrokeCompileState(
+            localThickness,
+            localThickness,
+            localThickness,
+            localThickness * maximumScale,
+            RequiresAffineStrokeGeometry(fullTransform),
+            IsHairline: false);
     }
+
+    internal static bool IsRenderableStroke(Pen? pen)
+    {
+        return pen != null &&
+            float.IsFinite(pen.Thickness) &&
+            (pen.IsHairline || pen.Thickness > 0f);
+    }
+
+    internal static bool TryResolveLocalStrokeThickness(
+        in RenderCommand cmd,
+        out float localThickness)
+    {
+        var pen = cmd.Pen;
+        if (!IsRenderableStroke(pen))
+        {
+            localThickness = 0f;
+            return false;
+        }
+
+        if (pen!.IsHairline)
+        {
+            // Dash values on a Skia hairline use the documented logical
+            // one-unit basis. The sentinel itself remains on the Pen so
+            // compilation and replay can still distinguish device hairlines
+            // from ordinary one-unit strokes.
+            localThickness = 1f;
+            return true;
+        }
+
+        localThickness = pen.Thickness;
+        if (!cmd.IsPenThicknessLocal && cmd.Transform != default)
+        {
+            if (!IsFiniteInvertibleAffine2D(cmd.Transform) ||
+                !TransformMetrics.TryGetStrokeScale(cmd.Transform, out var recordedScale))
+            {
+                localThickness = 0f;
+                return false;
+            }
+            localThickness /= recordedScale;
+        }
+
+        return float.IsFinite(localThickness) && localThickness > 0f;
+    }
+
+    private void CompileDashedStrokePath(
+        in RenderCommand cmd,
+        PathGeometry sourcePath,
+        in StrokeCompileState stroke,
+        Matrix4x4 transform)
+    {
+        var pen = cmd.Pen!;
+        PathGeometry dashedPath;
+        Pen undashedPen;
+        if (cmd.GeometryCache?.TryGetDashedStrokePath(
+                pen,
+                stroke.LocalThickness,
+                out dashedPath,
+                out undashedPen) != true)
+        {
+            if (!TryCreateDashedStrokePath(
+                    sourcePath,
+                    pen,
+                    stroke.LocalThickness,
+                    out dashedPath))
+            {
+                throw new NotSupportedException(
+                    "Dashed strokes are not supported for this geometry.");
+            }
+
+            undashedPen = CreateUndashedPen(pen, stroke.LocalThickness);
+        }
+
+        var pathCommand = cmd;
+        pathCommand.Type = RenderCommandType.DrawPath;
+        pathCommand.Path = dashedPath;
+        pathCommand.Brush = null;
+        pathCommand.Pen = undashedPen;
+        pathCommand.Transform = default;
+        pathCommand.IsPenThicknessLocal = true;
+        CompilePathCommand(pathCommand, transform);
+    }
+
+    private void CompileRetainedStrokePath(
+        in RenderCommand cmd,
+        PathGeometry sourcePath,
+        in StrokeCompileState stroke,
+        Matrix4x4 transform)
+    {
+        if (cmd.Pen!.HasDashPattern)
+        {
+            CompileDashedStrokePath(cmd, sourcePath, stroke, transform);
+            return;
+        }
+
+        var pathCommand = cmd;
+        pathCommand.Type = RenderCommandType.DrawPath;
+        pathCommand.Path = sourcePath;
+        pathCommand.Brush = null;
+        pathCommand.Transform = default;
+        pathCommand.IsPenThicknessLocal = true;
+
+        // Current recorders already retain source-space thickness, so the common
+        // path preserves pen identity. Only legacy pre-scaled commands need a
+        // one-time compatibility pen carrying the recovered local width.
+        if (!cmd.IsPenThicknessLocal && !cmd.Pen.IsHairline)
+        {
+            pathCommand.Pen = CreatePenWithThickness(
+                cmd.Pen,
+                stroke.RetainedThickness);
+        }
+
+        CompilePathCommand(pathCommand, transform);
+    }
+
+    private static bool RequiresEndpointCapGeometry(Pen pen) =>
+        pen.StartLineCap != PenLineCap.Flat ||
+        pen.EndLineCap != PenLineCap.Flat;
 
     private void CompileLineCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         SwitchBatch(BatchType.Vector);
-        if (cmd.Pen == null || cmd.Pen.Thickness <= 0f) return;
-        if (cmd.Pen.HasDashPattern)
+        if (!IsRenderableStroke(cmd.Pen)) return;
+        var stroke = ResolveStrokeCompileState(cmd, transform);
+        if (!stroke.IsValid) return;
+        if (cmd.Pen!.HasDashPattern || RequiresEndpointCapGeometry(cmd.Pen))
         {
             var path = cmd.GeometryCache?.StrokePath ??
                 RenderCommandGeometryCache.CreateLinePath(cmd.Position, cmd.Position2);
-
-            var pathCmd = cmd;
-            pathCmd.Type = RenderCommandType.DrawPath;
-            pathCmd.Path = path;
-            pathCmd.Brush = null;
-            pathCmd.Transform = default;
-            CompilePathCommand(pathCmd, transform);
+            CompileRetainedStrokePath(cmd, path, stroke, transform);
             return;
         }
 
@@ -9515,9 +10348,37 @@ SceneStateUploadComplete:
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
 
+        if (stroke.RequiresAffineGeometry)
+        {
+            var vertexStart = _vectorVerticesList.Count;
+            var indexStart = _vectorIndicesList.Count;
+            CollectionsMarshal.SetCount(_vectorVerticesList, vertexStart + 4);
+            CollectionsMarshal.SetCount(_vectorIndicesList, indexStart + 6);
+            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
+            var indices = CollectionsMarshal.AsSpan(_vectorIndicesList);
+            var vertexCount = vertexStart;
+            var indexCount = indexStart;
+            AppendAffineStrokeLineVertices(
+                vertices,
+                indices,
+                ref vertexCount,
+                ref indexCount,
+                penSolidColor,
+                penBrushIdx,
+                stroke.LocalGeometryThickness,
+                cmd.Position,
+                cmd.Position2,
+                transform,
+                cmd.IsEdgeAliased);
+            CollectionsMarshal.SetCount(_vectorVerticesList, vertexCount);
+            CollectionsMarshal.SetCount(_vectorIndicesList, indexCount);
+            ClampVectorVerticesToActiveClip(startIndex);
+            return;
+        }
+
         var p0_pos = Vector2.Transform(cmd.Position, transform);
         var p1_pos = Vector2.Transform(cmd.Position2, transform);
-        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
+        float thickness = stroke.EncodedThickness;
         var lineShapeType = EncodeShapeType(cmd, 3f);
 
         uint idxStart = (uint)startIndex;
@@ -9542,16 +10403,7 @@ SceneStateUploadComplete:
         indexSpan[4] = idxStart + 3;
         indexSpan[5] = idxStart + 2;
 
-        if (_activeClipRect.HasValue)
-        {
-            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
-            for (int i = startIndex; i < vertices.Length; i++)
-            {
-                var v = vertices[i];
-                v.Position = ClampToClip(v.Position);
-                vertices[i] = v;
-            }
-        }
+        ClampVectorVerticesToActiveClip(startIndex);
     }
 
     private void CompileLine3DCommand(RenderCommand cmd, Matrix4x4 transform)
@@ -9568,11 +10420,52 @@ SceneStateUploadComplete:
     private void CompileBezierCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         SwitchBatch(BatchType.Vector);
-        if (cmd.Pen == null || cmd.Pen.Thickness <= 0f) return;
+        if (!IsRenderableStroke(cmd.Pen)) return;
+        var stroke = ResolveStrokeCompileState(cmd, transform);
+        if (!stroke.IsValid) return;
+        if (cmd.Pen!.HasDashPattern || RequiresEndpointCapGeometry(cmd.Pen))
+        {
+            var path = cmd.GeometryCache?.StrokePath ??
+                RenderCommandGeometryCache.CreateQuadraticBezierPath(
+                    cmd.Position,
+                    cmd.Position2,
+                    cmd.Position3);
+            CompileRetainedStrokePath(cmd, path, stroke, transform);
+            return;
+        }
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
+        float thickness = stroke.EncodedThickness;
+
+        if (stroke.RequiresAffineGeometry)
+        {
+            const int affineSegmentCount = 24;
+            var vertexStart = _vectorVerticesList.Count;
+            var indexStart = _vectorIndicesList.Count;
+            CollectionsMarshal.SetCount(_vectorVerticesList, vertexStart + (4 * affineSegmentCount));
+            CollectionsMarshal.SetCount(_vectorIndicesList, indexStart + (6 * affineSegmentCount));
+            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
+            var indices = CollectionsMarshal.AsSpan(_vectorIndicesList);
+            var vertexCount = vertexStart;
+            var indexCount = indexStart;
+            AppendAffineStrokeQuadraticVertices(
+                vertices,
+                indices,
+                ref vertexCount,
+                ref indexCount,
+                penBrushIdx,
+                stroke.LocalGeometryThickness,
+                cmd.Position,
+                cmd.Position2,
+                cmd.Position3,
+                transform,
+                cmd.IsEdgeAliased);
+            CollectionsMarshal.SetCount(_vectorVerticesList, vertexCount);
+            CollectionsMarshal.SetCount(_vectorIndicesList, indexCount);
+            ClampVectorVerticesToActiveClip(startIndex);
+            return;
+        }
 
         var p0_trans = Vector2.Transform(cmd.Position, transform);
         var p1_trans = Vector2.Transform(cmd.Position2, transform);
@@ -9610,26 +10503,60 @@ SceneStateUploadComplete:
             indexSpan[baseIdx + 5] = nextLeft;
         }
 
-        if (_activeClipRect.HasValue)
-        {
-            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
-            for (int i = startIndex; i < vertices.Length; i++)
-            {
-                var v = vertices[i];
-                v.Position = ClampToClip(v.Position);
-                vertices[i] = v;
-            }
-        }
+        ClampVectorVerticesToActiveClip(startIndex);
     }
 
     private void CompileCubicBezierCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         SwitchBatch(BatchType.Vector);
-        if (cmd.Pen == null || cmd.Pen.Thickness <= 0f) return;
+        if (!IsRenderableStroke(cmd.Pen)) return;
+        var stroke = ResolveStrokeCompileState(cmd, transform);
+        if (!stroke.IsValid) return;
+        if (cmd.Pen!.HasDashPattern || RequiresEndpointCapGeometry(cmd.Pen))
+        {
+            var path = cmd.GeometryCache?.StrokePath ??
+                RenderCommandGeometryCache.CreateCubicBezierPath(
+                    cmd.Position,
+                    cmd.Position2,
+                    cmd.Position3,
+                    cmd.Position4);
+            CompileRetainedStrokePath(cmd, path, stroke, transform);
+            return;
+        }
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = ResolveDeviceStrokeThickness(cmd, transform);
+        float thickness = stroke.EncodedThickness;
+
+        if (stroke.RequiresAffineGeometry)
+        {
+            const int affineSegmentCount = 24;
+            var vertexStart = _vectorVerticesList.Count;
+            var indexStart = _vectorIndicesList.Count;
+            CollectionsMarshal.SetCount(_vectorVerticesList, vertexStart + (4 * affineSegmentCount));
+            CollectionsMarshal.SetCount(_vectorIndicesList, indexStart + (6 * affineSegmentCount));
+            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
+            var indices = CollectionsMarshal.AsSpan(_vectorIndicesList);
+            var vertexCount = vertexStart;
+            var indexCount = indexStart;
+            AppendAffineStrokeCubicVertices(
+                vertices,
+                indices,
+                ref vertexCount,
+                ref indexCount,
+                penBrushIdx,
+                stroke.LocalGeometryThickness,
+                cmd.Position,
+                cmd.Position2,
+                cmd.Position3,
+                cmd.Position4,
+                transform,
+                cmd.IsEdgeAliased);
+            CollectionsMarshal.SetCount(_vectorVerticesList, vertexCount);
+            CollectionsMarshal.SetCount(_vectorIndicesList, indexCount);
+            ClampVectorVerticesToActiveClip(startIndex);
+            return;
+        }
 
         var p0_trans = Vector2.Transform(cmd.Position, transform);
         var p1_trans = Vector2.Transform(cmd.Position2, transform);
@@ -9668,45 +10595,54 @@ SceneStateUploadComplete:
             indexSpan[baseIdx + 5] = nextLeft;
         }
 
-        if (_activeClipRect.HasValue)
-        {
-            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
-            for (int i = startIndex; i < vertices.Length; i++)
-            {
-                var v = vertices[i];
-                v.Position = ClampToClip(v.Position);
-                vertices[i] = v;
-            }
-        }
+        ClampVectorVerticesToActiveClip(startIndex);
     }
 
     private void CompilePolylineCommand(IRenderDataProvider? provider, RenderCommand cmd, Matrix4x4 transform)
     {
-        SwitchBatch(BatchType.Vector);
-        if (cmd.Pen == null || cmd.Pen.Thickness <= 0f) return;
+        ReadOnlySpan<Vector2> pointsSpan = cmd.PolylinePoints is { Length: > 0 } inlinePoints
+            ? inlinePoints
+            : provider != null && cmd.PointBufferCount > 0
+                ? provider.GetPoints(cmd.PointBufferOffset, cmd.PointBufferCount)
+                : ReadOnlySpan<Vector2>.Empty;
 
-        ReadOnlySpan<Vector2> pointsSpan = provider != null ?
-            provider.GetPoints(cmd.PointBufferOffset, cmd.PointBufferCount) :
-            cmd.PolylinePoints;
+        CompilePolylinePoints(pointsSpan, cmd, transform);
+    }
+
+    private void CompilePolylinePoints(
+        ReadOnlySpan<Vector2> pointsSpan,
+        RenderCommand cmd,
+        Matrix4x4 transform)
+    {
+        SwitchBatch(BatchType.Vector);
+        if (!IsRenderableStroke(cmd.Pen)) return;
+        var stroke = ResolveStrokeCompileState(cmd, transform);
+        if (!stroke.IsValid) return;
 
         int count = pointsSpan.Length;
         if (count < 2) return;
 
+        if (cmd.Pen!.HasDashPattern ||
+            cmd.IsClosed ||
+            count > 2 ||
+            RequiresEndpointCapGeometry(cmd.Pen))
+        {
+            var path = cmd.GeometryCache?.StrokePath ??
+                RenderCommandGeometryCache.CreatePolylinePath(
+                    pointsSpan,
+                    cmd.IsClosed);
+            CompileRetainedStrokePath(cmd, path, stroke, transform);
+            return;
+        }
+
         int startIndex = _vectorVerticesList.Count;
         float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
         var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-        float thickness = cmd.Pen.Thickness;
+        float thickness = stroke.EncodedThickness;
         var lineShapeType = EncodeShapeType(cmd, 3f);
 
         int segmentCount = count - 1;
         if (cmd.IsClosed) segmentCount++;
-
-        // Pre-transform all points to screen space in one batch
-        Span<Vector2> transformed = count <= 512 ? stackalloc Vector2[count] : new Vector2[count];
-        for (int i = 0; i < count; i++)
-        {
-            transformed[i] = Vector2.Transform(pointsSpan[i], transform);
-        }
 
         // We will append 4 vertices and 6 indices for each segment
         int totalVerticesToAdd = segmentCount * 4;
@@ -9720,10 +10656,38 @@ SceneStateUploadComplete:
         CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + totalIndicesToAdd);
         var indexSpan = CollectionsMarshal.AsSpan(_vectorIndicesList).Slice(originalIndexCount, totalIndicesToAdd);
 
+        if (stroke.RequiresAffineGeometry)
+        {
+            var affineVertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
+            var affineIndices = CollectionsMarshal.AsSpan(_vectorIndicesList);
+            var currentVertexCount = originalVertexCount;
+            var currentIndexCount = originalIndexCount;
+            for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+            {
+                AppendAffineStrokeLineVertices(
+                    affineVertices,
+                    affineIndices,
+                    ref currentVertexCount,
+                    ref currentIndexCount,
+                    penSolidColor,
+                    penBrushIdx,
+                    stroke.LocalGeometryThickness,
+                    pointsSpan[segmentIndex % count],
+                    pointsSpan[(segmentIndex + 1) % count],
+                    transform,
+                    cmd.IsEdgeAliased);
+            }
+
+            CollectionsMarshal.SetCount(_vectorVerticesList, currentVertexCount);
+            CollectionsMarshal.SetCount(_vectorIndicesList, currentIndexCount);
+            ClampVectorVerticesToActiveClip(startIndex);
+            return;
+        }
+
         for (int i = 0; i < segmentCount; i++)
         {
-            var p0_pos = transformed[i % count];
-            var p1_pos = transformed[(i + 1) % count];
+            var p0_pos = Vector2.Transform(pointsSpan[i % count], transform);
+            var p1_pos = Vector2.Transform(pointsSpan[(i + 1) % count], transform);
 
             uint idxStart = (uint)(originalVertexCount + i * 4);
 
@@ -9742,16 +10706,7 @@ SceneStateUploadComplete:
             indexSpan[iIdx + 5] = idxStart + 2;
         }
 
-        if (_activeClipRect.HasValue)
-        {
-            var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
-            for (int i = startIndex; i < vertices.Length; i++)
-            {
-                var v = vertices[i];
-                v.Position = ClampToClip(v.Position);
-                vertices[i] = v;
-            }
-        }
+        ClampVectorVerticesToActiveClip(startIndex);
     }
 
     private void CompileSplineCommand(IRenderDataProvider? provider, RenderCommand cmd, Matrix4x4 transform)
@@ -10097,16 +11052,18 @@ SceneStateUploadComplete:
     private void CompileEllipseCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         SwitchBatch(BatchType.Vector);
+        var stroke = ResolveStrokeCompileState(cmd, transform);
         int startIndex = _vectorVerticesList.Count;
         var center = cmd.Position2;
         var rx = cmd.RadiusX;
         var ry = cmd.RadiusY;
         var shapeSize = new Vector2(2f * rx, 2f * ry);
         var ellipseShapeType = EncodeShapeType(cmd, 1f);
+        var antialiasPadding = GetAnalyticPrimitiveLocalAntialiasPadding(transform);
 
         if (cmd.Brush != null)
         {
-            float pad = 1.5f;
+            float pad = antialiasPadding;
             var f0_pos = Vector2.Transform(new Vector2(center.X - rx - pad, center.Y - ry - pad), transform);
             var f1_pos = Vector2.Transform(new Vector2(center.X + rx + pad, center.Y - ry - pad), transform);
             var f2_pos = Vector2.Transform(new Vector2(center.X + rx + pad, center.Y + ry + pad), transform);
@@ -10138,16 +11095,17 @@ SceneStateUploadComplete:
             indexSpan[5] = idxStart + 3;
         }
 
-        if (cmd.Pen != null && cmd.Pen.Thickness > 0f)
+        if (stroke.IsValid)
         {
-            float pad = cmd.Pen.Thickness / 2f + 1.5f;
+            var pen = cmd.Pen!;
+            float pad = stroke.LocalBoundsThickness / 2f + antialiasPadding;
             var p0_pos = Vector2.Transform(new Vector2(center.X - rx - pad, center.Y - ry - pad), transform);
             var p1_pos = Vector2.Transform(new Vector2(center.X + rx + pad, center.Y - ry - pad), transform);
             var p2_pos = Vector2.Transform(new Vector2(center.X + rx + pad, center.Y + ry + pad), transform);
             var p3_pos = Vector2.Transform(new Vector2(center.X - rx - pad, center.Y + ry + pad), transform);
 
-            float penBrushIdx = RegisterBrush(cmd.Pen.Brush);
-            var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solidPen) ? solidPen.Color : new Vector4(center.X, center.Y, 0f, 0f);
+            float penBrushIdx = RegisterBrush(pen.Brush);
+            var penSolidColor = (pen.Brush is SolidColorBrush solidPen) ? solidPen.Color : new Vector4(center.X, center.Y, 0f, 0f);
 
             uint idxStart = (uint)_vectorVerticesList.Count;
 
@@ -10155,10 +11113,10 @@ SceneStateUploadComplete:
             CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + 4);
             var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, 4);
 
-            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-rx - pad, -ry - pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, ellipseShapeType);
-            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(rx + pad, -ry - pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, ellipseShapeType);
-            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(rx + pad, ry + pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, ellipseShapeType);
-            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-rx - pad, ry + pad), penBrushIdx, shapeSize, 0f, cmd.Pen.Thickness, ellipseShapeType);
+            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-rx - pad, -ry - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
+            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(rx + pad, -ry - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
+            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(rx + pad, ry + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
+            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-rx - pad, ry + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
 
             int originalIndexCount = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + 6);
@@ -10193,6 +11151,7 @@ SceneStateUploadComplete:
     private void CompileRoundedRectCommand(RenderCommand cmd, Matrix4x4 transform)
     {
         var r = cmd.Rect;
+        var stroke = ResolveStrokeCompileState(cmd, transform);
         var radiusX = Math.Min(MathF.Abs(cmd.RadiusX), r.Width / 2f);
         var radiusY = Math.Min(MathF.Abs(cmd.RadiusY), r.Height / 2f);
 
@@ -10208,16 +11167,22 @@ SceneStateUploadComplete:
             pathCommand.Type = RenderCommandType.DrawPath;
             pathCommand.Path = GetOrCreateRoundedRectanglePath(r, radiusX, radiusY);
             pathCommand.Transform = default;
+            if (stroke.IsValid)
+            {
+                pathCommand.Pen = CreatePenWithThickness(cmd.Pen!, stroke.RetainedThickness);
+                pathCommand.IsPenThicknessLocal = true;
+            }
             CompilePathCommand(pathCommand, transform);
             return;
         }
 
         bool hasFill = cmd.Brush != null;
-        bool hasStroke = cmd.Pen != null && cmd.Pen.Thickness > 0f;
+        bool hasStroke = stroke.IsValid;
         bool isSolidRoundedCandidate = ActiveCompilationContext == null &&
             (hasFill || hasStroke) &&
             (!hasFill || cmd.Brush is SolidColorBrush) &&
-            (!hasStroke || cmd.Pen!.Brush is SolidColorBrush);
+            (!hasStroke || cmd.Pen!.Brush is SolidColorBrush) &&
+            !stroke.IsHairline;
         if (isSolidRoundedCandidate)
         {
             _currentSolidRoundedPrimitiveCount++;
@@ -10232,10 +11197,11 @@ SceneStateUploadComplete:
         float hHalf = r.Height / 2f;
         var shapeSize = new Vector2(r.Width, r.Height);
         var roundedRectShapeType = EncodeShapeType(cmd, 2f);
+        var antialiasPadding = GetAnalyticPrimitiveLocalAntialiasPadding(transform);
 
         if (cmd.Brush != null)
         {
-            float pad = 1.5f;
+            float pad = antialiasPadding;
             var f0_pos = Vector2.Transform(new Vector2(r.X - pad, r.Y - pad), transform);
             var f1_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y - pad), transform);
             var f2_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y + r.Height + pad), transform);
@@ -10271,19 +11237,20 @@ SceneStateUploadComplete:
             indexSpan[5] = idxStart + 3;
         }
 
-        if (cmd.Pen != null && cmd.Pen.Thickness > 0f)
+        if (hasStroke)
         {
-            float pad = cmd.Pen.Thickness / 2f + 1.5f;
+            var pen = cmd.Pen!;
+            float pad = stroke.LocalBoundsThickness / 2f + antialiasPadding;
             var p0_pos = Vector2.Transform(new Vector2(r.X - pad, r.Y - pad), transform);
             var p1_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y - pad), transform);
             var p2_pos = Vector2.Transform(new Vector2(r.X + r.Width + pad, r.Y + r.Height + pad), transform);
             var p3_pos = Vector2.Transform(new Vector2(r.X - pad, r.Y + r.Height + pad), transform);
 
-            float penBrushIdx = useSolidRoundedPipeline ? 0f : RegisterBrush(cmd.Pen.Brush);
-            var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solidPen) ? solidPen.Color : new Vector4(r.X + wHalf, r.Y + hHalf, 0f, 0f);
+            float penBrushIdx = useSolidRoundedPipeline ? 0f : RegisterBrush(pen.Brush);
+            var penSolidColor = (pen.Brush is SolidColorBrush solidPen) ? solidPen.Color : new Vector4(r.X + wHalf, r.Y + hHalf, 0f, 0f);
             if (useSolidRoundedPipeline)
             {
-                penSolidColor.W *= cmd.Pen.Brush.Opacity * _activeOpacity;
+                penSolidColor.W *= pen.Brush.Opacity * _activeOpacity;
             }
 
             uint idxStart = (uint)_vectorVerticesList.Count;
@@ -10292,10 +11259,10 @@ SceneStateUploadComplete:
             CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + 4);
             var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, 4);
 
-            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, radius, cmd.Pen.Thickness, roundedRectShapeType);
-            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, radius, cmd.Pen.Thickness, roundedRectShapeType);
-            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, radius, cmd.Pen.Thickness, roundedRectShapeType);
-            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, radius, cmd.Pen.Thickness, roundedRectShapeType);
+            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
+            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
+            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
+            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
 
             int originalIndexCount = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + 6);
@@ -11058,22 +12025,13 @@ SceneStateUploadComplete:
             float baseCursorX = runGlyph.Position.X - runGlyph.Glyph.BearX;
             float baseCursorY = runGlyph.Position.Y - runGlyph.Glyph.BearY;
 
-            if (VectorEngine == VectorRenderingEngine.Wavefront)
+            if (_wavefrontFrameEnabled)
             {
-                var glyphBaselinePosition = new Vector2(
-                    baseCursorX + cmd.Position.X,
-                    baseCursorY + cmd.Position.Y);
-                var glyphTransform = Matrix4x4.CreateTranslation(
-                    glyphBaselinePosition.X,
-                    glyphBaselinePosition.Y,
-                    0f) * activeTransform;
-                (_wavefrontEngine ??= new WavefrontVectorEngine(_context)).DrawGlyph(
-                    glyphFont,
-                    glyphIdx,
-                    cmd.FontSize,
-                    glyphTransform,
-                    cmd.Brush ?? new SolidColorBrush(Vector4.One));
-                continue;
+                // The current Wavefront text instance does not retain shaping
+                // presentation state (opacity, font transform, color layers,
+                // masks, or ordered mixing with Atlas primitives). Preserve the
+                // complete text contract by retrying the whole frame in Atlas.
+                throw WavefrontFrameFallbackException.Instance;
             }
 
             var hasBitmapGlyph = glyphFont.HasBitmapGlyphs &&
@@ -11767,7 +12725,9 @@ SceneStateUploadComplete:
             var figure = figures[figureIndex];
             var transformedFigure = new PathFigure(TransformPoint(figure.StartPoint), figure.IsClosed)
             {
-                IsFilled = figure.IsFilled
+                IsFilled = figure.IsFilled,
+                StrokeStartLineCap = figure.StrokeStartLineCap,
+                StrokeEndLineCap = figure.StrokeEndLineCap
             };
             var segments = figure.Segments;
             for (var segmentIndex = 0; segmentIndex < segments.Count; segmentIndex++)
@@ -13399,6 +14359,22 @@ SceneStateUploadComplete:
     internal Vector2 ClampToClip(Vector2 p)
     {
         return p;
+    }
+
+    private void ClampVectorVerticesToActiveClip(int startIndex)
+    {
+        if (!_activeClipRect.HasValue)
+        {
+            return;
+        }
+
+        var vertices = CollectionsMarshal.AsSpan(_vectorVerticesList);
+        for (var index = startIndex; index < vertices.Length; index++)
+        {
+            var vertex = vertices[index];
+            vertex.Position = ClampToClip(vertex.Position);
+            vertices[index] = vertex;
+        }
     }
 
     private unsafe bool ApplyDrawCallScissor(
@@ -15062,6 +16038,18 @@ SceneStateUploadComplete:
                             {
                                 _context.Api.RenderPassEncoderSetBindGroup(pass, 1, *pPathAtlas, 0, null);
                             }
+                            _context.Api.RenderPassEncoderSetVertexBuffer(
+                                pass,
+                                0,
+                                _vectorVertexBuffer.BufferPtr,
+                                0,
+                                _vectorVertexBuffer.Size);
+                            _context.Api.RenderPassEncoderSetIndexBuffer(
+                                pass,
+                                _vectorIndexBuffer.BufferPtr,
+                                IndexFormat.Uint32,
+                                0,
+                                _vectorIndexBuffer.Size);
                             currentType = DrawCallType.Vector;
                             currentBlendMode = dc.BlendMode;
                             currentPipelineHasMask = hasMask;
@@ -15499,6 +16487,10 @@ SceneStateUploadComplete:
             for (var commandIndex = 0; commandIndex < commandCount; commandIndex++)
             {
                 var cmd = commands[commandIndex];
+                var activeTransform = cmd.Type != RenderCommandType.DrawPath &&
+                    cmd.Transform != default
+                        ? cmd.Transform
+                        : Matrix4x4.Identity;
                 bool savedUseGpuTransformsActive = _useGpuTransformsActive;
                 if (cmd.UseGpuTransforms)
                 {
@@ -15508,7 +16500,7 @@ SceneStateUploadComplete:
                 switch (cmd.Type)
                 {
                     case RenderCommandType.DrawRect:
-                        CompileRectCommand(cmd, Matrix4x4.Identity);
+                        CompileRectCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawPath:
                         CompilePathCommand(cmd, Matrix4x4.Identity);
@@ -15520,7 +16512,7 @@ SceneStateUploadComplete:
                             if (pipeline != null)
                             {
                                 var localCmd = cmd;
-                                pipeline.Compile(this, null, Matrix4x4.Identity, ref localCmd);
+                                pipeline.Compile(this, null, activeTransform, ref localCmd);
                                 staticDrawCallList.Add(new CompositorDrawCall
                                 {
                                     Type = DrawCallType.Extension,
@@ -15558,22 +16550,22 @@ SceneStateUploadComplete:
                         pendingTextStart = (uint)_textVerticesList.Count;
                         break;
                     case RenderCommandType.DrawText:
-                        CompileTextCommand(cmd, null, Matrix4x4.Identity);
+                        CompileTextCommand(cmd, null, activeTransform);
                         break;
                     case RenderCommandType.DrawGlyphRun:
-                        CompileGlyphRunCommand(cmd, Matrix4x4.Identity);
+                        CompileGlyphRunCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawTexture:
-                        CompileTextureCommand(cmd, Matrix4x4.Identity);
+                        CompileTextureCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.PushClip:
-                        PushClipRect(cmd.Rect, Matrix4x4.Identity);
+                        PushClipRect(cmd.Rect, activeTransform);
                         break;
                     case RenderCommandType.PopClip:
                         PopClipRect();
                         break;
                     case RenderCommandType.DrawLine:
-                        CompileLineCommand(cmd, Matrix4x4.Identity);
+                        CompileLineCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawLine3D:
                         CommitStaticDrawCalls();
@@ -15582,7 +16574,7 @@ SceneStateUploadComplete:
                             if (pipeline != null)
                             {
                                 var localCmd = cmd;
-                                pipeline.Compile(this, null, Matrix4x4.Identity, ref localCmd);
+                                pipeline.Compile(this, null, activeTransform, ref localCmd);
                                 staticDrawCallList.Add(new CompositorDrawCall
                                 {
                                     Type = DrawCallType.Extension,
@@ -15597,25 +16589,25 @@ SceneStateUploadComplete:
                         pendingTextStart = (uint)_textVerticesList.Count;
                         break;
                     case RenderCommandType.DrawEllipse:
-                        CompileEllipseCommand(cmd, Matrix4x4.Identity);
+                        CompileEllipseCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawDotGrid:
-                        CompileDotGridCommand(cmd, Matrix4x4.Identity);
+                        CompileDotGridCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawCircle:
-                        CompileCircleCommand(cmd, Matrix4x4.Identity);
+                        CompileCircleCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawRoundedRect:
-                        CompileRoundedRectCommand(cmd, Matrix4x4.Identity);
+                        CompileRoundedRectCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawBezier:
-                        CompileBezierCommand(cmd, Matrix4x4.Identity);
+                        CompileBezierCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawCubicBezier:
-                        CompileCubicBezierCommand(cmd, Matrix4x4.Identity);
+                        CompileCubicBezierCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawPolyline:
-                        CompilePolylineCommand(null, cmd, Matrix4x4.Identity);
+                        CompilePolylineCommand(null, cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawSpline:
                         CommitStaticDrawCalls();
@@ -15624,7 +16616,7 @@ SceneStateUploadComplete:
                             if (pipeline != null)
                             {
                                 var localCmd = cmd;
-                                pipeline.Compile(this, null, Matrix4x4.Identity, ref localCmd);
+                                pipeline.Compile(this, null, activeTransform, ref localCmd);
                                 staticDrawCallList.Add(new CompositorDrawCall
                                 {
                                     Type = DrawCallType.Extension,
@@ -15645,9 +16637,14 @@ SceneStateUploadComplete:
                             {
                                 CommitStaticDrawCalls();
                                 var localCmd = cmd;
-                                var compileTransform = localCmd.ExtensionId == CompositorBuiltInExtensions.AcisSolid
-                                    ? localCmd.Transform
-                                    : Matrix4x4.Identity;
+                                var compileTransform = localCmd.ExtensionId switch
+                                {
+                                    CompositorBuiltInExtensions.AcisSolid => localCmd.Transform,
+                                    CompositorBuiltInExtensions.Spline or
+                                    CompositorBuiltInExtensions.Hatch or
+                                    CompositorBuiltInExtensions.Line3D => activeTransform,
+                                    _ => Matrix4x4.Identity
+                                };
                                 pipeline.Compile(this, null, compileTransform, ref localCmd);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
@@ -15693,16 +16690,16 @@ SceneStateUploadComplete:
                         }
                         break;
                     case RenderCommandType.FillTriangle:
-                        CompileFillTriangleCommand(cmd, Matrix4x4.Identity);
+                        CompileFillTriangleCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawVertexMesh:
-                        CompileVertexMeshCommand(cmd, Matrix4x4.Identity);
+                        CompileVertexMeshCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawPointBatch:
-                        CompilePointBatchCommand(cmd, Matrix4x4.Identity);
+                        CompilePointBatchCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.FillQuad:
-                        CompileFillQuadCommand(cmd, Matrix4x4.Identity);
+                        CompileFillQuadCommand(cmd, activeTransform);
                         break;
                 }
 
@@ -15948,6 +16945,10 @@ SceneStateUploadComplete:
             for (var commandIndex = 0; commandIndex < commandCount; commandIndex++)
             {
                 var cmd = commands[commandIndex];
+                var activeTransform = cmd.Type != RenderCommandType.DrawPath &&
+                    cmd.Transform != default
+                        ? cmd.Transform
+                        : Matrix4x4.Identity;
                 bool savedUseGpuTransformsActive = _useGpuTransformsActive;
                 if (cmd.UseGpuTransforms)
                 {
@@ -15957,7 +16958,7 @@ SceneStateUploadComplete:
                 switch (cmd.Type)
                 {
                     case RenderCommandType.DrawRect:
-                        CompileRectCommand(cmd, Matrix4x4.Identity);
+                        CompileRectCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawPath:
                         CompilePathCommand(cmd, Matrix4x4.Identity);
@@ -15969,7 +16970,7 @@ SceneStateUploadComplete:
                             if (pipeline != null)
                             {
                                 var localCmd = cmd;
-                                pipeline.Compile(this, context, Matrix4x4.Identity, ref localCmd);
+                                pipeline.Compile(this, context, activeTransform, ref localCmd);
                                 staticDrawCallList.Add(new CompositorDrawCall
                                 {
                                     Type = DrawCallType.Extension,
@@ -16007,22 +17008,22 @@ SceneStateUploadComplete:
                         pendingTextStart = (uint)_textVerticesList.Count;
                         break;
                     case RenderCommandType.DrawText:
-                        CompileTextCommand(cmd, null, Matrix4x4.Identity);
+                        CompileTextCommand(cmd, null, activeTransform);
                         break;
                     case RenderCommandType.DrawGlyphRun:
-                        CompileGlyphRunCommand(cmd, Matrix4x4.Identity);
+                        CompileGlyphRunCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawTexture:
-                        CompileTextureCommand(cmd, Matrix4x4.Identity);
+                        CompileTextureCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.PushClip:
-                        PushClipRect(cmd.Rect, Matrix4x4.Identity);
+                        PushClipRect(cmd.Rect, activeTransform);
                         break;
                     case RenderCommandType.PopClip:
                         PopClipRect();
                         break;
                     case RenderCommandType.DrawLine:
-                        CompileLineCommand(cmd, Matrix4x4.Identity);
+                        CompileLineCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawLine3D:
                         CommitStaticDrawCalls();
@@ -16031,7 +17032,7 @@ SceneStateUploadComplete:
                             if (pipeline != null)
                             {
                                 var localCmd = cmd;
-                                pipeline.Compile(this, context, Matrix4x4.Identity, ref localCmd);
+                                pipeline.Compile(this, context, activeTransform, ref localCmd);
                                 staticDrawCallList.Add(new CompositorDrawCall
                                 {
                                     Type = DrawCallType.Extension,
@@ -16046,25 +17047,25 @@ SceneStateUploadComplete:
                         pendingTextStart = (uint)_textVerticesList.Count;
                         break;
                     case RenderCommandType.DrawEllipse:
-                        CompileEllipseCommand(cmd, Matrix4x4.Identity);
+                        CompileEllipseCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawDotGrid:
-                        CompileDotGridCommand(cmd, Matrix4x4.Identity);
+                        CompileDotGridCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawCircle:
-                        CompileCircleCommand(cmd, Matrix4x4.Identity);
+                        CompileCircleCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawRoundedRect:
-                        CompileRoundedRectCommand(cmd, Matrix4x4.Identity);
+                        CompileRoundedRectCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawBezier:
-                        CompileBezierCommand(cmd, Matrix4x4.Identity);
+                        CompileBezierCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawCubicBezier:
-                        CompileCubicBezierCommand(cmd, Matrix4x4.Identity);
+                        CompileCubicBezierCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawPolyline:
-                        CompilePolylineCommand(context, cmd, Matrix4x4.Identity);
+                        CompilePolylineCommand(context, cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawSpline:
                         CommitStaticDrawCalls();
@@ -16073,7 +17074,7 @@ SceneStateUploadComplete:
                             if (pipeline != null)
                             {
                                 var localCmd = cmd;
-                                pipeline.Compile(this, context, Matrix4x4.Identity, ref localCmd);
+                                pipeline.Compile(this, context, activeTransform, ref localCmd);
                                 staticDrawCallList.Add(new CompositorDrawCall
                                 {
                                     Type = DrawCallType.Extension,
@@ -16094,9 +17095,14 @@ SceneStateUploadComplete:
                             {
                                 CommitStaticDrawCalls();
                                 var localCmd = cmd;
-                                var compileTransform = localCmd.ExtensionId == CompositorBuiltInExtensions.AcisSolid
-                                    ? localCmd.Transform
-                                    : Matrix4x4.Identity;
+                                var compileTransform = localCmd.ExtensionId switch
+                                {
+                                    CompositorBuiltInExtensions.AcisSolid => localCmd.Transform,
+                                    CompositorBuiltInExtensions.Spline or
+                                    CompositorBuiltInExtensions.Hatch or
+                                    CompositorBuiltInExtensions.Line3D => activeTransform,
+                                    _ => Matrix4x4.Identity
+                                };
                                 pipeline.Compile(this, context, compileTransform, ref localCmd);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
@@ -16142,16 +17148,16 @@ SceneStateUploadComplete:
                         }
                         break;
                     case RenderCommandType.FillTriangle:
-                        CompileFillTriangleCommand(cmd, Matrix4x4.Identity);
+                        CompileFillTriangleCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawVertexMesh:
-                        CompileVertexMeshCommand(cmd, Matrix4x4.Identity);
+                        CompileVertexMeshCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawPointBatch:
-                        CompilePointBatchCommand(cmd, Matrix4x4.Identity);
+                        CompilePointBatchCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.FillQuad:
-                        CompileFillQuadCommand(cmd, Matrix4x4.Identity);
+                        CompileFillQuadCommand(cmd, activeTransform);
                         break;
                     case RenderCommandType.DrawGpuLineSeries:
                         CommitStaticDrawCalls();
@@ -16220,7 +17226,7 @@ SceneStateUploadComplete:
                         pendingTextStart = (uint)_textVerticesList.Count;
                         break;
                     case RenderCommandType.DrawPicture:
-                        CompilePicture(cmd.Picture, Matrix4x4.Identity);
+                        CompilePicture(cmd.Picture, activeTransform);
                         break;
                 }
 
@@ -18421,7 +19427,10 @@ SceneStateUploadComplete:
         PathGeometry path,
         Pen pen,
         Rect bounds,
-        Matrix4x4 transform)
+        Matrix4x4 transform,
+        bool isPenThicknessLocal,
+        Matrix4x4 recordedTransform,
+        RenderCommandGeometryCache? geometryCache)
     {
         _currentFrameOpacityMaskDemand++;
         _peakOpacityMaskDemand = Math.Max(
@@ -18433,14 +19442,30 @@ SceneStateUploadComplete:
 
         try
         {
-            CompilePathCommand(
-                new RenderCommand
-                {
-                    Type = RenderCommandType.DrawPath,
-                    Path = path,
-                    Pen = pen
-                },
-                transform);
+            var sourceCommand = new RenderCommand
+            {
+                Pen = pen,
+                Transform = recordedTransform,
+                IsPenThicknessLocal = isPenThicknessLocal,
+                GeometryCache = geometryCache
+            };
+            var stroke = ResolveStrokeCompileState(sourceCommand, transform);
+            if (stroke.IsValid)
+            {
+                var retainedPen = stroke.RetainedThickness == pen.Thickness
+                    ? pen
+                    : CreatePenWithThickness(pen, stroke.RetainedThickness);
+                CompilePathCommand(
+                    new RenderCommand
+                    {
+                        Type = RenderCommandType.DrawPath,
+                        Path = path,
+                        Pen = retainedPen,
+                        IsPenThicknessLocal = true,
+                        GeometryCache = geometryCache
+                    },
+                    transform);
+            }
             CommitPendingDrawCalls();
         }
         finally

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -478,11 +478,14 @@ public unsafe partial class Compositor : IDisposable
         float LocalBoundsThickness,
         float DeviceThickness,
         bool RequiresAffineGeometry,
-        bool IsHairline)
+        bool IsHairline,
+        bool IsFixedDevice)
     {
         public float EncodedThickness => IsHairline
             ? Pen.HairlineThickness
-            : DeviceThickness;
+            : IsFixedDevice
+                ? EncodeFixedDeviceStrokeThickness(DeviceThickness)
+                : DeviceThickness;
 
         public float RetainedThickness => IsHairline
             ? Pen.HairlineThickness
@@ -498,6 +501,9 @@ public unsafe partial class Compositor : IDisposable
             float.IsFinite(DeviceThickness) &&
             DeviceThickness > 0f;
     }
+
+    private static float EncodeFixedDeviceStrokeThickness(float thickness) =>
+        -MathF.Max(thickness + 1f, MathF.BitIncrement(1f));
 
     private readonly record struct VectorGlyphPathCacheKey(
         PathGeometry Outline,
@@ -6048,7 +6054,8 @@ SceneStateUploadComplete:
                 command.Pen.EndLineCap,
                 command.Pen.DashCap,
                 command.Pen.DashArray,
-                command.Pen.DashOffset);
+                command.Pen.DashOffset,
+                command.Pen.StrokeTransformMode);
         }
     }
 
@@ -6086,7 +6093,8 @@ SceneStateUploadComplete:
             command.Pen.EndLineCap,
             command.Pen.DashCap,
             command.Pen.DashArray,
-            command.Pen.DashOffset);
+            command.Pen.DashOffset,
+            command.Pen.StrokeTransformMode);
     }
 
     private static Brush? TransformCommandBrush(Brush? brush, Matrix4x4 inverseCommandTransform)
@@ -6164,7 +6172,7 @@ SceneStateUploadComplete:
         bool useSolidRectPipeline = ActiveCompilationContext == null &&
             (!hasFill || cmd.Brush is SolidColorBrush) &&
             (!hasStroke || cmd.Pen!.Brush is SolidColorBrush) &&
-            (!hasStroke || !stroke.IsHairline);
+            (!hasStroke || (!stroke.IsHairline && !stroke.IsFixedDevice));
         SwitchBatch(useSolidRectPipeline ? BatchType.SolidRect : BatchType.Vector);
         int startIndex = _vectorVerticesList.Count;
         var r = cmd.Rect;
@@ -6234,10 +6242,13 @@ SceneStateUploadComplete:
             CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + 4);
             var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, 4);
 
-            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
-            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
-            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
-            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, rectShapeType);
+            float shaderThickness = stroke.IsFixedDevice
+                ? stroke.EncodedThickness
+                : stroke.RetainedThickness;
+            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, shaderThickness, rectShapeType);
+            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, 0f, shaderThickness, rectShapeType);
+            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, 0f, shaderThickness, rectShapeType);
+            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, 0f, shaderThickness, rectShapeType);
 
             int originalIndexCount = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + 6);
@@ -7554,6 +7565,8 @@ SceneStateUploadComplete:
                                 transform,
                                 useAffineStrokeGeometry,
                                 stroke.IsHairline,
+                                stroke.IsFixedDevice,
+                                stroke.DeviceThickness,
                                 cmd.IsEdgeAliased,
                                 isStart: false,
                                 lineCap: endLineCap);
@@ -7635,6 +7648,8 @@ SceneStateUploadComplete:
                             transform,
                             useAffineStrokeGeometry,
                             stroke.IsHairline,
+                            stroke.IsFixedDevice,
+                            stroke.DeviceThickness,
                             cmd.IsEdgeAliased,
                             isStart: true,
                             lineCap: startLineCap);
@@ -7931,6 +7946,8 @@ SceneStateUploadComplete:
                         transform,
                         useAffineStrokeGeometry,
                         stroke.IsHairline,
+                        stroke.IsFixedDevice,
+                        stroke.DeviceThickness,
                         cmd.IsEdgeAliased,
                         isStart: false,
                         lineCap: endLineCap);
@@ -8509,7 +8526,8 @@ SceneStateUploadComplete:
             pen.MiterLimit,
             pen.DashCap,
             pen.DashCap,
-            pen.DashCap);
+            pen.DashCap,
+            strokeTransformMode: pen.StrokeTransformMode);
     }
 
     private static Pen CreatePenWithThickness(Pen pen, float localThickness)
@@ -8523,7 +8541,8 @@ SceneStateUploadComplete:
             pen.EndLineCap,
             pen.DashCap,
             pen.DashArray,
-            pen.DashOffset);
+            pen.DashOffset,
+            pen.StrokeTransformMode);
     }
 
     private static int CountStrokeSegmentJoinTriangleBudget(PathFigure figure)
@@ -9199,9 +9218,12 @@ SceneStateUploadComplete:
         // quad large enough for half that pixel plus the calibrated 1.5-pixel
         // antialias fringe. Late affine transforms conservatively enlarge this
         // two-unit local halo in Vector.wgsl using sigma_min.
+        float retainedDeviceThickness = thickness < Pen.HairlineThickness
+            ? -thickness - 1f
+            : thickness;
         float pad = thickness == Pen.HairlineThickness
             ? 2.0f
-            : thickness * 0.5f + 2.0f;
+            : retainedDeviceThickness * 0.5f + 2.0f;
         if (!TryGetTransformedArcBounds(segmentStart, arc, transform, pad, out Vector2 min, out Vector2 max))
         {
             Vector2 extent = new(
@@ -9330,9 +9352,9 @@ SceneStateUploadComplete:
         bool isEdgeAliased,
         bool isSmoothJoin)
     {
-        if (pen.IsHairline)
+        if (pen.IsHairline || pen.IsFixed)
         {
-            AppendHairlineJoinVertices(
+            AppendDeviceStrokeJoinVertices(
                 verticesSpan,
                 indicesSpan,
                 ref currentVertexCount,
@@ -9345,7 +9367,10 @@ SceneStateUploadComplete:
                 localOutgoingDirection,
                 transform,
                 isEdgeAliased,
-                isSmoothJoin);
+                isSmoothJoin,
+                pen.IsHairline
+                    ? Pen.HairlineThickness
+                    : EncodeFixedDeviceStrokeThickness(pen.Thickness));
             return;
         }
 
@@ -9446,13 +9471,15 @@ SceneStateUploadComplete:
         Matrix4x4 transform,
         bool useAffineStrokeGeometry,
         bool isHairline,
+        bool isFixedDevice,
+        float deviceThickness,
         bool isEdgeAliased,
         bool isStart,
         PenLineCap lineCap)
     {
-        if (isHairline)
+        if (isHairline || isFixedDevice)
         {
-            AppendHairlineCapVertices(
+            AppendDeviceStrokeCapVertices(
                 verticesSpan,
                 indicesSpan,
                 ref currentVertexCount,
@@ -9464,7 +9491,10 @@ SceneStateUploadComplete:
                 transform,
                 isEdgeAliased,
                 isStart,
-                isFullCap: false);
+                isFullCap: false,
+                isHairline
+                    ? Pen.HairlineThickness
+                    : EncodeFixedDeviceStrokeThickness(deviceThickness));
             return;
         }
 
@@ -9501,7 +9531,7 @@ SceneStateUploadComplete:
             isStart);
     }
 
-    private static void AppendHairlineCapVertices(
+    private static void AppendDeviceStrokeCapVertices(
         Span<VectorVertex> verticesSpan,
         Span<uint> indicesSpan,
         ref int currentVertexCount,
@@ -9513,7 +9543,8 @@ SceneStateUploadComplete:
         Matrix4x4 transform,
         bool isEdgeAliased,
         bool isStart,
-        bool isFullCap)
+        bool isFullCap,
+        float encodedThickness)
     {
         if (lineCap is not (
             PenLineCap.Square or
@@ -9544,7 +9575,7 @@ SceneStateUploadComplete:
             penBrushIdx,
             new Vector2(index, 0f),
             0f,
-            Pen.HairlineThickness,
+            encodedThickness,
             EncodeShapeType(isEdgeAliased, HairlineCapShapeType));
         verticesSpan.Slice(currentVertexCount, 4).Fill(descriptor);
         currentVertexCount += 4;
@@ -9554,7 +9585,7 @@ SceneStateUploadComplete:
             index);
     }
 
-    private static void AppendHairlineJoinVertices(
+    private static void AppendDeviceStrokeJoinVertices(
         Span<VectorVertex> verticesSpan,
         Span<uint> indicesSpan,
         ref int currentVertexCount,
@@ -9567,7 +9598,8 @@ SceneStateUploadComplete:
         Vector2 localOutgoingDirection,
         Matrix4x4 transform,
         bool isEdgeAliased,
-        bool isSmoothJoin)
+        bool isSmoothJoin,
+        float encodedThickness)
     {
         if (isSmoothJoin)
         {
@@ -9607,7 +9639,7 @@ SceneStateUploadComplete:
             penBrushIdx,
             outgoingDirection,
             0f,
-            Pen.HairlineThickness,
+            encodedThickness,
             EncodeShapeType(isEdgeAliased, HairlineJoinShapeType));
         verticesSpan.Slice(currentVertexCount, 4).Fill(descriptor);
         currentVertexCount += 4;
@@ -10028,12 +10060,15 @@ SceneStateUploadComplete:
             return;
         }
 
-        if (pen.IsHairline)
+        if (pen.IsHairline || pen.IsFixed)
         {
+            var encodedThickness = pen.IsHairline
+                ? Pen.HairlineThickness
+                : EncodeFixedDeviceStrokeThickness(thickness);
             if (pen.StartLineCap == pen.EndLineCap &&
                 pen.StartLineCap is PenLineCap.Round or PenLineCap.Square)
             {
-                AppendHairlineCapVertices(
+                AppendDeviceStrokeCapVertices(
                     verticesSpan,
                     indicesSpan,
                     ref currentVertexCount,
@@ -10045,11 +10080,12 @@ SceneStateUploadComplete:
                     transform,
                     isEdgeAliased,
                     isStart: false,
-                    isFullCap: true);
+                    isFullCap: true,
+                    encodedThickness: encodedThickness);
                 return;
             }
 
-            AppendHairlineCapVertices(
+            AppendDeviceStrokeCapVertices(
                 verticesSpan,
                 indicesSpan,
                 ref currentVertexCount,
@@ -10061,8 +10097,9 @@ SceneStateUploadComplete:
                 transform,
                 isEdgeAliased,
                 isStart: true,
-                isFullCap: false);
-            AppendHairlineCapVertices(
+                isFullCap: false,
+                encodedThickness: encodedThickness);
+            AppendDeviceStrokeCapVertices(
                 verticesSpan,
                 indicesSpan,
                 ref currentVertexCount,
@@ -10074,7 +10111,8 @@ SceneStateUploadComplete:
                 transform,
                 isEdgeAliased,
                 isStart: false,
-                isFullCap: false);
+                isFullCap: false,
+                encodedThickness: encodedThickness);
             return;
         }
 
@@ -10390,7 +10428,23 @@ SceneStateUploadComplete:
                 1f / minimumScale,
                 1f,
                 RequiresAffineGeometry: false,
-                IsHairline: true);
+                IsHairline: true,
+                IsFixedDevice: false);
+        }
+
+        if (cmd.Pen.IsFixed)
+        {
+            // Fixed positive strokes transform their centerline first and
+            // expand the requested width in device space. Conservative local
+            // bounds use sigma_min so late downscales cannot clip the stroke.
+            return new StrokeCompileState(
+                localThickness,
+                localThickness / maximumScale,
+                localThickness / minimumScale,
+                localThickness,
+                RequiresAffineGeometry: false,
+                IsHairline: false,
+                IsFixedDevice: true);
         }
 
         return new StrokeCompileState(
@@ -10399,7 +10453,8 @@ SceneStateUploadComplete:
             localThickness,
             localThickness * maximumScale,
             RequiresAffineStrokeGeometry(fullTransform),
-            IsHairline: false);
+            IsHairline: false,
+            IsFixedDevice: false);
     }
 
     internal static bool IsRenderableStroke(Pen? pen)
@@ -10919,6 +10974,8 @@ SceneStateUploadComplete:
                         transform,
                         useAffineStrokeGeometry,
                         stroke.IsHairline,
+                        stroke.IsFixedDevice,
+                        stroke.DeviceThickness,
                         cmd.IsEdgeAliased,
                         isStart: true,
                         lineCap: cmd.Pen.StartLineCap);
@@ -10982,6 +11039,8 @@ SceneStateUploadComplete:
                 transform,
                 useAffineStrokeGeometry,
                 stroke.IsHairline,
+                stroke.IsFixedDevice,
+                stroke.DeviceThickness,
                 cmd.IsEdgeAliased,
                 isStart: false,
                 lineCap: cmd.Pen.EndLineCap);
@@ -11538,10 +11597,13 @@ SceneStateUploadComplete:
             CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + 4);
             var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, 4);
 
-            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-rx - pad, -ry - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
-            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(rx + pad, -ry - pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
-            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(rx + pad, ry + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
-            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-rx - pad, ry + pad), penBrushIdx, shapeSize, 0f, stroke.RetainedThickness, ellipseShapeType);
+            float shaderThickness = stroke.IsFixedDevice
+                ? stroke.EncodedThickness
+                : stroke.RetainedThickness;
+            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-rx - pad, -ry - pad), penBrushIdx, shapeSize, 0f, shaderThickness, ellipseShapeType);
+            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(rx + pad, -ry - pad), penBrushIdx, shapeSize, 0f, shaderThickness, ellipseShapeType);
+            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(rx + pad, ry + pad), penBrushIdx, shapeSize, 0f, shaderThickness, ellipseShapeType);
+            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-rx - pad, ry + pad), penBrushIdx, shapeSize, 0f, shaderThickness, ellipseShapeType);
 
             int originalIndexCount = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + 6);
@@ -11619,7 +11681,7 @@ SceneStateUploadComplete:
             (hasFill || hasStroke) &&
             (!hasFill || cmd.Brush is SolidColorBrush) &&
             (!hasStroke || cmd.Pen!.Brush is SolidColorBrush) &&
-            (!hasStroke || !stroke.IsHairline);
+            (!hasStroke || (!stroke.IsHairline && !stroke.IsFixedDevice));
         if (isSolidRoundedCandidate)
         {
             _currentSolidRoundedPrimitiveCount++;
@@ -11696,10 +11758,13 @@ SceneStateUploadComplete:
             CollectionsMarshal.SetCount(_vectorVerticesList, originalVertexCount + 4);
             var vertexSpan = CollectionsMarshal.AsSpan(_vectorVerticesList).Slice(originalVertexCount, 4);
 
-            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
-            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
-            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
-            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, radius, stroke.RetainedThickness, roundedRectShapeType);
+            float shaderThickness = stroke.IsFixedDevice
+                ? stroke.EncodedThickness
+                : stroke.RetainedThickness;
+            vertexSpan[0] = new VectorVertex(p0_pos, penSolidColor, new Vector2(-wHalf - pad, -hHalf - pad), penBrushIdx, shapeSize, radius, shaderThickness, roundedRectShapeType);
+            vertexSpan[1] = new VectorVertex(p1_pos, penSolidColor, new Vector2(wHalf + pad, -hHalf - pad), penBrushIdx, shapeSize, radius, shaderThickness, roundedRectShapeType);
+            vertexSpan[2] = new VectorVertex(p2_pos, penSolidColor, new Vector2(wHalf + pad, hHalf + pad), penBrushIdx, shapeSize, radius, shaderThickness, roundedRectShapeType);
+            vertexSpan[3] = new VectorVertex(p3_pos, penSolidColor, new Vector2(-wHalf - pad, hHalf + pad), penBrushIdx, shapeSize, radius, shaderThickness, roundedRectShapeType);
 
             int originalIndexCount = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorIndicesList, originalIndexCount + 6);

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -447,6 +447,9 @@ public unsafe partial class Compositor : IDisposable
     private const int DirectRoundedMaximumCornerSegmentCount = 128;
     private const float DirectRoundedMaximumDeviceChordError = 0.25f;
     private const float AffineStrokeArcMaxAngleRadians = MathF.PI / 24f;
+    private const int MinimumAffineBezierSegments = 24;
+    private const int MaximumAffineBezierSegments = 1024;
+    private const double AffineBezierMaxDeviceError = 0.25;
     private const float AnalyticPrimitiveAntialiasPaddingPixels = 1.5f;
     // Matches Skia grayscale edge weight for axis-aligned vector glyphs rasterized at 8x8 coverage.
     private const float SmallTextPathCoverageGamma = 0.72f;
@@ -7445,13 +7448,27 @@ SceneStateUploadComplete:
                     }
                     else if (segment is QuadraticBezierSegment)
                     {
-                        const int N = 24;
+                        int N = useAffineStrokeGeometry
+                            ? GetAffineQuadraticSegmentCount(
+                                segmentStart,
+                                ((QuadraticBezierSegment)segment).ControlPoint,
+                                ((QuadraticBezierSegment)segment).Point,
+                                transform)
+                            : 24;
                         maxVertices += useAffineStrokeGeometry ? 4 * N : 2 * (N + 1);
                         maxIndices += 6 * N;
                     }
                     else if (segment is CubicBezierSegment)
                     {
-                        const int N = 24;
+                        var cubic = (CubicBezierSegment)segment;
+                        int N = useAffineStrokeGeometry
+                            ? GetAffineCubicSegmentCount(
+                                segmentStart,
+                                cubic.ControlPoint1,
+                                cubic.ControlPoint2,
+                                cubic.Point,
+                                transform)
+                            : 24;
                         maxVertices += useAffineStrokeGeometry ? 4 * N : 2 * (N + 1);
                         maxIndices += 6 * N;
                     }
@@ -7703,7 +7720,12 @@ SceneStateUploadComplete:
                                 quad.ControlPoint,
                                 quad.Point,
                                 transform,
-                                cmd.IsEdgeAliased);
+                                cmd.IsEdgeAliased,
+                                GetAffineQuadraticSegmentCount(
+                                    segmentStart,
+                                    quad.ControlPoint,
+                                    quad.Point,
+                                    transform));
                         }
                         else
                         {
@@ -7760,7 +7782,13 @@ SceneStateUploadComplete:
                                 cubic.ControlPoint2,
                                 cubic.Point,
                                 transform,
-                                cmd.IsEdgeAliased);
+                                cmd.IsEdgeAliased,
+                                GetAffineCubicSegmentCount(
+                                    segmentStart,
+                                    cubic.ControlPoint1,
+                                    cubic.ControlPoint2,
+                                    cubic.Point,
+                                    transform));
                         }
                         else
                         {
@@ -8767,9 +8795,9 @@ SceneStateUploadComplete:
         Vector2 control,
         Vector2 end,
         Matrix4x4 transform,
-        bool isEdgeAliased)
+        bool isEdgeAliased,
+        int segmentCount)
     {
-        const int segmentCount = 24;
         var previousPoint = start;
         var previousTangent = GetQuadraticTangent(start, control, end, 0f);
 
@@ -8798,6 +8826,59 @@ SceneStateUploadComplete:
         }
     }
 
+    internal static int GetAffineQuadraticSegmentCount(
+        Vector2 start,
+        Vector2 control,
+        Vector2 end,
+        Matrix4x4 transform)
+    {
+        Vector2 p0 = Vector2.Transform(start, transform);
+        Vector2 p1 = Vector2.Transform(control, transform);
+        Vector2 p2 = Vector2.Transform(end, transform);
+        double curvature = Length(
+            (double)p0.X - (2d * p1.X) + p2.X,
+            (double)p0.Y - (2d * p1.Y) + p2.Y);
+        return ResolveAffineBezierSegmentCount(
+            curvature / (4d * AffineBezierMaxDeviceError));
+    }
+
+    internal static int GetAffineCubicSegmentCount(
+        Vector2 start,
+        Vector2 control1,
+        Vector2 control2,
+        Vector2 end,
+        Matrix4x4 transform)
+    {
+        Vector2 p0 = Vector2.Transform(start, transform);
+        Vector2 p1 = Vector2.Transform(control1, transform);
+        Vector2 p2 = Vector2.Transform(control2, transform);
+        Vector2 p3 = Vector2.Transform(end, transform);
+        double firstCurvature = Length(
+            (double)p0.X - (2d * p1.X) + p2.X,
+            (double)p0.Y - (2d * p1.Y) + p2.Y);
+        double secondCurvature = Length(
+            (double)p1.X - (2d * p2.X) + p3.X,
+            (double)p1.Y - (2d * p2.Y) + p3.Y);
+        double curvature = Math.Max(firstCurvature, secondCurvature);
+        return ResolveAffineBezierSegmentCount(
+            (0.75d * curvature) / AffineBezierMaxDeviceError);
+    }
+
+    private static int ResolveAffineBezierSegmentCount(double squaredCount)
+    {
+        if (!double.IsFinite(squaredCount))
+            return MaximumAffineBezierSegments;
+        if (squaredCount <= MinimumAffineBezierSegments * MinimumAffineBezierSegments)
+            return MinimumAffineBezierSegments;
+        if (squaredCount >= MaximumAffineBezierSegments * MaximumAffineBezierSegments)
+            return MaximumAffineBezierSegments;
+
+        return (int)Math.Ceiling(Math.Sqrt(squaredCount));
+    }
+
+    private static double Length(double x, double y) =>
+        Math.Sqrt((x * x) + (y * y));
+
     private static void AppendAffineStrokeCubicVertices(
         Span<VectorVertex> verticesSpan,
         Span<uint> indicesSpan,
@@ -8810,9 +8891,9 @@ SceneStateUploadComplete:
         Vector2 control2,
         Vector2 end,
         Matrix4x4 transform,
-        bool isEdgeAliased)
+        bool isEdgeAliased,
+        int segmentCount)
     {
-        const int segmentCount = 24;
         var previousPoint = start;
         var previousTangent = GetCubicTangent(start, control1, control2, end, 0f);
 
@@ -10548,7 +10629,11 @@ SceneStateUploadComplete:
 
         if (stroke.RequiresAffineGeometry)
         {
-            const int affineSegmentCount = 24;
+            int affineSegmentCount = GetAffineQuadraticSegmentCount(
+                cmd.Position,
+                cmd.Position2,
+                cmd.Position3,
+                transform);
             var vertexStart = _vectorVerticesList.Count;
             var indexStart = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorVerticesList, vertexStart + (4 * affineSegmentCount));
@@ -10568,7 +10653,8 @@ SceneStateUploadComplete:
                 cmd.Position2,
                 cmd.Position3,
                 transform,
-                cmd.IsEdgeAliased);
+                cmd.IsEdgeAliased,
+                affineSegmentCount);
             CollectionsMarshal.SetCount(_vectorVerticesList, vertexCount);
             CollectionsMarshal.SetCount(_vectorIndicesList, indexCount);
             ClampVectorVerticesToActiveClip(startIndex);
@@ -10638,7 +10724,12 @@ SceneStateUploadComplete:
 
         if (stroke.RequiresAffineGeometry)
         {
-            const int affineSegmentCount = 24;
+            int affineSegmentCount = GetAffineCubicSegmentCount(
+                cmd.Position,
+                cmd.Position2,
+                cmd.Position3,
+                cmd.Position4,
+                transform);
             var vertexStart = _vectorVerticesList.Count;
             var indexStart = _vectorIndicesList.Count;
             CollectionsMarshal.SetCount(_vectorVerticesList, vertexStart + (4 * affineSegmentCount));
@@ -10659,7 +10750,8 @@ SceneStateUploadComplete:
                 cmd.Position3,
                 cmd.Position4,
                 transform,
-                cmd.IsEdgeAliased);
+                cmd.IsEdgeAliased,
+                affineSegmentCount);
             CollectionsMarshal.SetCount(_vectorVerticesList, vertexCount);
             CollectionsMarshal.SetCount(_vectorIndicesList, indexCount);
             ClampVectorVerticesToActiveClip(startIndex);

--- a/src/ProGPU.Scene/DxfStaticBuffer.cs
+++ b/src/ProGPU.Scene/DxfStaticBuffer.cs
@@ -370,13 +370,29 @@ public unsafe class DxfStaticBuffer : IDisposable
     {
         if (UniformBuffer == null) return;
 
+        if (!TransformMetrics.TryGetStrokeScales(
+                modelToScreen,
+                out var maximumStrokeScale,
+                out var minimumStrokeScale))
+        {
+            maximumStrokeScale = 0f;
+            minimumStrokeScale = 0f;
+        }
+
         var uniformsData = new GpuUniforms
         {
             Projection = projection,
             Mvp = modelToScreen,
             View = Matrix4x4.Identity,
             CanvasSize = canvasSize,
-            DpiScale = dpiScale
+            DpiScale = dpiScale,
+            // GpuUniforms is a fixed 224-byte ABI shared by vector, text, and
+            // texture pipelines. Pad1 is otherwise unused and lets static
+            // vector draws cache the affine basis' maximum/minimum singular
+            // values once per viewport update. Conformal strokes use the
+            // scalar fast path; other invertible transforms retain exact local
+            // outlines without recomputing these metrics for every vertex.
+            Pad1 = new Vector2(maximumStrokeScale, minimumStrokeScale)
         };
 
         UniformBuffer.WriteSingle(uniformsData);

--- a/src/ProGPU.Scene/Extensions/SplineExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/SplineExtensionPipeline.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Numerics;
-using System.Runtime.InteropServices;
-using ProGPU.Vector;
 
 namespace ProGPU.Scene.Extensions
 {
@@ -13,98 +10,7 @@ namespace ProGPU.Scene.Extensions
             Matrix4x4 transform,
             ref RenderCommand cmd)
         {
-            if (cmd.Pen == null) return;
-
-            ReadOnlySpan<Vector2> controlPoints = provider != null ? 
-                provider.GetPoints(cmd.PointBufferOffset, cmd.PointBufferCount) : 
-                cmd.PolylinePoints;
-
-            ReadOnlySpan<double> knots = provider != null ? 
-                provider.GetDoubles(cmd.DoubleBufferOffset, cmd.DoubleBufferCount) : 
-                cmd.SplineKnots;
-
-            ReadOnlySpan<double> weights = provider != null && cmd.WeightBufferCount > 0 ? 
-                provider.GetDoubles(cmd.WeightBufferOffset, cmd.WeightBufferCount) : 
-                cmd.SplineWeights;
-
-            if (controlPoints.Length < 2 || knots.IsEmpty) return;
-
-            int degree = cmd.SplineDegree;
-
-            if (knots.Length < controlPoints.Length + degree + 1)
-            {
-                var fallbackCmd = new RenderCommand
-                {
-                    Pen = cmd.Pen,
-                    PointBufferOffset = cmd.PointBufferOffset,
-                    PointBufferCount = cmd.PointBufferCount,
-                    PolylinePoints = cmd.PolylinePoints,
-                    IsClosed = cmd.IsClosed
-                };
-                compositor.CompilePolyline(provider, fallbackCmd, transform);
-                return;
-            }
-
-            int numPoints = SplineGeometry.GetScreenSegmentCount(controlPoints, transform);
-            if (numPoints == 0) return;
-
-            Span<Vector2> transformed = numPoints + 1 <= 512 ? stackalloc Vector2[numPoints + 1] : new Vector2[numPoints + 1];
-            if (!SplineGeometry.TryEvaluatePoints(degree, controlPoints, knots, weights, transform, transformed))
-            {
-                return;
-            }
-
-            int startIndex = compositor.VectorVertices.Count;
-            float penBrushIdx = compositor.RegisterBrush(cmd.Pen.Brush);
-            var penSolidColor = (cmd.Pen.Brush is SolidColorBrush solid) ? solid.Color : new Vector4(1f, 1f, 1f, 1f);
-            float thickness = cmd.Pen.Thickness;
-            bool closeSpline = cmd.IsClosed &&
-                Vector2.DistanceSquared(transformed[0], transformed[transformed.Length - 1]) > 1e-8f;
-            int segmentCount = numPoints + (closeSpline ? 1 : 0);
-
-            int totalVerticesToAdd = segmentCount * 4;
-            int totalIndicesToAdd = segmentCount * 6;
-
-            int originalVertexCount = compositor.VectorVertices.Count;
-            CollectionsMarshal.SetCount(compositor.VectorVertices, originalVertexCount + totalVerticesToAdd);
-            var vertexSpan = CollectionsMarshal.AsSpan(compositor.VectorVertices).Slice(originalVertexCount, totalVerticesToAdd);
-
-            int originalIndexCount = compositor.VectorIndices.Count;
-            CollectionsMarshal.SetCount(compositor.VectorIndices, originalIndexCount + totalIndicesToAdd);
-            var indexSpan = CollectionsMarshal.AsSpan(compositor.VectorIndices).Slice(originalIndexCount, totalIndicesToAdd);
-
-            for (int i = 0; i < segmentCount; i++)
-            {
-                var p0_pos = transformed[i];
-                var p1_pos = i == numPoints ? transformed[0] : transformed[i + 1];
-
-                uint idxStart = (uint)(originalVertexCount + i * 4);
-
-                int vIdx = i * 4;
-                vertexSpan[vIdx] = new VectorVertex(p0_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, 1f, thickness, 3f);
-                vertexSpan[vIdx + 1] = new VectorVertex(p0_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, -1f, thickness, 3f);
-                vertexSpan[vIdx + 2] = new VectorVertex(p1_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, 2f, thickness, 3f);
-                vertexSpan[vIdx + 3] = new VectorVertex(p1_pos, penSolidColor, p0_pos, penBrushIdx, p1_pos, -2f, thickness, 3f);
-
-                int iIdx = i * 6;
-                indexSpan[iIdx] = idxStart;
-                indexSpan[iIdx + 1] = idxStart + 1;
-                indexSpan[iIdx + 2] = idxStart + 2;
-                indexSpan[iIdx + 3] = idxStart + 1;
-                indexSpan[iIdx + 4] = idxStart + 3;
-                indexSpan[iIdx + 5] = idxStart + 2;
-            }
-
-            if (compositor.ActiveClipRect.HasValue)
-            {
-                var vertices = CollectionsMarshal.AsSpan(compositor.VectorVertices);
-                for (int i = startIndex; i < vertices.Length; i++)
-                {
-                    var v = vertices[i];
-                    v.Position = compositor.ClampToClip(v.Position);
-                    vertices[i] = v;
-                }
-            }
+            compositor.CompileSpline(provider, cmd, transform);
         }
 
         public unsafe void Render(

--- a/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
+++ b/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
@@ -235,7 +235,16 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         if (Compositor.IsRenderableStroke(command.Pen) &&
             Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
-            if (command.Pen!.IsHairline)
+            if (command.Pen!.HasDashPattern)
+            {
+                AddDashedPrimitiveStroke(
+                    command,
+                    transform,
+                    id,
+                    zIndex,
+                    localThickness);
+            }
+            else if (command.Pen.IsHairline)
             {
                 TryAddDeviceHairlinePathStrokePrimitive(
                     command.GeometryCache?.StrokePath ??
@@ -269,7 +278,16 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         if (Compositor.IsRenderableStroke(command.Pen) &&
             Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
-            if (command.Pen!.IsHairline)
+            if (command.Pen!.HasDashPattern)
+            {
+                AddDashedPrimitiveStroke(
+                    command,
+                    transform,
+                    id,
+                    zIndex,
+                    localThickness);
+            }
+            else if (command.Pen.IsHairline)
             {
                 TryAddDeviceHairlinePathStrokePrimitive(
                     command.GeometryCache?.StrokePath ??
@@ -306,7 +324,16 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         if (Compositor.IsRenderableStroke(command.Pen) &&
             Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
-            if (command.Pen!.IsHairline)
+            if (command.Pen!.HasDashPattern)
+            {
+                AddDashedPrimitiveStroke(
+                    command,
+                    transform,
+                    id,
+                    zIndex,
+                    localThickness);
+            }
+            else if (command.Pen.IsHairline)
             {
                 TryAddDeviceHairlinePathStrokePrimitive(
                     command.GeometryCache?.StrokePath ??
@@ -323,6 +350,49 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             {
                 AddPrimitive(GpuHitTestPrimitive.EllipseStroke(id, min, max, localThickness, 0f, transform, zIndex));
             }
+        }
+    }
+
+    private void AddDashedPrimitiveStroke(
+        in RenderCommand command,
+        Matrix4x4 transform,
+        int id,
+        float zIndex,
+        float localThickness)
+    {
+        var sourcePath = command.GeometryCache?.StrokePath ??
+            RenderCommandGeometryCache.CreatePrimitiveStrokePath(command);
+        var pen = command.Pen!;
+        if (sourcePath == null ||
+            !TryGetDashedStrokePath(
+                command,
+                sourcePath,
+                pen,
+                localThickness,
+                out var strokePath,
+                out var strokePen))
+        {
+            return;
+        }
+
+        if (pen.IsHairline)
+        {
+            TryAddDeviceHairlinePathStrokePrimitive(
+                strokePath,
+                transform,
+                id,
+                zIndex,
+                strokePen);
+        }
+        else
+        {
+            TryAddPathStrokePrimitive(
+                strokePath,
+                transform,
+                id,
+                zIndex,
+                strokePen,
+                localThickness);
         }
     }
 

--- a/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
+++ b/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
@@ -65,14 +65,8 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 
         switch (command.Type)
         {
-            case RenderCommandType.PushClip:
-                PushClip(command.Rect, activeTransform);
-                return;
             case RenderCommandType.PopClip:
                 PopClip();
-                return;
-            case RenderCommandType.PushGeometryClip:
-                PushGeometryClip(command, activeTransform);
                 return;
             case RenderCommandType.PopGeometryClip:
                 PopClip();
@@ -82,6 +76,36 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 return;
             case RenderCommandType.PopOpacity:
                 PopOpacity();
+                return;
+            case RenderCommandType.PushOpacityMask:
+            case RenderCommandType.PopOpacityMask:
+                // Opacity masks are compositor state, not independently
+                // hittable geometry. Precise alpha-mask sampling is outside
+                // the retained geometric hit-test contract; preserve the
+                // enclosed primitives without adding a phantom bounds hit.
+                return;
+        }
+
+        if (!IsFiniteInvertibleAffine2D(activeTransform))
+        {
+            // Preserve clip-stack balance while making an invalid clip reject
+            // all descendants. Precise rendering also fails closed for these
+            // transforms; substituting Identity here creates ghost hits.
+            if (command.Type is RenderCommandType.PushClip or
+                RenderCommandType.PushGeometryClip)
+            {
+                _clipStack.Push(ClipState.Empty);
+            }
+            return;
+        }
+
+        switch (command.Type)
+        {
+            case RenderCommandType.PushClip:
+                PushClip(command.Rect, activeTransform);
+                return;
+            case RenderCommandType.PushGeometryClip:
+                PushGeometryClip(command, activeTransform);
                 return;
         }
 
@@ -122,7 +146,6 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 AddPath(command, activeTransform, primitiveId, zIndex);
                 break;
             case RenderCommandType.DrawTexture:
-            case RenderCommandType.PushOpacityMask:
                 AddBounds(command.Rect, activeTransform, primitiveId, zIndex);
                 break;
             case RenderCommandType.DrawText:
@@ -209,9 +232,27 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             zIndex += 0.25f;
         }
 
-        if (command.Pen is { Thickness: > 0f } pen)
+        if (Compositor.IsRenderableStroke(command.Pen) &&
+            Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
-            AddPrimitive(GpuHitTestPrimitive.RectangleStroke(id, min, max, Vector2.Zero, pen.Thickness, 0f, transform, zIndex));
+            if (command.Pen!.IsHairline)
+            {
+                TryAddDeviceHairlinePathStrokePrimitive(
+                    command.GeometryCache?.StrokePath ??
+                        PrimitivePathGeometry.CreateRectangle(
+                            command.Rect.X,
+                            command.Rect.Y,
+                            command.Rect.Width,
+                            command.Rect.Height),
+                    transform,
+                    id,
+                    zIndex,
+                    command.Pen!);
+            }
+            else
+            {
+                AddPrimitive(GpuHitTestPrimitive.RectangleStroke(id, min, max, Vector2.Zero, localThickness, 0f, transform, zIndex));
+            }
         }
     }
 
@@ -225,9 +266,29 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             zIndex += 0.25f;
         }
 
-        if (command.Pen is { Thickness: > 0f } pen)
+        if (Compositor.IsRenderableStroke(command.Pen) &&
+            Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
-            AddPrimitive(GpuHitTestPrimitive.RectangleStroke(id, min, max, radius, pen.Thickness, 0f, transform, zIndex));
+            if (command.Pen!.IsHairline)
+            {
+                TryAddDeviceHairlinePathStrokePrimitive(
+                    command.GeometryCache?.StrokePath ??
+                        PrimitivePathGeometry.CreateRoundedRectangle(
+                            command.Rect.X,
+                            command.Rect.Y,
+                            command.Rect.Width,
+                            command.Rect.Height,
+                            command.RadiusX,
+                            command.RadiusY),
+                    transform,
+                    id,
+                    zIndex,
+                    command.Pen!);
+            }
+            else
+            {
+                AddPrimitive(GpuHitTestPrimitive.RectangleStroke(id, min, max, radius, localThickness, 0f, transform, zIndex));
+            }
         }
     }
 
@@ -242,9 +303,26 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             zIndex += 0.25f;
         }
 
-        if (command.Pen is { Thickness: > 0f } pen)
+        if (Compositor.IsRenderableStroke(command.Pen) &&
+            Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
-            AddPrimitive(GpuHitTestPrimitive.EllipseStroke(id, min, max, pen.Thickness, 0f, transform, zIndex));
+            if (command.Pen!.IsHairline)
+            {
+                TryAddDeviceHairlinePathStrokePrimitive(
+                    command.GeometryCache?.StrokePath ??
+                        PrimitivePathGeometry.CreateEllipse(
+                            center,
+                            command.RadiusX,
+                            command.RadiusY),
+                    transform,
+                    id,
+                    zIndex,
+                    command.Pen!);
+            }
+            else
+            {
+                AddPrimitive(GpuHitTestPrimitive.EllipseStroke(id, min, max, localThickness, 0f, transform, zIndex));
+            }
         }
     }
 
@@ -256,7 +334,12 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 
     private void AddLine(RenderCommand command, Matrix4x4 transform, int id, float zIndex)
     {
-        if (command.Pen is not { Thickness: > 0f } pen)
+        if (!Compositor.IsRenderableStroke(command.Pen))
+        {
+            return;
+        }
+        var pen = command.Pen!;
+        if (!Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
             return;
         }
@@ -266,29 +349,48 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             var linePath = command.GeometryCache?.StrokePath ??
                 RenderCommandGeometryCache.CreateLinePath(command.Position, command.Position2);
 
-            if (TryGetDashedStrokePath(command, linePath, pen, out var strokePath, out var strokePen))
+            if (TryGetDashedStrokePath(command, linePath, pen, localThickness, out var strokePath, out var strokePen))
             {
-                TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                if (pen.IsHairline)
+                {
+                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                }
+                else
+                {
+                    TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen, localThickness);
+                }
             }
 
             return;
         }
 
+        var lineTransform = pen.IsHairline ? Matrix4x4.Identity : transform;
+        var lineStart = pen.IsHairline
+            ? Vector2.Transform(command.Position, transform)
+            : command.Position;
+        var lineEnd = pen.IsHairline
+            ? Vector2.Transform(command.Position2, transform)
+            : command.Position2;
         AddPrimitive(GpuHitTestPrimitive.LineStroke(
             id,
-            command.Position,
-            command.Position2,
-            pen.Thickness,
+            lineStart,
+            lineEnd,
+            pen.IsHairline ? 1f : localThickness,
             ToLineGeometryCap(pen.StartLineCap),
             ToLineGeometryCap(pen.EndLineCap),
             0f,
-            transform,
+            lineTransform,
             zIndex));
     }
 
     private void AddQuadraticBezier(RenderCommand command, Matrix4x4 transform, int id, float zIndex)
     {
-        if (command.Pen is not { Thickness: > 0f } pen)
+        if (!Compositor.IsRenderableStroke(command.Pen))
+        {
+            return;
+        }
+        var pen = command.Pen!;
+        if (!Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
             return;
         }
@@ -297,6 +399,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             command.GeometryCache?.StrokePath ??
                 RenderCommandGeometryCache.CreateQuadraticBezierPath(command.Position, command.Position2, command.Position3),
             pen,
+            localThickness,
             command.GeometryCache,
             transform,
             id,
@@ -305,7 +408,12 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 
     private void AddCubicBezier(RenderCommand command, Matrix4x4 transform, int id, float zIndex)
     {
-        if (command.Pen is not { Thickness: > 0f } pen)
+        if (!Compositor.IsRenderableStroke(command.Pen))
+        {
+            return;
+        }
+        var pen = command.Pen!;
+        if (!Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
             return;
         }
@@ -314,6 +422,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             command.GeometryCache?.StrokePath ??
                 RenderCommandGeometryCache.CreateCubicBezierPath(command.Position, command.Position2, command.Position3, command.Position4),
             pen,
+            localThickness,
             command.GeometryCache,
             transform,
             id,
@@ -323,6 +432,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
     private void AddBezierPathStroke(
         PathGeometry path,
         Pen pen,
+        float localThickness,
         RenderCommandGeometryCache? geometryCache,
         Matrix4x4 transform,
         int id,
@@ -330,15 +440,29 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
     {
         if (pen.HasDashPattern)
         {
-            if (TryGetDashedStrokePath(geometryCache, path, pen, out var strokePath, out var strokePen))
+            if (TryGetDashedStrokePath(geometryCache, path, pen, localThickness, out var strokePath, out var strokePen))
             {
-                TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                if (pen.IsHairline)
+                {
+                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                }
+                else
+                {
+                    TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen, localThickness);
+                }
             }
 
             return;
         }
 
-        TryAddPathStrokePrimitive(path, transform, id, zIndex, pen);
+        if (pen.IsHairline)
+        {
+            TryAddDeviceHairlinePathStrokePrimitive(path, transform, id, zIndex, pen);
+        }
+        else
+        {
+            TryAddPathStrokePrimitive(path, transform, id, zIndex, pen, localThickness);
+        }
     }
 
     private void AddPath(RenderCommand command, Matrix4x4 activeTransform, int id, float zIndex)
@@ -352,24 +476,54 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         Matrix4x4 transform = command.Transform == default
             ? activeTransform
             : command.Transform * activeTransform;
+        if (!IsFiniteInvertibleAffine2D(transform))
+        {
+            return;
+        }
 
-        Pen? pen = command.Pen is { Thickness: > 0f } activePen ? activePen : null;
+        Pen? pen = Compositor.IsRenderableStroke(command.Pen)
+            ? command.Pen
+            : null;
+        var localThickness = 0f;
+        var hasLocalStroke = pen != null &&
+            Compositor.TryResolveLocalStrokeThickness(command, out localThickness);
         if (pen?.HasDashPattern != true)
         {
-            if (!TryCompileHitTestPath(command.GeometryCache?.FillPath ?? commandPath, out var path))
+            var fillSource = command.GeometryCache?.FillPath ?? commandPath;
+            CompiledHitTestPath? solidFillPath = null;
+            if (command.Brush != null &&
+                TryCompileHitTestPath(fillSource, out var compiledFillPath))
             {
-                return;
-            }
-
-            if (command.Brush != null)
-            {
-                AddPathFillPrimitive(path, transform, id, zIndex);
+                solidFillPath = compiledFillPath;
+                AddPathFillPrimitive(compiledFillPath, transform, id, zIndex);
                 zIndex += 0.25f;
             }
 
-            if (pen != null)
+            if (hasLocalStroke)
             {
-                AddPathStrokePrimitive(path, transform, id, zIndex, pen);
+                var strokeSource = command.GeometryCache?.StrokePath ?? commandPath;
+                if (pen!.IsHairline)
+                {
+                    TryAddDeviceHairlinePathStrokePrimitive(
+                        strokeSource,
+                        transform,
+                        id,
+                        zIndex,
+                        pen);
+                }
+                else
+                {
+                    TryAddPathStrokePrimitive(
+                        strokeSource,
+                        transform,
+                        id,
+                        zIndex,
+                        pen,
+                        localThickness,
+                        solidFillPath.HasValue && ReferenceEquals(strokeSource, fillSource)
+                            ? solidFillPath
+                            : null);
+                }
             }
 
             return;
@@ -382,43 +536,67 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             zIndex += 0.25f;
         }
 
-        if (!TryGetDashedStrokePath(command, commandPath, pen, out var strokePath, out var strokePen))
+        if (!hasLocalStroke ||
+            !TryGetDashedStrokePath(command, commandPath, pen, localThickness, out var strokePath, out var strokePen))
         {
             return;
         }
 
-        TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+        if (pen.IsHairline)
+        {
+            TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+        }
+        else
+        {
+            TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen, localThickness);
+        }
     }
 
     private static bool TryGetDashedStrokePath(
         in RenderCommand command,
         PathGeometry fallbackPath,
         Pen pen,
+        float localThickness,
         out PathGeometry strokePath,
         out Pen strokePen)
     {
-        return TryGetDashedStrokePath(command.GeometryCache, fallbackPath, pen, out strokePath, out strokePen);
+        return TryGetDashedStrokePath(
+            command.GeometryCache,
+            fallbackPath,
+            pen,
+            localThickness,
+            out strokePath,
+            out strokePen);
     }
 
     private static bool TryGetDashedStrokePath(
         RenderCommandGeometryCache? geometryCache,
         PathGeometry fallbackPath,
         Pen pen,
+        float localThickness,
         out PathGeometry strokePath,
         out Pen strokePen)
     {
-        if (geometryCache?.TryGetDashedStrokePath(pen, out strokePath, out strokePen) == true)
+        if (geometryCache?.TryGetDashedStrokePath(
+                pen,
+                localThickness,
+                out strokePath,
+                out strokePen) == true)
         {
             return true;
         }
 
-        if (!Compositor.TryCreateDashedStrokePath(fallbackPath, pen, out strokePath))
+        if (!Compositor.TryCreateDashedStrokePath(
+                fallbackPath,
+                pen,
+                localThickness,
+                out strokePath))
         {
             strokePen = null!;
             return false;
         }
 
-        strokePen = Compositor.CreateUndashedPen(pen);
+        strokePen = Compositor.CreateUndashedPen(pen, localThickness);
         return true;
     }
 
@@ -514,14 +692,316 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         Matrix4x4 transform,
         int id,
         float zIndex,
-        Pen pen)
+        Pen pen,
+        float localThickness,
+        CompiledHitTestPath? precompiledPath = null)
+    {
+        if (!pen.IsHairline &&
+            (HasStrokeCapOverride(path) ||
+             pen.StartLineCap != PenLineCap.Round ||
+             pen.EndLineCap != PenLineCap.Round))
+        {
+            if (TryAddLoweredLineStrokePrimitives(path, transform, id, zIndex, pen, localThickness) ||
+                TryAddLoweredPathStrokePrimitives(
+                    path,
+                    transform,
+                    id,
+                    zIndex,
+                    pen,
+                    localThickness,
+                    precompiledPath))
+            {
+                return true;
+            }
+        }
+
+        if (precompiledPath.HasValue)
+        {
+            AddPathStrokePrimitive(
+                precompiledPath.Value,
+                transform,
+                id,
+                zIndex,
+                localThickness);
+            return true;
+        }
+
+        return TryAddPathStrokePrimitive(path, transform, id, zIndex, localThickness);
+    }
+
+    private static bool HasStrokeCapOverride(PathGeometry path)
+    {
+        var figures = path.Figures;
+        for (int figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            var figure = figures[figureIndex];
+            if (figure.StrokeStartLineCap.HasValue || figure.StrokeEndLineCap.HasValue)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryAddLoweredLineStrokePrimitives(
+        PathGeometry path,
+        Matrix4x4 transform,
+        int id,
+        float zIndex,
+        Pen pen,
+        float localThickness)
+    {
+        var figures = path.Figures;
+        for (int figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            var figure = figures[figureIndex];
+            if (figure.IsClosed ||
+                figure.Segments.Count != 1 ||
+                figure.Segments[0] is not LineSegment { IsStroked: true })
+            {
+                return false;
+            }
+
+        }
+
+        if (figures.Count == 0)
+        {
+            return false;
+        }
+
+        for (int figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            var figure = figures[figureIndex];
+            var line = (LineSegment)figure.Segments[0];
+            AddPrimitive(GpuHitTestPrimitive.LineStroke(
+                id,
+                figure.StartPoint,
+                line.Point,
+                localThickness,
+                ToLineGeometryCap(figure.StrokeStartLineCap ?? pen.StartLineCap),
+                ToLineGeometryCap(figure.StrokeEndLineCap ?? pen.EndLineCap),
+                tolerance: 0f,
+                transform: transform,
+                zIndex: zIndex));
+        }
+
+        return true;
+    }
+
+    private bool TryAddLoweredPathStrokePrimitives(
+        PathGeometry path,
+        Matrix4x4 transform,
+        int id,
+        float zIndex,
+        Pen pen,
+        float localThickness,
+        CompiledHitTestPath? precompiledPath)
+    {
+        var figures = path.Figures;
+        var expectedSegmentCount = 0;
+        for (int figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            expectedSegmentCount += CountCompiledFigureSegments(figures[figureIndex]);
+        }
+
+        if (expectedSegmentCount == 0)
+        {
+            return false;
+        }
+
+        CompiledHitTestPath compiledPath;
+        if (precompiledPath.HasValue)
+        {
+            compiledPath = precompiledPath.Value;
+        }
+        else if (!TryCompileHitTestPath(path, out compiledPath))
+        {
+            return false;
+        }
+
+        if (compiledPath.SegmentCount != (uint)expectedSegmentCount)
+        {
+            return false;
+        }
+
+        uint figureStartSegment = compiledPath.StartSegment;
+        for (int figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            var figure = figures[figureIndex];
+            var figureSegmentCount = CountCompiledFigureSegments(figure);
+            if (figureSegmentCount == 0)
+            {
+                continue;
+            }
+
+            if (!TryGetCompiledFigureBounds(figure, out var figureMin, out var figureMax))
+            {
+                return false;
+            }
+
+            var figurePath = new CompiledHitTestPath(
+                figureMin,
+                figureMax,
+                figureStartSegment,
+                checked((uint)figureSegmentCount),
+                compiledPath.FillRule);
+            AddPathStrokePrimitive(
+                figurePath,
+                transform,
+                id,
+                zIndex,
+                localThickness,
+                figure.IsClosed
+                    ? LineGeometryCap.Round
+                    : ToLineGeometryCap(figure.StrokeStartLineCap ?? pen.StartLineCap),
+                figure.IsClosed
+                    ? LineGeometryCap.Round
+                    : ToLineGeometryCap(figure.StrokeEndLineCap ?? pen.EndLineCap));
+            figureStartSegment += checked((uint)figureSegmentCount);
+        }
+
+        return true;
+    }
+
+    private static int CountCompiledFigureSegments(PathFigure figure)
+    {
+        var count = 0;
+        var currentPoint = figure.StartPoint;
+        var segments = figure.Segments;
+        for (int segmentIndex = 0; segmentIndex < segments.Count; segmentIndex++)
+        {
+            switch (segments[segmentIndex])
+            {
+                case LineSegment line:
+                    count++;
+                    currentPoint = line.Point;
+                    break;
+                case QuadraticBezierSegment quadratic:
+                    count++;
+                    currentPoint = quadratic.Point;
+                    break;
+                case CubicBezierSegment cubic:
+                    count++;
+                    currentPoint = cubic.Point;
+                    break;
+                case ArcSegment arc:
+                    if (ArcSegmentGeometry.TryGetArcCenter(
+                            currentPoint,
+                            arc.Point,
+                            arc.Size,
+                            arc.RotationAngle,
+                            arc.IsLargeArc,
+                            arc.SweepDirection,
+                            out _,
+                            out _,
+                            out _,
+                            out _,
+                            out _) ||
+                        currentPoint != arc.Point)
+                    {
+                        count++;
+                    }
+
+                    currentPoint = arc.Point;
+                    break;
+            }
+        }
+
+        if (figure.IsClosed && currentPoint != figure.StartPoint)
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static bool TryGetCompiledFigureBounds(
+        PathFigure figure,
+        out Vector2 min,
+        out Vector2 max)
+    {
+        var minValue = new Vector2(float.MaxValue);
+        var maxValue = new Vector2(float.MinValue);
+        var hasBounds = false;
+
+        void Update(Vector2 point)
+        {
+            if (!float.IsFinite(point.X) || !float.IsFinite(point.Y))
+            {
+                return;
+            }
+
+            minValue = Vector2.Min(minValue, point);
+            maxValue = Vector2.Max(maxValue, point);
+            hasBounds = true;
+        }
+
+        var currentPoint = figure.StartPoint;
+        Update(currentPoint);
+        var segments = figure.Segments;
+        for (int segmentIndex = 0; segmentIndex < segments.Count; segmentIndex++)
+        {
+            switch (segments[segmentIndex])
+            {
+                case LineSegment line:
+                    Update(line.Point);
+                    currentPoint = line.Point;
+                    break;
+                case QuadraticBezierSegment quadratic:
+                    Update(quadratic.ControlPoint);
+                    Update(quadratic.Point);
+                    currentPoint = quadratic.Point;
+                    break;
+                case CubicBezierSegment cubic:
+                    Update(cubic.ControlPoint1);
+                    Update(cubic.ControlPoint2);
+                    Update(cubic.Point);
+                    currentPoint = cubic.Point;
+                    break;
+                case ArcSegment arc:
+                    if (ArcSegmentGeometry.TryGetArcBounds(
+                            currentPoint,
+                            arc,
+                            out var arcMin,
+                            out var arcMax))
+                    {
+                        Update(arcMin);
+                        Update(arcMax);
+                    }
+                    else
+                    {
+                        Update(arc.Point);
+                    }
+
+                    currentPoint = arc.Point;
+                    break;
+            }
+        }
+
+        if (figure.IsClosed)
+        {
+            Update(figure.StartPoint);
+        }
+
+        min = hasBounds ? minValue : default;
+        max = hasBounds ? maxValue : default;
+        return hasBounds;
+    }
+
+    private bool TryAddPathStrokePrimitive(
+        PathGeometry path,
+        Matrix4x4 transform,
+        int id,
+        float zIndex,
+        float localThickness)
     {
         if (!TryCompileHitTestPath(path, out var strokePath))
         {
             return false;
         }
 
-        AddPathStrokePrimitive(strokePath, transform, id, zIndex, pen);
+        AddPathStrokePrimitive(strokePath, transform, id, zIndex, localThickness);
         return true;
     }
 
@@ -530,7 +1010,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         Matrix4x4 transform,
         int id,
         float zIndex,
-        Pen pen)
+        float localThickness)
     {
         AddPrimitive(GpuHitTestPrimitive.PathStroke(
             id,
@@ -538,10 +1018,258 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             path.Max,
             path.StartSegment,
             path.SegmentCount,
-            pen.Thickness,
+            localThickness,
             0f,
             transform,
             zIndex));
+    }
+
+    private void AddPathStrokePrimitive(
+        CompiledHitTestPath path,
+        Matrix4x4 transform,
+        int id,
+        float zIndex,
+        float localThickness,
+        LineGeometryCap startCap,
+        LineGeometryCap endCap)
+    {
+        AddPrimitive(GpuHitTestPrimitive.PathStroke(
+            id,
+            path.Min,
+            path.Max,
+            path.StartSegment,
+            path.SegmentCount,
+            localThickness,
+            0f,
+            startCap,
+            endCap,
+            transform,
+            zIndex));
+    }
+
+    /// <summary>
+    /// Compiles a retained path into framebuffer coordinates for a Skia
+    /// device hairline. This keeps the precise GPU hit-test primitive at one
+    /// pixel under anisotropic scale and shear instead of approximating it
+    /// with one inverse-scaled local width.
+    /// </summary>
+    private bool TryAddDeviceHairlinePathStrokePrimitive(
+        PathGeometry path,
+        Matrix4x4 transform,
+        int id,
+        float zIndex,
+        Pen pen)
+    {
+        var segmentCheckpoint = _pathSegments.Count;
+        var primitiveCheckpoint = _primitives.Count;
+        if (!TryCompileHitTestPath(path, out var localPath))
+        {
+            return false;
+        }
+
+        var localStart = checked((int)localPath.StartSegment);
+        var localEnd = checked(localStart + (int)localPath.SegmentCount);
+        var expectedSegmentCount = 0;
+        var figures = path.Figures;
+        for (var figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            expectedSegmentCount += CountCompiledFigureSegments(figures[figureIndex]);
+        }
+
+        if (localStart != segmentCheckpoint ||
+            localEnd != _pathSegments.Count ||
+            expectedSegmentCount != (int)localPath.SegmentCount)
+        {
+            Rollback();
+            return false;
+        }
+
+        var transformedStart = _pathSegments.Count;
+        var localFigureStart = localStart;
+        for (var figureIndex = 0; figureIndex < figures.Count; figureIndex++)
+        {
+            var figure = figures[figureIndex];
+            var localFigureCount = CountCompiledFigureSegments(figure);
+            if (localFigureCount == 0)
+            {
+                continue;
+            }
+
+            var figureTransformedStart = _pathSegments.Count;
+            var transformedMin = new Vector2(float.PositiveInfinity);
+            var transformedMax = new Vector2(float.NegativeInfinity);
+            var localFigureEnd = localFigureStart + localFigureCount;
+            for (var segmentIndex = localFigureStart; segmentIndex < localFigureEnd; segmentIndex++)
+            {
+                var segment = _pathSegments[segmentIndex];
+                switch (segment.SegmentType)
+                {
+                    case 0u:
+                        AppendTransformedHairlineSegment(
+                            segment,
+                            transform,
+                            pointCount: 2,
+                            ref transformedMin,
+                            ref transformedMax);
+                        break;
+                    case 1u:
+                        AppendTransformedHairlineSegment(
+                            segment,
+                            transform,
+                            pointCount: 3,
+                            ref transformedMin,
+                            ref transformedMax);
+                        break;
+                    case 2u:
+                        AppendTransformedHairlineSegment(
+                            segment,
+                            transform,
+                            pointCount: 4,
+                            ref transformedMin,
+                            ref transformedMax);
+                        break;
+                    case 3u:
+                        AppendTransformedHairlineArc(
+                            segment,
+                            transform,
+                            ref transformedMin,
+                            ref transformedMax);
+                        break;
+                }
+            }
+
+            var figureTransformedCount = _pathSegments.Count - figureTransformedStart;
+            if (figureTransformedCount <= 0 ||
+                !float.IsFinite(transformedMin.X) ||
+                !float.IsFinite(transformedMin.Y) ||
+                !float.IsFinite(transformedMax.X) ||
+                !float.IsFinite(transformedMax.Y))
+            {
+                Rollback();
+                return false;
+            }
+
+            var finalFigureStart = localStart + (figureTransformedStart - transformedStart);
+            AddPathStrokePrimitive(
+                new CompiledHitTestPath(
+                    transformedMin,
+                    transformedMax,
+                    checked((uint)finalFigureStart),
+                    checked((uint)figureTransformedCount),
+                    localPath.FillRule),
+                Matrix4x4.Identity,
+                id,
+                zIndex,
+                localThickness: 1f,
+                figure.IsClosed
+                    ? LineGeometryCap.Round
+                    : ToLineGeometryCap(figure.StrokeStartLineCap ?? pen.StartLineCap),
+                figure.IsClosed
+                    ? LineGeometryCap.Round
+                    : ToLineGeometryCap(figure.StrokeEndLineCap ?? pen.EndLineCap));
+            localFigureStart = localFigureEnd;
+        }
+
+        // The compiler appends local-space source segments before the framebuffer
+        // copies. Remove that now-unused range; the precomputed primitive offsets
+        // above already target the compacted framebuffer-space segment indices.
+        _pathSegments.RemoveRange(localStart, localEnd - localStart);
+        return true;
+
+        void Rollback()
+        {
+            if (_pathSegments.Count > segmentCheckpoint)
+            {
+                _pathSegments.RemoveRange(
+                    segmentCheckpoint,
+                    _pathSegments.Count - segmentCheckpoint);
+            }
+
+            if (_primitives.Count > primitiveCheckpoint)
+            {
+                _primitives.RemoveRange(
+                    primitiveCheckpoint,
+                    _primitives.Count - primitiveCheckpoint);
+            }
+        }
+    }
+
+    private void AppendTransformedHairlineSegment(
+        GpuPathSegment segment,
+        Matrix4x4 transform,
+        int pointCount,
+        ref Vector2 min,
+        ref Vector2 max)
+    {
+        segment.P0 = TransformHairlinePoint(segment.P0, transform, ref min, ref max);
+        segment.P1 = TransformHairlinePoint(segment.P1, transform, ref min, ref max);
+        if (pointCount >= 3)
+        {
+            segment.P2 = TransformHairlinePoint(segment.P2, transform, ref min, ref max);
+        }
+        if (pointCount >= 4)
+        {
+            segment.P3 = TransformHairlinePoint(segment.P3, transform, ref min, ref max);
+        }
+        _pathSegments.Add(segment);
+    }
+
+    private void AppendTransformedHairlineArc(
+        GpuPathSegment segment,
+        Matrix4x4 transform,
+        ref Vector2 min,
+        ref Vector2 max)
+    {
+        const int ArcSubdivisionCount = 32;
+        var thetaStart = BitConverter.UInt32BitsToSingle(segment.Pad0);
+        var deltaTheta = BitConverter.UInt32BitsToSingle(segment.Pad1);
+        var rotation = BitConverter.UInt32BitsToSingle(segment.Pad2);
+        var cosine = MathF.Cos(rotation);
+        var sine = MathF.Sin(rotation);
+        var previous = TransformHairlinePoint(
+            EvaluateArc(thetaStart),
+            transform,
+            ref min,
+            ref max);
+        for (var subdivision = 1; subdivision <= ArcSubdivisionCount; subdivision++)
+        {
+            var theta = thetaStart +
+                deltaTheta * (subdivision / (float)ArcSubdivisionCount);
+            var next = TransformHairlinePoint(
+                EvaluateArc(theta),
+                transform,
+                ref min,
+                ref max);
+            _pathSegments.Add(new GpuPathSegment
+            {
+                P0 = previous,
+                P1 = next,
+                SegmentType = 0u
+            });
+            previous = next;
+        }
+
+        Vector2 EvaluateArc(float theta)
+        {
+            var local = new Vector2(
+                MathF.Cos(theta) * segment.P3.X,
+                MathF.Sin(theta) * segment.P3.Y);
+            return segment.P2 + new Vector2(
+                local.X * cosine - local.Y * sine,
+                local.X * sine + local.Y * cosine);
+        }
+    }
+
+    private static Vector2 TransformHairlinePoint(
+        Vector2 point,
+        Matrix4x4 transform,
+        ref Vector2 min,
+        ref Vector2 max)
+    {
+        var transformed = Vector2.Transform(point, transform);
+        min = Vector2.Min(min, transformed);
+        max = Vector2.Max(max, transformed);
+        return transformed;
     }
 
     private readonly record struct CompiledHitTestPath(
@@ -744,7 +1472,12 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         IRenderDataProvider? provider)
     {
         ReadOnlySpan<Vector2> points = GetPolylinePoints(command, provider);
-        if (points.Length < 2 || command.Pen is not { Thickness: > 0f } pen)
+        if (points.Length < 2 || !Compositor.IsRenderableStroke(command.Pen))
+        {
+            return;
+        }
+        var pen = command.Pen!;
+        if (!Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
             return;
         }
@@ -753,15 +1486,29 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             RenderCommandGeometryCache.CreatePolylinePath(points, command.IsClosed);
         if (pen.HasDashPattern)
         {
-            if (TryGetDashedStrokePath(command, path, pen, out var strokePath, out var strokePen))
+            if (TryGetDashedStrokePath(command, path, pen, localThickness, out var strokePath, out var strokePen))
             {
-                TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                if (pen.IsHairline)
+                {
+                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                }
+                else
+                {
+                    TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen, localThickness);
+                }
             }
 
             return;
         }
 
-        TryAddPathStrokePrimitive(path, transform, id, zIndex, pen);
+        if (pen.IsHairline)
+        {
+            TryAddDeviceHairlinePathStrokePrimitive(path, transform, id, zIndex, pen);
+        }
+        else
+        {
+            TryAddPathStrokePrimitive(path, transform, id, zIndex, pen, localThickness);
+        }
     }
 
     private void AddExtension(
@@ -792,7 +1539,12 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         float zIndex,
         IRenderDataProvider? provider)
     {
-        if (command.Pen is not { Thickness: > 0f } pen)
+        if (!Compositor.IsRenderableStroke(command.Pen))
+        {
+            return;
+        }
+        var pen = command.Pen!;
+        if (!Compositor.TryResolveLocalStrokeThickness(command, out var localThickness))
         {
             return;
         }
@@ -821,15 +1573,29 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 
         if (pen.HasDashPattern)
         {
-            if (TryGetDashedStrokePath(command, path, pen, out var strokePath, out var strokePen))
+            if (TryGetDashedStrokePath(command, path, pen, localThickness, out var strokePath, out var strokePen))
             {
-                TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                if (pen.IsHairline)
+                {
+                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                }
+                else
+                {
+                    TryAddPathStrokePrimitive(strokePath, transform, id, zIndex, strokePen, localThickness);
+                }
             }
 
             return;
         }
 
-        TryAddPathStrokePrimitive(path, transform, id, zIndex, pen);
+        if (pen.IsHairline)
+        {
+            TryAddDeviceHairlinePathStrokePrimitive(path, transform, id, zIndex, pen);
+        }
+        else
+        {
+            TryAddPathStrokePrimitive(path, transform, id, zIndex, pen, localThickness);
+        }
     }
 
     private void AddGpuLineSeries(
@@ -850,6 +1616,10 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         Vector2 scale = NormalizeSeriesScale(command.Scale);
         Vector2 translate = command.Translate;
         Matrix4x4 seriesTransform = GetCommandTransform(command, transform);
+        if (!IsFiniteInvertibleAffine2D(seriesTransform))
+        {
+            return;
+        }
 
         PathGeometry? path = null;
         PathFigure? figure = null;
@@ -904,7 +1674,12 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 return;
             }
 
-            TryAddPathStrokePrimitive(path, seriesTransform, id, zIndex + chunkIndex * 0.0001f, pen);
+            TryAddPathStrokePrimitive(
+                path,
+                seriesTransform,
+                id,
+                zIndex + chunkIndex * 0.0001f,
+                pen.Thickness);
             chunkIndex++;
             path = null;
             figure = null;
@@ -934,6 +1709,11 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         Vector2 scale = NormalizeSeriesScale(command.Scale);
         Vector2 translate = command.Translate;
         Matrix4x4 seriesTransform = GetCommandTransform(command, transform);
+        if (!IsFiniteInvertibleAffine2D(seriesTransform))
+        {
+            return;
+        }
+
         float defaultRadius = command.RadiusX;
         for (int i = 0; i < pointsCount; i++)
         {
@@ -965,10 +1745,10 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 
     private static ReadOnlySpan<Vector2> GetPointBuffer(RenderCommand command, IRenderDataProvider? provider)
     {
-        return provider != null && command.PointBufferCount > 0
-            ? provider.GetPoints(command.PointBufferOffset, command.PointBufferCount)
-            : command.PolylinePoints is { Length: > 0 } points
-                ? points
+        return command.PolylinePoints is { Length: > 0 } points
+            ? points
+            : provider != null && command.PointBufferCount > 0
+                ? provider.GetPoints(command.PointBufferOffset, command.PointBufferCount)
                 : ReadOnlySpan<Vector2>.Empty;
     }
 
@@ -1188,6 +1968,32 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         return transform == default ? Matrix4x4.Identity : transform;
     }
 
+    private static bool IsFiniteInvertibleAffine2D(Matrix4x4 transform)
+    {
+        const float epsilon = 0.0001f;
+        if (!float.IsFinite(transform.M11) ||
+            !float.IsFinite(transform.M12) ||
+            !float.IsFinite(transform.M21) ||
+            !float.IsFinite(transform.M22) ||
+            !float.IsFinite(transform.M41) ||
+            !float.IsFinite(transform.M42) ||
+            MathF.Abs(transform.M13) > epsilon ||
+            MathF.Abs(transform.M14) > epsilon ||
+            MathF.Abs(transform.M23) > epsilon ||
+            MathF.Abs(transform.M24) > epsilon ||
+            MathF.Abs(transform.M31) > epsilon ||
+            MathF.Abs(transform.M32) > epsilon ||
+            MathF.Abs(transform.M34) > epsilon ||
+            MathF.Abs(transform.M44 - 1f) > epsilon)
+        {
+            return false;
+        }
+
+        var determinant = transform.M11 * transform.M22 -
+            transform.M12 * transform.M21;
+        return float.IsFinite(determinant) && determinant != 0f;
+    }
+
     private static bool IsFinite(Vector2 value)
     {
         return float.IsFinite(value.X) && float.IsFinite(value.Y);
@@ -1340,6 +2146,10 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         PathGeometry? Path = null,
         bool HasPath = false)
     {
+        public static ClipState Empty { get; } = new(
+            Vector2.One,
+            Vector2.Zero);
+
         public static ClipState Unbounded { get; } = new(
             new Vector2(float.NegativeInfinity, float.NegativeInfinity),
             new Vector2(float.PositiveInfinity, float.PositiveInfinity));

--- a/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
+++ b/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
@@ -12,11 +12,17 @@ namespace ProGPU.Scene;
 public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 {
     private const int MaxLineSeriesSegmentsPerPathPrimitive = 128;
-    private const int MinimumHairlineArcSubdivisions = 32;
-    private const int MaximumHairlineArcSubdivisions = 4096;
-    private const double HairlineArcMaxDeviceError = 0.25;
+    private const int MinimumDeviceStrokeArcSubdivisions = 32;
+    private const int MaximumDeviceStrokeArcSubdivisions = 4096;
+    private const double DeviceStrokeArcMaxDeviceError = 0.25;
     private const int IntersectPathOperation = 1;
     private const float OpacityEpsilon = 0.0001f;
+
+    private static bool UsesDeviceStrokeWidth(Pen pen) =>
+        pen.IsHairline || pen.IsFixed;
+
+    private static float GetDeviceStrokeWidth(Pen pen) =>
+        pen.IsHairline ? 1f : pen.Thickness;
 
     private readonly IPathHitTestCompilationCache? _pathHitTestCompilationCache;
     private readonly List<GpuHitTestPrimitive> _primitives = new();
@@ -247,9 +253,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                     zIndex,
                     localThickness);
             }
-            else if (command.Pen.IsHairline)
+            else if (UsesDeviceStrokeWidth(command.Pen))
             {
-                TryAddDeviceHairlinePathStrokePrimitive(
+                TryAddDevicePathStrokePrimitive(
                     command.GeometryCache?.StrokePath ??
                         PrimitivePathGeometry.CreateRectangle(
                             command.Rect.X,
@@ -290,9 +296,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                     zIndex,
                     localThickness);
             }
-            else if (command.Pen.IsHairline)
+            else if (UsesDeviceStrokeWidth(command.Pen))
             {
-                TryAddDeviceHairlinePathStrokePrimitive(
+                TryAddDevicePathStrokePrimitive(
                     command.GeometryCache?.StrokePath ??
                         PrimitivePathGeometry.CreateRoundedRectangle(
                             command.Rect.X,
@@ -336,9 +342,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                     zIndex,
                     localThickness);
             }
-            else if (command.Pen.IsHairline)
+            else if (UsesDeviceStrokeWidth(command.Pen))
             {
-                TryAddDeviceHairlinePathStrokePrimitive(
+                TryAddDevicePathStrokePrimitive(
                     command.GeometryCache?.StrokePath ??
                         PrimitivePathGeometry.CreateEllipse(
                             center,
@@ -378,9 +384,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             return;
         }
 
-        if (pen.IsHairline)
+        if (UsesDeviceStrokeWidth(pen))
         {
-            TryAddDeviceHairlinePathStrokePrimitive(
+            TryAddDevicePathStrokePrimitive(
                 strokePath,
                 transform,
                 id,
@@ -424,9 +430,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 
             if (TryGetDashedStrokePath(command, linePath, pen, localThickness, out var strokePath, out var strokePen))
             {
-                if (pen.IsHairline)
+                if (UsesDeviceStrokeWidth(pen))
                 {
-                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                    TryAddDevicePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
                 }
                 else
                 {
@@ -437,18 +443,19 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             return;
         }
 
-        var lineTransform = pen.IsHairline ? Matrix4x4.Identity : transform;
-        var lineStart = pen.IsHairline
+        var usesDeviceStrokeWidth = UsesDeviceStrokeWidth(pen);
+        var lineTransform = usesDeviceStrokeWidth ? Matrix4x4.Identity : transform;
+        var lineStart = usesDeviceStrokeWidth
             ? Vector2.Transform(command.Position, transform)
             : command.Position;
-        var lineEnd = pen.IsHairline
+        var lineEnd = usesDeviceStrokeWidth
             ? Vector2.Transform(command.Position2, transform)
             : command.Position2;
         AddPrimitive(GpuHitTestPrimitive.LineStroke(
             id,
             lineStart,
             lineEnd,
-            pen.IsHairline ? 1f : localThickness,
+            usesDeviceStrokeWidth ? GetDeviceStrokeWidth(pen) : localThickness,
             ToLineGeometryCap(pen.StartLineCap),
             ToLineGeometryCap(pen.EndLineCap),
             0f,
@@ -515,9 +522,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         {
             if (TryGetDashedStrokePath(geometryCache, path, pen, localThickness, out var strokePath, out var strokePen))
             {
-                if (pen.IsHairline)
+                if (UsesDeviceStrokeWidth(pen))
                 {
-                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                    TryAddDevicePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
                 }
                 else
                 {
@@ -528,9 +535,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             return;
         }
 
-        if (pen.IsHairline)
+        if (UsesDeviceStrokeWidth(pen))
         {
-            TryAddDeviceHairlinePathStrokePrimitive(path, transform, id, zIndex, pen);
+            TryAddDevicePathStrokePrimitive(path, transform, id, zIndex, pen);
         }
         else
         {
@@ -575,14 +582,15 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             if (hasLocalStroke)
             {
                 var strokeSource = command.GeometryCache?.StrokePath ?? commandPath;
-                if (pen!.IsHairline)
+                var activePen = pen!;
+                if (UsesDeviceStrokeWidth(activePen))
                 {
-                    TryAddDeviceHairlinePathStrokePrimitive(
+                    TryAddDevicePathStrokePrimitive(
                         strokeSource,
                         transform,
                         id,
                         zIndex,
-                        pen);
+                        activePen);
                 }
                 else
                 {
@@ -591,7 +599,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                         transform,
                         id,
                         zIndex,
-                        pen,
+                        activePen,
                         localThickness,
                         solidFillPath.HasValue && ReferenceEquals(strokeSource, fillSource)
                             ? solidFillPath
@@ -615,9 +623,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             return;
         }
 
-        if (pen.IsHairline)
+        if (UsesDeviceStrokeWidth(pen))
         {
-            TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+            TryAddDevicePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
         }
         else
         {
@@ -769,7 +777,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         float localThickness,
         CompiledHitTestPath? precompiledPath = null)
     {
-        if (!pen.IsHairline &&
+        if (!UsesDeviceStrokeWidth(pen) &&
             (HasStrokeCapOverride(path) ||
              pen.StartLineCap != PenLineCap.Round ||
              pen.EndLineCap != PenLineCap.Round))
@@ -1121,12 +1129,12 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
     }
 
     /// <summary>
-    /// Compiles a retained path into framebuffer coordinates for a Skia
-    /// device hairline. This keeps the precise GPU hit-test primitive at one
-    /// pixel under anisotropic scale and shear instead of approximating it
-    /// with one inverse-scaled local width.
+    /// Compiles a retained path into framebuffer coordinates for a device-width
+    /// stroke. This keeps both Skia hairlines and explicit positive fixed widths
+    /// exact under anisotropic scale and shear instead of approximating either
+    /// contract with one inverse-scaled local width.
     /// </summary>
-    private bool TryAddDeviceHairlinePathStrokePrimitive(
+    private bool TryAddDevicePathStrokePrimitive(
         PathGeometry path,
         Matrix4x4 transform,
         int id,
@@ -1178,7 +1186,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 switch (segment.SegmentType)
                 {
                     case 0u:
-                        AppendTransformedHairlineSegment(
+                        AppendTransformedDeviceStrokeSegment(
                             segment,
                             transform,
                             pointCount: 2,
@@ -1186,7 +1194,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                             ref transformedMax);
                         break;
                     case 1u:
-                        AppendTransformedHairlineSegment(
+                        AppendTransformedDeviceStrokeSegment(
                             segment,
                             transform,
                             pointCount: 3,
@@ -1194,7 +1202,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                             ref transformedMax);
                         break;
                     case 2u:
-                        AppendTransformedHairlineSegment(
+                        AppendTransformedDeviceStrokeSegment(
                             segment,
                             transform,
                             pointCount: 4,
@@ -1202,7 +1210,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                             ref transformedMax);
                         break;
                     case 3u:
-                        AppendTransformedHairlineArc(
+                        AppendTransformedDeviceStrokeArc(
                             segment,
                             transform,
                             ref transformedMin,
@@ -1233,7 +1241,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 Matrix4x4.Identity,
                 id,
                 zIndex,
-                localThickness: 1f,
+                localThickness: GetDeviceStrokeWidth(pen),
                 figure.IsClosed
                     ? LineGeometryCap.Round
                     : ToLineGeometryCap(figure.StrokeStartLineCap ?? pen.StartLineCap),
@@ -1267,33 +1275,33 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         }
     }
 
-    private void AppendTransformedHairlineSegment(
+    private void AppendTransformedDeviceStrokeSegment(
         GpuPathSegment segment,
         Matrix4x4 transform,
         int pointCount,
         ref Vector2 min,
         ref Vector2 max)
     {
-        segment.P0 = TransformHairlinePoint(segment.P0, transform, ref min, ref max);
-        segment.P1 = TransformHairlinePoint(segment.P1, transform, ref min, ref max);
+        segment.P0 = TransformDeviceStrokePoint(segment.P0, transform, ref min, ref max);
+        segment.P1 = TransformDeviceStrokePoint(segment.P1, transform, ref min, ref max);
         if (pointCount >= 3)
         {
-            segment.P2 = TransformHairlinePoint(segment.P2, transform, ref min, ref max);
+            segment.P2 = TransformDeviceStrokePoint(segment.P2, transform, ref min, ref max);
         }
         if (pointCount >= 4)
         {
-            segment.P3 = TransformHairlinePoint(segment.P3, transform, ref min, ref max);
+            segment.P3 = TransformDeviceStrokePoint(segment.P3, transform, ref min, ref max);
         }
         _pathSegments.Add(segment);
     }
 
-    private void AppendTransformedHairlineArc(
+    private void AppendTransformedDeviceStrokeArc(
         GpuPathSegment segment,
         Matrix4x4 transform,
         ref Vector2 min,
         ref Vector2 max)
     {
-        int arcSubdivisionCount = GetHairlineArcSubdivisionCount(
+        int arcSubdivisionCount = GetDeviceStrokeArcSubdivisionCount(
             segment,
             transform);
         var thetaStart = BitConverter.UInt32BitsToSingle(segment.Pad0);
@@ -1301,7 +1309,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         var rotation = BitConverter.UInt32BitsToSingle(segment.Pad2);
         var cosine = MathF.Cos(rotation);
         var sine = MathF.Sin(rotation);
-        var previous = TransformHairlinePoint(
+        var previous = TransformDeviceStrokePoint(
             EvaluateArc(thetaStart),
             transform,
             ref min,
@@ -1310,7 +1318,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         {
             var theta = thetaStart +
                 deltaTheta * (subdivision / (float)arcSubdivisionCount);
-            var next = TransformHairlinePoint(
+            var next = TransformDeviceStrokePoint(
                 EvaluateArc(theta),
                 transform,
                 ref min,
@@ -1335,7 +1343,7 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         }
     }
 
-    internal static int GetHairlineArcSubdivisionCount(
+    internal static int GetDeviceStrokeArcSubdivisionCount(
         in GpuPathSegment segment,
         Matrix4x4 transform)
     {
@@ -1359,34 +1367,34 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 ellipseTransform,
                 out float maximumRadius))
         {
-            return MinimumHairlineArcSubdivisions;
+            return MinimumDeviceStrokeArcSubdivisions;
         }
 
         double sweep = Math.Abs((double)deltaTheta);
-        if (sweep == 0d || maximumRadius <= HairlineArcMaxDeviceError)
-            return MinimumHairlineArcSubdivisions;
+        if (sweep == 0d || maximumRadius <= DeviceStrokeArcMaxDeviceError)
+            return MinimumDeviceStrokeArcSubdivisions;
 
         double cosineLimit = Math.Clamp(
-            1d - (HairlineArcMaxDeviceError / maximumRadius),
+            1d - (DeviceStrokeArcMaxDeviceError / maximumRadius),
             -1d,
             1d);
         double maximumAngle = 2d * Math.Acos(cosineLimit);
         if (!double.IsFinite(maximumAngle) || maximumAngle <= 0d)
-            return MaximumHairlineArcSubdivisions;
+            return MaximumDeviceStrokeArcSubdivisions;
 
         double required = Math.Ceiling(sweep / maximumAngle);
         if (!double.IsFinite(required) ||
-            required >= MaximumHairlineArcSubdivisions)
+            required >= MaximumDeviceStrokeArcSubdivisions)
         {
-            return MaximumHairlineArcSubdivisions;
+            return MaximumDeviceStrokeArcSubdivisions;
         }
 
         return Math.Max(
-            MinimumHairlineArcSubdivisions,
+            MinimumDeviceStrokeArcSubdivisions,
             (int)required);
     }
 
-    private static Vector2 TransformHairlinePoint(
+    private static Vector2 TransformDeviceStrokePoint(
         Vector2 point,
         Matrix4x4 transform,
         ref Vector2 min,
@@ -1614,9 +1622,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         {
             if (TryGetDashedStrokePath(command, path, pen, localThickness, out var strokePath, out var strokePen))
             {
-                if (pen.IsHairline)
+                if (UsesDeviceStrokeWidth(pen))
                 {
-                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                    TryAddDevicePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
                 }
                 else
                 {
@@ -1627,9 +1635,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             return;
         }
 
-        if (pen.IsHairline)
+        if (UsesDeviceStrokeWidth(pen))
         {
-            TryAddDeviceHairlinePathStrokePrimitive(path, transform, id, zIndex, pen);
+            TryAddDevicePathStrokePrimitive(path, transform, id, zIndex, pen);
         }
         else
         {
@@ -1701,9 +1709,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         {
             if (TryGetDashedStrokePath(command, path, pen, localThickness, out var strokePath, out var strokePen))
             {
-                if (pen.IsHairline)
+                if (UsesDeviceStrokeWidth(pen))
                 {
-                    TryAddDeviceHairlinePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
+                    TryAddDevicePathStrokePrimitive(strokePath, transform, id, zIndex, strokePen);
                 }
                 else
                 {
@@ -1714,9 +1722,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             return;
         }
 
-        if (pen.IsHairline)
+        if (UsesDeviceStrokeWidth(pen))
         {
-            TryAddDeviceHairlinePathStrokePrimitive(path, transform, id, zIndex, pen);
+            TryAddDevicePathStrokePrimitive(path, transform, id, zIndex, pen);
         }
         else
         {

--- a/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
+++ b/src/ProGPU.Scene/GpuRenderCommandHitTestCache.cs
@@ -12,6 +12,9 @@ namespace ProGPU.Scene;
 public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
 {
     private const int MaxLineSeriesSegmentsPerPathPrimitive = 128;
+    private const int MinimumHairlineArcSubdivisions = 32;
+    private const int MaximumHairlineArcSubdivisions = 4096;
+    private const double HairlineArcMaxDeviceError = 0.25;
     private const int IntersectPathOperation = 1;
     private const float OpacityEpsilon = 0.0001f;
 
@@ -1290,7 +1293,9 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
         ref Vector2 min,
         ref Vector2 max)
     {
-        const int ArcSubdivisionCount = 32;
+        int arcSubdivisionCount = GetHairlineArcSubdivisionCount(
+            segment,
+            transform);
         var thetaStart = BitConverter.UInt32BitsToSingle(segment.Pad0);
         var deltaTheta = BitConverter.UInt32BitsToSingle(segment.Pad1);
         var rotation = BitConverter.UInt32BitsToSingle(segment.Pad2);
@@ -1301,10 +1306,10 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
             transform,
             ref min,
             ref max);
-        for (var subdivision = 1; subdivision <= ArcSubdivisionCount; subdivision++)
+        for (var subdivision = 1; subdivision <= arcSubdivisionCount; subdivision++)
         {
             var theta = thetaStart +
-                deltaTheta * (subdivision / (float)ArcSubdivisionCount);
+                deltaTheta * (subdivision / (float)arcSubdivisionCount);
             var next = TransformHairlinePoint(
                 EvaluateArc(theta),
                 transform,
@@ -1328,6 +1333,57 @@ public sealed class GpuRenderCommandHitTestCacheBuilder : IDisposable
                 local.X * cosine - local.Y * sine,
                 local.X * sine + local.Y * cosine);
         }
+    }
+
+    internal static int GetHairlineArcSubdivisionCount(
+        in GpuPathSegment segment,
+        Matrix4x4 transform)
+    {
+        float deltaTheta = BitConverter.UInt32BitsToSingle(segment.Pad1);
+        float rotation = BitConverter.UInt32BitsToSingle(segment.Pad2);
+        float cosine = MathF.Cos(rotation);
+        float sine = MathF.Sin(rotation);
+        Vector2 cosineBasis = Vector2.TransformNormal(
+            new Vector2(segment.P3.X * cosine, segment.P3.X * sine),
+            transform);
+        Vector2 sineBasis = Vector2.TransformNormal(
+            new Vector2(-segment.P3.Y * sine, segment.P3.Y * cosine),
+            transform);
+        var ellipseTransform = new Matrix4x4(
+            cosineBasis.X, cosineBasis.Y, 0f, 0f,
+            sineBasis.X, sineBasis.Y, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0f, 0f, 0f, 1f);
+        if (!float.IsFinite(deltaTheta) ||
+            !TransformMetrics.TryGetStrokeScale(
+                ellipseTransform,
+                out float maximumRadius))
+        {
+            return MinimumHairlineArcSubdivisions;
+        }
+
+        double sweep = Math.Abs((double)deltaTheta);
+        if (sweep == 0d || maximumRadius <= HairlineArcMaxDeviceError)
+            return MinimumHairlineArcSubdivisions;
+
+        double cosineLimit = Math.Clamp(
+            1d - (HairlineArcMaxDeviceError / maximumRadius),
+            -1d,
+            1d);
+        double maximumAngle = 2d * Math.Acos(cosineLimit);
+        if (!double.IsFinite(maximumAngle) || maximumAngle <= 0d)
+            return MaximumHairlineArcSubdivisions;
+
+        double required = Math.Ceiling(sweep / maximumAngle);
+        if (!double.IsFinite(required) ||
+            required >= MaximumHairlineArcSubdivisions)
+        {
+            return MaximumHairlineArcSubdivisions;
+        }
+
+        return Math.Max(
+            MinimumHairlineArcSubdivisions,
+            (int)required);
     }
 
     private static Vector2 TransformHairlinePoint(

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -455,6 +455,51 @@ public sealed class RenderCommandGeometryCache
         return new RenderCommandGeometryCache(null, primaryPath, secondaryPath);
     }
 
+    internal static RenderCommandGeometryCache? CreateForDashedPrimitive(
+        in RenderCommand command)
+    {
+        if (command.Pen?.HasDashPattern != true)
+        {
+            return null;
+        }
+
+        var strokePath = CreatePrimitiveStrokePath(command);
+        return strokePath == null ? null : ForStrokePath(strokePath);
+    }
+
+    internal static PathGeometry? CreatePrimitiveStrokePath(
+        in RenderCommand command)
+    {
+        return command.Type switch
+        {
+            RenderCommandType.DrawRect =>
+                PrimitivePathGeometry.CreateRectangle(
+                    command.Rect.X,
+                    command.Rect.Y,
+                    command.Rect.Width,
+                    command.Rect.Height),
+            RenderCommandType.DrawRoundedRect =>
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    command.Rect.X,
+                    command.Rect.Y,
+                    command.Rect.Width,
+                    command.Rect.Height,
+                    command.RadiusX,
+                    command.RadiusY),
+            RenderCommandType.DrawEllipse =>
+                PrimitivePathGeometry.CreateEllipse(
+                    command.Position2,
+                    command.RadiusX,
+                    command.RadiusY),
+            RenderCommandType.DrawCircle =>
+                PrimitivePathGeometry.CreateEllipse(
+                    command.Position2,
+                    command.RadiusX,
+                    command.RadiusX),
+            _ => null
+        };
+    }
+
     public bool TryGetDashedStrokePath(Pen pen, out PathGeometry dashedStrokePath, out Pen undashedStrokePen)
     {
         ArgumentNullException.ThrowIfNull(pen);
@@ -3420,6 +3465,13 @@ public class DrawingContext :
         return result;
     }
 
+    private void AddAnalyticPrimitiveCommand(RenderCommand command)
+    {
+        command.GeometryCache =
+            RenderCommandGeometryCache.CreateForDashedPrimitive(command);
+        Commands.Add(command);
+    }
+
     public void DrawRectangle(Brush? brush, Pen? pen, Rect rect)
     {
         if (brush is BackdropMaterialBrush backdropMaterial)
@@ -3433,7 +3485,7 @@ public class DrawingContext :
             brush = null;
         }
 
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawRect,
             Rect = rect,
@@ -3456,7 +3508,7 @@ public class DrawingContext :
             brush = null;
         }
 
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawRect,
             Rect = rect,
@@ -4047,7 +4099,7 @@ public class DrawingContext :
 
     public void DrawEllipse(Brush? brush, Pen? pen, Vector2 center, float radiusX, float radiusY)
     {
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawEllipse,
             Brush = brush,
@@ -4067,7 +4119,7 @@ public class DrawingContext :
         float radiusY,
         Matrix4x4 transform)
     {
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawEllipse,
             Brush = brush,
@@ -4087,7 +4139,7 @@ public class DrawingContext :
 
     public void DrawCircle(Brush? brush, Pen? pen, Vector2 center, float radius)
     {
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawCircle,
             Brush = brush,
@@ -4148,7 +4200,7 @@ public class DrawingContext :
             brush = null;
         }
 
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawRoundedRect,
             Brush = brush,
@@ -4184,7 +4236,7 @@ public class DrawingContext :
             brush = null;
         }
 
-        Commands.Add(new RenderCommand
+        AddAnalyticPrimitiveCommand(new RenderCommand
         {
             Type = RenderCommandType.DrawRoundedRect,
             Brush = brush,
@@ -4951,6 +5003,11 @@ public class DrawingContext :
 
         PathGeometry? strokePath = command.Type switch
         {
+            RenderCommandType.DrawRect or
+            RenderCommandType.DrawRoundedRect or
+            RenderCommandType.DrawEllipse or
+            RenderCommandType.DrawCircle when pen.HasDashPattern =>
+                RenderCommandGeometryCache.CreatePrimitiveStrokePath(command),
             RenderCommandType.DrawLine when RequiresEndpointCapGeometry(pen) =>
                 RenderCommandGeometryCache.CreateLinePath(
                     command.Position,
@@ -5041,6 +5098,8 @@ public class DrawingContext :
         else
         {
             command.Rect = TranslateRect(command.Rect, translation);
+            command.GeometryCache =
+                RenderCommandGeometryCache.CreateForDashedPrimitive(command);
         }
     }
 

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -415,6 +415,7 @@ public sealed class RenderCommandGeometryCache
     private PenLineCap _undashedStrokeStartLineCap;
     private PenLineCap _undashedStrokeEndLineCap;
     private PenLineCap _undashedStrokeDashCap;
+    private PenStrokeTransformMode _undashedStrokeTransformMode;
 
     private RenderCommandGeometryCache(
         PathGeometry? strokePath,
@@ -573,6 +574,7 @@ public sealed class RenderCommandGeometryCache
         _undashedStrokeStartLineCap = pen.StartLineCap;
         _undashedStrokeEndLineCap = pen.EndLineCap;
         _undashedStrokeDashCap = pen.DashCap;
+        _undashedStrokeTransformMode = pen.StrokeTransformMode;
         return true;
     }
 
@@ -677,7 +679,8 @@ public sealed class RenderCommandGeometryCache
             _undashedStrokeMiterLimit == pen.MiterLimit &&
             _undashedStrokeStartLineCap == pen.StartLineCap &&
             _undashedStrokeEndLineCap == pen.EndLineCap &&
-            _undashedStrokeDashCap == pen.DashCap;
+            _undashedStrokeDashCap == pen.DashCap &&
+            _undashedStrokeTransformMode == pen.StrokeTransformMode;
     }
 }
 

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -4387,16 +4387,7 @@ public class DrawingContext :
             PointBufferOffset = offset,
             PointBufferCount = count,
             IsClosed = isClosed,
-            IsPenThicknessLocal = true,
-            GeometryCache = pen.HasDashPattern ||
-                isClosed ||
-                count > 2 ||
-                RequiresEndpointCapGeometry(pen)
-                ? RenderCommandGeometryCache.ForStrokePath(
-                    RenderCommandGeometryCache.CreatePolylinePath(
-                        points,
-                        isClosed))
-                : null
+            IsPenThicknessLocal = true
         });
     }
 
@@ -4449,17 +4440,7 @@ public class DrawingContext :
             WeightBufferCount = weightCount,
             SplineDegree = degree,
             IsClosed = isClosed,
-            IsPenThicknessLocal = true,
-            // Retain the sampled centerline once so connected spline segments use
-            // the pen's join/cap contract and stable replay does not allocate or
-            // resample the spline on every frame.
-            GeometryCache = RenderCommandGeometryCache.ForStrokePath(
-                SplineGeometry.CreatePath(
-                    controlPoints,
-                    knots,
-                    weights,
-                    degree,
-                    isClosed))
+            IsPenThicknessLocal = true
         });
     }
 
@@ -5025,44 +5006,6 @@ public class DrawingContext :
                     command.Position4),
             _ => null
         };
-
-        if (command.Type == RenderCommandType.DrawPolyline)
-        {
-            var points = command.PolylinePoints is { Length: > 0 } inlinePoints
-                ? inlinePoints.AsSpan()
-                : GetPoints(command.PointBufferOffset, command.PointBufferCount);
-            if (pen.HasDashPattern ||
-                command.IsClosed ||
-                points.Length > 2 ||
-                RequiresEndpointCapGeometry(pen))
-            {
-                strokePath = RenderCommandGeometryCache.CreatePolylinePath(
-                    points,
-                    command.IsClosed);
-            }
-        }
-        else if (command.Type == RenderCommandType.DrawSpline ||
-            (command.Type == RenderCommandType.DrawExtension &&
-             command.ExtensionId == CompositorBuiltInExtensions.Spline))
-        {
-            var points = command.PolylinePoints is { Length: > 0 } inlinePoints
-                ? inlinePoints.AsSpan()
-                : GetPoints(command.PointBufferOffset, command.PointBufferCount);
-            var knots = command.SplineKnots is { Length: > 0 } inlineKnots
-                ? inlineKnots.AsSpan()
-                : GetDoubles(command.DoubleBufferOffset, command.DoubleBufferCount);
-            var weights = command.SplineWeights is { Length: > 0 } inlineWeights
-                ? inlineWeights.AsSpan()
-                : command.WeightBufferCount > 0
-                    ? GetDoubles(command.WeightBufferOffset, command.WeightBufferCount)
-                    : ReadOnlySpan<double>.Empty;
-            strokePath = RenderCommandGeometryCache.CreateSplinePath(
-                points,
-                knots,
-                weights,
-                command.SplineDegree,
-                command.IsClosed);
-        }
 
         command.GeometryCache = strokePath == null
             ? null

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -400,9 +400,21 @@ internal interface IImageEffectDataProvider
 
 public sealed class RenderCommandGeometryCache
 {
-    private int _dashedStrokeSignature;
     private PathGeometry? _dashedStrokePath;
+    private float _dashedStrokeLocalThickness;
+    private double _dashedStrokeDashOffset;
+    private double[]? _dashedStrokeDashArray;
+    private PenLineCap _dashedStrokeStartLineCap;
+    private PenLineCap _dashedStrokeEndLineCap;
+    private PenLineCap _dashedStrokeDashCap;
     private Pen? _undashedStrokePen;
+    private Brush? _undashedStrokeSourceBrush;
+    private float _undashedStrokeLocalThickness;
+    private PenLineJoin _undashedStrokeLineJoin;
+    private float _undashedStrokeMiterLimit;
+    private PenLineCap _undashedStrokeStartLineCap;
+    private PenLineCap _undashedStrokeEndLineCap;
+    private PenLineCap _undashedStrokeDashCap;
 
     private RenderCommandGeometryCache(
         PathGeometry? strokePath,
@@ -446,6 +458,20 @@ public sealed class RenderCommandGeometryCache
     public bool TryGetDashedStrokePath(Pen pen, out PathGeometry dashedStrokePath, out Pen undashedStrokePen)
     {
         ArgumentNullException.ThrowIfNull(pen);
+        return TryGetDashedStrokePath(
+            pen,
+            pen.IsHairline ? 1f : pen.Thickness,
+            out dashedStrokePath,
+            out undashedStrokePen);
+    }
+
+    internal bool TryGetDashedStrokePath(
+        Pen pen,
+        float localThickness,
+        out PathGeometry dashedStrokePath,
+        out Pen undashedStrokePen)
+    {
+        ArgumentNullException.ThrowIfNull(pen);
 
         if (StrokePath == null)
         {
@@ -454,26 +480,54 @@ public sealed class RenderCommandGeometryCache
             return false;
         }
 
-        int signature = ComputeDashedStrokeSignature(pen);
+        // A transformed picture reconstructs gradient brushes and their owning pens on
+        // every replay. Paint identity is deliberately excluded from this geometry key:
+        // dash placement depends on the local width, offset, and interval values, while
+        // the lowered per-figure endpoint metadata also depends on all three source caps.
+        // Comparing the exact values keeps a cache hit O(D), for D dash intervals, while
+        // avoiding both hash collisions and an O(G) path rebuild for G emitted segments.
+        var dashArray = pen.DashArrayStorage;
         if (_dashedStrokePath != null &&
-            _undashedStrokePen != null &&
-            _dashedStrokeSignature == signature)
+            DashedStrokeGeometryMatches(pen, localThickness, dashArray))
         {
             dashedStrokePath = _dashedStrokePath;
+        }
+        else
+        {
+            if (!Compositor.TryCreateDashedStrokePath(StrokePath, pen, localThickness, out dashedStrokePath))
+            {
+                undashedStrokePen = null!;
+                return false;
+            }
+
+            _dashedStrokePath = dashedStrokePath;
+            _dashedStrokeLocalThickness = localThickness;
+            _dashedStrokeDashOffset = pen.DashOffset;
+            _dashedStrokeDashArray = dashArray;
+            _dashedStrokeStartLineCap = pen.StartLineCap;
+            _dashedStrokeEndLineCap = pen.EndLineCap;
+            _dashedStrokeDashCap = pen.DashCap;
+        }
+
+        // The centerline geometry may be shared by many equivalent reconstructed pens,
+        // but the paint must never be. Reuse the derived pen only while every source
+        // input used to create it still matches, including brush reference identity.
+        // A mutable brush remains safe because the derived pen retains that same object.
+        if (_undashedStrokePen != null && UndashedStrokePenMatches(pen, localThickness))
+        {
             undashedStrokePen = _undashedStrokePen;
             return true;
         }
 
-        if (!Compositor.TryCreateDashedStrokePath(StrokePath, pen, out dashedStrokePath))
-        {
-            undashedStrokePen = null!;
-            return false;
-        }
-
-        undashedStrokePen = Compositor.CreateUndashedPen(pen);
-        _dashedStrokePath = dashedStrokePath;
+        undashedStrokePen = Compositor.CreateUndashedPen(pen, localThickness);
         _undashedStrokePen = undashedStrokePen;
-        _dashedStrokeSignature = signature;
+        _undashedStrokeSourceBrush = pen.Brush;
+        _undashedStrokeLocalThickness = localThickness;
+        _undashedStrokeLineJoin = pen.LineJoin;
+        _undashedStrokeMiterLimit = pen.MiterLimit;
+        _undashedStrokeStartLineCap = pen.StartLineCap;
+        _undashedStrokeEndLineCap = pen.EndLineCap;
+        _undashedStrokeDashCap = pen.DashCap;
         return true;
     }
 
@@ -542,33 +596,43 @@ public sealed class RenderCommandGeometryCache
         return SplineGeometry.CreatePath(controlPoints, knots, weights, degree, isClosed);
     }
 
-    private static int ComputeDashedStrokeSignature(Pen pen)
+    private bool DashedStrokeGeometryMatches(
+        Pen pen,
+        float localThickness,
+        double[]? dashArray)
     {
-        var hash = new HashCode();
-        hash.Add(pen.Brush);
-        hash.Add(pen.Thickness);
-        hash.Add(pen.LineJoin);
-        hash.Add(pen.MiterLimit);
-        hash.Add(pen.StartLineCap);
-        hash.Add(pen.EndLineCap);
-        hash.Add(pen.DashCap);
-        hash.Add(pen.DashOffset);
-
-        var dashArray = pen.DashArray;
-        if (dashArray != null)
+        if (_dashedStrokeLocalThickness != localThickness ||
+            _dashedStrokeDashOffset != pen.DashOffset ||
+            _dashedStrokeStartLineCap != pen.StartLineCap ||
+            _dashedStrokeEndLineCap != pen.EndLineCap ||
+            _dashedStrokeDashCap != pen.DashCap ||
+            _dashedStrokeDashArray == null ||
+            dashArray == null ||
+            _dashedStrokeDashArray.Length != dashArray.Length)
         {
-            hash.Add(dashArray.Length);
-            for (int i = 0; i < dashArray.Length; i++)
+            return false;
+        }
+
+        for (int i = 0; i < dashArray.Length; i++)
+        {
+            if (_dashedStrokeDashArray[i] != dashArray[i])
             {
-                hash.Add(dashArray[i]);
+                return false;
             }
         }
-        else
-        {
-            hash.Add(0);
-        }
 
-        return hash.ToHashCode();
+        return true;
+    }
+
+    private bool UndashedStrokePenMatches(Pen pen, float localThickness)
+    {
+        return ReferenceEquals(_undashedStrokeSourceBrush, pen.Brush) &&
+            _undashedStrokeLocalThickness == localThickness &&
+            _undashedStrokeLineJoin == pen.LineJoin &&
+            _undashedStrokeMiterLimit == pen.MiterLimit &&
+            _undashedStrokeStartLineCap == pen.StartLineCap &&
+            _undashedStrokeEndLineCap == pen.EndLineCap &&
+            _undashedStrokeDashCap == pen.DashCap;
     }
 }
 
@@ -3374,7 +3438,8 @@ public class DrawingContext :
             Type = RenderCommandType.DrawRect,
             Rect = rect,
             Brush = brush,
-            Pen = pen
+            Pen = pen,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -3397,7 +3462,8 @@ public class DrawingContext :
             Rect = rect,
             Brush = brush,
             Pen = pen,
-            Transform = transform
+            Transform = transform,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -3409,6 +3475,7 @@ public class DrawingContext :
             Brush = brush,
             Pen = pen,
             Path = path,
+            IsPenThicknessLocal = pen is not null,
             GeometryCache = RenderCommandGeometryCache.ForPath(path)
         });
     }
@@ -3438,6 +3505,7 @@ public class DrawingContext :
             Brush = brush,
             Pen = pen,
             Path = path,
+            IsPenThicknessLocal = pen is not null,
             GeometryCache = geometryCache
         });
     }
@@ -3451,6 +3519,7 @@ public class DrawingContext :
             Pen = pen,
             Path = path,
             Transform = transform,
+            IsPenThicknessLocal = pen is not null,
             GeometryCache = RenderCommandGeometryCache.ForPath(path)
         });
     }
@@ -3481,6 +3550,7 @@ public class DrawingContext :
             Pen = pen,
             Path = path,
             Transform = transform,
+            IsPenThicknessLocal = pen is not null,
             GeometryCache = geometryCache
         });
     }
@@ -3899,7 +3969,9 @@ public class DrawingContext :
             Path = geometry,
             Pen = pen,
             Rect = bounds,
-            Transform = transform
+            Transform = transform,
+            IsPenThicknessLocal = true,
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(geometry)
         });
     }
 
@@ -3924,13 +3996,25 @@ public class DrawingContext :
 
     public void DrawLine(Pen pen, Vector2 p1, Vector2 p2)
     {
+        DrawLine(pen, p1, p2, default);
+    }
+
+    public void DrawLine(
+        Pen pen,
+        Vector2 p1,
+        Vector2 p2,
+        Matrix4x4 transform)
+    {
+        ArgumentNullException.ThrowIfNull(pen);
         Commands.Add(new RenderCommand
         {
             Type = RenderCommandType.DrawLine,
             Pen = pen,
             Position = p1,
             Position2 = p2,
-            GeometryCache = pen.HasDashPattern
+            Transform = transform,
+            IsPenThicknessLocal = true,
+            GeometryCache = RequiresEndpointCapGeometry(pen)
                 ? RenderCommandGeometryCache.ForStrokePath(
                     RenderCommandGeometryCache.CreateLinePath(p1, p2))
                 : null
@@ -3970,7 +4054,8 @@ public class DrawingContext :
             Pen = pen,
             Position2 = center,
             RadiusX = radiusX,
-            RadiusY = radiusY
+            RadiusY = radiusY,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -3990,7 +4075,8 @@ public class DrawingContext :
             Position2 = center,
             RadiusX = radiusX,
             RadiusY = radiusY,
-            Transform = transform
+            Transform = transform,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -4007,7 +4093,8 @@ public class DrawingContext :
             Brush = brush,
             Pen = pen,
             Position2 = center,
-            RadiusX = radius
+            RadiusX = radius,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -4068,7 +4155,8 @@ public class DrawingContext :
             Pen = pen,
             Rect = rect,
             RadiusX = radiusX,
-            RadiusY = radiusY
+            RadiusY = radiusY,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -4104,7 +4192,8 @@ public class DrawingContext :
             Rect = rect,
             RadiusX = radiusX,
             RadiusY = radiusY,
-            Transform = transform
+            Transform = transform,
+            IsPenThicknessLocal = pen is not null
         });
     }
 
@@ -4121,7 +4210,15 @@ public class DrawingContext :
             Pen = pen,
             Position = p0,
             Position2 = p1,
-            Position3 = p2
+            Position3 = p2,
+            IsPenThicknessLocal = true,
+            GeometryCache = RequiresEndpointCapGeometry(pen)
+                ? RenderCommandGeometryCache.ForStrokePath(
+                    RenderCommandGeometryCache.CreateQuadraticBezierPath(
+                        p0,
+                        p1,
+                        p2))
+                : null
         });
     }
 
@@ -4134,7 +4231,16 @@ public class DrawingContext :
             Position = p0,
             Position2 = p1,
             Position3 = p2,
-            Position4 = p3
+            Position4 = p3,
+            IsPenThicknessLocal = true,
+            GeometryCache = RequiresEndpointCapGeometry(pen)
+                ? RenderCommandGeometryCache.ForStrokePath(
+                    RenderCommandGeometryCache.CreateCubicBezierPath(
+                        p0,
+                        p1,
+                        p2,
+                        p3))
+                : null
         });
     }
 
@@ -4228,7 +4334,17 @@ public class DrawingContext :
             Pen = pen,
             PointBufferOffset = offset,
             PointBufferCount = count,
-            IsClosed = isClosed
+            IsClosed = isClosed,
+            IsPenThicknessLocal = true,
+            GeometryCache = pen.HasDashPattern ||
+                isClosed ||
+                count > 2 ||
+                RequiresEndpointCapGeometry(pen)
+                ? RenderCommandGeometryCache.ForStrokePath(
+                    RenderCommandGeometryCache.CreatePolylinePath(
+                        points,
+                        isClosed))
+                : null
         });
     }
 
@@ -4280,9 +4396,25 @@ public class DrawingContext :
             WeightBufferOffset = weightOffset,
             WeightBufferCount = weightCount,
             SplineDegree = degree,
-            IsClosed = isClosed
+            IsClosed = isClosed,
+            IsPenThicknessLocal = true,
+            // Retain the sampled centerline once so connected spline segments use
+            // the pen's join/cap contract and stable replay does not allocate or
+            // resample the spline on every frame.
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(
+                SplineGeometry.CreatePath(
+                    controlPoints,
+                    knots,
+                    weights,
+                    degree,
+                    isClosed))
         });
     }
+
+    private static bool RequiresEndpointCapGeometry(Pen pen) =>
+        pen.HasDashPattern ||
+        pen.StartLineCap != PenLineCap.Flat ||
+        pen.EndLineCap != PenLineCap.Flat;
 
     public void DrawAcisSolid(Pen pen, ReadOnlySpan<Line3D> edges, Matrix4x4 modelTransform)
     {
@@ -4572,6 +4704,12 @@ public class DrawingContext :
                 {
                     ComposeAppendTranslation(ref adjustedCmd, translation);
                 }
+                else if (adjustedCmd.Type == RenderCommandType.PushOpacityMask && adjustedCmd.Path != null)
+                {
+                    // Path-mask bounds and centerline are both local to the command;
+                    // composing once translates both when the mask is compiled.
+                    ComposeAppendTranslation(ref adjustedCmd, translation);
+                }
                 else if (adjustedCmd.Type == RenderCommandType.DrawRect ||
                     adjustedCmd.Type == RenderCommandType.DrawTexture ||
                     adjustedCmd.Type == RenderCommandType.DrawRoundedRect ||
@@ -4583,7 +4721,8 @@ public class DrawingContext :
                 else if (adjustedCmd.Type == RenderCommandType.PushGeometryClip ||
                          adjustedCmd.Type == RenderCommandType.DrawPath ||
                          adjustedCmd.Type == RenderCommandType.DrawVertexMesh ||
-                         adjustedCmd.Type == RenderCommandType.DrawPointBatch)
+                         adjustedCmd.Type == RenderCommandType.DrawPointBatch ||
+                         IsAppendTransformBackedCommand(adjustedCmd))
                 {
                     ComposeAppendTranslation(ref adjustedCmd, translation);
                 }
@@ -4633,9 +4772,9 @@ public class DrawingContext :
                         }
                         adjustedCmd.PolylinePoints = newPoints;
                     }
-                }
 
-                adjustedCmd.GeometryCache = null;
+                    RebuildTranslatedStrokeGeometryCache(ref adjustedCmd);
+                }
             }
 
             Commands.Add(adjustedCmd);
@@ -4801,6 +4940,78 @@ public class DrawingContext :
         }
     }
 
+    private void RebuildTranslatedStrokeGeometryCache(ref RenderCommand command)
+    {
+        var pen = command.Pen;
+        if (pen == null)
+        {
+            command.GeometryCache = null;
+            return;
+        }
+
+        PathGeometry? strokePath = command.Type switch
+        {
+            RenderCommandType.DrawLine when RequiresEndpointCapGeometry(pen) =>
+                RenderCommandGeometryCache.CreateLinePath(
+                    command.Position,
+                    command.Position2),
+            RenderCommandType.DrawBezier when RequiresEndpointCapGeometry(pen) =>
+                RenderCommandGeometryCache.CreateQuadraticBezierPath(
+                    command.Position,
+                    command.Position2,
+                    command.Position3),
+            RenderCommandType.DrawCubicBezier when RequiresEndpointCapGeometry(pen) =>
+                RenderCommandGeometryCache.CreateCubicBezierPath(
+                    command.Position,
+                    command.Position2,
+                    command.Position3,
+                    command.Position4),
+            _ => null
+        };
+
+        if (command.Type == RenderCommandType.DrawPolyline)
+        {
+            var points = command.PolylinePoints is { Length: > 0 } inlinePoints
+                ? inlinePoints.AsSpan()
+                : GetPoints(command.PointBufferOffset, command.PointBufferCount);
+            if (pen.HasDashPattern ||
+                command.IsClosed ||
+                points.Length > 2 ||
+                RequiresEndpointCapGeometry(pen))
+            {
+                strokePath = RenderCommandGeometryCache.CreatePolylinePath(
+                    points,
+                    command.IsClosed);
+            }
+        }
+        else if (command.Type == RenderCommandType.DrawSpline ||
+            (command.Type == RenderCommandType.DrawExtension &&
+             command.ExtensionId == CompositorBuiltInExtensions.Spline))
+        {
+            var points = command.PolylinePoints is { Length: > 0 } inlinePoints
+                ? inlinePoints.AsSpan()
+                : GetPoints(command.PointBufferOffset, command.PointBufferCount);
+            var knots = command.SplineKnots is { Length: > 0 } inlineKnots
+                ? inlineKnots.AsSpan()
+                : GetDoubles(command.DoubleBufferOffset, command.DoubleBufferCount);
+            var weights = command.SplineWeights is { Length: > 0 } inlineWeights
+                ? inlineWeights.AsSpan()
+                : command.WeightBufferCount > 0
+                    ? GetDoubles(command.WeightBufferOffset, command.WeightBufferCount)
+                    : ReadOnlySpan<double>.Empty;
+            strokePath = RenderCommandGeometryCache.CreateSplinePath(
+                points,
+                knots,
+                weights,
+                command.SplineDegree,
+                command.IsClosed);
+        }
+
+        command.GeometryCache = strokePath == null
+            ? null
+            : RenderCommandGeometryCache.ForStrokePath(strokePath);
+    }
+
     private void TranslatePointBufferSlice(int offset, int count, Vector2 translation)
     {
         for (int i = 0; i < count; i++)
@@ -4854,6 +5065,26 @@ public class DrawingContext :
                (command.Type == RenderCommandType.DrawExtension &&
                 (command.ExtensionId == CompositorBuiltInExtensions.GpuLineSeries ||
                  command.ExtensionId == CompositorBuiltInExtensions.GpuScatterSeries));
+    }
+
+    private static bool IsAppendTransformBackedCommand(RenderCommand command)
+    {
+        if (command.Type is RenderCommandType.DrawPicture or
+            RenderCommandType.DrawVisual or
+            RenderCommandType.DrawHatch or
+            RenderCommandType.DrawDotGrid or
+            RenderCommandType.DrawLine3D or
+            RenderCommandType.DrawAcisSolid or
+            RenderCommandType.DrawStaticDxf)
+        {
+            return true;
+        }
+
+        return command.Type == RenderCommandType.DrawExtension &&
+            command.ExtensionId is CompositorBuiltInExtensions.Hatch or
+                CompositorBuiltInExtensions.Line3D or
+                CompositorBuiltInExtensions.AcisSolid or
+                CompositorBuiltInExtensions.StaticDxf;
     }
 
     private static void TranslateGpuSeriesCommand(ref RenderCommand command, Vector2 translation)

--- a/src/ProGPU.Tests.Headless/GdiShimTests.cs
+++ b/src/ProGPU.Tests.Headless/GdiShimTests.cs
@@ -682,7 +682,7 @@ public class GdiShimTests
     }
 
     [Fact]
-    public void DrawLineScalesPenWidthByWorldTransform()
+    public void DrawLineRetainsLocalPenWidthAndCompilesWorldTransform()
     {
         using var graphics = Graphics.FromHwnd(IntPtr.Zero);
         using var pen = new Pen(Color.Red, 2f);
@@ -692,9 +692,20 @@ public class GdiShimTests
 
         var command = Assert.Single(graphics.DrawingContext.Commands);
         Assert.Equal(RenderCommandType.DrawLine, command.Type);
-        Assert.Equal(6f, command.Pen!.Thickness);
-        Assert.Equal(new Vector2(3f, 6f), command.Position);
-        Assert.Equal(new Vector2(15f, 6f), command.Position2);
+        Assert.Equal(2f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
+        Assert.Equal(new Vector2(1f, 2f), command.Position);
+        Assert.Equal(new Vector2(5f, 2f), command.Position2);
+        Assert.Equal(Matrix4x4.CreateScale(3f, 3f, 1f), command.Transform);
+
+        using var buffer = HeadlessWindow.Shared.Compositor.CompileStaticDxf(
+            graphics.DrawingContext);
+        Assert.Equal(4, buffer.VectorVertices.Length);
+        Assert.All(
+            buffer.VectorVertices,
+            static vertex => Assert.Equal(6f, vertex.StrokeThickness));
+        Assert.Equal(new Vector2(3f, 6f), buffer.VectorVertices[0].Position);
+        Assert.Equal(new Vector2(15f, 6f), buffer.VectorVertices[2].Position);
     }
 
     [Fact]
@@ -726,7 +737,7 @@ public class GdiShimTests
     }
 
     [Fact]
-    public void DrawLinePreservesNormalizedDashPatternAndOffsetWhenScalingPenWidth()
+    public void DrawLinePreservesNormalizedDashPatternAndOffsetWithLocalPenProvenance()
     {
         using var graphics = Graphics.FromHwnd(IntPtr.Zero);
         using var pen = new Pen(Color.Black, 2f)
@@ -739,9 +750,22 @@ public class GdiShimTests
         graphics.DrawLine(pen, 0f, 0f, 10f, 0f);
 
         var command = Assert.Single(graphics.DrawingContext.Commands);
-        Assert.Equal(6f, command.Pen!.Thickness);
+        Assert.Equal(RenderCommandType.DrawLine, command.Type);
+        Assert.Equal(2f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
         Assert.Equal(new[] { 1.0, 1.0 }, command.Pen.DashArray);
         Assert.Equal(0.5, command.Pen.DashOffset);
+        Assert.Equal(new Vector2(0f, 0f), command.Position);
+        Assert.Equal(new Vector2(10f, 0f), command.Position2);
+        Assert.Equal(Matrix4x4.CreateScale(3f, 3f, 1f), command.Transform);
+        Assert.NotNull(command.GeometryCache?.StrokePath);
+
+        using var buffer = HeadlessWindow.Shared.Compositor.CompileStaticDxf(
+            graphics.DrawingContext);
+        Assert.NotEmpty(buffer.VectorVertices);
+        Assert.All(
+            buffer.VectorVertices,
+            static vertex => Assert.Equal(6f, vertex.StrokeThickness));
     }
 
     [Fact]
@@ -795,7 +819,7 @@ public class GdiShimTests
     }
 
     [Fact]
-    public void DrawPathScalesPenWidthByWorldTransform()
+    public void DrawPathRetainsLocalPenWidthAndCompilesWorldTransform()
     {
         using var graphics = Graphics.FromHwnd(IntPtr.Zero);
         using var pen = new Pen(Color.Red, 2f);
@@ -807,7 +831,22 @@ public class GdiShimTests
 
         var command = Assert.Single(graphics.DrawingContext.Commands);
         Assert.Equal(RenderCommandType.DrawPath, command.Type);
-        Assert.Equal(6f, command.Pen!.Thickness);
+        Assert.Equal(2f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
+        Assert.Equal(Matrix4x4.CreateScale(3f, 3f, 1f), command.Transform);
+
+        using var buffer = HeadlessWindow.Shared.Compositor.CompileStaticDxf(
+            graphics.DrawingContext);
+        Assert.NotEmpty(buffer.VectorVertices);
+        Assert.All(
+            buffer.VectorVertices,
+            static vertex => Assert.Equal(6f, vertex.StrokeThickness));
+        Assert.Contains(
+            buffer.VectorVertices,
+            static vertex => vertex.Position == new Vector2(3f, 6f));
+        Assert.Contains(
+            buffer.VectorVertices,
+            static vertex => vertex.Position == new Vector2(15f, 6f));
     }
 
     [Fact]

--- a/src/ProGPU.Tests.Headless/SamplePagesTests.cs
+++ b/src/ProGPU.Tests.Headless/SamplePagesTests.cs
@@ -1730,32 +1730,17 @@ public class SamplePagesTests : IDisposable
     {
         EnsureFontsAndStateLoaded();
 
-        string specPath = "/Users/wieslawsoltes/Downloads/spec.txt";
-        string markdownContent = "";
-        if (File.Exists(specPath))
+        // Keep the virtualization workload hermetic. A developer-local markdown
+        // file can contain different block shapes and makes this completeness
+        // contract machine-dependent.
+        var documentBuilder = new System.Text.StringBuilder();
+        documentBuilder.AppendLine("# Mock Massive Markdown Document");
+        for (int i = 0; i < 1500; i++)
         {
-            try
-            {
-                markdownContent = File.ReadAllText(specPath);
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-                Console.WriteLine($"[Headless] Falling back to generated markdown because '{specPath}' is inaccessible: {ex.Message}");
-            }
+            documentBuilder.AppendLine($"Paragraph {i}: This dense generated markdown content verifies virtualized block-based flow layout, scrolling, and rendering without depending on a local Downloads fixture.");
+            documentBuilder.AppendLine();
         }
-
-        if (markdownContent.Length == 0)
-        {
-            // Fallback: Generate a massive dense markdown document.
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine("# Mock Massive Markdown Document");
-            for (int i = 0; i < 1500; i++)
-            {
-                sb.AppendLine($"Paragraph {i}: This dense generated markdown content verifies virtualized block-based flow layout, scrolling, and rendering without depending on a local Downloads fixture.");
-                sb.AppendLine();
-            }
-            markdownContent = sb.ToString();
-        }
+        string markdownContent = documentBuilder.ToString();
 
         var scrollViewer = new ScrollViewer
         {

--- a/src/ProGPU.Tests.Headless/SamplePagesTests.cs
+++ b/src/ProGPU.Tests.Headless/SamplePagesTests.cs
@@ -1021,6 +1021,24 @@ public class SamplePagesTests : IDisposable
     }
 
     [Fact]
+    public void Test_DxfRenderContext_UsesPositiveFixedDeviceStrokeWidths()
+    {
+        EnsureFontsAndStateLoaded();
+        var context = new ProGPU.Dxf.DxfRenderContext(
+            new DrawingContext(),
+            AppState.GetFont()!);
+        var line = new netDxf.Entities.Line(
+            new netDxf.Vector2(-10d, 0d),
+            new netDxf.Vector2(10d, 0d));
+
+        var pen = context.GetCachedPen(line, 1.2f);
+
+        Assert.Equal(1.2f, pen.Thickness);
+        Assert.False(pen.IsHairline);
+        Assert.Equal(PenStrokeTransformMode.Fixed, pen.StrokeTransformMode);
+    }
+
+    [Fact]
     public void Test_DxfCanvasControl_ZoomRetainsGeometryAndGlyphOutlinesWithoutRecompilation()
     {
         EnsureFontsAndStateLoaded();

--- a/src/ProGPU.Tests.Headless/WavefrontFallbackRenderTests.cs
+++ b/src/ProGPU.Tests.Headless/WavefrontFallbackRenderTests.cs
@@ -1,0 +1,317 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Scene;
+using ProGPU.Vector;
+using Silk.NET.WebGPU;
+using Xunit;
+
+namespace ProGPU.Tests.Headless;
+
+[Collection("HeadlessTests")]
+public sealed class WavefrontFallbackRenderTests
+{
+    private const uint SurfaceSize = 64;
+
+    [Fact]
+    public void StrokeOnlyPathPreservesBorderAndDoesNotFillInterior()
+    {
+        using var window = CreateWavefrontWindow(new StrokeOnlyPathVisual());
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        AssertRed(ReadPixel(pixels, x: 10, y: 32));
+        AssertBlack(ReadPixel(pixels, x: 32, y: 32));
+    }
+
+    [Fact]
+    public void FilledAndStrokedPathPreservesBothBrushColors()
+    {
+        using var window = CreateWavefrontWindow(new FilledAndStrokedPathVisual());
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        AssertRed(ReadPixel(pixels, x: 12, y: 32));
+        AssertGreen(ReadPixel(pixels, x: 32, y: 32));
+    }
+
+    [Fact]
+    public void FilledPathFollowedByDirectRectanglePreservesDrawOrder()
+    {
+        using var window = CreateWavefrontWindow(new MixedOrderedVisual());
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        AssertBlue(ReadPixel(pixels, x: 16, y: 32));
+        AssertGreen(ReadPixel(pixels, x: 29, y: 32));
+        AssertRed(ReadPixel(pixels, x: 36, y: 32));
+    }
+
+    [Fact]
+    public void GeometryClipDoesNotEscapeItsMask()
+    {
+        using var window = CreateWavefrontWindow(new GeometryClipVisual());
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        AssertBlue(ReadPixel(pixels, x: 32, y: 24));
+        AssertBlack(ReadPixel(pixels, x: 8, y: 8));
+        AssertBlack(ReadPixel(pixels, x: 20, y: 40));
+    }
+
+    [Fact]
+    public void EvenOddPathPreservesItsHole()
+    {
+        using var window = CreateWavefrontWindow(new EvenOddPathVisual());
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        AssertGreen(ReadPixel(pixels, x: 14, y: 32));
+        AssertBlack(ReadPixel(pixels, x: 32, y: 32));
+    }
+
+    [Fact]
+    public void PathOpacityIsAppliedByFallbackRenderer()
+    {
+        using var window = CreateWavefrontWindow(new TranslucentPathVisual());
+
+        window.Render();
+
+        RgbaPixel pixel = ReadPixel(window.ReadPixels(), x: 32, y: 32);
+        Assert.InRange(pixel.Red, (byte)120, (byte)136);
+        Assert.InRange(pixel.Green, (byte)0, (byte)3);
+        Assert.InRange(pixel.Blue, (byte)0, (byte)3);
+        Assert.InRange(pixel.Alpha, (byte)252, byte.MaxValue);
+    }
+
+    [Fact]
+    public void MoreThanWavefrontCellCapacityDoesNotDropLaterPaths()
+    {
+        using var window = CreateWavefrontWindow(new WavefrontCapacityVisual());
+
+        window.Render();
+
+        AssertBlue(ReadPixel(window.ReadPixels(), x: 32, y: 32));
+    }
+
+    [Fact]
+    public void NonConformalTransformUsesTheExactAtlasFallback()
+    {
+        using var atlasWindow = CreateWindow(
+            new NonConformalPathVisual(),
+            Compositor.VectorRenderingEngine.Atlas);
+        using var wavefrontWindow = CreateWindow(
+            new NonConformalPathVisual(),
+            Compositor.VectorRenderingEngine.Wavefront);
+
+        atlasWindow.Render();
+        wavefrontWindow.Render();
+
+        Assert.Equal(atlasWindow.ReadPixels(), wavefrontWindow.ReadPixels());
+    }
+
+    private static HeadlessWindow CreateWavefrontWindow(FrameworkElement content)
+        => CreateWindow(content, Compositor.VectorRenderingEngine.Wavefront);
+
+    private static HeadlessWindow CreateWindow(
+        FrameworkElement content,
+        Compositor.VectorRenderingEngine vectorEngine)
+    {
+        var window = new HeadlessWindow(
+            SurfaceSize,
+            SurfaceSize,
+            renderFormat: TextureFormat.Bgra8Unorm)
+        {
+            Content = content
+        };
+        window.Compositor.ClearColor = new Vector4(0f, 0f, 0f, 1f);
+        window.Compositor.VectorEngine = vectorEngine;
+        return window;
+    }
+
+    private static PathGeometry CreateRectanglePath(
+        float left,
+        float top,
+        float right,
+        float bottom)
+    {
+        var figure = new PathFigure(new Vector2(left, top), isClosed: true);
+        figure.Segments.Add(new LineSegment(new Vector2(right, top)));
+        figure.Segments.Add(new LineSegment(new Vector2(right, bottom)));
+        figure.Segments.Add(new LineSegment(new Vector2(left, bottom)));
+        var path = new PathGeometry();
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static RgbaPixel ReadPixel(byte[] pixels, int x, int y)
+    {
+        int offset = ((y * checked((int)SurfaceSize)) + x) * 4;
+        return new RgbaPixel(
+            pixels[offset],
+            pixels[offset + 1],
+            pixels[offset + 2],
+            pixels[offset + 3]);
+    }
+
+    private static void AssertRed(RgbaPixel pixel)
+    {
+        Assert.InRange(pixel.Red, (byte)220, byte.MaxValue);
+        Assert.InRange(pixel.Green, (byte)0, (byte)35);
+        Assert.InRange(pixel.Blue, (byte)0, (byte)35);
+        Assert.InRange(pixel.Alpha, (byte)245, byte.MaxValue);
+    }
+
+    private static void AssertGreen(RgbaPixel pixel)
+    {
+        Assert.InRange(pixel.Red, (byte)0, (byte)35);
+        Assert.InRange(pixel.Green, (byte)220, byte.MaxValue);
+        Assert.InRange(pixel.Blue, (byte)0, (byte)35);
+        Assert.InRange(pixel.Alpha, (byte)245, byte.MaxValue);
+    }
+
+    private static void AssertBlue(RgbaPixel pixel)
+    {
+        Assert.InRange(pixel.Red, (byte)0, (byte)35);
+        Assert.InRange(pixel.Green, (byte)0, (byte)35);
+        Assert.InRange(pixel.Blue, (byte)220, byte.MaxValue);
+        Assert.InRange(pixel.Alpha, (byte)245, byte.MaxValue);
+    }
+
+    private static void AssertBlack(RgbaPixel pixel)
+    {
+        Assert.InRange(pixel.Red, (byte)0, (byte)3);
+        Assert.InRange(pixel.Green, (byte)0, (byte)3);
+        Assert.InRange(pixel.Blue, (byte)0, (byte)3);
+        Assert.InRange(pixel.Alpha, (byte)252, byte.MaxValue);
+    }
+
+    private readonly record struct RgbaPixel(byte Red, byte Green, byte Blue, byte Alpha);
+
+    private sealed class StrokeOnlyPathVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path = CreateRectanglePath(10f, 10f, 54f, 54f);
+        private readonly Pen _pen = new(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            6f);
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPath(null, _pen, _path);
+    }
+
+    private sealed class FilledAndStrokedPathVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path = CreateRectanglePath(12f, 12f, 52f, 52f);
+        private readonly SolidColorBrush _fill = new(new Vector4(0f, 1f, 0f, 1f));
+        private readonly Pen _pen = new(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            6f);
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPath(_fill, _pen, _path);
+    }
+
+    private sealed class MixedOrderedVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path = CreateRectanglePath(8f, 8f, 50f, 56f);
+        private readonly SolidColorBrush _blue = new(new Vector4(0f, 0f, 1f, 1f));
+        private readonly SolidColorBrush _red = new(new Vector4(1f, 0f, 0f, 1f));
+        private readonly Pen _greenPen = new(
+            new SolidColorBrush(new Vector4(0f, 1f, 0f, 1f)),
+            4f);
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawPath(_blue, null, _path);
+            context.DrawRectangle(
+                _red,
+                _greenPen,
+                new Rect(28f, 16f, 28f, 32f));
+        }
+    }
+
+    private sealed class GeometryClipVisual : FrameworkElement
+    {
+        private readonly PathGeometry _clip;
+        private readonly SolidColorBrush _blue = new(new Vector4(0f, 0f, 1f, 1f));
+
+        public GeometryClipVisual()
+        {
+            var figure = new PathFigure(new Vector2(16f, 16f), isClosed: true);
+            figure.Segments.Add(new LineSegment(new Vector2(48f, 16f)));
+            figure.Segments.Add(new LineSegment(new Vector2(32f, 48f)));
+            _clip = new PathGeometry();
+            _clip.Figures.Add(figure);
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.PushGeometryClip(_clip);
+            context.DrawRectangle(_blue, null, new Rect(0f, 0f, 64f, 64f));
+            context.PopGeometryClip();
+        }
+    }
+
+    private sealed class EvenOddPathVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path;
+        private readonly SolidColorBrush _green = new(new Vector4(0f, 1f, 0f, 1f));
+
+        public EvenOddPathVisual()
+        {
+            _path = new PathGeometry { FillRule = FillRule.EvenOdd };
+            _path.Figures.Add(CreateRectanglePath(8f, 8f, 56f, 56f).Figures[0]);
+            _path.Figures.Add(CreateRectanglePath(24f, 24f, 40f, 40f).Figures[0]);
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPath(_green, null, _path);
+    }
+
+    private sealed class TranslucentPathVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path = CreateRectanglePath(12f, 12f, 52f, 52f);
+        private readonly SolidColorBrush _red = new(new Vector4(1f, 0f, 0f, 1f));
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.PushOpacity(0.5f);
+            context.DrawPath(_red, null, _path);
+            context.PopOpacity();
+        }
+    }
+
+    private sealed class WavefrontCapacityVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path = CreateRectanglePath(12f, 12f, 52f, 52f);
+        private readonly SolidColorBrush _red = new(new Vector4(1f, 0f, 0f, 1f));
+        private readonly SolidColorBrush _blue = new(new Vector4(0f, 0f, 1f, 1f));
+
+        public override void OnRender(DrawingContext context)
+        {
+            for (var index = 0; index < 64; index++)
+            {
+                context.DrawPath(_red, null, _path);
+            }
+
+            context.DrawPath(_blue, null, _path);
+        }
+    }
+
+    private sealed class NonConformalPathVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path = CreateRectanglePath(6f, 12f, 26f, 44f);
+        private readonly SolidColorBrush _blue = new(new Vector4(0f, 0f, 1f, 1f));
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPath(
+                _blue,
+                null,
+                _path,
+                Matrix4x4.CreateScale(2f, 1f, 1f));
+    }
+}

--- a/src/ProGPU.Tests/AnalyticPrimitiveTransformPaddingTests.cs
+++ b/src/ProGPU.Tests/AnalyticPrimitiveTransformPaddingTests.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class AnalyticPrimitiveTransformPaddingTests
+{
+    private const int LateTransformSurfaceSize = 96;
+    private const float TargetTop = 24.75f;
+    private const float TargetHeight = 15.5f;
+
+    private static readonly Matrix4x4 LateUniformDownscale =
+        Matrix4x4.CreateScale(0.1f, 0.1f, 1f) *
+        Matrix4x4.CreateTranslation(32.25f, 40.75f, 0f);
+
+    [Fact]
+    public void StrokeScalesReportBothSingularValuesForShear()
+    {
+        var transform = Matrix4x4.Identity;
+        transform.M12 = 1f;
+
+        Assert.True(TransformMetrics.TryGetStrokeScales(
+            transform,
+            out var maximumScale,
+            out var minimumScale));
+
+        var goldenRatio = (1f + MathF.Sqrt(5f)) * 0.5f;
+        Assert.Equal(goldenRatio, maximumScale, precision: 6);
+        Assert.Equal(1f / goldenRatio, minimumScale, precision: 6);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidTransforms))]
+    public void StrokeScalesRejectInvalidOrCollapsedTransforms(Matrix4x4 transform)
+    {
+        Assert.False(TransformMetrics.TryGetStrokeScales(
+            transform,
+            out var maximumScale,
+            out var minimumScale));
+        Assert.Equal(0f, maximumScale);
+        Assert.Equal(0f, minimumScale);
+    }
+
+    [Theory]
+    [InlineData(AnalyticPrimitiveKind.Rectangle)]
+    [InlineData(AnalyticPrimitiveKind.Ellipse)]
+    [InlineData(AnalyticPrimitiveKind.RoundedRectangle)]
+    public void StrongAnisotropicDownscalePreservesFillEdgeCoverage(
+        AnalyticPrimitiveKind primitiveKind)
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new AnalyticPrimitiveVisual(
+            primitiveKind,
+            isStroke: false,
+            isTransformed: false);
+        window.Render();
+        var referencePixels = window.ReadPixels();
+
+        window.Content = new AnalyticPrimitiveVisual(
+            primitiveKind,
+            isStroke: false,
+            isTransformed: true);
+        window.Render();
+        var transformedPixels = window.ReadPixels();
+
+        Assert.InRange(GetRed(referencePixels, x: 32, y: 24), 1, 254);
+        AssertCentralScanlineMatches(referencePixels, transformedPixels);
+        Assert.InRange(GetPrimitiveMinimumY(window, primitiveKind), 23.24f, 23.26f);
+    }
+
+    [Theory]
+    [InlineData(AnalyticPrimitiveKind.Rectangle)]
+    [InlineData(AnalyticPrimitiveKind.Ellipse)]
+    [InlineData(AnalyticPrimitiveKind.RoundedRectangle)]
+    public void StrongUniformDownscalePreservesStrokeEdgeCoverage(
+        AnalyticPrimitiveKind primitiveKind)
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new AnalyticPrimitiveVisual(
+            primitiveKind,
+            isStroke: true,
+            isTransformed: false);
+        window.Render();
+        var referencePixels = window.ReadPixels();
+
+        window.Content = new AnalyticPrimitiveVisual(
+            primitiveKind,
+            isStroke: true,
+            isTransformed: true);
+        window.Render();
+        var transformedPixels = window.ReadPixels();
+
+        Assert.InRange(GetRed(referencePixels, x: 32, y: 22), 1, 254);
+        AssertCentralScanlineMatches(referencePixels, transformedPixels);
+        Assert.InRange(GetPrimitiveMinimumY(window, primitiveKind), 21.24f, 21.26f);
+    }
+
+    [Theory]
+    [InlineData(AnalyticPrimitiveKind.Rectangle, false, false)]
+    [InlineData(AnalyticPrimitiveKind.Rectangle, false, true)]
+    [InlineData(AnalyticPrimitiveKind.Rectangle, true, false)]
+    [InlineData(AnalyticPrimitiveKind.Rectangle, true, true)]
+    [InlineData(AnalyticPrimitiveKind.Ellipse, false, false)]
+    [InlineData(AnalyticPrimitiveKind.Ellipse, false, true)]
+    [InlineData(AnalyticPrimitiveKind.Ellipse, true, false)]
+    [InlineData(AnalyticPrimitiveKind.Ellipse, true, true)]
+    [InlineData(AnalyticPrimitiveKind.RoundedRectangle, false, false)]
+    [InlineData(AnalyticPrimitiveKind.RoundedRectangle, false, true)]
+    [InlineData(AnalyticPrimitiveKind.RoundedRectangle, true, false)]
+    [InlineData(AnalyticPrimitiveKind.RoundedRectangle, true, true)]
+    public void LateUniformDownscalePreservesAnalyticQuadCoverage(
+        AnalyticPrimitiveKind primitiveKind,
+        bool isStroke,
+        bool useStaticBuffer)
+    {
+        var expected = RenderLateTransformCommand(
+            CreateLateAnalyticCommand(primitiveKind, isStroke),
+            useStaticBuffer,
+            bakeTransform: true);
+        var actual = RenderLateTransformCommand(
+            CreateLateAnalyticCommand(primitiveKind, isStroke),
+            useStaticBuffer,
+            bakeTransform: false);
+
+        AssertLateCoverageMatches(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LateUniformDownscalePreservesOrdinaryArcQuadCoverage(
+        bool useStaticBuffer)
+    {
+        var expected = RenderLateTransformCommand(
+            CreateLateArcCommand(),
+            useStaticBuffer,
+            bakeTransform: true);
+        var actual = RenderLateTransformCommand(
+            CreateLateArcCommand(),
+            useStaticBuffer,
+            bakeTransform: false);
+
+        AssertLateCoverageMatches(expected, actual);
+    }
+
+    public static TheoryData<Matrix4x4> InvalidTransforms => new()
+    {
+        Matrix4x4.CreateScale(1f, 0f, 1f),
+        new Matrix4x4(
+            float.NaN, 0f, 0f, 0f,
+            0f, 1f, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0f, 0f, 0f, 1f)
+    };
+
+    private static void AssertCentralScanlineMatches(
+        byte[] expected,
+        byte[] actual)
+    {
+        for (var y = 20; y <= 45; y++)
+        {
+            var expectedRed = GetRed(expected, x: 32, y);
+            var actualRed = GetRed(actual, x: 32, y);
+            Assert.True(
+                Math.Abs(expectedRed - actualRed) <= 3,
+                $"Row {y} expected red {expectedRed}, actual red {actualRed}.");
+        }
+    }
+
+    private static byte GetRed(byte[] pixels, int x, int y) =>
+        pixels[(y * 64 + x) * 4];
+
+    private static RenderCommand CreateLateAnalyticCommand(
+        AnalyticPrimitiveKind primitiveKind,
+        bool isStroke)
+    {
+        var brush = new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f));
+        var command = new RenderCommand
+        {
+            Brush = isStroke ? null : brush,
+            Pen = isStroke ? new Pen(brush, 20f) : null,
+            IsPenThicknessLocal = isStroke
+        };
+        switch (primitiveKind)
+        {
+            case AnalyticPrimitiveKind.Rectangle:
+                command.Type = RenderCommandType.DrawRect;
+                command.Rect = new Rect(0f, 0f, 320f, 155f);
+                break;
+            case AnalyticPrimitiveKind.Ellipse:
+                command.Type = RenderCommandType.DrawEllipse;
+                command.Position2 = new Vector2(160f, 77.5f);
+                command.RadiusX = 160f;
+                command.RadiusY = 77.5f;
+                break;
+            case AnalyticPrimitiveKind.RoundedRectangle:
+                command.Type = RenderCommandType.DrawRoundedRect;
+                command.Rect = new Rect(0f, 0f, 320f, 155f);
+                command.RadiusX = 60f;
+                command.RadiusY = 60f;
+                break;
+        }
+
+        return command;
+    }
+
+    private static RenderCommand CreateLateArcCommand()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(0f, 77.5f));
+        figure.Segments.Add(new ArcSegment(
+            new Vector2(320f, 77.5f),
+            new Vector2(160f, 77.5f),
+            rotationAngle: 0f,
+            isLargeArc: false,
+            SweepDirection.Clockwise));
+        path.Figures.Add(figure);
+        var brush = new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f));
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(brush, 20f),
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static byte[] RenderLateTransformCommand(
+        RenderCommand command,
+        bool useStaticBuffer,
+        bool bakeTransform)
+    {
+        using var window = new HeadlessWindow(
+            LateTransformSurfaceSize,
+            LateTransformSurfaceSize);
+        DxfStaticBuffer? buffer = null;
+        if (bakeTransform)
+        {
+            command.Transform = LateUniformDownscale;
+        }
+        else if (!useStaticBuffer)
+        {
+            command.UseGpuTransforms = true;
+            command.CameraView = LateUniformDownscale;
+        }
+
+        if (useStaticBuffer)
+        {
+            var context = new DrawingContext();
+            context.Commands.Add(command);
+            buffer = window.Compositor.CompileStaticDxf(context);
+            window.Content = new LateStaticVisual(
+                buffer,
+                bakeTransform ? Matrix4x4.Identity : LateUniformDownscale);
+        }
+        else
+        {
+            window.Content = new LateCommandVisual(command);
+        }
+
+        try
+        {
+            window.Render();
+            return window.ReadPixels();
+        }
+        finally
+        {
+            buffer?.Dispose();
+        }
+    }
+
+    private static void AssertLateCoverageMatches(byte[] expected, byte[] actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var expectedBounds = GetLateCoverageBounds(expected);
+        var actualBounds = GetLateCoverageBounds(actual);
+        var missingPixels = 0;
+        for (var index = 2; index < expected.Length; index += 4)
+        {
+            if (expected[index] > 1 && actual[index] <= 1)
+            {
+                missingPixels++;
+            }
+        }
+
+        Assert.True(expectedBounds.MaxX >= expectedBounds.MinX);
+        Assert.True(
+            expectedBounds == actualBounds && missingPixels == 0,
+            $"Late-transform coverage mismatch: expected bounds {expectedBounds}, " +
+            $"actual bounds {actualBounds}, missing pixels {missingPixels}.");
+    }
+
+    private static (int MinX, int MinY, int MaxX, int MaxY) GetLateCoverageBounds(
+        byte[] pixels)
+    {
+        var minX = LateTransformSurfaceSize;
+        var minY = LateTransformSurfaceSize;
+        var maxX = -1;
+        var maxY = -1;
+        for (var y = 0; y < LateTransformSurfaceSize; y++)
+        {
+            for (var x = 0; x < LateTransformSurfaceSize; x++)
+            {
+                if (pixels[(y * LateTransformSurfaceSize + x) * 4 + 2] <= 1)
+                {
+                    continue;
+                }
+
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        return (minX, minY, maxX, maxY);
+    }
+
+    private static float GetPrimitiveMinimumY(
+        HeadlessWindow window,
+        AnalyticPrimitiveKind primitiveKind)
+    {
+        var expectedShapeType = (float)primitiveKind;
+        var vertices = window.Compositor.VectorVertices
+            .Where(vertex => MathF.Abs(vertex.ShapeType - expectedShapeType) < 0.01f)
+            .ToArray();
+        Assert.Equal(4, vertices.Length);
+        return vertices.Min(static vertex => vertex.Position.Y);
+    }
+
+    public enum AnalyticPrimitiveKind
+    {
+        Rectangle = 0,
+        Ellipse = 1,
+        RoundedRectangle = 2
+    }
+
+    private sealed class AnalyticPrimitiveVisual : FrameworkElement
+    {
+        private readonly Brush _fill = new SolidColorBrush(
+            new Vector4(1f, 0f, 0f, 1f));
+
+        private readonly AnalyticPrimitiveKind _primitiveKind;
+        private readonly bool _isStroke;
+        private readonly bool _isTransformed;
+
+        public AnalyticPrimitiveVisual(
+            AnalyticPrimitiveKind primitiveKind,
+            bool isStroke,
+            bool isTransformed)
+        {
+            _primitiveKind = primitiveKind;
+            _isStroke = isStroke;
+            _isTransformed = isTransformed;
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            if (_isTransformed)
+            {
+                DrawTransformed(context);
+                return;
+            }
+
+            var targetRect = new Rect(16f, TargetTop, 32f, TargetHeight);
+            var brush = _isStroke ? null : _fill;
+            var pen = _isStroke ? CreatePen(4f) : null;
+            switch (_primitiveKind)
+            {
+                case AnalyticPrimitiveKind.Rectangle:
+                    context.DrawRectangle(brush, pen, targetRect);
+                    break;
+                case AnalyticPrimitiveKind.Ellipse:
+                    context.DrawEllipse(
+                        brush,
+                        pen,
+                        new Vector2(32f, TargetTop + TargetHeight * 0.5f),
+                        16f,
+                        TargetHeight * 0.5f);
+                    break;
+                case AnalyticPrimitiveKind.RoundedRectangle:
+                    context.DrawRoundedRectangle(brush, pen, targetRect, 6f, 6f);
+                    break;
+            }
+        }
+
+        private void DrawTransformed(DrawingContext context)
+        {
+            var scaleX = _isStroke ? 0.02f : 0.5f;
+            const float scaleY = 0.02f;
+            var transform = Matrix4x4.CreateScale(scaleX, scaleY, 1f) *
+                Matrix4x4.CreateTranslation(16f, TargetTop, 0f);
+            var sourceWidth = 32f / scaleX;
+            var sourceHeight = TargetHeight / scaleY;
+            var sourceRect = new Rect(0f, 0f, sourceWidth, sourceHeight);
+            var brush = _isStroke ? null : _fill;
+            var pen = _isStroke ? CreatePen(4f / scaleY) : null;
+            var radius = 6f / scaleX;
+
+            switch (_primitiveKind)
+            {
+                case AnalyticPrimitiveKind.Rectangle:
+                    context.DrawRectangle(brush, pen, sourceRect, transform);
+                    break;
+                case AnalyticPrimitiveKind.Ellipse:
+                    context.DrawEllipse(
+                        brush,
+                        pen,
+                        new Vector2(
+                            sourceRect.X + sourceRect.Width * 0.5f,
+                            sourceRect.Y + sourceRect.Height * 0.5f),
+                        sourceWidth * 0.5f,
+                        sourceHeight * 0.5f,
+                        transform);
+                    break;
+                case AnalyticPrimitiveKind.RoundedRectangle:
+                    context.DrawRoundedRectangle(
+                        brush,
+                        pen,
+                        sourceRect,
+                        radius,
+                        radius,
+                        transform);
+                    break;
+            }
+        }
+
+        private Pen CreatePen(float thickness) => new(_fill, thickness);
+    }
+
+    private sealed class LateStaticVisual : FrameworkElement
+    {
+        private readonly DxfStaticBuffer _buffer;
+
+        public LateStaticVisual(DxfStaticBuffer buffer, Matrix4x4 transform)
+        {
+            _buffer = buffer;
+            Transform = transform;
+            Width = LateTransformSurfaceSize;
+            Height = LateTransformSurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawStaticDxf(_buffer);
+    }
+
+    private sealed class LateCommandVisual : FrameworkElement
+    {
+        private readonly RenderCommand _command;
+
+        public LateCommandVisual(RenderCommand command)
+        {
+            _command = command;
+            Width = LateTransformSurfaceSize;
+            Height = LateTransformSurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.Commands.Add(_command);
+    }
+}

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -6706,6 +6706,70 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void AppendComposesTranslationForOpaqueAndNestedPayloadCommands()
+    {
+        var translation = new Vector2(20f, 30f);
+        var expectedTransform = Matrix4x4.CreateTranslation(20f, 30f, 0f);
+        var path = RenderCommandGeometryCache.CreateLinePath(
+            new Vector2(2f, 3f),
+            new Vector2(12f, 3f));
+        var brush = new SolidColorBrush(Vector4.One);
+        var pen = new Pen(brush, 2f);
+        var visual = new Visual();
+        var staticBuffer = new object();
+        using var picture = new GpuPicture([], [], [], [], []);
+        var source = new DrawingContext();
+        source.DrawPicture(picture);
+        source.DrawVisual(visual);
+        source.DrawHatch(brush, path);
+        source.DrawDotGrid(brush, new Rect(1f, 2f, 10f, 12f), 4f, 1f, new Vector2(0.5f));
+        source.DrawLine3D(pen, new Vector3(1f, 2f, 3f), new Vector3(4f, 5f, 6f));
+        Line3D[] acisEdges =
+        [
+            new(new Vector3(2f, 4f, 6f), new Vector3(8f, 10f, 12f))
+        ];
+        source.DrawAcisSolid(
+            pen,
+            acisEdges.AsSpan(),
+            Matrix4x4.Identity);
+        source.DrawStaticDxf(staticBuffer);
+
+        var target = new DrawingContext();
+        target.Append(source, translation);
+
+        Assert.Equal(7, target.Commands.Count);
+        Assert.All(target.Commands, command =>
+            Assert.Equal(expectedTransform, command.Transform));
+        Assert.Same(picture, target.Commands[0].Picture);
+        Assert.Same(visual, target.Commands[1].Visual);
+        Assert.Same(path, target.Commands[2].Path);
+        Assert.Equal(new Rect(1f, 2f, 10f, 12f), target.Commands[3].Rect);
+        Assert.Equal(new Vector2(0.5f), target.Commands[3].Position2);
+        Assert.Equal(source.FloatBuffer, target.FloatBuffer);
+        Assert.Equal(source.Line3DBuffer, target.Line3DBuffer);
+        Assert.Same(staticBuffer, target.Commands[6].DataParam);
+    }
+
+    [Theory]
+    [InlineData(RenderCommandType.DrawHatch)]
+    [InlineData(RenderCommandType.DrawLine3D)]
+    [InlineData(RenderCommandType.DrawAcisSolid)]
+    [InlineData(RenderCommandType.DrawStaticDxf)]
+    public void AppendComposesTranslationForLegacyOpaquePayloadCommands(
+        RenderCommandType commandType)
+    {
+        var source = new DrawingContext();
+        source.Commands.Add(new RenderCommand { Type = commandType });
+
+        var target = new DrawingContext();
+        target.Append(source, new Vector2(20f, 30f));
+
+        Assert.Equal(
+            Matrix4x4.CreateTranslation(20f, 30f, 0f),
+            Assert.Single(target.Commands).Transform);
+    }
+
+    [Fact]
     public void AppendTranslatesPictureOpacityMaskContent()
     {
         var recorder = new GpuPictureRecorder();
@@ -6727,6 +6791,39 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
         Assert.Same(picture, target.Commands[0].Picture);
         Assert.Equal(20f, target.Commands[0].Transform.M41);
         Assert.Equal(30f, target.Commands[0].Transform.M42);
+        Assert.Equal(RenderCommandType.PopOpacityMask, target.Commands[1].Type);
+    }
+
+    [Fact]
+    public void AppendTranslatesPathOpacityMaskByComposingItsTransform()
+    {
+        var source = new DrawingContext();
+        var path = RenderCommandGeometryCache.CreateLinePath(
+            new Vector2(2f, 3f),
+            new Vector2(12f, 3f));
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 2f,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+        var bounds = new Rect(0f, 0f, 16f, 8f);
+        source.PushOpacityMask(path, pen, bounds, Matrix4x4.Identity);
+        source.PopOpacityMask();
+        var sourceCache = source.Commands[0].GeometryCache;
+
+        var target = new DrawingContext();
+        target.Append(source, new Vector2(20f, 30f));
+
+        Assert.Equal(2, target.Commands.Count);
+        var command = target.Commands[0];
+        Assert.Same(path, command.Path);
+        Assert.Same(pen, command.Pen);
+        Assert.Same(sourceCache, command.GeometryCache);
+        Assert.Equal(bounds, command.Rect);
+        Assert.True(command.IsPenThicknessLocal);
+        Assert.Equal(
+            Matrix4x4.CreateTranslation(20f, 30f, 0f),
+            command.Transform);
         Assert.Equal(RenderCommandType.PopOpacityMask, target.Commands[1].Type);
     }
 
@@ -6781,6 +6878,7 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
         Assert.Same(path, target.Commands[0].Path);
         Assert.Same(brush, target.Commands[0].Brush);
         Assert.Same(pen, target.Commands[0].Pen);
+        Assert.Same(source.Commands[0].GeometryCache, target.Commands[0].GeometryCache);
         Assert.Equal(Matrix4x4.CreateTranslation(20f, 30f, 0f), target.Commands[0].Transform);
     }
 

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -879,6 +879,35 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
         Assert.InRange(window.Compositor.CachedTextLayoutGlyphCount, visibleRows * 2, 32_768);
     }
 
+    [Theory]
+    [InlineData(1f, 12f)]
+    [InlineData(0.5f, 6f)]
+    [InlineData(0.25f, 3f)]
+    public void VisualTransformScalesStrokeThicknessWithItsGeometry(float scale, float expectedDeviceThickness)
+    {
+        // A visual-tree transform is composed into the compositor's active transform rather than
+        // into the command's own transform, so the pen thickness that reaches CompileLineCommand is
+        // still in local units. Leaving it there kept strokes at their unscaled width while the
+        // geometry shrank, which made adjacent edges of a lopsided Border overlap into a solid block.
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new ScaledStrokeVisual(scale);
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        int paintedRows = 0;
+        for (var y = 0; y < 64; y++)
+        {
+            // The line is drawn across the middle of the window; sample a column inside its span.
+            if (pixels[(y * 64 + 32) * 4 + 2] > 128)
+            {
+                paintedRows++;
+            }
+        }
+
+        Assert.InRange(paintedRows, expectedDeviceThickness - 1.5f, expectedDeviceThickness + 1.5f);
+    }
+
     [Fact]
     public void SolidRectangleFillAndStrokeUseSpecializedBatchAndComposeOpacity()
     {
@@ -9271,6 +9300,29 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                 null,
                 path,
                 Matrix4x4.Identity);
+        }
+    }
+
+    private sealed class ScaledStrokeVisual : FrameworkElement
+    {
+        private readonly float _scale;
+
+        public ScaledStrokeVisual(float scale)
+        {
+            _scale = scale;
+            Width = 64f;
+            Height = 64f;
+            // Scale about the window centre so the stroke stays in view at every scale factor.
+            Transform =
+                Matrix4x4.CreateTranslation(-32f, -32f, 0f) *
+                Matrix4x4.CreateScale(scale, scale, 1f) *
+                Matrix4x4.CreateTranslation(32f, 32f, 0f);
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var stroke = new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f));
+            context.DrawLine(new Pen(stroke, 12f), new Vector2(0f, 32f), new Vector2(64f, 32f));
         }
     }
 

--- a/src/ProGPU.Tests/DashCapSemanticsTests.cs
+++ b/src/ProGPU.Tests/DashCapSemanticsTests.cs
@@ -1,0 +1,708 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using SkiaSharp;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class DashCapSemanticsTests
+{
+    [Fact]
+    public void LoweredOpenDashUsesDashCapsInternallyAndSourceCapsOnlyAtReachedEndpoints()
+    {
+        var path = CreateLinePath(Vector2.Zero, new Vector2(34f, 0f));
+        var cache = RenderCommandGeometryCache.ForStrokePath(path);
+        var pen = CreateDistinctCapPen();
+
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var dashedPath, out var loweredPen));
+
+        Assert.Equal(PenLineCap.Round, loweredPen.StartLineCap);
+        Assert.Equal(PenLineCap.Round, loweredPen.EndLineCap);
+        Assert.Equal(PenLineCap.Round, loweredPen.DashCap);
+        Assert.Collection(
+            dashedPath.Figures,
+            first =>
+            {
+                Assert.Equal(PenLineCap.Flat, first.StrokeStartLineCap);
+                Assert.Null(first.StrokeEndLineCap);
+                AssertLine(first, new Vector2(0f, 0f), new Vector2(8f, 0f));
+            },
+            middle =>
+            {
+                Assert.Null(middle.StrokeStartLineCap);
+                Assert.Null(middle.StrokeEndLineCap);
+                AssertLine(middle, new Vector2(16f, 0f), new Vector2(24f, 0f));
+            },
+            last =>
+            {
+                Assert.Null(last.StrokeStartLineCap);
+                Assert.Equal(PenLineCap.Square, last.StrokeEndLineCap);
+                AssertLine(last, new Vector2(32f, 0f), new Vector2(34f, 0f));
+            });
+
+        var transformed = dashedPath.CreateTransformed(Matrix4x4.CreateTranslation(5f, 7f, 0f));
+        Assert.Equal(PenLineCap.Flat, transformed.Figures[0].StrokeStartLineCap);
+        Assert.Equal(PenLineCap.Square, transformed.Figures[^1].StrokeEndLineCap);
+
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var cachedPath, out var cachedPen));
+        Assert.Same(dashedPath, cachedPath);
+        Assert.Same(loweredPen, cachedPen);
+    }
+
+    [Fact]
+    public void DashedGeometryCacheInvalidatesWhenAnySourceCapChanges()
+    {
+        var path = CreateLinePath(Vector2.Zero, new Vector2(34f, 0f));
+        var cache = RenderCommandGeometryCache.ForStrokePath(path);
+        var firstPen = CreateDistinctCapPen();
+
+        Assert.True(cache.TryGetDashedStrokePath(firstPen, out var firstPath, out _));
+
+        var secondPen = new Pen(
+            firstPen.Brush,
+            firstPen.Thickness,
+            startLineCap: PenLineCap.Triangle,
+            endLineCap: PenLineCap.Flat,
+            dashCap: PenLineCap.Square,
+            dashArray: firstPen.DashArray,
+            dashOffset: firstPen.DashOffset);
+        Assert.True(cache.TryGetDashedStrokePath(secondPen, out var secondPath, out var secondLoweredPen));
+
+        Assert.NotSame(firstPath, secondPath);
+        Assert.Equal(PenLineCap.Triangle, secondPath.Figures[0].StrokeStartLineCap);
+        Assert.Equal(PenLineCap.Flat, secondPath.Figures[^1].StrokeEndLineCap);
+        Assert.Equal(PenLineCap.Square, secondLoweredPen.StartLineCap);
+        Assert.Equal(PenLineCap.Square, secondLoweredPen.EndLineCap);
+    }
+
+    [Fact]
+    public void SourceCapsAreNotAppliedWhenTheDashPatternLeavesBothEndpointsInGaps()
+    {
+        var path = CreateLinePath(Vector2.Zero, new Vector2(6f, 0f));
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 1f,
+            startLineCap: PenLineCap.Triangle,
+            endLineCap: PenLineCap.Square,
+            dashCap: PenLineCap.Round,
+            dashArray: [2.0, 2.0],
+            dashOffset: 2.0);
+
+        Assert.True(Compositor.TryCreateDashedStrokePath(path, pen, out var dashedPath));
+
+        var dash = Assert.Single(dashedPath.Figures);
+        AssertLine(dash, new Vector2(2f, 0f), new Vector2(4f, 0f));
+        Assert.Null(dash.StrokeStartLineCap);
+        Assert.Null(dash.StrokeEndLineCap);
+    }
+
+    [Fact]
+    public void LoweredClosedDashMergesTheCyclicRunAcrossTheSourceSeam()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(Vector2.Zero, isClosed: true);
+        figure.Segments.Add(new LineSegment(new Vector2(4f, 0f)));
+        figure.Segments.Add(new LineSegment(new Vector2(4f, 4f)));
+        figure.Segments.Add(new LineSegment(new Vector2(0f, 4f)));
+        path.Figures.Add(figure);
+        var cache = RenderCommandGeometryCache.ForStrokePath(path);
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 1f,
+            startLineCap: PenLineCap.Square,
+            endLineCap: PenLineCap.Triangle,
+            dashCap: PenLineCap.Round,
+            dashArray: [6.0, 4.0]);
+
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var dashedPath, out _));
+
+        var cyclicRun = Assert.Single(dashedPath.Figures);
+        Assert.False(cyclicRun.IsClosed);
+        Assert.Null(cyclicRun.StrokeStartLineCap);
+        Assert.Null(cyclicRun.StrokeEndLineCap);
+        Assert.Equal(new Vector2(2f, 4f), cyclicRun.StartPoint);
+        Assert.Equal(4, cyclicRun.Segments.Count);
+        Assert.Equal(new Vector2(0f, 4f), Assert.IsType<LineSegment>(cyclicRun.Segments[0]).Point);
+        Assert.Equal(Vector2.Zero, Assert.IsType<LineSegment>(cyclicRun.Segments[1]).Point);
+        Assert.Equal(new Vector2(4f, 0f), Assert.IsType<LineSegment>(cyclicRun.Segments[2]).Point);
+        Assert.Equal(new Vector2(4f, 2f), Assert.IsType<LineSegment>(cyclicRun.Segments[3]).Point);
+    }
+
+    [Fact]
+    public void LoweredClosedDashMarksAContourCoveredByOneRunAsClosed()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(Vector2.Zero, isClosed: true);
+        figure.Segments.Add(new LineSegment(new Vector2(4f, 0f)));
+        figure.Segments.Add(new LineSegment(new Vector2(4f, 4f)));
+        figure.Segments.Add(new LineSegment(new Vector2(0f, 4f)));
+        path.Figures.Add(figure);
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 1f,
+            dashCap: PenLineCap.Round,
+            dashArray: [20.0, 1.0]);
+
+        Assert.True(Compositor.TryCreateDashedStrokePath(path, pen, out var dashedPath));
+
+        var closedRun = Assert.Single(dashedPath.Figures);
+        Assert.True(closedRun.IsClosed);
+        Assert.Null(closedRun.StrokeStartLineCap);
+        Assert.Null(closedRun.StrokeEndLineCap);
+    }
+
+    [Fact]
+    public void DistinctLoweredLineCapsFeedExactGpuHitPrimitives()
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = CreateLinePath(new Vector2(10f, 16f), new Vector2(44f, 16f));
+        var pen = CreateDistinctCapPen(thickness: 4f, dashArray: [2.0, 2.0]);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = pen,
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
+
+        Assert.Collection(
+            index.Primitives,
+            first =>
+            {
+                AssertCaps(first, LineGeometryCap.Flat, LineGeometryCap.Round);
+                Assert.Equal(new Vector4(10f, 16f, 18f, 16f), first.Data0);
+            },
+            middle => AssertCaps(middle, LineGeometryCap.Round, LineGeometryCap.Round),
+            last => AssertCaps(last, LineGeometryCap.Round, LineGeometryCap.Square));
+        Assert.Empty(index.PathSegments);
+
+        Assert.False(TryHit(gpu, index, 9f));
+        Assert.True(TryHit(gpu, index, 12f));
+        Assert.False(TryHit(gpu, index, 22f));
+        Assert.True(TryHit(gpu, index, 45f));
+        Assert.False(TryHit(gpu, index, 47f));
+    }
+
+    [Fact]
+    public void CurvedLoweredDashUsesCapAwarePerFigurePathHitPrimitives()
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(10f, 16f));
+        figure.Segments.Add(new QuadraticBezierSegment(
+            new Vector2(26f, 4f),
+            new Vector2(44f, 16f)));
+        path.Figures.Add(figure);
+        var pen = CreateDistinctCapPen(thickness: 4f, dashArray: [2.0, 2.0]);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = pen,
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
+
+        Assert.True(index.Primitives.Count >= 2);
+        Assert.All(index.Primitives, primitive =>
+            Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind));
+        Assert.Equal((float)(uint)LineGeometryCap.Flat, index.Primitives[0].Data2.X);
+        Assert.Equal((float)(uint)LineGeometryCap.Round, index.Primitives[0].Data2.Y);
+        Assert.Equal(new Vector2(10f, 16f), index.PathSegments[0].P0);
+        Assert.True(index.Primitives[0].Data0.Z < index.Primitives[^1].Data0.X);
+        Assert.True(index.Primitives[0].BoundsMax.X < index.Primitives[^1].BoundsMin.X);
+
+        var outsideHit = GpuHitTestEngine.TryHitTestPoint(
+            gpu,
+            index,
+            new Vector2(9f, 16f),
+            out var outsideResult);
+        Assert.False(
+            outsideHit,
+            $"primitive={outsideResult.PrimitiveIndex}; " +
+            string.Join(" | ", index.Primitives.Select(static primitive =>
+                $"segments={primitive.Data1.X}:{primitive.Data1.Y} caps={primitive.Data2.X}:{primitive.Data2.Y}")));
+        Assert.True(TryHit(gpu, index, 11f));
+    }
+
+    [Fact]
+    public void FlatDashCapWithoutEndpointOverridesStillUsesFlatHitPrimitives()
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = CreateLinePath(new Vector2(10f, 16f), new Vector2(44f, 16f));
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 4f,
+            startLineCap: PenLineCap.Flat,
+            endLineCap: PenLineCap.Flat,
+            dashCap: PenLineCap.Flat,
+            dashArray: [2.0, 2.0]);
+        var cache = RenderCommandGeometryCache.ForStrokePath(path);
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var loweredPath, out _));
+        Assert.All(loweredPath.Figures, figure =>
+        {
+            Assert.Null(figure.StrokeStartLineCap);
+            Assert.Null(figure.StrokeEndLineCap);
+        });
+
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = pen,
+            GeometryCache = cache
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
+
+        Assert.All(index.Primitives, primitive =>
+            AssertCaps(primitive, LineGeometryCap.Flat, LineGeometryCap.Flat));
+        Assert.False(TryHit(gpu, index, 9f));
+        Assert.True(TryHit(gpu, index, 11f));
+    }
+
+    [Fact]
+    public void PlainFlatQuadraticRejectsTheRoundEndpointHalo()
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(10f, 16f));
+        figure.Segments.Add(new QuadraticBezierSegment(
+            new Vector2(26f, 4f),
+            new Vector2(44f, 16f)));
+        path.Figures.Add(figure);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                thickness: 4f,
+                startLineCap: PenLineCap.Flat,
+                endLineCap: PenLineCap.Flat),
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex();
+
+        var primitive = Assert.Single(index.Primitives);
+        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
+        Assert.Equal((float)(uint)LineGeometryCap.Flat, primitive.Data2.X);
+        Assert.Equal((float)(uint)LineGeometryCap.Flat, primitive.Data2.Y);
+        Assert.False(TryHit(gpu, index, 9f));
+        Assert.True(TryHit(gpu, index, 11f));
+    }
+
+    [Fact]
+    public void PlainFlatHairlinePathRejectsTheRoundEndpointHalo()
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = CreateLinePath(new Vector2(10f, 16f), new Vector2(44f, 16f));
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                thickness: Pen.HairlineThickness,
+                startLineCap: PenLineCap.Flat,
+                endLineCap: PenLineCap.Flat),
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex();
+
+        var primitive = Assert.Single(index.Primitives);
+        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
+        Assert.Equal((float)(uint)LineGeometryCap.Flat, primitive.Data2.X);
+        Assert.Equal((float)(uint)LineGeometryCap.Flat, primitive.Data2.Y);
+        Assert.Single(index.PathSegments);
+        Assert.False(TryHit(gpu, index, 9.75f));
+        Assert.True(TryHit(gpu, index, 10.25f));
+    }
+
+    [Fact]
+    public void DashedHairlineSplitsCapsPerRunAndKeepsOnlyFramebufferSegments()
+    {
+        var path = CreateLinePath(new Vector2(10f, 16f), new Vector2(44f, 16f));
+        var pen = CreateDistinctCapPen(
+            thickness: Pen.HairlineThickness,
+            dashArray: [2.0, 2.0]);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = pen,
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.CreateScale(2f, 1f, 1f));
+        var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
+
+        Assert.Equal(9, index.Primitives.Count);
+        Assert.Equal(index.Primitives.Count, index.PathSegments.Count);
+        Assert.All(index.Primitives, primitive =>
+            Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind));
+        Assert.Equal((float)(uint)LineGeometryCap.Flat, index.Primitives[0].Data2.X);
+        Assert.Equal((float)(uint)LineGeometryCap.Round, index.Primitives[0].Data2.Y);
+        Assert.Equal((float)(uint)LineGeometryCap.Round, index.Primitives[^1].Data2.X);
+        Assert.Equal((float)(uint)LineGeometryCap.Square, index.Primitives[^1].Data2.Y);
+        Assert.Equal(new Vector2(20f, 16f), index.PathSegments[0].P0);
+        Assert.Equal(new Vector2(88f, 16f), index.PathSegments[^1].P1);
+    }
+
+    [Theory]
+    [InlineData(PenLineCap.Flat, false)]
+    [InlineData(PenLineCap.Square, true)]
+    [InlineData(PenLineCap.Round, true)]
+    [InlineData(PenLineCap.Triangle, true)]
+    public void PathStrokeRegionQueriesHonorEndpointCaps(
+        PenLineCap cap,
+        bool expectedHit)
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(10f, 16f));
+        figure.Segments.Add(new QuadraticBezierSegment(
+            new Vector2(26f, 16f),
+            new Vector2(44f, 16f)));
+        path.Figures.Add(figure);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                thickness: 4f,
+                startLineCap: cap,
+                endLineCap: cap),
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex();
+        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, Assert.Single(index.Primitives).Kind);
+
+        var results = new GpuHitTestResult[2];
+        var boundsHit = GpuHitTestEngine.TryQueryBoundsAll(
+            gpu,
+            index,
+            new Vector2(8.8f, 15.8f),
+            new Vector2(9.2f, 16.2f),
+            results,
+            out var boundsHitCount,
+            out var boundsSummary);
+        Assert.Equal(expectedHit, boundsHit);
+        Assert.Equal(expectedHit ? 1 : 0, boundsHitCount);
+        Assert.Equal(1u, boundsSummary.PreciseTests);
+
+        Array.Clear(results);
+        var ellipseHit = GpuHitTestEngine.TryQueryEllipseAll(
+            gpu,
+            index,
+            new Vector2(8.8f, 15.8f),
+            new Vector2(9.2f, 16.2f),
+            results,
+            out var ellipseHitCount,
+            out var ellipseSummary);
+        Assert.Equal(expectedHit, ellipseHit);
+        Assert.Equal(expectedHit ? 1 : 0, ellipseHitCount);
+        Assert.Equal(1u, ellipseSummary.PreciseTests);
+    }
+
+    [Theory]
+    [InlineData(PenLineCap.Flat, false, false)]
+    [InlineData(PenLineCap.Square, true, true)]
+    [InlineData(PenLineCap.Round, false, true)]
+    [InlineData(PenLineCap.Triangle, false, false)]
+    public void PathStrokeRegionQueriesDistinguishCapShapes(
+        PenLineCap cap,
+        bool expectedSquareCornerHit,
+        bool expectedRoundShoulderHit)
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(10f, 16f));
+        figure.Segments.Add(new QuadraticBezierSegment(
+            new Vector2(26f, 16f),
+            new Vector2(44f, 16f)));
+        path.Figures.Add(figure);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            HitTestId = 417,
+            Path = path,
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                thickness: 4f,
+                startLineCap: cap,
+                endLineCap: cap),
+            GeometryCache = RenderCommandGeometryCache.ForStrokePath(path)
+        }, Matrix4x4.Identity);
+        var index = builder.BuildIndex();
+        var results = new GpuHitTestResult[2];
+
+        var cornerHit = GpuHitTestEngine.TryQueryBoundsAll(
+            gpu,
+            index,
+            new Vector2(8.45f, 17.45f),
+            new Vector2(8.55f, 17.55f),
+            results,
+            out var cornerHitCount,
+            out var cornerSummary);
+        Assert.Equal(expectedSquareCornerHit, cornerHit);
+        Assert.Equal(expectedSquareCornerHit ? 1 : 0, cornerHitCount);
+        Assert.Equal(1u, cornerSummary.PreciseTests);
+
+        Array.Clear(results);
+        var shoulderHit = GpuHitTestEngine.TryQueryEllipseAll(
+            gpu,
+            index,
+            new Vector2(8.95f, 17.45f),
+            new Vector2(9.05f, 17.55f),
+            results,
+            out var shoulderHitCount,
+            out var shoulderSummary);
+        Assert.Equal(expectedRoundShoulderHit, shoulderHit);
+        Assert.Equal(expectedRoundShoulderHit ? 1 : 0, shoulderHitCount);
+        Assert.Equal(1u, shoulderSummary.PreciseTests);
+    }
+
+    [Fact]
+    public void DistinctDashCapsRenderAtTheirOwnEndpoints()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(56, 32);
+        window.Content = new DistinctDashCapVisual();
+
+        try
+        {
+            window.Render();
+            var pixels = window.ReadPixels();
+
+            AssertDark(ReadPixel(pixels, window.Width, 9, 16));
+            AssertRed(ReadPixel(pixels, window.Width, 19, 16));
+            AssertDark(ReadPixel(pixels, window.Width, 22, 16));
+            AssertRed(ReadPixel(pixels, window.Width, 45, 16));
+            AssertDark(ReadPixel(pixels, window.Width, 47, 16));
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
+    public void HairlineDashUsesUnitPatternBasisAndPreservesTheSentinel()
+    {
+        var path = CreateLinePath(Vector2.Zero, new Vector2(10f, 0f));
+        var pen = CreateDistinctCapPen(thickness: Pen.HairlineThickness, dashArray: [2.0, 2.0]);
+
+        Assert.True(Compositor.TryCreateDashedStrokePath(path, pen, out var dashedPath));
+        var loweredPen = Compositor.CreateUndashedPen(pen, localThickness: 1f);
+
+        Assert.True(loweredPen.IsHairline);
+        Assert.Equal(Pen.HairlineThickness, loweredPen.Thickness);
+        AssertLine(dashedPath.Figures[0], Vector2.Zero, new Vector2(2f, 0f));
+        AssertLine(dashedPath.Figures[1], new Vector2(4f, 0f), new Vector2(6f, 0f));
+    }
+
+    [Fact]
+    public void PictureArchiveRoundTripsPerFigureStrokeCaps()
+    {
+        var path = CreateLinePath(Vector2.Zero, new Vector2(10f, 0f));
+        path.Figures[0].StrokeStartLineCap = PenLineCap.Triangle;
+        path.Figures[0].StrokeEndLineCap = PenLineCap.Square;
+        var gpuPicture = new GpuPicture(
+            [new RenderCommand
+            {
+                Type = RenderCommandType.DrawPath,
+                Path = path,
+                Pen = new Pen(new SolidColorBrush(Vector4.One), 2f)
+            }],
+            [],
+            [],
+            [],
+            []);
+        using var picture = new SKPicture(gpuPicture, new SKRect(0f, 0f, 16f, 16f));
+        using var data = picture.Serialize();
+        using var copy = SKPicture.Deserialize(data);
+
+        var actualFigure = Assert.Single(Assert.Single(copy!.Picture.Commands).Path!.Figures);
+        Assert.Equal(PenLineCap.Triangle, actualFigure.StrokeStartLineCap);
+        Assert.Equal(PenLineCap.Square, actualFigure.StrokeEndLineCap);
+    }
+
+    [Fact]
+    public void PictureArchiveStillReadsVersionOnePathsWithoutCapMetadata()
+    {
+        var path = CreateLinePath(Vector2.Zero, new Vector2(10f, 0f));
+        path.Figures[0].StrokeStartLineCap = PenLineCap.Triangle;
+        path.Figures[0].StrokeEndLineCap = PenLineCap.Square;
+        var legacyTransform = Matrix4x4.CreateScale(3f, 3f, 1f);
+        using var gpuPicture = new GpuPicture(
+            [new RenderCommand
+            {
+                Type = RenderCommandType.DrawPath,
+                Path = path,
+                Pen = new Pen(new SolidColorBrush(Vector4.One), 6f),
+                Transform = legacyTransform,
+                IsPenThicknessLocal = false
+            }],
+            [],
+            [],
+            [],
+            []);
+        var bytes = PictureArchive.Serialize(
+            gpuPicture,
+            new SKRect(0f, 0f, 16f, 16f),
+            archiveVersion: 1);
+
+        Assert.Equal(1, BitConverter.ToInt32(bytes, sizeof(ulong)));
+        using var copy = SKPicture.Deserialize(bytes);
+
+        var actual = Assert.Single(copy!.Picture.Commands);
+        Assert.False(actual.IsPenThicknessLocal);
+        Assert.Equal(6f, actual.Pen!.Thickness);
+        Assert.Equal(legacyTransform, actual.Transform);
+        var actualFigure = Assert.Single(actual.Path!.Figures);
+        Assert.Null(actualFigure.StrokeStartLineCap);
+        Assert.Null(actualFigure.StrokeEndLineCap);
+        AssertLine(actualFigure, Vector2.Zero, new Vector2(10f, 0f));
+    }
+
+    [Fact]
+    public void SkPathOffsetAndReversePreservePerFigureStrokeCaps()
+    {
+        using var source = new SKPath();
+        var sourceFigure = new PathFigure(Vector2.Zero)
+        {
+            StrokeStartLineCap = PenLineCap.Triangle,
+            StrokeEndLineCap = PenLineCap.Square
+        };
+        sourceFigure.Segments.Add(new LineSegment(new Vector2(10f, 0f)));
+        source.Geometry.Figures.Add(sourceFigure);
+
+        using var offset = new SKPath(source);
+        offset.Offset(3f, 5f);
+        var offsetFigure = Assert.Single(offset.Geometry.Figures);
+        Assert.Equal(PenLineCap.Triangle, offsetFigure.StrokeStartLineCap);
+        Assert.Equal(PenLineCap.Square, offsetFigure.StrokeEndLineCap);
+
+        using var reversed = new SKPath();
+#pragma warning disable CS0618
+        reversed.AddPathReverse(source);
+#pragma warning restore CS0618
+        var reversedFigure = Assert.Single(reversed.Geometry.Figures);
+        Assert.Equal(PenLineCap.Square, reversedFigure.StrokeStartLineCap);
+        Assert.Equal(PenLineCap.Triangle, reversedFigure.StrokeEndLineCap);
+    }
+
+    private static PathGeometry CreateLinePath(Vector2 start, Vector2 end)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(start);
+        figure.Segments.Add(new LineSegment(end));
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static Pen CreateDistinctCapPen(float thickness = 1f, double[]? dashArray = null) =>
+        new(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            thickness,
+            startLineCap: PenLineCap.Flat,
+            endLineCap: PenLineCap.Square,
+            dashCap: PenLineCap.Round,
+            dashArray: dashArray ?? [8.0, 8.0]);
+
+    private static void AssertLine(PathFigure figure, Vector2 start, Vector2 end)
+    {
+        Assert.False(figure.IsClosed);
+        Assert.Equal(start, figure.StartPoint);
+        Assert.Equal(end, Assert.IsType<LineSegment>(Assert.Single(figure.Segments)).Point);
+    }
+
+    private static void AssertCaps(
+        GpuHitTestPrimitive primitive,
+        LineGeometryCap startCap,
+        LineGeometryCap endCap)
+    {
+        Assert.Equal(GpuHitTestPrimitiveKind.LineStroke, primitive.Kind);
+        Assert.Equal((float)(uint)startCap, primitive.Data1.Z);
+        Assert.Equal((float)(uint)endCap, primitive.Data1.W);
+    }
+
+    private static bool TryHit(WgpuContext gpu, GpuHitTestIndex index, float x) =>
+        GpuHitTestEngine.TryHitTestPoint(
+            gpu,
+            index,
+            new Vector2(x, 16f),
+            out GpuHitTestResult result) && result.Id == 417;
+
+    private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
+    {
+        var index = ((y * (int)width) + x) * 4;
+        return new RgbaPixel(
+            pixels[index],
+            pixels[index + 1],
+            pixels[index + 2],
+            pixels[index + 3]);
+    }
+
+    private static void AssertRed(RgbaPixel pixel) =>
+        Assert.True(pixel.R >= 160 && pixel.G <= 64 && pixel.B <= 64, $"Expected red, found {pixel}.");
+
+    private static void AssertDark(RgbaPixel pixel) =>
+        Assert.True(pixel.R <= 48 && pixel.G <= 48 && pixel.B <= 48, $"Expected dark, found {pixel}.");
+
+    private readonly record struct RgbaPixel(byte R, byte G, byte B, byte A);
+
+    private sealed class DistinctDashCapVisual : FrameworkElement
+    {
+        public DistinctDashCapVisual()
+        {
+            Width = 56f;
+            Height = 32f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                new SolidColorBrush(new Vector4(0f, 0f, 0f, 1f)),
+                null,
+                new Rect(0f, 0f, 56f, 32f));
+            context.DrawPath(
+                null,
+                CreateDistinctCapPen(thickness: 4f, dashArray: [2.0, 2.0]),
+                CreateLinePath(new Vector2(10f, 16f), new Vector2(44f, 16f)));
+        }
+    }
+}

--- a/src/ProGPU.Tests/DashedAnalyticPrimitiveTests.cs
+++ b/src/ProGPU.Tests/DashedAnalyticPrimitiveTests.cs
@@ -1,0 +1,442 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using SkiaSharp;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class DashedAnalyticPrimitiveTests
+{
+    private const uint SurfaceSize = 96;
+    private static readonly Rect PrimitiveBounds = new(16f, 16f, 56f, 48f);
+    private static readonly Vector2 PrimitiveCenter = new(44f, 40f);
+    private static readonly Matrix4x4 AffineTransform = new(
+        1.05f, 0.18f, 0f, 0f,
+        -0.22f, 0.78f, 0f, 0f,
+        0f, 0f, 1f, 0f,
+        0f, 4f, 0f, 1f);
+    private static readonly AnalyticPrimitiveKind[] AllKinds =
+    [
+        AnalyticPrimitiveKind.Rectangle,
+        AnalyticPrimitiveKind.Ellipse,
+        AnalyticPrimitiveKind.Circle,
+        AnalyticPrimitiveKind.CircularRoundedRectangle,
+        AnalyticPrimitiveKind.EllipticalRoundedRectangle
+    ];
+
+    public static TheoryData<AnalyticPrimitiveKind> PrimitiveKinds => new()
+    {
+        AnalyticPrimitiveKind.Rectangle,
+        AnalyticPrimitiveKind.Ellipse,
+        AnalyticPrimitiveKind.Circle,
+        AnalyticPrimitiveKind.CircularRoundedRectangle,
+        AnalyticPrimitiveKind.EllipticalRoundedRectangle
+    };
+
+    public static TheoryData<AnalyticPrimitiveKind, bool> PrimitiveTransformCases => new()
+    {
+        { AnalyticPrimitiveKind.Rectangle, false },
+        { AnalyticPrimitiveKind.Rectangle, true },
+        { AnalyticPrimitiveKind.Ellipse, false },
+        { AnalyticPrimitiveKind.Ellipse, true },
+        { AnalyticPrimitiveKind.Circle, false },
+        { AnalyticPrimitiveKind.Circle, true },
+        { AnalyticPrimitiveKind.CircularRoundedRectangle, false },
+        { AnalyticPrimitiveKind.CircularRoundedRectangle, true },
+        { AnalyticPrimitiveKind.EllipticalRoundedRectangle, false },
+        { AnalyticPrimitiveKind.EllipticalRoundedRectangle, true }
+    };
+
+    [Theory]
+    [MemberData(nameof(PrimitiveKinds))]
+    public void RecorderRetainsSourcePathForDashedAnalyticPrimitive(
+        AnalyticPrimitiveKind kind)
+    {
+        var context = new DrawingContext();
+
+        RecordPrimitive(context, kind, brush: null, CreateDashPen());
+
+        RenderCommand command = Assert.Single(context.Commands);
+        Assert.Equal(GetCommandType(kind), command.Type);
+        Assert.NotNull(command.GeometryCache?.StrokePath);
+        Assert.NotEmpty(command.GeometryCache!.StrokePath!.Figures);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrimitiveTransformCases))]
+    public void DashedAnalyticPrimitiveMatchesEquivalentPath(
+        AnalyticPrimitiveKind kind,
+        bool useAffineTransform)
+    {
+        Matrix4x4 transform = useAffineTransform
+            ? AffineTransform
+            : Matrix4x4.Identity;
+        using var window = CreateWindow();
+
+        window.Content = new AnalyticPrimitiveVisual(kind, transform);
+        window.Render();
+        byte[] analyticPixels = window.ReadPixels();
+
+        window.Content = new PathPrimitiveVisual(kind, transform);
+        window.Render();
+        byte[] pathPixels = window.ReadPixels();
+
+        AssertPixelBuffersEqual(pathPixels, analyticPixels, kind, useAffineTransform);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrimitiveKinds))]
+    public void DashedAnalyticPrimitiveUsesPathStrokeHitPrimitives(
+        AnalyticPrimitiveKind kind)
+    {
+        var context = new DrawingContext();
+        RecordPrimitive(context, kind, brush: null, CreateDashPen());
+        RenderCommand command = Assert.Single(context.Commands);
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+
+        builder.AddCommand(command, Matrix4x4.Identity, id: 913);
+        GpuHitTestIndex index = builder.BuildIndex(
+            maxDepth: 2,
+            maxPrimitivesPerNode: 1);
+
+        Assert.NotEmpty(index.Primitives);
+        Assert.All(index.Primitives, primitive =>
+        {
+            Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
+            Assert.Equal(913, primitive.Id);
+        });
+        Assert.NotEmpty(index.PathSegments);
+    }
+
+    [Fact]
+    public void DashedRectangleGpuHitTestRejectsPatternGap()
+    {
+        using var gpu = new WgpuContext();
+        gpu.Initialize(null);
+        var context = new DrawingContext();
+        RecordPrimitive(
+            context,
+            AnalyticPrimitiveKind.Rectangle,
+            brush: null,
+            CreateDashPen());
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(
+            Assert.Single(context.Commands),
+            Matrix4x4.Identity,
+            id: 914);
+        GpuHitTestIndex index = builder.BuildIndex(
+            maxDepth: 2,
+            maxPrimitivesPerNode: 1);
+
+        bool dashHit = GpuHitTestEngine.TryHitTestPoint(
+            gpu,
+            index,
+            new Vector2(24f, 16f),
+            out GpuHitTestResult dashResult);
+        bool gapHit = GpuHitTestEngine.TryHitTestPoint(
+            gpu,
+            index,
+            new Vector2(36f, 16f),
+            out GpuHitTestResult gapResult);
+
+        Assert.True(dashHit);
+        Assert.Equal(914, dashResult.Id);
+        Assert.False(gapHit);
+        Assert.False(gapResult.HasHit);
+    }
+
+    [Fact]
+    public void PictureArchiveRestoresDashedAnalyticStrokeCaches()
+    {
+        var recorder = new GpuPictureRecorder();
+        DrawingContext context = recorder.BeginRecording(
+            new Rect(0f, 0f, SurfaceSize, SurfaceSize));
+        foreach (AnalyticPrimitiveKind kind in AllKinds)
+        {
+            RecordPrimitive(context, kind, brush: null, CreateDashPen());
+        }
+
+        using GpuPicture gpuPicture = recorder.EndRecording();
+        using var picture = new SKPicture(
+            gpuPicture,
+            new SKRect(0f, 0f, SurfaceSize, SurfaceSize));
+        using SKData data = picture.Serialize();
+        using SKPicture? copy = SKPicture.Deserialize(data);
+
+        Assert.NotNull(copy);
+        IReadOnlyList<RenderCommand> commands = copy.Picture.Commands;
+        Assert.Equal(AllKinds.Length, commands.Count);
+        for (var index = 0; index < commands.Count; index++)
+        {
+            RenderCommand command = commands[index];
+            Assert.Equal(GetCommandType(AllKinds[index]), command.Type);
+            RenderCommandGeometryCache cache = Assert.IsType<RenderCommandGeometryCache>(
+                command.GeometryCache);
+            Assert.NotNull(cache.StrokePath);
+            Assert.True(cache.TryGetDashedStrokePath(
+                command.Pen!,
+                out PathGeometry firstPath,
+                out Pen firstPen));
+            Assert.True(cache.TryGetDashedStrokePath(
+                command.Pen!,
+                out PathGeometry secondPath,
+                out Pen secondPen));
+            Assert.Same(firstPath, secondPath);
+            Assert.Same(firstPen, secondPen);
+        }
+    }
+
+    [Fact]
+    public void FilledDashedRectangleDoesNotEmitContinuousAnalyticStroke()
+    {
+        using var window = CreateWindow();
+        window.Content = new FilledDashedRectangleVisual();
+
+        window.Render();
+
+        Assert.DoesNotContain(
+            window.Compositor.VectorVertices,
+            static vertex => vertex.ShapeType == 0f && vertex.StrokeThickness > 0f);
+        byte[] pixels = window.ReadPixels();
+        AssertRed(ReadPixel(pixels, x: 24, y: 17));
+        AssertBlue(ReadPixel(pixels, x: 36, y: 17));
+    }
+
+    private static HeadlessWindow CreateWindow()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableGpuHitTesting = false,
+            EnableCompiledSceneCache = false,
+            EnableIncrementalScenePages = false,
+            PrimarySampleCount = 1
+        };
+        var window = new HeadlessWindow(
+            SurfaceSize,
+            SurfaceSize,
+            options);
+        window.Compositor.ClearColor = new Vector4(0f, 0f, 0f, 1f);
+        return window;
+    }
+
+    private static Pen CreateDashPen() => new(
+        new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+        thickness: 4f,
+        lineJoin: PenLineJoin.Round,
+        miterLimit: 8f,
+        startLineCap: PenLineCap.Flat,
+        endLineCap: PenLineCap.Flat,
+        dashCap: PenLineCap.Flat,
+        dashArray: [4d, 2d],
+        dashOffset: 0d);
+
+    private static void RecordPrimitive(
+        DrawingContext context,
+        AnalyticPrimitiveKind kind,
+        Brush? brush,
+        Pen pen)
+    {
+        switch (kind)
+        {
+            case AnalyticPrimitiveKind.Rectangle:
+                context.DrawRectangle(brush, pen, PrimitiveBounds);
+                break;
+            case AnalyticPrimitiveKind.Ellipse:
+                context.DrawEllipse(
+                    brush,
+                    pen,
+                    PrimitiveCenter,
+                    radiusX: 28f,
+                    radiusY: 24f);
+                break;
+            case AnalyticPrimitiveKind.Circle:
+                context.DrawCircle(brush, pen, PrimitiveCenter, radius: 24f);
+                break;
+            case AnalyticPrimitiveKind.CircularRoundedRectangle:
+                context.DrawRoundedRectangle(
+                    brush,
+                    pen,
+                    PrimitiveBounds,
+                    radiusX: 10f,
+                    radiusY: 10f);
+                break;
+            case AnalyticPrimitiveKind.EllipticalRoundedRectangle:
+                context.DrawRoundedRectangle(
+                    brush,
+                    pen,
+                    PrimitiveBounds,
+                    radiusX: 14f,
+                    radiusY: 7f);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind));
+        }
+    }
+
+    private static PathGeometry CreatePrimitivePath(AnalyticPrimitiveKind kind)
+    {
+        return kind switch
+        {
+            AnalyticPrimitiveKind.Rectangle =>
+                PrimitivePathGeometry.CreateRectangle(
+                    PrimitiveBounds.X,
+                    PrimitiveBounds.Y,
+                    PrimitiveBounds.Width,
+                    PrimitiveBounds.Height),
+            AnalyticPrimitiveKind.Ellipse =>
+                PrimitivePathGeometry.CreateEllipse(
+                    PrimitiveCenter,
+                    radiusX: 28f,
+                    radiusY: 24f),
+            AnalyticPrimitiveKind.Circle =>
+                PrimitivePathGeometry.CreateEllipse(
+                    PrimitiveCenter,
+                    radiusX: 24f,
+                    radiusY: 24f),
+            AnalyticPrimitiveKind.CircularRoundedRectangle =>
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    PrimitiveBounds.X,
+                    PrimitiveBounds.Y,
+                    PrimitiveBounds.Width,
+                    PrimitiveBounds.Height,
+                    radiusX: 10f,
+                    radiusY: 10f),
+            AnalyticPrimitiveKind.EllipticalRoundedRectangle =>
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    PrimitiveBounds.X,
+                    PrimitiveBounds.Y,
+                    PrimitiveBounds.Width,
+                    PrimitiveBounds.Height,
+                    radiusX: 14f,
+                    radiusY: 7f),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+    }
+
+    private static RenderCommandType GetCommandType(AnalyticPrimitiveKind kind)
+    {
+        return kind switch
+        {
+            AnalyticPrimitiveKind.Rectangle => RenderCommandType.DrawRect,
+            AnalyticPrimitiveKind.Ellipse => RenderCommandType.DrawEllipse,
+            AnalyticPrimitiveKind.Circle => RenderCommandType.DrawCircle,
+            AnalyticPrimitiveKind.CircularRoundedRectangle or
+            AnalyticPrimitiveKind.EllipticalRoundedRectangle =>
+                RenderCommandType.DrawRoundedRect,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+    }
+
+    private static void AssertPixelBuffersEqual(
+        byte[] expected,
+        byte[] actual,
+        AnalyticPrimitiveKind kind,
+        bool affine)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var differingBytes = 0;
+        var maximumDifference = 0;
+        for (var index = 0; index < expected.Length; index++)
+        {
+            int difference = Math.Abs(expected[index] - actual[index]);
+            if (difference == 0)
+            {
+                continue;
+            }
+
+            differingBytes++;
+            maximumDifference = Math.Max(maximumDifference, difference);
+        }
+
+        Assert.True(
+            differingBytes == 0,
+            $"{kind} ({(affine ? "affine" : "identity")}) differed from DrawPath " +
+            $"in {differingBytes} bytes; maximum channel difference {maximumDifference}.");
+    }
+
+    private static RgbaPixel ReadPixel(byte[] pixels, int x, int y)
+    {
+        int offset = ((y * checked((int)SurfaceSize)) + x) * 4;
+        return new RgbaPixel(
+            pixels[offset],
+            pixels[offset + 1],
+            pixels[offset + 2],
+            pixels[offset + 3]);
+    }
+
+    private static void AssertRed(RgbaPixel pixel)
+    {
+        Assert.InRange(pixel.Red, (byte)220, byte.MaxValue);
+        Assert.InRange(pixel.Green, (byte)0, (byte)35);
+        Assert.InRange(pixel.Blue, (byte)0, (byte)35);
+    }
+
+    private static void AssertBlue(RgbaPixel pixel)
+    {
+        Assert.InRange(pixel.Red, (byte)0, (byte)35);
+        Assert.InRange(pixel.Green, (byte)0, (byte)35);
+        Assert.InRange(pixel.Blue, (byte)220, byte.MaxValue);
+    }
+
+    private readonly record struct RgbaPixel(byte Red, byte Green, byte Blue, byte Alpha);
+
+    public enum AnalyticPrimitiveKind
+    {
+        Rectangle,
+        Ellipse,
+        Circle,
+        CircularRoundedRectangle,
+        EllipticalRoundedRectangle
+    }
+
+    private sealed class AnalyticPrimitiveVisual : FrameworkElement
+    {
+        private readonly AnalyticPrimitiveKind _kind;
+        private readonly Pen _pen = CreateDashPen();
+
+        public AnalyticPrimitiveVisual(
+            AnalyticPrimitiveKind kind,
+            Matrix4x4 transform)
+        {
+            _kind = kind;
+            Width = SurfaceSize;
+            Height = SurfaceSize;
+            Transform = transform;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            RecordPrimitive(context, _kind, brush: null, _pen);
+    }
+
+    private sealed class PathPrimitiveVisual : FrameworkElement
+    {
+        private readonly PathGeometry _path;
+        private readonly Pen _pen = CreateDashPen();
+
+        public PathPrimitiveVisual(
+            AnalyticPrimitiveKind kind,
+            Matrix4x4 transform)
+        {
+            _path = CreatePrimitivePath(kind);
+            Width = SurfaceSize;
+            Height = SurfaceSize;
+            Transform = transform;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPath(brush: null, _pen, _path);
+    }
+
+    private sealed class FilledDashedRectangleVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _fill = new(new Vector4(0f, 0f, 1f, 1f));
+        private readonly Pen _pen = CreateDashPen();
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawRectangle(_fill, _pen, PrimitiveBounds);
+    }
+}

--- a/src/ProGPU.Tests/DashedStrokeGeometryCacheTests.cs
+++ b/src/ProGPU.Tests/DashedStrokeGeometryCacheTests.cs
@@ -1,0 +1,177 @@
+using System.Numerics;
+using ProGPU.Scene;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class DashedStrokeGeometryCacheTests
+{
+    [Fact]
+    public void ReconstructedPictureGradientPenReusesGeometryWithoutKeepingStalePaint()
+    {
+        var cache = CreateLineCache();
+        var firstBrush = CreateGradientBrush(Matrix4x4.CreateTranslation(2f, 3f, 0f));
+        var firstPen = CreatePen(firstBrush);
+
+        Assert.True(cache.TryGetDashedStrokePath(firstPen, out var firstPath, out var firstUndashedPen));
+
+        // Picture replay reconstructs a gradient and its pen after composing the
+        // command transform even when the effective paint is value-identical.
+        var replayBrush = CreateGradientBrush(Matrix4x4.CreateTranslation(2f, 3f, 0f));
+        var replayPen = CreatePen(replayBrush);
+        Assert.True(cache.TryGetDashedStrokePath(replayPen, out var replayPath, out var replayUndashedPen));
+
+        Assert.Same(firstPath, replayPath);
+        Assert.NotSame(firstUndashedPen, replayUndashedPen);
+        Assert.Same(replayBrush, replayUndashedPen.Brush);
+        Assert.NotSame(firstBrush, replayUndashedPen.Brush);
+
+        // A stable replay with the same retained paint also reuses the derived pen.
+        Assert.True(cache.TryGetDashedStrokePath(replayPen, out var stablePath, out var stableUndashedPen));
+        Assert.Same(replayPath, stablePath);
+        Assert.Same(replayUndashedPen, stableUndashedPen);
+    }
+
+    [Fact]
+    public void DashGeometryCacheInvalidatesEveryPlacementInput()
+    {
+        var cache = CreateLineCache();
+        var pen = CreatePen(new SolidColorBrush(Vector4.One));
+
+        Assert.True(cache.TryGetDashedStrokePath(pen, 2f, out var initialPath, out _));
+
+        Assert.True(cache.TryGetDashedStrokePath(pen, 3f, out var widthPath, out _));
+        Assert.NotSame(initialPath, widthPath);
+
+        pen.DashOffset = 0.75;
+        Assert.True(cache.TryGetDashedStrokePath(pen, 3f, out var offsetPath, out _));
+        Assert.NotSame(widthPath, offsetPath);
+
+        pen.DashArray = [3.0, 1.0];
+        Assert.True(cache.TryGetDashedStrokePath(pen, 3f, out var intervalPath, out _));
+        Assert.NotSame(offsetPath, intervalPath);
+
+        pen.DashArray = [3.0, 1.0, 2.0, 1.0];
+        Assert.True(cache.TryGetDashedStrokePath(pen, 3f, out var intervalCountPath, out _));
+        Assert.NotSame(intervalPath, intervalCountPath);
+    }
+
+    [Fact]
+    public void StrokePaintStyleRefreshesDerivedPenWithoutRebuildingDashGeometry()
+    {
+        var cache = CreateLineCache();
+        var pen = CreatePen(new SolidColorBrush(Vector4.One));
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var retainedPath, out var previousPen));
+
+        pen.LineJoin = PenLineJoin.Round;
+        AssertPaintOnlyChange(cache, pen, retainedPath, ref previousPen);
+
+        pen.MiterLimit = 4f;
+        AssertPaintOnlyChange(cache, pen, retainedPath, ref previousPen);
+
+        pen.Brush = new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f));
+        AssertPaintOnlyChange(cache, pen, retainedPath, ref previousPen);
+        Assert.Same(pen.Brush, previousPen.Brush);
+    }
+
+    [Fact]
+    public void StrokeCapsRebuildDashGeometryBecauseTheyPlaceRunEndpoints()
+    {
+        var cache = CreateLineCache();
+        var pen = CreatePen(new SolidColorBrush(Vector4.One));
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var initialPath, out _));
+
+        pen.StartLineCap = PenLineCap.Square;
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var startCapPath, out _));
+        Assert.NotSame(initialPath, startCapPath);
+
+        pen.EndLineCap = PenLineCap.Triangle;
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var endCapPath, out _));
+        Assert.NotSame(startCapPath, endCapPath);
+
+        pen.DashCap = PenLineCap.Round;
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var dashCapPath, out _));
+        Assert.NotSame(endCapPath, dashCapPath);
+    }
+
+    [Fact]
+    public void StableDashGeometryCacheHitIsAllocationFree()
+    {
+        var cache = CreateLineCache();
+        var pen = CreatePen(new SolidColorBrush(Vector4.One));
+        Assert.True(cache.TryGetDashedStrokePath(pen, out var expectedPath, out var expectedPen));
+
+        for (var index = 0; index < 128; index++)
+        {
+            if (!cache.TryGetDashedStrokePath(pen, out _, out _))
+            {
+                throw new InvalidOperationException("The warmed dash cache unexpectedly missed.");
+            }
+        }
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        PathGeometry? actualPath = null;
+        Pen? actualPen = null;
+        for (var index = 0; index < 10_000; index++)
+        {
+            if (!cache.TryGetDashedStrokePath(pen, out actualPath, out actualPen))
+            {
+                throw new InvalidOperationException("The warmed dash cache unexpectedly missed.");
+            }
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.Equal(0, allocated);
+        Assert.Same(expectedPath, actualPath);
+        Assert.Same(expectedPen, actualPen);
+    }
+
+    private static void AssertPaintOnlyChange(
+        RenderCommandGeometryCache cache,
+        Pen sourcePen,
+        PathGeometry expectedPath,
+        ref Pen previousPen)
+    {
+        Assert.True(cache.TryGetDashedStrokePath(sourcePen, out var path, out var derivedPen));
+        Assert.Same(expectedPath, path);
+        Assert.NotSame(previousPen, derivedPen);
+        previousPen = derivedPen;
+    }
+
+    private static RenderCommandGeometryCache CreateLineCache()
+    {
+        return RenderCommandGeometryCache.ForStrokePath(
+            RenderCommandGeometryCache.CreateLinePath(
+                Vector2.Zero,
+                new Vector2(40f, 0f)));
+    }
+
+    private static Pen CreatePen(Brush brush)
+    {
+        return new Pen(
+            brush,
+            thickness: 2f,
+            lineJoin: PenLineJoin.Bevel,
+            miterLimit: 8f,
+            startLineCap: PenLineCap.Flat,
+            endLineCap: PenLineCap.Flat,
+            dashCap: PenLineCap.Square,
+            dashArray: [2.0, 1.0],
+            dashOffset: 0.25);
+    }
+
+    private static LinearGradientBrush CreateGradientBrush(Matrix4x4 coordinateTransform)
+    {
+        return new LinearGradientBrush(
+            Vector2.Zero,
+            new Vector2(40f, 0f),
+            [
+                new GradientStop(new Vector4(1f, 0f, 0f, 1f), 0f),
+                new GradientStop(new Vector4(0f, 0f, 1f, 1f), 1f)
+            ])
+        {
+            CoordinateTransform = coordinateTransform
+        };
+    }
+}

--- a/src/ProGPU.Tests/DirectStrokeCapRenderingTests.cs
+++ b/src/ProGPU.Tests/DirectStrokeCapRenderingTests.cs
@@ -126,7 +126,7 @@ public sealed class DirectStrokeCapRenderingTests
             IsPenThicknessLocal = true
         };
 
-        Assert.NotNull(direct.GeometryCache?.StrokePath);
+        Assert.Null(direct.GeometryCache);
         Assert.Equal(Render(expected), Render(direct));
     }
 
@@ -168,7 +168,7 @@ public sealed class DirectStrokeCapRenderingTests
             IsPenThicknessLocal = true
         };
 
-        Assert.NotNull(direct.GeometryCache?.StrokePath);
+        Assert.Null(direct.GeometryCache);
         Assert.Equal(Render(expected), Render(direct));
     }
 
@@ -179,7 +179,7 @@ public sealed class DirectStrokeCapRenderingTests
     [InlineData(PenLineJoin.Bevel, true)]
     [InlineData(PenLineJoin.Round, false)]
     [InlineData(PenLineJoin.Round, true)]
-    public void SplineCapsAndJoinsMatchItsRetainedCenterline(
+    public void SplineCapsAndJoinsMatchItsAdaptiveCenterline(
         PenLineJoin lineJoin,
         bool useAffineTransform)
     {
@@ -206,8 +206,27 @@ public sealed class DirectStrokeCapRenderingTests
         var spline = Assert.Single(context.Commands);
         spline.Transform = transform;
         spline.IsPenThicknessLocal = true;
-        var retainedPath = Assert.IsType<PathGeometry>(
-            spline.GeometryCache?.StrokePath);
+        spline.PolylinePoints = controlPoints;
+        spline.SplineKnots = knots;
+        spline.PointBufferOffset = 0;
+        spline.PointBufferCount = 0;
+        spline.DoubleBufferOffset = 0;
+        spline.DoubleBufferCount = 0;
+        Assert.Null(spline.GeometryCache);
+        int segmentCount = SplineGeometry.GetScreenSegmentCount(
+            controlPoints,
+            transform);
+        var sampledPoints = new Vector2[segmentCount + 1];
+        Assert.True(SplineGeometry.TryEvaluatePoints(
+            2,
+            controlPoints,
+            knots,
+            ReadOnlySpan<double>.Empty,
+            Matrix4x4.Identity,
+            sampledPoints));
+        var retainedPath = RenderCommandGeometryCache.CreatePolylinePath(
+            sampledPoints,
+            isClosed: false);
 
         var expected = new RenderCommand
         {
@@ -223,7 +242,7 @@ public sealed class DirectStrokeCapRenderingTests
     }
 
     [Fact]
-    public void AppendTranslationRebuildsConnectedPolylineCacheOnce()
+    public void AppendTranslationKeepsConnectedPolylineCacheFree()
     {
         Vector2[] points =
         [
@@ -239,24 +258,22 @@ public sealed class DirectStrokeCapRenderingTests
             endLineCap: PenLineCap.Triangle);
         var source = new DrawingContext();
         source.DrawPolyline(pen, points);
-        var sourceCache = Assert.IsType<RenderCommandGeometryCache>(
-            source.Commands[0].GeometryCache);
+        Assert.Null(source.Commands[0].GeometryCache);
 
         var target = new DrawingContext();
         target.Append(source, new Vector2(20f, 30f));
 
         var command = Assert.Single(target.Commands);
-        var translatedCache = Assert.IsType<RenderCommandGeometryCache>(
-            command.GeometryCache);
-        Assert.NotSame(sourceCache, translatedCache);
-        var figure = Assert.Single(translatedCache.StrokePath!.Figures);
-        Assert.Equal(new Vector2(22f, 34f), figure.StartPoint);
+        Assert.Null(command.GeometryCache);
+        Assert.Equal(
+            new Vector2(22f, 34f),
+            target.PointBuffer[command.PointBufferOffset]);
         Assert.Equal(
             new Vector2(28f, 32f),
-            Assert.IsType<LineSegment>(figure.Segments[0]).Point);
+            target.PointBuffer[command.PointBufferOffset + 1]);
         Assert.Equal(
             new Vector2(34f, 36f),
-            Assert.IsType<LineSegment>(figure.Segments[1]).Point);
+            target.PointBuffer[command.PointBufferOffset + 2]);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/DirectStrokeCapRenderingTests.cs
+++ b/src/ProGPU.Tests/DirectStrokeCapRenderingTests.cs
@@ -1,0 +1,397 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class DirectStrokeCapRenderingTests
+{
+    private const int SurfaceSize = 128;
+
+    [Theory]
+    [InlineData(DirectCapStrokeKind.Line, PenLineCap.Round, false)]
+    [InlineData(DirectCapStrokeKind.Line, PenLineCap.Round, true)]
+    [InlineData(DirectCapStrokeKind.Line, PenLineCap.Square, false)]
+    [InlineData(DirectCapStrokeKind.Line, PenLineCap.Square, true)]
+    [InlineData(DirectCapStrokeKind.Line, PenLineCap.Triangle, false)]
+    [InlineData(DirectCapStrokeKind.Line, PenLineCap.Triangle, true)]
+    [InlineData(DirectCapStrokeKind.Quadratic, PenLineCap.Round, false)]
+    [InlineData(DirectCapStrokeKind.Quadratic, PenLineCap.Round, true)]
+    [InlineData(DirectCapStrokeKind.Quadratic, PenLineCap.Square, false)]
+    [InlineData(DirectCapStrokeKind.Quadratic, PenLineCap.Square, true)]
+    [InlineData(DirectCapStrokeKind.Quadratic, PenLineCap.Triangle, false)]
+    [InlineData(DirectCapStrokeKind.Quadratic, PenLineCap.Triangle, true)]
+    [InlineData(DirectCapStrokeKind.Cubic, PenLineCap.Round, false)]
+    [InlineData(DirectCapStrokeKind.Cubic, PenLineCap.Round, true)]
+    [InlineData(DirectCapStrokeKind.Cubic, PenLineCap.Square, false)]
+    [InlineData(DirectCapStrokeKind.Cubic, PenLineCap.Square, true)]
+    [InlineData(DirectCapStrokeKind.Cubic, PenLineCap.Triangle, false)]
+    [InlineData(DirectCapStrokeKind.Cubic, PenLineCap.Triangle, true)]
+    public void DirectPrimitiveCapsMatchEquivalentRetainedPath(
+        DirectCapStrokeKind kind,
+        PenLineCap cap,
+        bool useAffineTransform)
+    {
+        var transform = useAffineTransform
+            ? CreateAffineTransform()
+            : Matrix4x4.Identity;
+        var pen = new Pen(
+            new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+            thickness: 10f,
+            startLineCap: cap,
+            endLineCap: cap);
+        var path = CreatePath(kind);
+        var direct = CreateDirectCommand(kind, pen, transform);
+        var expected = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = pen,
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
+
+        var expectedPixels = Render(expected);
+        var actualPixels = Render(direct);
+
+        Assert.Equal(expectedPixels, actualPixels);
+    }
+
+    [Theory]
+    [InlineData(DirectCapStrokeKind.Line)]
+    [InlineData(DirectCapStrokeKind.Quadratic)]
+    [InlineData(DirectCapStrokeKind.Cubic)]
+    public void NonFlatDirectPrimitiveRetainsItsPathAtRecordingTime(
+        DirectCapStrokeKind kind)
+    {
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 4f,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+
+        var command = CreateRecordedCommand(kind, pen);
+
+        Assert.NotNull(command.GeometryCache);
+        Assert.NotNull(command.GeometryCache!.StrokePath);
+    }
+
+    [Theory]
+    [InlineData(PenLineJoin.Miter, false)]
+    [InlineData(PenLineJoin.Miter, true)]
+    [InlineData(PenLineJoin.Bevel, false)]
+    [InlineData(PenLineJoin.Bevel, true)]
+    [InlineData(PenLineJoin.Round, false)]
+    [InlineData(PenLineJoin.Round, true)]
+    public void ConnectedPolylineCapsAndJoinsMatchEquivalentRetainedPath(
+        PenLineJoin lineJoin,
+        bool useAffineTransform)
+    {
+        Vector2[] points =
+        [
+            new(30f, 88f),
+            new(64f, 30f),
+            new(98f, 88f)
+        ];
+        var pen = new Pen(
+            new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+            thickness: 10f,
+            lineJoin: lineJoin,
+            miterLimit: 4f,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+        var transform = useAffineTransform
+            ? CreateAffineTransform()
+            : Matrix4x4.Identity;
+        var context = new DrawingContext();
+        context.DrawPolyline(pen, points);
+        var direct = Assert.Single(context.Commands);
+        direct.Transform = transform;
+        direct.IsPenThicknessLocal = true;
+
+        var path = RenderCommandGeometryCache.CreatePolylinePath(
+            points,
+            isClosed: false);
+        var expected = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = pen,
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
+
+        Assert.NotNull(direct.GeometryCache?.StrokePath);
+        Assert.Equal(Render(expected), Render(direct));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClosedPolylineJoinsMatchEquivalentRetainedPath(
+        bool useAffineTransform)
+    {
+        Vector2[] points =
+        [
+            new(32f, 88f),
+            new(64f, 28f),
+            new(96f, 88f)
+        ];
+        var pen = new Pen(
+            new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+            thickness: 10f,
+            lineJoin: PenLineJoin.Round);
+        var transform = useAffineTransform
+            ? CreateAffineTransform()
+            : Matrix4x4.Identity;
+        var context = new DrawingContext();
+        context.DrawPolyline(pen, points, isClosed: true);
+        var direct = Assert.Single(context.Commands);
+        direct.Transform = transform;
+        direct.IsPenThicknessLocal = true;
+
+        var path = RenderCommandGeometryCache.CreatePolylinePath(
+            points,
+            isClosed: true);
+        var expected = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = pen,
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
+
+        Assert.NotNull(direct.GeometryCache?.StrokePath);
+        Assert.Equal(Render(expected), Render(direct));
+    }
+
+    [Theory]
+    [InlineData(PenLineJoin.Miter, false)]
+    [InlineData(PenLineJoin.Miter, true)]
+    [InlineData(PenLineJoin.Bevel, false)]
+    [InlineData(PenLineJoin.Bevel, true)]
+    [InlineData(PenLineJoin.Round, false)]
+    [InlineData(PenLineJoin.Round, true)]
+    public void SplineCapsAndJoinsMatchItsRetainedCenterline(
+        PenLineJoin lineJoin,
+        bool useAffineTransform)
+    {
+        Vector2[] controlPoints =
+        [
+            new(24f, 82f),
+            new(42f, 24f),
+            new(82f, 108f),
+            new(104f, 46f)
+        ];
+        double[] knots = [0d, 0d, 0d, 1d, 2d, 2d, 2d];
+        var pen = new Pen(
+            new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+            thickness: 9f,
+            lineJoin: lineJoin,
+            miterLimit: 4f,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+        var transform = useAffineTransform
+            ? CreateAffineTransform()
+            : Matrix4x4.Identity;
+        var context = new DrawingContext();
+        context.DrawSpline(pen, controlPoints, knots, degree: 2);
+        var spline = Assert.Single(context.Commands);
+        spline.Transform = transform;
+        spline.IsPenThicknessLocal = true;
+        var retainedPath = Assert.IsType<PathGeometry>(
+            spline.GeometryCache?.StrokePath);
+
+        var expected = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = retainedPath,
+            GeometryCache = RenderCommandGeometryCache.ForPath(retainedPath),
+            Pen = pen,
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
+
+        Assert.Equal(Render(expected), Render(spline));
+    }
+
+    [Fact]
+    public void AppendTranslationRebuildsConnectedPolylineCacheOnce()
+    {
+        Vector2[] points =
+        [
+            new(2f, 4f),
+            new(8f, 2f),
+            new(14f, 6f)
+        ];
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 3f,
+            lineJoin: PenLineJoin.Round,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+        var source = new DrawingContext();
+        source.DrawPolyline(pen, points);
+        var sourceCache = Assert.IsType<RenderCommandGeometryCache>(
+            source.Commands[0].GeometryCache);
+
+        var target = new DrawingContext();
+        target.Append(source, new Vector2(20f, 30f));
+
+        var command = Assert.Single(target.Commands);
+        var translatedCache = Assert.IsType<RenderCommandGeometryCache>(
+            command.GeometryCache);
+        Assert.NotSame(sourceCache, translatedCache);
+        var figure = Assert.Single(translatedCache.StrokePath!.Figures);
+        Assert.Equal(new Vector2(22f, 34f), figure.StartPoint);
+        Assert.Equal(
+            new Vector2(28f, 32f),
+            Assert.IsType<LineSegment>(figure.Segments[0]).Point);
+        Assert.Equal(
+            new Vector2(34f, 36f),
+            Assert.IsType<LineSegment>(figure.Segments[1]).Point);
+    }
+
+    [Fact]
+    public void AppendTranslationPreservesCacheWhenItComposesTheTransform()
+    {
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 3f,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+        var source = new DrawingContext();
+        source.DrawLine(
+            pen,
+            new Vector2(2f, 4f),
+            new Vector2(14f, 6f),
+            Matrix4x4.CreateScale(2f, 3f, 1f));
+        var sourceCache = source.Commands[0].GeometryCache;
+
+        var target = new DrawingContext();
+        target.Append(source, new Vector2(20f, 30f));
+
+        var command = Assert.Single(target.Commands);
+        Assert.Same(sourceCache, command.GeometryCache);
+        Assert.Equal(
+            Matrix4x4.CreateScale(2f, 3f, 1f) *
+            Matrix4x4.CreateTranslation(20f, 30f, 0f),
+            command.Transform);
+    }
+
+    private static RenderCommand CreateDirectCommand(
+        DirectCapStrokeKind kind,
+        Pen pen,
+        Matrix4x4 transform)
+    {
+        var command = CreateRecordedCommand(kind, pen);
+        command.Transform = transform;
+        command.IsPenThicknessLocal = true;
+        return command;
+    }
+
+    private static RenderCommand CreateRecordedCommand(
+        DirectCapStrokeKind kind,
+        Pen pen)
+    {
+        var context = new DrawingContext();
+        switch (kind)
+        {
+            case DirectCapStrokeKind.Line:
+                context.DrawLine(pen, new Vector2(28f, 68f), new Vector2(100f, 60f));
+                break;
+            case DirectCapStrokeKind.Quadratic:
+                context.DrawQuadraticBezier(
+                    pen,
+                    new Vector2(28f, 76f),
+                    new Vector2(64f, 24f),
+                    new Vector2(100f, 68f));
+                break;
+            case DirectCapStrokeKind.Cubic:
+                context.DrawCubicBezier(
+                    pen,
+                    new Vector2(28f, 80f),
+                    new Vector2(42f, 20f),
+                    new Vector2(84f, 108f),
+                    new Vector2(100f, 52f));
+                break;
+        }
+
+        return Assert.Single(context.Commands);
+    }
+
+    private static PathGeometry CreatePath(DirectCapStrokeKind kind)
+    {
+        var path = new PathGeometry();
+        PathFigure figure;
+        switch (kind)
+        {
+            case DirectCapStrokeKind.Line:
+                figure = new PathFigure(new Vector2(28f, 68f));
+                figure.Segments.Add(new LineSegment(new Vector2(100f, 60f)));
+                break;
+            case DirectCapStrokeKind.Quadratic:
+                figure = new PathFigure(new Vector2(28f, 76f));
+                figure.Segments.Add(new QuadraticBezierSegment(
+                    new Vector2(64f, 24f),
+                    new Vector2(100f, 68f)));
+                break;
+            default:
+                figure = new PathFigure(new Vector2(28f, 80f));
+                figure.Segments.Add(new CubicBezierSegment(
+                    new Vector2(42f, 20f),
+                    new Vector2(84f, 108f),
+                    new Vector2(100f, 52f)));
+                break;
+        }
+
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static Matrix4x4 CreateAffineTransform()
+    {
+        var affine = Matrix4x4.CreateScale(1.25f, 0.7f, 1f);
+        affine.M21 += 0.45f;
+        return Matrix4x4.CreateTranslation(-64f, -64f, 0f) *
+            affine *
+            Matrix4x4.CreateTranslation(64f, 64f, 0f);
+    }
+
+    private static byte[] Render(RenderCommand command)
+    {
+        using var window = new HeadlessWindow(SurfaceSize, SurfaceSize);
+        window.Content = new CommandVisual(command);
+        window.Render();
+        return window.ReadPixels();
+    }
+
+    private sealed class CommandVisual : FrameworkElement
+    {
+        private readonly RenderCommand _command;
+
+        public CommandVisual(RenderCommand command)
+        {
+            _command = command;
+            Width = SurfaceSize;
+            Height = SurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.Commands.Add(_command);
+    }
+
+    public enum DirectCapStrokeKind
+    {
+        Line,
+        Quadratic,
+        Cubic
+    }
+}

--- a/src/ProGPU.Tests/GpuHitTestingTests.cs
+++ b/src/ProGPU.Tests/GpuHitTestingTests.cs
@@ -392,6 +392,32 @@ public sealed class GpuHitTestingTests
     }
 
     [Fact]
+    public void RenderCommandCacheKeepsPositiveFixedLineWidthInDeviceSpace()
+    {
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawLine,
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                thickness: 12f,
+                strokeTransformMode: PenStrokeTransformMode.Fixed),
+            Position = new Vector2(10f, 10f),
+            Position2 = new Vector2(20f, 10f),
+            IsPenThicknessLocal = true
+        }, Matrix4x4.CreateScale(4f, 4f, 1f), id: 240);
+
+        var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
+
+        var primitive = Assert.Single(index.Primitives);
+        Assert.Equal(GpuHitTestPrimitiveKind.LineStroke, primitive.Kind);
+        Assert.Equal(new Vector4(40f, 40f, 80f, 40f), primitive.Data0);
+        Assert.Equal(12f, primitive.Data1.X);
+        Assert.Equal(new Vector2(34f, 34f), primitive.BoundsMin);
+        Assert.Equal(new Vector2(86f, 46f), primitive.BoundsMax);
+    }
+
+    [Fact]
     public void RenderCommandCacheCachesEllipseHelperDataForGpuHitTesting()
     {
         var builder = new GpuRenderCommandHitTestCacheBuilder();

--- a/src/ProGPU.Tests/GpuHitTestingTests.cs
+++ b/src/ProGPU.Tests/GpuHitTestingTests.cs
@@ -634,10 +634,13 @@ public sealed class GpuHitTestingTests
 
         var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
 
-        var primitive = Assert.Single(index.Primitives);
-        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
-        Assert.Equal(80, primitive.Id);
-        Assert.NotEmpty(index.PathSegments);
+        Assert.Equal(2, index.Primitives.Count);
+        Assert.All(index.Primitives, primitive =>
+        {
+            Assert.Equal(GpuHitTestPrimitiveKind.LineStroke, primitive.Kind);
+            Assert.Equal(80, primitive.Id);
+        });
+        Assert.Empty(index.PathSegments);
     }
 
     [Fact]
@@ -659,10 +662,14 @@ public sealed class GpuHitTestingTests
         builder.AddCommand(command, Matrix4x4.Identity, id: 88);
         var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
 
-        var primitive = Assert.Single(index.Primitives);
-        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
-        Assert.Equal(88, primitive.Id);
-        Assert.Equal(1, compiler.CallCount);
+        Assert.Equal(2, index.Primitives.Count);
+        Assert.All(index.Primitives, primitive =>
+        {
+            Assert.Equal(GpuHitTestPrimitiveKind.LineStroke, primitive.Kind);
+            Assert.Equal(88, primitive.Id);
+        });
+        Assert.Empty(index.PathSegments);
+        Assert.Equal(0, compiler.CallCount);
         Assert.Equal(0, compiler.CompileCount);
     }
 
@@ -742,7 +749,7 @@ public sealed class GpuHitTestingTests
     }
 
     [Fact]
-    public void DrawingContextDefersSplineGeometryUntilGpuHitTesting()
+    public void DrawingContextRetainsSplineGeometryForRenderingAndGpuHitTesting()
     {
         var context = new DrawingContext();
         context.DrawSpline(
@@ -754,7 +761,7 @@ public sealed class GpuHitTestingTests
             [0d, 0d, 1d, 1d],
             degree: 1);
         var command = Assert.Single(context.Commands);
-        Assert.Null(command.GeometryCache);
+        Assert.NotNull(command.GeometryCache?.StrokePath);
 
         var compiler = new CountingPathHitTestCompilationCache();
         var builder = new GpuRenderCommandHitTestCacheBuilder(compiler);
@@ -970,9 +977,12 @@ public sealed class GpuHitTestingTests
 
         var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
 
-        var primitive = Assert.Single(index.Primitives);
-        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
-        Assert.Equal(87, primitive.Id);
+        Assert.Equal(3, index.Primitives.Count);
+        Assert.All(index.Primitives, primitive =>
+        {
+            Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
+            Assert.Equal(87, primitive.Id);
+        });
         Assert.NotEmpty(index.PathSegments);
     }
 
@@ -1299,9 +1309,10 @@ public sealed class GpuHitTestingTests
         }, Matrix4x4.Identity);
         var index = builder.BuildIndex(maxDepth: 2, maxPrimitivesPerNode: 1);
 
-        var primitive = Assert.Single(index.Primitives);
-        Assert.Equal(GpuHitTestPrimitiveKind.PathStroke, primitive.Kind);
-        Assert.True(index.PathSegments.Count > 1);
+        Assert.Equal(3, index.Primitives.Count);
+        Assert.All(index.Primitives, primitive =>
+            Assert.Equal(GpuHitTestPrimitiveKind.LineStroke, primitive.Kind));
+        Assert.Empty(index.PathSegments);
 
         bool dashHit = GpuHitTestEngine.TryHitTestPoint(context, index, new Vector2(2f, 0f), out GpuHitTestResult dashResult);
         bool gapHit = GpuHitTestEngine.TryHitTestPoint(context, index, new Vector2(6f, 0f), out GpuHitTestResult gapResult);

--- a/src/ProGPU.Tests/GpuHitTestingTests.cs
+++ b/src/ProGPU.Tests/GpuHitTestingTests.cs
@@ -548,6 +548,38 @@ public sealed class GpuHitTestingTests
     }
 
     [Fact]
+    public void HairlineArcHitGeometryAdaptsToFramebufferRadius()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(1000f, 0f));
+        figure.Segments.Add(new ArcSegment(
+            new Vector2(-1000f, 0f),
+            new Vector2(1000f, 1000f),
+            rotationAngle: 0f,
+            isLargeArc: false,
+            SweepDirection.Clockwise));
+        path.Figures.Add(figure);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                Pen.HairlineThickness),
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            IsPenThicknessLocal = true
+        }, Matrix4x4.Identity, id: 4324);
+
+        var index = builder.BuildIndex(
+            maxDepth: 2,
+            maxPrimitivesPerNode: 1);
+
+        Assert.Single(index.Primitives);
+        Assert.True(index.PathSegments.Count > 32);
+    }
+
+    [Fact]
     public void RenderCommandCacheBuildsPathPrimitiveSegments()
     {
         var builder = new GpuRenderCommandHitTestCacheBuilder();

--- a/src/ProGPU.Tests/GpuHitTestingTests.cs
+++ b/src/ProGPU.Tests/GpuHitTestingTests.cs
@@ -749,7 +749,7 @@ public sealed class GpuHitTestingTests
     }
 
     [Fact]
-    public void DrawingContextRetainsSplineGeometryForRenderingAndGpuHitTesting()
+    public void DrawingContextKeepsSplineRecordingCacheFreeForGpuHitTesting()
     {
         var context = new DrawingContext();
         context.DrawSpline(
@@ -761,7 +761,7 @@ public sealed class GpuHitTestingTests
             [0d, 0d, 1d, 1d],
             degree: 1);
         var command = Assert.Single(context.Commands);
-        Assert.NotNull(command.GeometryCache?.StrokePath);
+        Assert.Null(command.GeometryCache);
 
         var compiler = new CountingPathHitTestCompilationCache();
         var builder = new GpuRenderCommandHitTestCacheBuilder(compiler);

--- a/src/ProGPU.Tests/GpuLateTransformHitTestingTests.cs
+++ b/src/ProGPU.Tests/GpuLateTransformHitTestingTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class GpuLateTransformHitTestingTests
+{
+    [Fact]
+    public void LateGpuTransformHitsResolvedDeviceCoordinatesOnly()
+    {
+        using var window = new HeadlessWindow(128, 128);
+        window.Content = new CommandVisual(new RenderCommand
+        {
+            Type = RenderCommandType.DrawRect,
+            Rect = new Rect(0f, 0f, 10f, 10f),
+            Brush = WhiteBrush(),
+            HitTestId = 701,
+            UseGpuTransforms = true,
+            CameraView = Matrix4x4.CreateScale(2f, 3f, 1f) *
+                Matrix4x4.CreateTranslation(40f, 30f, 0f)
+        });
+
+        window.Render();
+
+        Assert.True(window.Compositor.TryHitTestPoint(
+            new Vector2(50f, 45f),
+            out var transformedHit));
+        Assert.Equal(701, transformedHit.Id);
+        Assert.False(window.Compositor.TryHitTestPoint(
+            new Vector2(5f, 5f),
+            out _));
+    }
+
+    [Fact]
+    public void NestedPictureCarriesResolvedLateTransformIntoChildHitGeometry()
+    {
+        using var child = new GpuPicture(
+            [
+                new RenderCommand
+                {
+                    Type = RenderCommandType.DrawRect,
+                    Rect = new Rect(0f, 0f, 10f, 10f),
+                    Brush = WhiteBrush(),
+                    HitTestId = 702
+                }
+            ],
+            [],
+            [],
+            [],
+            []);
+        using var parent = new GpuPicture(
+            [
+                new RenderCommand
+                {
+                    Type = RenderCommandType.DrawPicture,
+                    Picture = child,
+                    Transform = Matrix4x4.CreateTranslation(5f, 0f, 0f)
+                }
+            ],
+            [],
+            [],
+            [],
+            []);
+        using var window = new HeadlessWindow(128, 128);
+        window.Content = new CommandVisual(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPicture,
+            Picture = parent,
+            UseGpuTransforms = true,
+            CameraView = Matrix4x4.CreateScale(2f, 3f, 1f) *
+                Matrix4x4.CreateTranslation(40f, 30f, 0f)
+        });
+
+        window.Render();
+
+        Assert.True(window.Compositor.TryHitTestPoint(
+            new Vector2(60f, 45f),
+            out var transformedHit));
+        Assert.Equal(702, transformedHit.Id);
+        Assert.False(window.Compositor.TryHitTestPoint(
+            new Vector2(5f, 5f),
+            out _));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InvalidAffineTransformDoesNotCreateGhostHitPrimitive(bool nonFinite)
+    {
+        var transform = nonFinite
+            ? new Matrix4x4(
+                float.NaN, 0f, 0f, 0f,
+                0f, 1f, 0f, 0f,
+                0f, 0f, 1f, 0f,
+                0f, 0f, 0f, 1f)
+            : Matrix4x4.CreateScale(0f, 1f, 1f);
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawRect,
+            Rect = new Rect(0f, 0f, 10f, 10f),
+            Brush = WhiteBrush(),
+            HitTestId = 703
+        }, transform);
+
+        var index = builder.BuildIndex();
+
+        Assert.Empty(index.Primitives);
+    }
+
+    [Theory]
+    [InlineData(InvalidPathTransformKind.Collapsed)]
+    [InlineData(InvalidPathTransformKind.NonFinite)]
+    [InlineData(InvalidPathTransformKind.OverflowWhenComposed)]
+    public void InvalidComposedPathTransformDoesNotCreateGhostHitGeometry(
+        InvalidPathTransformKind kind)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(Vector2.Zero, isClosed: true);
+        figure.Segments.Add(new LineSegment(new Vector2(10f, 0f)));
+        figure.Segments.Add(new LineSegment(new Vector2(10f, 10f)));
+        figure.Segments.Add(new LineSegment(new Vector2(0f, 10f)));
+        path.Figures.Add(figure);
+        var commandTransform = kind switch
+        {
+            InvalidPathTransformKind.Collapsed =>
+                Matrix4x4.CreateScale(0f, 1f, 1f),
+            InvalidPathTransformKind.NonFinite => new Matrix4x4(
+                float.NaN, 0f, 0f, 0f,
+                0f, 1f, 0f, 0f,
+                0f, 0f, 1f, 0f,
+                0f, 0f, 0f, 1f),
+            _ => Matrix4x4.CreateScale(float.MaxValue, 1f, 1f)
+        };
+        var activeTransform = kind == InvalidPathTransformKind.OverflowWhenComposed
+            ? Matrix4x4.CreateScale(2f, 1f, 1f)
+            : Matrix4x4.CreateTranslation(20f, 30f, 0f);
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Brush = WhiteBrush(),
+            Transform = commandTransform,
+            HitTestId = 708
+        }, activeTransform);
+
+        var index = builder.BuildIndex();
+
+        Assert.Empty(index.Primitives);
+        Assert.Empty(index.PathSegments);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InvalidComposedSeriesTransformDoesNotCreateGhostHitGeometry(
+        bool isScatter)
+    {
+        var context = new DrawingContext();
+        var brush = WhiteBrush();
+        if (isScatter)
+        {
+            context.DrawGpuScatterSeries(
+                [5f, 5f, 20f, 20f],
+                pointsCount: 2,
+                radius: 2f,
+                brush);
+        }
+        else
+        {
+            context.DrawGpuLineSeries(
+                [0f, 0f, 10f, 0f, 10f, 10f],
+                pointsCount: 3,
+                thickness: 2f,
+                brush);
+        }
+
+        var command = Assert.Single(context.Commands);
+        command.Transform = Matrix4x4.CreateScale(0f, 1f, 1f);
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(command, Matrix4x4.Identity, context, id: 709);
+
+        var index = builder.BuildIndex();
+
+        Assert.Empty(index.Primitives);
+        Assert.Empty(index.PathSegments);
+    }
+
+    [Fact]
+    public void InvalidClipRejectsDescendantsAndPopRestoresFollowingHits()
+    {
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.PushClip,
+            Rect = new Rect(0f, 0f, 10f, 10f)
+        }, Matrix4x4.CreateScale(0f, 1f, 1f));
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawRect,
+            Rect = new Rect(0f, 0f, 10f, 10f),
+            Brush = WhiteBrush(),
+            HitTestId = 704
+        }, Matrix4x4.Identity);
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.PopClip
+        }, Matrix4x4.Identity);
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawRect,
+            Rect = new Rect(20f, 0f, 10f, 10f),
+            Brush = WhiteBrush(),
+            HitTestId = 705
+        }, Matrix4x4.Identity);
+
+        var index = builder.BuildIndex();
+
+        var primitive = Assert.Single(index.Primitives);
+        Assert.Equal(705, primitive.Id);
+    }
+
+    [Fact]
+    public void OpacityMaskStateDoesNotCreatePhantomBoundsPrimitive()
+    {
+        using var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.PushOpacityMask,
+            Rect = new Rect(0f, 0f, 100f, 100f),
+            Brush = WhiteBrush(),
+            HitTestId = 706
+        }, Matrix4x4.Identity);
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.DrawRect,
+            Rect = new Rect(10f, 10f, 10f, 10f),
+            Brush = WhiteBrush(),
+            HitTestId = 707
+        }, Matrix4x4.Identity);
+        builder.AddCommand(new RenderCommand
+        {
+            Type = RenderCommandType.PopOpacityMask
+        }, Matrix4x4.Identity);
+
+        var index = builder.BuildIndex();
+
+        var primitive = Assert.Single(index.Primitives);
+        Assert.Equal(707, primitive.Id);
+    }
+
+    private static SolidColorBrush WhiteBrush() =>
+        new(new Vector4(1f, 1f, 1f, 1f));
+
+    private sealed class CommandVisual : FrameworkElement
+    {
+        private readonly RenderCommand _command;
+
+        public CommandVisual(RenderCommand command)
+        {
+            _command = command;
+            Width = 128f;
+            Height = 128f;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.Commands.Add(_command);
+    }
+
+    public enum InvalidPathTransformKind
+    {
+        Collapsed,
+        NonFinite,
+        OverflowWhenComposed
+    }
+}

--- a/src/ProGPU.Tests/GpuTransformedStrokeScalingTests.cs
+++ b/src/ProGPU.Tests/GpuTransformedStrokeScalingTests.cs
@@ -1,0 +1,945 @@
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Xaml;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class GpuTransformedStrokeScalingTests
+{
+    private const int SmallSurfaceSize = 64;
+    private const int LargeSurfaceSize = 128;
+
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    [InlineData(DirectStrokeKind.Arc)]
+    public void StaticViewportTransformScalesDirectStrokeOnGpu(DirectStrokeKind kind)
+    {
+        using var window = new HeadlessWindow(SmallSurfaceSize, SmallSurfaceSize);
+        var context = CreateStrokeContext(kind);
+        using var buffer = window.Compositor.CompileStaticDxf(context);
+        window.Content = new StaticStrokeVisual(
+            buffer,
+            ScaleAboutCenter(0.5f),
+            SmallSurfaceSize);
+
+        window.Render();
+
+        Assert.InRange(
+            CountPaintedRows(window.ReadPixels(), SmallSurfaceSize, x: 32),
+            4,
+            8);
+    }
+
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    [InlineData(DirectStrokeKind.Arc)]
+    public void DynamicGpuTransformScalesDirectStrokeOnGpu(DirectStrokeKind kind)
+    {
+        using var window = new HeadlessWindow(SmallSurfaceSize, SmallSurfaceSize);
+        window.Content = new GpuTransformStrokeVisual(
+            kind,
+            ScaleAboutCenter(0.5f),
+            SmallSurfaceSize);
+
+        window.Render();
+
+        Assert.InRange(
+            CountPaintedRows(window.ReadPixels(), SmallSurfaceSize, x: 32),
+            4,
+            8);
+    }
+
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    public void StaticAnisotropicTransformRetainsExactHorizontalAndVerticalOutlines(
+        DirectStrokeKind kind)
+    {
+        AssertAnisotropicAxisStrokes(kind, useStaticBuffer: true);
+    }
+
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    public void DynamicAnisotropicTransformRetainsExactHorizontalAndVerticalOutlines(
+        DirectStrokeKind kind)
+    {
+        AssertAnisotropicAxisStrokes(kind, useStaticBuffer: false);
+    }
+
+    [Fact]
+    public void StaticAnisotropicTransformRetainsExactArcOutline()
+    {
+        AssertAnisotropicArc(useStaticBuffer: true);
+    }
+
+    [Fact]
+    public void DynamicAnisotropicTransformRetainsExactArcOutline()
+    {
+        AssertAnisotropicArc(useStaticBuffer: false);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShearRetainsLocalHorizontalStrokeOutline(bool useStaticBuffer)
+    {
+        using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
+        var transform = ShearAboutCenter(0.75f);
+        var context = CreateStrokeContext(
+            DirectStrokeKind.Line,
+            vertical: false,
+            LargeSurfaceSize);
+        DxfStaticBuffer? buffer = null;
+        if (useStaticBuffer)
+        {
+            buffer = window.Compositor.CompileStaticDxf(context);
+            window.Content = new StaticStrokeVisual(
+                buffer,
+                transform,
+                LargeSurfaceSize);
+        }
+        else
+        {
+            window.Content = new GpuTransformStrokeVisual(
+                DirectStrokeKind.Line,
+                transform,
+                LargeSurfaceSize,
+                vertical: false);
+        }
+
+        try
+        {
+            window.Render();
+            Assert.InRange(
+                CountPaintedRows(
+                    window.ReadPixels(),
+                    LargeSurfaceSize,
+                    x: LargeSurfaceSize / 2),
+                10,
+                14);
+        }
+        finally
+        {
+            buffer?.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    [InlineData(DirectStrokeKind.Arc)]
+    public void StaticSingularTransformFailsClosed(DirectStrokeKind kind)
+    {
+        AssertTransformFailsClosed(
+            kind,
+            useStaticBuffer: true,
+            ScaleAboutCenter(1f, 0f, LargeSurfaceSize));
+    }
+
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    [InlineData(DirectStrokeKind.Arc)]
+    public void DynamicSingularTransformFailsClosed(DirectStrokeKind kind)
+    {
+        AssertTransformFailsClosed(
+            kind,
+            useStaticBuffer: false,
+            ScaleAboutCenter(1f, 0f, LargeSurfaceSize));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void NonFiniteTransformFailsClosed(bool useStaticBuffer)
+    {
+        var transform = Matrix4x4.Identity;
+        transform.M11 = float.NaN;
+        AssertTransformFailsClosed(
+            DirectStrokeKind.Line,
+            useStaticBuffer,
+            transform);
+    }
+
+    [Theory]
+    [InlineData(AffinePolygonKind.Line)]
+    [InlineData(AffinePolygonKind.Quadratic)]
+    [InlineData(AffinePolygonKind.Cubic)]
+    [InlineData(AffinePolygonKind.Polyline)]
+    public void StaticLateAffinePolygonMatchesBakedTransform(
+        AffinePolygonKind kind)
+    {
+        var initial = ScaleAboutCenter(1.25f, 0.8f, LargeSurfaceSize);
+        var late = ScaleAboutCenter(0.75f, 1.25f, LargeSurfaceSize);
+        var actual = RenderStaticAffineCommand(
+            CreateAffinePolygonCommand(kind, initial),
+            late,
+            out var shapeTypes);
+        var expected = RenderStaticAffineCommand(
+            CreateAffinePolygonCommand(kind, initial * late),
+            Matrix4x4.Identity,
+            out _);
+
+        AssertExpectedAffinePolygonShapeTypes(kind, shapeTypes);
+        Assert.True(CountPaintedPixels(expected) > 0);
+        Assert.True(CountPaintedPixels(actual) > 0);
+        AssertImagesNear(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(AffinePolygonKind.Line)]
+    [InlineData(AffinePolygonKind.Quadratic)]
+    [InlineData(AffinePolygonKind.Cubic)]
+    [InlineData(AffinePolygonKind.Polyline)]
+    public void DynamicLateAffinePolygonMatchesBakedTransform(
+        AffinePolygonKind kind)
+    {
+        var initial = ScaleAboutCenter(1.25f, 0.8f, LargeSurfaceSize);
+        var late = ScaleAboutCenter(0.75f, 1.25f, LargeSurfaceSize);
+        var actualCommand = CreateAffinePolygonCommand(kind, initial);
+        actualCommand.UseGpuTransforms = true;
+        actualCommand.CameraView = late;
+
+        var actual = RenderDynamicAffineCommand(actualCommand);
+        var expected = RenderDynamicAffineCommand(
+            CreateAffinePolygonCommand(kind, initial * late));
+
+        Assert.True(CountPaintedPixels(expected) > 0);
+        Assert.True(CountPaintedPixels(actual) > 0);
+        AssertImagesNear(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void StronglyDownscaledPartialArcMatchesBakedAffineOutline(
+        bool useStaticBuffer)
+    {
+        var late = ScaleAboutCenter(1f, 0.2f, LargeSurfaceSize);
+        byte[] actual;
+        byte[] expected;
+        if (useStaticBuffer)
+        {
+            actual = RenderStaticAffineCommand(
+                CreateQuarterArcCommand(Matrix4x4.Identity),
+                late,
+                out var actualShapeTypes);
+            expected = RenderStaticAffineCommand(
+                CreateQuarterArcCommand(late),
+                Matrix4x4.Identity,
+                out _);
+            Assert.Contains(12, actualShapeTypes);
+        }
+        else
+        {
+            var actualCommand = CreateQuarterArcCommand(Matrix4x4.Identity);
+            actualCommand.UseGpuTransforms = true;
+            actualCommand.CameraView = late;
+            actual = RenderDynamicAffineCommand(actualCommand);
+            expected = RenderDynamicAffineCommand(
+                CreateQuarterArcCommand(late));
+        }
+
+        Assert.True(CountPaintedPixels(expected) > 0);
+        Assert.True(CountPaintedPixels(actual) > 0);
+        // The native analytic arc covers three threshold-edge pixels that the
+        // 24-section CPU fallback omits. Require identical bounds and prohibit
+        // any missing reference coverage so quad clipping cannot hide in AA.
+        AssertCoverageEquivalent(
+            expected,
+            actual,
+            maximumMissingPixels: 0,
+            maximumExtraPixels: 3);
+    }
+
+    [Fact]
+    public void VectorShaderScopesExplicitScaleToDirect2DStrokes()
+    {
+        Assert.Contains(
+            "sType == 3u || sType == 5u || sType == 6u || sType == 12u",
+            Shaders.VectorShader);
+        Assert.Contains(
+            "direct_2d_stroke_scales(isStatic, useGpuTransforms)",
+            Shaders.VectorShader);
+        Assert.Contains(
+            "!is_conformal_stroke_transform(directStrokeScales)",
+            Shaders.VectorShader);
+        Assert.Contains(
+            "input.localStrokeMode > 0.5",
+            Shaders.VectorShader);
+        Assert.Contains(
+            "discardLateAffineShape",
+            Shaders.VectorShader);
+        Assert.Contains(
+            "sType >= 13u && sType <= 17u",
+            Shaders.VectorShader);
+        Assert.Contains(
+            "let hairlineCenter = select(",
+            Shaders.VectorShader);
+        Assert.DoesNotContain(
+            "sType == 8u || sType == 12u",
+            Shaders.VectorShader);
+    }
+
+    [Fact]
+    public void StaticStrokeScaleCachePreservesSharedUniformAbi()
+    {
+        Assert.Equal(224, Marshal.SizeOf<GpuUniforms>());
+        Assert.Equal(
+            216,
+            Marshal.OffsetOf<GpuUniforms>(nameof(GpuUniforms.Pad1)).ToInt32());
+    }
+
+    private static Matrix4x4 ScaleAboutCenter(float scale) =>
+        ScaleAboutCenter(scale, scale, SmallSurfaceSize);
+
+    private static Matrix4x4 ScaleAboutCenter(
+        float scaleX,
+        float scaleY,
+        int surfaceSize) =>
+        Matrix4x4.CreateTranslation(
+            -surfaceSize * 0.5f,
+            -surfaceSize * 0.5f,
+            0f) *
+        Matrix4x4.CreateScale(scaleX, scaleY, 1f) *
+        Matrix4x4.CreateTranslation(
+            surfaceSize * 0.5f,
+            surfaceSize * 0.5f,
+            0f);
+
+    private static Matrix4x4 ShearAboutCenter(float shearX)
+    {
+        var shear = Matrix4x4.Identity;
+        shear.M21 = shearX;
+        return Matrix4x4.CreateTranslation(-64f, -64f, 0f) *
+            shear *
+            Matrix4x4.CreateTranslation(64f, 64f, 0f);
+    }
+
+    private static void AssertAnisotropicAxisStrokes(
+        DirectStrokeKind kind,
+        bool useStaticBuffer)
+    {
+        var transform = ScaleAboutCenter(2f, 0.5f, LargeSurfaceSize);
+        var horizontalPixels = RenderStroke(
+            kind,
+            vertical: false,
+            transform,
+            useStaticBuffer);
+        var verticalPixels = RenderStroke(
+            kind,
+            vertical: true,
+            transform,
+            useStaticBuffer);
+
+        Assert.InRange(
+            CountPaintedRows(
+                horizontalPixels,
+                LargeSurfaceSize,
+                x: LargeSurfaceSize / 2),
+            4,
+            8);
+        Assert.InRange(
+            CountPaintedColumns(
+                verticalPixels,
+                LargeSurfaceSize,
+                y: LargeSurfaceSize / 2),
+            21,
+            27);
+    }
+
+    private static void AssertAnisotropicArc(bool useStaticBuffer)
+    {
+        var pixels = RenderStroke(
+            DirectStrokeKind.Arc,
+            vertical: false,
+            ScaleAboutCenter(2f, 0.5f, LargeSurfaceSize),
+            useStaticBuffer,
+            fullArc: true);
+
+        Assert.InRange(
+            CountPaintedRows(
+                pixels,
+                LargeSurfaceSize,
+                x: 64,
+                start: 44,
+                endExclusive: 61),
+            4,
+            8);
+        Assert.InRange(
+            CountPaintedColumns(
+                pixels,
+                LargeSurfaceSize,
+                y: 64,
+                start: 96,
+                endExclusive: 128),
+            21,
+            27);
+    }
+
+    private static void AssertTransformFailsClosed(
+        DirectStrokeKind kind,
+        bool useStaticBuffer,
+        Matrix4x4 transform)
+    {
+        var pixels = RenderStroke(
+            kind,
+            vertical: false,
+            transform,
+            useStaticBuffer,
+            fullArc: kind == DirectStrokeKind.Arc);
+        Assert.Equal(0, CountPaintedPixels(pixels));
+    }
+
+    private static RenderCommand CreateAffinePolygonCommand(
+        AffinePolygonKind kind,
+        Matrix4x4 transform)
+    {
+        var pen = kind == AffinePolygonKind.Polyline
+            ? new Pen(
+                new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                12f,
+                PenLineJoin.Round,
+                startLineCap: PenLineCap.Round,
+                endLineCap: PenLineCap.Round)
+            : CreatePen();
+        var command = new RenderCommand
+        {
+            Pen = pen,
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
+        switch (kind)
+        {
+            case AffinePolygonKind.Line:
+                command.Type = RenderCommandType.DrawLine;
+                command.Position = new Vector2(24f, 64f);
+                command.Position2 = new Vector2(104f, 64f);
+                break;
+            case AffinePolygonKind.Quadratic:
+                command.Type = RenderCommandType.DrawBezier;
+                command.Position = new Vector2(24f, 72f);
+                command.Position2 = new Vector2(64f, 28f);
+                command.Position3 = new Vector2(104f, 72f);
+                break;
+            case AffinePolygonKind.Cubic:
+                command.Type = RenderCommandType.DrawCubicBezier;
+                command.Position = new Vector2(24f, 76f);
+                command.Position2 = new Vector2(40f, 20f);
+                command.Position3 = new Vector2(88f, 108f);
+                command.Position4 = new Vector2(104f, 52f);
+                break;
+            case AffinePolygonKind.Polyline:
+                command.Type = RenderCommandType.DrawPath;
+                command.Path = CreatePolylinePath();
+                command.GeometryCache = RenderCommandGeometryCache.ForPath(
+                    command.Path);
+                break;
+        }
+
+        return command;
+    }
+
+    private static PathGeometry CreatePolylinePath()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(28f, 84f));
+        figure.Segments.Add(new LineSegment(new Vector2(64f, 32f)));
+        figure.Segments.Add(new LineSegment(new Vector2(100f, 84f)));
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static RenderCommand CreateQuarterArcCommand(Matrix4x4 transform)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(64f, 40f));
+        figure.Segments.Add(new ArcSegment(
+            new Vector2(88f, 64f),
+            new Vector2(24f, 24f),
+            rotationAngle: 0f,
+            isLargeArc: false,
+            SweepDirection.Clockwise));
+        path.Figures.Add(figure);
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = CreatePen(),
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static byte[] RenderStaticAffineCommand(
+        RenderCommand command,
+        Matrix4x4 lateTransform,
+        out HashSet<int> shapeTypes)
+    {
+        using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
+        using var buffer = window.Compositor.CompileStaticDxf([command]);
+        shapeTypes = new HashSet<int>();
+        foreach (var vertex in buffer.VectorVertices)
+        {
+            shapeTypes.Add(DecodeShapeType(vertex.ShapeType));
+        }
+
+        window.Content = new StaticStrokeVisual(
+            buffer,
+            lateTransform,
+            LargeSurfaceSize);
+        window.Render();
+        return window.ReadPixels();
+    }
+
+    private static byte[] RenderDynamicAffineCommand(RenderCommand command)
+    {
+        using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
+        window.Content = new CommandVisual(command);
+        window.Render();
+        return window.ReadPixels();
+    }
+
+    private static int DecodeShapeType(float encodedShapeType)
+    {
+        if (encodedShapeType >= 1000f)
+        {
+            encodedShapeType -= 1000f;
+        }
+        if (encodedShapeType >= 195f)
+        {
+            encodedShapeType -= 200f;
+        }
+        else if (encodedShapeType >= 95f)
+        {
+            encodedShapeType -= 100f;
+        }
+
+        return (int)MathF.Round(encodedShapeType);
+    }
+
+    private static void AssertExpectedAffinePolygonShapeTypes(
+        AffinePolygonKind kind,
+        HashSet<int> shapeTypes)
+    {
+        switch (kind)
+        {
+            case AffinePolygonKind.Line:
+                Assert.Contains(14, shapeTypes);
+                break;
+            case AffinePolygonKind.Quadratic:
+            case AffinePolygonKind.Cubic:
+                Assert.Contains(15, shapeTypes);
+                Assert.Contains(16, shapeTypes);
+                Assert.Contains(17, shapeTypes);
+                break;
+            case AffinePolygonKind.Polyline:
+                Assert.Contains(13, shapeTypes);
+                Assert.Contains(14, shapeTypes);
+                break;
+        }
+    }
+
+    private static void AssertImagesNear(
+        byte[] expected,
+        byte[] actual,
+        int maximumAllowedDelta = 24,
+        int maximumMateriallyDifferentPixels = 128)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var maximumDelta = 0;
+        var materiallyDifferentPixels = 0;
+        for (var index = 2; index < expected.Length; index += 4)
+        {
+            var delta = Math.Abs(expected[index] - actual[index]);
+            maximumDelta = Math.Max(maximumDelta, delta);
+            if (delta > 8)
+            {
+                materiallyDifferentPixels++;
+            }
+        }
+
+        Assert.True(
+            maximumDelta <= maximumAllowedDelta &&
+                materiallyDifferentPixels <= maximumMateriallyDifferentPixels,
+            $"Affine render mismatch: max delta {maximumDelta}, " +
+            $"materially different pixels {materiallyDifferentPixels}.");
+    }
+
+    private static void AssertCoverageEquivalent(
+        byte[] expected,
+        byte[] actual,
+        int maximumMissingPixels,
+        int maximumExtraPixels)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var expectedOnly = 0;
+        var actualOnly = 0;
+        var expectedBounds = GetCoverageBounds(expected);
+        var actualBounds = GetCoverageBounds(actual);
+        for (var index = 2; index < expected.Length; index += 4)
+        {
+            var expectedCovered = expected[index] > 128;
+            var actualCovered = actual[index] > 128;
+            if (expectedCovered && !actualCovered)
+            {
+                expectedOnly++;
+            }
+            else if (actualCovered && !expectedCovered)
+            {
+                actualOnly++;
+            }
+        }
+
+        Assert.True(
+            expectedBounds == actualBounds &&
+                expectedOnly <= maximumMissingPixels &&
+                actualOnly <= maximumExtraPixels,
+            $"Coverage mismatch: expected bounds {expectedBounds}, actual bounds {actualBounds}, " +
+            $"missing pixels {expectedOnly}, extra pixels {actualOnly}.");
+    }
+
+    private static (int MinX, int MinY, int MaxX, int MaxY) GetCoverageBounds(byte[] pixels)
+    {
+        var minX = LargeSurfaceSize;
+        var minY = LargeSurfaceSize;
+        var maxX = -1;
+        var maxY = -1;
+        for (var y = 0; y < LargeSurfaceSize; y++)
+        {
+            for (var x = 0; x < LargeSurfaceSize; x++)
+            {
+                if (pixels[(y * LargeSurfaceSize + x) * 4 + 2] <= 128)
+                {
+                    continue;
+                }
+
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        return (minX, minY, maxX, maxY);
+    }
+
+    private static byte[] RenderStroke(
+        DirectStrokeKind kind,
+        bool vertical,
+        Matrix4x4 transform,
+        bool useStaticBuffer,
+        bool fullArc = false)
+    {
+        using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
+        DxfStaticBuffer? buffer = null;
+        if (useStaticBuffer)
+        {
+            var context = CreateStrokeContext(
+                kind,
+                vertical,
+                LargeSurfaceSize,
+                fullArc);
+            buffer = window.Compositor.CompileStaticDxf(context);
+            window.Content = new StaticStrokeVisual(
+                buffer,
+                transform,
+                LargeSurfaceSize);
+        }
+        else
+        {
+            window.Content = new GpuTransformStrokeVisual(
+                kind,
+                transform,
+                LargeSurfaceSize,
+                vertical,
+                fullArc);
+        }
+
+        try
+        {
+            window.Render();
+            return window.ReadPixels();
+        }
+        finally
+        {
+            buffer?.Dispose();
+        }
+    }
+
+    private static DrawingContext CreateStrokeContext(
+        DirectStrokeKind kind,
+        bool vertical = false,
+        int surfaceSize = SmallSurfaceSize,
+        bool fullArc = false)
+    {
+        var center = surfaceSize * 0.5f;
+        var start = surfaceSize == SmallSurfaceSize ? 0f : 16f;
+        var end = surfaceSize == SmallSurfaceSize ? 64f : 112f;
+        var p0 = vertical
+            ? new Vector2(center, start)
+            : new Vector2(start, center);
+        var p1 = vertical
+            ? new Vector2(center, end)
+            : new Vector2(end, center);
+        var control1 = Vector2.Lerp(p0, p1, 1f / 3f);
+        var control2 = Vector2.Lerp(p0, p1, 2f / 3f);
+
+        var context = new DrawingContext();
+        var pen = CreatePen();
+        switch (kind)
+        {
+            case DirectStrokeKind.Line:
+                context.DrawLine(pen, p0, p1);
+                break;
+            case DirectStrokeKind.Quadratic:
+                context.DrawQuadraticBezier(
+                    pen,
+                    p0,
+                    Vector2.Lerp(p0, p1, 0.5f),
+                    p1);
+                break;
+            case DirectStrokeKind.Cubic:
+                context.DrawCubicBezier(pen, p0, control1, control2, p1);
+                break;
+            case DirectStrokeKind.Arc:
+                context.DrawPath(
+                    null,
+                    pen,
+                    fullArc ? CreateFullArcPath(center) : CreateArcPath());
+                break;
+        }
+
+        return context;
+    }
+
+    private static Pen CreatePen() => new(
+        new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+        12f);
+
+    private static PathGeometry CreateArcPath()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(8f, 32f));
+        figure.Segments.Add(new ArcSegment(
+            new Vector2(56f, 32f),
+            new Vector2(24f, 24f),
+            rotationAngle: 0f,
+            isLargeArc: false,
+            SweepDirection.Clockwise));
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static PathGeometry CreateFullArcPath(float center)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(center - 24f, center));
+        figure.Segments.Add(new ArcSegment(
+            new Vector2(center + 24f, center),
+            new Vector2(24f, 24f),
+            rotationAngle: 0f,
+            isLargeArc: false,
+            SweepDirection.Clockwise));
+        figure.Segments.Add(new ArcSegment(
+            new Vector2(center - 24f, center),
+            new Vector2(24f, 24f),
+            rotationAngle: 0f,
+            isLargeArc: false,
+            SweepDirection.Clockwise));
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static int CountPaintedRows(
+        byte[] pixels,
+        int surfaceSize,
+        int x,
+        int start = 0,
+        int? endExclusive = null)
+    {
+        var count = 0;
+        for (var y = start; y < (endExclusive ?? surfaceSize); y++)
+        {
+            if (pixels[(y * surfaceSize + x) * 4 + 2] > 128)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountPaintedColumns(
+        byte[] pixels,
+        int surfaceSize,
+        int y,
+        int start = 0,
+        int? endExclusive = null)
+    {
+        var count = 0;
+        for (var x = start; x < (endExclusive ?? surfaceSize); x++)
+        {
+            if (pixels[(y * surfaceSize + x) * 4 + 2] > 128)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountPaintedPixels(byte[] pixels)
+    {
+        var count = 0;
+        for (var index = 2; index < pixels.Length; index += 4)
+        {
+            if (pixels[index] > 128)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private sealed class StaticStrokeVisual : FrameworkElement
+    {
+        private readonly DxfStaticBuffer _buffer;
+
+        public StaticStrokeVisual(
+            DxfStaticBuffer buffer,
+            Matrix4x4 transform,
+            int surfaceSize)
+        {
+            _buffer = buffer;
+            Width = surfaceSize;
+            Height = surfaceSize;
+            Transform = transform;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawStaticDxf(_buffer);
+    }
+
+    private sealed class GpuTransformStrokeVisual : FrameworkElement
+    {
+        private readonly DirectStrokeKind _kind;
+        private readonly Matrix4x4 _cameraView;
+        private readonly int _surfaceSize;
+        private readonly bool _vertical;
+        private readonly bool _fullArc;
+        private readonly Pen _pen = CreatePen();
+
+        public GpuTransformStrokeVisual(
+            DirectStrokeKind kind,
+            Matrix4x4 cameraView,
+            int surfaceSize,
+            bool vertical = false,
+            bool fullArc = false)
+        {
+            _kind = kind;
+            _cameraView = cameraView;
+            _surfaceSize = surfaceSize;
+            _vertical = vertical;
+            _fullArc = fullArc;
+            Width = surfaceSize;
+            Height = surfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var center = _surfaceSize * 0.5f;
+            var start = _surfaceSize == SmallSurfaceSize ? 0f : 16f;
+            var end = _surfaceSize == SmallSurfaceSize ? 64f : 112f;
+            var p0 = _vertical
+                ? new Vector2(center, start)
+                : new Vector2(start, center);
+            var p1 = _vertical
+                ? new Vector2(center, end)
+                : new Vector2(end, center);
+            var command = new RenderCommand
+            {
+                Pen = _pen,
+                Position = p0,
+                UseGpuTransforms = true,
+                CameraView = _cameraView
+            };
+            switch (_kind)
+            {
+                case DirectStrokeKind.Line:
+                    command.Type = RenderCommandType.DrawLine;
+                    command.Position2 = p1;
+                    break;
+                case DirectStrokeKind.Quadratic:
+                    command.Type = RenderCommandType.DrawBezier;
+                    command.Position2 = Vector2.Lerp(p0, p1, 0.5f);
+                    command.Position3 = p1;
+                    break;
+                case DirectStrokeKind.Cubic:
+                    command.Type = RenderCommandType.DrawCubicBezier;
+                    command.Position2 = Vector2.Lerp(p0, p1, 1f / 3f);
+                    command.Position3 = Vector2.Lerp(p0, p1, 2f / 3f);
+                    command.Position4 = p1;
+                    break;
+                case DirectStrokeKind.Arc:
+                    command.Type = RenderCommandType.DrawPath;
+                    command.Path = _fullArc
+                        ? CreateFullArcPath(center)
+                        : CreateArcPath();
+                    command.GeometryCache = RenderCommandGeometryCache.ForPath(
+                        command.Path);
+                    break;
+            }
+
+            context.Commands.Add(command);
+        }
+    }
+
+    private sealed class CommandVisual : FrameworkElement
+    {
+        private readonly RenderCommand _command;
+
+        public CommandVisual(RenderCommand command)
+        {
+            _command = command;
+            Width = LargeSurfaceSize;
+            Height = LargeSurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.Commands.Add(_command);
+    }
+
+    public enum AffinePolygonKind
+    {
+        Line,
+        Quadratic,
+        Cubic,
+        Polyline
+    }
+
+    public enum DirectStrokeKind
+    {
+        Line,
+        Quadratic,
+        Cubic,
+        Arc
+    }
+}

--- a/src/ProGPU.Tests/GpuTransformedStrokeScalingTests.cs
+++ b/src/ProGPU.Tests/GpuTransformedStrokeScalingTests.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using Microsoft.UI.Xaml;
 using ProGPU.Backend;
+using ProGPU.Dxf;
 using ProGPU.Scene;
 using ProGPU.Tests.Headless;
 using ProGPU.Vector;
@@ -305,6 +306,107 @@ public sealed class GpuTransformedStrokeScalingTests
             Marshal.OffsetOf<GpuUniforms>(nameof(GpuUniforms.Pad1)).ToInt32());
     }
 
+    [Theory]
+    [InlineData(DirectStrokeKind.Line)]
+    [InlineData(DirectStrokeKind.Quadratic)]
+    [InlineData(DirectStrokeKind.Cubic)]
+    public void FixedDeviceStaticStrokeKeepsPositiveWidthAcrossZoom(
+        DirectStrokeKind kind)
+    {
+        var zoomedOut = RenderStroke(
+            kind,
+            vertical: false,
+            ScaleAboutCenter(0.5f),
+            useStaticBuffer: true,
+            fixedDeviceStroke: true);
+        var zoomedIn = RenderStroke(
+            kind,
+            vertical: false,
+            ScaleAboutCenter(4f, 4f, LargeSurfaceSize),
+            useStaticBuffer: true,
+            fixedDeviceStroke: true);
+
+        var zoomedOutRows = CountPaintedRows(
+            zoomedOut,
+            LargeSurfaceSize,
+            x: LargeSurfaceSize / 2);
+        var zoomedInRows = CountPaintedRows(
+            zoomedIn,
+            LargeSurfaceSize,
+            x: LargeSurfaceSize / 2);
+
+        Assert.InRange(zoomedOutRows, 11, 13);
+        Assert.InRange(zoomedInRows, 11, 13);
+        Assert.InRange(Math.Abs(zoomedOutRows - zoomedInRows), 0, 1);
+    }
+
+    [Fact]
+    public void FixedDeviceStaticPolylineCapsAndJoinMatchBakedAffineCenterline()
+    {
+        var late = ScaleAboutCenter(1.6f, 0.7f, LargeSurfaceSize);
+        late.M21 += 0.35f;
+        var actual = RenderStaticAffineCommand(
+            CreateFixedPolylineCommand(Matrix4x4.Identity),
+            late,
+            out var shapeTypes);
+        var expected = RenderStaticAffineCommand(
+            CreateFixedPolylineCommand(late),
+            Matrix4x4.Identity,
+            out _);
+
+        Assert.Contains(22, shapeTypes);
+        Assert.Contains(23, shapeTypes);
+        AssertImagesNear(
+            expected,
+            actual,
+            maximumAllowedDelta: 8,
+            maximumMateriallyDifferentPixels: 32);
+    }
+
+    [Theory]
+    [InlineData(FixedAnalyticStrokeKind.Rectangle)]
+    [InlineData(FixedAnalyticStrokeKind.Ellipse)]
+    [InlineData(FixedAnalyticStrokeKind.RoundedRectangle)]
+    public void FixedDeviceStaticAnalyticStrokeKeepsPositiveWidthAcrossZoom(
+        FixedAnalyticStrokeKind kind)
+    {
+        var zoomedOut = RenderFixedAnalyticStroke(kind, 0.75f);
+        var zoomedIn = RenderFixedAnalyticStroke(kind, 2f);
+
+        var zoomedOutWidth = GetMaximumPaintedColumnRun(
+            zoomedOut,
+            LargeSurfaceSize,
+            y: LargeSurfaceSize / 2);
+        var zoomedInWidth = GetMaximumPaintedColumnRun(
+            zoomedIn,
+            LargeSurfaceSize,
+            y: LargeSurfaceSize / 2);
+
+        Assert.InRange(zoomedOutWidth, 11, 13);
+        Assert.InRange(zoomedInWidth, 11, 13);
+        Assert.InRange(Math.Abs(zoomedOutWidth - zoomedInWidth), 0, 1);
+    }
+
+    [Fact]
+    public void DxfStaticLineKeepsCosmeticWidthAcrossZoom()
+    {
+        var zoomedOut = RenderDxfLine(0.75f);
+        var zoomedIn = RenderDxfLine(2f);
+
+        var zoomedOutRows = CountPaintedRows(
+            zoomedOut,
+            LargeSurfaceSize,
+            x: LargeSurfaceSize / 2);
+        var zoomedInRows = CountPaintedRows(
+            zoomedIn,
+            LargeSurfaceSize,
+            x: LargeSurfaceSize / 2);
+
+        Assert.InRange(zoomedOutRows, 1, 2);
+        Assert.InRange(zoomedInRows, 1, 2);
+        Assert.InRange(Math.Abs(zoomedOutRows - zoomedInRows), 0, 1);
+    }
+
     private static Matrix4x4 ScaleAboutCenter(float scale) =>
         ScaleAboutCenter(scale, scale, SmallSurfaceSize);
 
@@ -453,6 +555,26 @@ public sealed class GpuTransformedStrokeScalingTests
         }
 
         return command;
+    }
+
+    private static RenderCommand CreateFixedPolylineCommand(Matrix4x4 transform)
+    {
+        var path = CreatePolylinePath();
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(
+                new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                12f,
+                PenLineJoin.Round,
+                startLineCap: PenLineCap.Round,
+                endLineCap: PenLineCap.Round,
+                strokeTransformMode: PenStrokeTransformMode.Fixed),
+            Transform = transform,
+            IsPenThicknessLocal = true
+        };
     }
 
     private static PathGeometry CreatePolylinePath()
@@ -645,7 +767,8 @@ public sealed class GpuTransformedStrokeScalingTests
         bool vertical,
         Matrix4x4 transform,
         bool useStaticBuffer,
-        bool fullArc = false)
+        bool fullArc = false,
+        bool fixedDeviceStroke = false)
     {
         using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
         DxfStaticBuffer? buffer = null;
@@ -655,7 +778,8 @@ public sealed class GpuTransformedStrokeScalingTests
                 kind,
                 vertical,
                 LargeSurfaceSize,
-                fullArc);
+                fullArc,
+                fixedDeviceStroke);
             buffer = window.Compositor.CompileStaticDxf(context);
             window.Content = new StaticStrokeVisual(
                 buffer,
@@ -687,7 +811,8 @@ public sealed class GpuTransformedStrokeScalingTests
         DirectStrokeKind kind,
         bool vertical = false,
         int surfaceSize = SmallSurfaceSize,
-        bool fullArc = false)
+        bool fullArc = false,
+        bool fixedDeviceStroke = false)
     {
         var center = surfaceSize * 0.5f;
         var start = surfaceSize == SmallSurfaceSize ? 0f : 16f;
@@ -702,7 +827,7 @@ public sealed class GpuTransformedStrokeScalingTests
         var control2 = Vector2.Lerp(p0, p1, 2f / 3f);
 
         var context = new DrawingContext();
-        var pen = CreatePen();
+        var pen = CreatePen(fixedDeviceStroke);
         switch (kind)
         {
             case DirectStrokeKind.Line:
@@ -729,9 +854,12 @@ public sealed class GpuTransformedStrokeScalingTests
         return context;
     }
 
-    private static Pen CreatePen() => new(
+    private static Pen CreatePen(bool fixedDeviceStroke = false) => new(
         new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
-        12f);
+        12f,
+        strokeTransformMode: fixedDeviceStroke
+            ? PenStrokeTransformMode.Fixed
+            : PenStrokeTransformMode.Normal);
 
     private static PathGeometry CreateArcPath()
     {
@@ -819,6 +947,102 @@ public sealed class GpuTransformedStrokeScalingTests
         return count;
     }
 
+    private static int GetMaximumPaintedColumnRun(
+        byte[] pixels,
+        int surfaceSize,
+        int y)
+    {
+        bool IsPainted(int x)
+        {
+            var offset = (y * surfaceSize + x) * 4;
+            return pixels[offset] > 128 ||
+                pixels[offset + 1] > 128 ||
+                pixels[offset + 2] > 128;
+        }
+
+        var maximum = 0;
+        var current = 0;
+        for (var x = 0; x < surfaceSize; x++)
+        {
+            if (IsPainted(x))
+            {
+                current++;
+                maximum = Math.Max(maximum, current);
+            }
+            else
+            {
+                current = 0;
+            }
+        }
+        return maximum;
+    }
+
+    private static byte[] RenderFixedAnalyticStroke(
+        FixedAnalyticStrokeKind kind,
+        float zoom)
+    {
+        const float radius = 20f;
+        var center = new Vector2(LargeSurfaceSize * 0.5f);
+        var context = new DrawingContext();
+        var pen = new Pen(
+            new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+            12f,
+            strokeTransformMode: PenStrokeTransformMode.Fixed);
+        var bounds = new Rect(
+            center.X - radius,
+            center.Y - radius,
+            radius * 2f,
+            radius * 2f);
+        switch (kind)
+        {
+            case FixedAnalyticStrokeKind.Rectangle:
+                context.DrawRectangle(null, pen, bounds);
+                break;
+            case FixedAnalyticStrokeKind.Ellipse:
+                context.DrawEllipse(null, pen, center, radius, radius);
+                break;
+            case FixedAnalyticStrokeKind.RoundedRectangle:
+                context.DrawRoundedRectangle(null, pen, bounds, 6f, 6f);
+                break;
+        }
+
+        using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
+        using var buffer = window.Compositor.CompileStaticDxf(context);
+        window.Content = new StaticStrokeVisual(
+            buffer,
+            ScaleAboutCenter(zoom, zoom, LargeSurfaceSize),
+            LargeSurfaceSize);
+        window.Render();
+        return window.ReadPixels();
+    }
+
+    private static byte[] RenderDxfLine(float zoom)
+    {
+        var document = new netDxf.DxfDocument();
+        document.AddEntity(new netDxf.Entities.Line(
+            new netDxf.Vector2(24d, LargeSurfaceSize * 0.5d),
+            new netDxf.Vector2(104d, LargeSurfaceSize * 0.5d)));
+
+        var drawingContext = new DrawingContext();
+        var dxfContext = new DxfRenderContext(drawingContext, null!)
+        {
+            EnableGpuTransforms = true,
+            IsCompilingStatic = true,
+            Zoom = zoom
+        };
+        dxfContext.ActiveLayers.Add("0");
+        DxfDocumentRenderer.Render(document, dxfContext);
+
+        using var window = new HeadlessWindow(LargeSurfaceSize, LargeSurfaceSize);
+        using var buffer = window.Compositor.CompileStaticDxf(drawingContext);
+        window.Content = new StaticStrokeVisual(
+            buffer,
+            ScaleAboutCenter(zoom, zoom, LargeSurfaceSize),
+            LargeSurfaceSize);
+        window.Render();
+        return window.ReadPixels();
+    }
+
     private sealed class StaticStrokeVisual : FrameworkElement
     {
         private readonly DxfStaticBuffer _buffer;
@@ -836,6 +1060,13 @@ public sealed class GpuTransformedStrokeScalingTests
 
         public override void OnRender(DrawingContext context) =>
             context.DrawStaticDxf(_buffer);
+    }
+
+    public enum FixedAnalyticStrokeKind
+    {
+        Rectangle,
+        Ellipse,
+        RoundedRectangle
     }
 
     private sealed class GpuTransformStrokeVisual : FrameworkElement

--- a/src/ProGPU.Tests/SkCanvasStateTests.cs
+++ b/src/ProGPU.Tests/SkCanvasStateTests.cs
@@ -2262,7 +2262,7 @@ public sealed class SkCanvasStateTests
     }
 
     [Fact]
-    public void DrawPathScalesStrokeWidthWithSetMatrix()
+    public void DrawPathKeepsStrokeWidthInLocalCoordinatesWithSetMatrix()
     {
         var context = new DrawingContext();
         using var canvas = new SKCanvas(context, 100f, 100f);
@@ -2287,8 +2287,47 @@ public sealed class SkCanvasStateTests
         var command = Assert.Single(context.Commands);
         Assert.Equal(RenderCommandType.DrawPath, command.Type);
         Assert.NotNull(command.Pen);
-        AssertNear(7.5f, command.Pen!.Thickness);
+        AssertNear(1.5f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
         AssertMatrixNear(matrix.ToMatrix4x4(), command.Transform);
+    }
+
+    [Fact]
+    public void DrawDashedPathRetainsAndReusesItsGeometryCache()
+    {
+        var context = new DrawingContext();
+        using var canvas = new SKCanvas(context, 100f, 100f);
+        using var path = new SKPath();
+        using var dash = SKPathEffect.CreateDash([6f, 3f], 1f);
+        using var paint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 2f,
+            PathEffect = dash
+        };
+
+        path.MoveTo(4f, 8f);
+        path.LineTo(80f, 8f);
+        canvas.DrawPath(path, paint);
+
+        var command = Assert.Single(context.Commands);
+        Assert.Equal(RenderCommandType.DrawPath, command.Type);
+        Assert.NotNull(command.Path);
+        Assert.NotNull(command.Pen);
+        Assert.NotNull(command.GeometryCache);
+        Assert.Same(command.Path, command.GeometryCache!.StrokePath);
+        Assert.Same(command.Path, command.GeometryCache.FillPath);
+
+        Assert.True(command.GeometryCache.TryGetDashedStrokePath(
+            command.Pen!,
+            out var firstPath,
+            out var firstPen));
+        Assert.True(command.GeometryCache.TryGetDashedStrokePath(
+            command.Pen!,
+            out var secondPath,
+            out var secondPen));
+        Assert.Same(firstPath, secondPath);
+        Assert.Same(firstPen, secondPen);
     }
 
     [Fact]
@@ -2308,7 +2347,8 @@ public sealed class SkCanvasStateTests
         var command = Assert.Single(context.Commands);
         Assert.Equal(RenderCommandType.DrawRect, command.Type);
         Assert.NotNull(command.Pen);
-        AssertNear(0.25f, command.Pen!.Thickness);
+        Assert.True(command.Pen!.IsHairline);
+        Assert.Equal(Pen.HairlineThickness, command.Pen.Thickness);
         Assert.True(command.IsPenThicknessLocal);
         AssertMatrixNear(Matrix4x4.CreateScale(4f, 4f, 1f), command.Transform);
     }

--- a/src/ProGPU.Tests/SkCanvasStateTests.cs
+++ b/src/ProGPU.Tests/SkCanvasStateTests.cs
@@ -2331,6 +2331,42 @@ public sealed class SkCanvasStateTests
     }
 
     [Fact]
+    public void DashedAnalyticPrimitivesRetainSourceStrokePaths()
+    {
+        var context = new DrawingContext();
+        using var canvas = new SKCanvas(context, 100f, 100f);
+        using var dash = SKPathEffect.CreateDash([6f, 3f], 1f);
+        using var paint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 2f,
+            PathEffect = dash
+        };
+
+        canvas.DrawRect(new SKRect(4f, 6f, 40f, 30f), paint);
+        canvas.DrawRoundRect(new SKRect(8f, 10f, 52f, 42f), 7f, 5f, paint);
+        canvas.DrawOval(new SKRect(12f, 14f, 60f, 48f), paint);
+        canvas.DrawCircle(38f, 36f, 18f, paint);
+
+        Assert.Collection(
+            context.Commands,
+            command => AssertDashedPrimitiveCache(command, RenderCommandType.DrawRect),
+            command => AssertDashedPrimitiveCache(command, RenderCommandType.DrawRoundedRect),
+            command => AssertDashedPrimitiveCache(command, RenderCommandType.DrawEllipse),
+            command => AssertDashedPrimitiveCache(command, RenderCommandType.DrawCircle));
+    }
+
+    private static void AssertDashedPrimitiveCache(
+        RenderCommand command,
+        RenderCommandType expectedType)
+    {
+        Assert.Equal(expectedType, command.Type);
+        Assert.True(command.Pen?.HasDashPattern);
+        Assert.NotNull(command.GeometryCache?.StrokePath);
+        Assert.NotEmpty(command.GeometryCache!.StrokePath!.Figures);
+    }
+
+    [Fact]
     public void DrawRectMapsZeroStrokeWidthToRenderableHairline()
     {
         var context = new DrawingContext();

--- a/src/ProGPU.Tests/SkCanvasStateTests.cs
+++ b/src/ProGPU.Tests/SkCanvasStateTests.cs
@@ -1697,6 +1697,50 @@ public sealed class SkCanvasStateTests
         Assert.Equal((byte)0, pixels[(60 * 64 + 37) * 4 + 3]);
     }
 
+    [Theory]
+    [InlineData(SKPaintStyle.Stroke)]
+    [InlineData(SKPaintStyle.StrokeAndFill)]
+    public void SpecialShaderPreservesTransformedHairlineStroke(
+        SKPaintStyle style)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(
+            80,
+            80,
+            SKColorType.Rgba8888,
+            SKAlphaType.Premul));
+        using var colorShader = SKShader.CreateColor(SKColors.Red);
+        using var colorFilter = SKColorFilter.CreateLumaColor();
+        using var shader = colorShader.WithColorFilter(colorFilter);
+        using var paint = new SKPaint
+        {
+            Shader = shader,
+            Style = style,
+            StrokeWidth = 0f,
+            StrokeCap = SKStrokeCap.Butt,
+            IsAntialias = false
+        };
+        using var path = new SKPath();
+        path.AddRect(new SKRect(8f, 8f, 24f, 24f));
+
+        surface.Canvas.Clear(SKColors.Transparent);
+        surface.Canvas.SetMatrix(SKMatrix.CreateScale(2f, 3f));
+        surface.Canvas.DrawPath(path, paint);
+        surface.Flush();
+
+        using var snapshot = surface.Snapshot();
+        byte[] pixels = snapshot.Texture.ReadPixels();
+        Assert.True(pixels[(24 * 80 + 24) * 4 + 3] > 0);
+        Assert.Equal((byte)0, pixels[(22 * 80 + 24) * 4 + 3]);
+        if (style == SKPaintStyle.StrokeAndFill)
+        {
+            Assert.True(pixels[(40 * 80 + 32) * 4 + 3] > 0);
+        }
+        else
+        {
+            Assert.Equal((byte)0, pixels[(40 * 80 + 32) * 4 + 3]);
+        }
+    }
+
     [Fact]
     public void DrawTextWithStrokePaintRendersGlyphOutlines()
     {

--- a/src/ProGPU.Tests/SkPictureSerializationCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPictureSerializationCompatibilityTests.cs
@@ -9,6 +9,81 @@ namespace ProGPU.Tests;
 public sealed class SkPictureSerializationCompatibilityTests
 {
     [Fact]
+    public void ArchiveRebuildsRetainedStrokeGeometryCachesOnce()
+    {
+        var recorder = new GpuPictureRecorder();
+        var context = recorder.BeginRecording(new Rect(0f, 0f, 64f, 64f));
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 3f,
+            lineJoin: PenLineJoin.Round,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle,
+            dashCap: PenLineCap.Square,
+            dashArray: [2d, 1d]);
+        context.DrawLine(pen, new Vector2(2f, 4f), new Vector2(18f, 4f));
+        context.DrawQuadraticBezier(
+            pen,
+            new Vector2(2f, 10f),
+            new Vector2(10f, 2f),
+            new Vector2(18f, 10f));
+        context.DrawCubicBezier(
+            pen,
+            new Vector2(2f, 16f),
+            new Vector2(6f, 8f),
+            new Vector2(14f, 24f),
+            new Vector2(18f, 16f));
+        context.DrawPolyline(
+            pen,
+            [new Vector2(2f, 24f), new Vector2(10f, 18f), new Vector2(18f, 24f)]);
+        context.DrawSpline(
+            pen,
+            [new Vector2(2f, 32f), new Vector2(8f, 26f), new Vector2(14f, 38f), new Vector2(20f, 32f)],
+            [0d, 0d, 0d, 1d, 2d, 2d, 2d],
+            degree: 2);
+        var maskPath = RenderCommandGeometryCache.CreateLinePath(
+            new Vector2(2f, 42f),
+            new Vector2(20f, 42f));
+        context.PushOpacityMask(
+            maskPath,
+            pen,
+            new Rect(0f, 38f, 24f, 8f),
+            Matrix4x4.Identity);
+        context.PopOpacityMask();
+
+        using var gpuPicture = recorder.EndRecording();
+        using var picture = new SKPicture(
+            gpuPicture,
+            new SKRect(0f, 0f, 64f, 64f));
+        using var data = picture.Serialize();
+        using var copy = SKPicture.Deserialize(data);
+
+        var commands = copy!.Picture.Commands;
+        Assert.NotNull(commands[0].GeometryCache?.StrokePath);
+        Assert.NotNull(commands[1].GeometryCache?.StrokePath);
+        Assert.NotNull(commands[2].GeometryCache?.StrokePath);
+        Assert.NotNull(commands[3].GeometryCache?.StrokePath);
+        Assert.NotNull(commands[4].GeometryCache?.StrokePath);
+        Assert.NotNull(commands[5].GeometryCache?.StrokePath);
+        Assert.Same(commands[5].Path, commands[5].GeometryCache?.StrokePath);
+
+        for (var index = 0; index < 6; index++)
+        {
+            var cache = Assert.IsType<RenderCommandGeometryCache>(commands[index].GeometryCache);
+            Assert.True(cache.TryGetDashedStrokePath(
+                commands[index].Pen!,
+                out var firstPath,
+                out var firstPen));
+            Assert.True(cache.TryGetDashedStrokePath(
+                commands[index].Pen!,
+                out var secondPath,
+                out var secondPen));
+            Assert.Same(firstPath, secondPath);
+            Assert.Same(firstPen, secondPen);
+        }
+    }
+
+    [Fact]
     public void VectorArchiveRoundTripsPathsBrushesPensAndBuffers()
     {
         var path = new PathGeometry { FillRule = FillRule.EvenOdd };
@@ -106,6 +181,8 @@ public sealed class SkPictureSerializationCompatibilityTests
         Assert.Equal(FillRule.EvenOdd, actual.Path!.FillRule);
         Assert.False(Assert.Single(actual.Path.Figures).IsFilled);
         Assert.IsType<ArcSegment>(actual.Path.Figures[0].Segments[^1]);
+        Assert.Same(actual.Path, actual.GeometryCache?.StrokePath);
+        Assert.Same(actual.Path, actual.GeometryCache?.FillPath);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/SkPictureSerializationCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPictureSerializationCompatibilityTests.cs
@@ -126,7 +126,8 @@ public sealed class SkPictureSerializationCompatibilityTests
             endLineCap: PenLineCap.Round,
             dashCap: PenLineCap.Triangle,
             dashArray: [2d, 4d],
-            dashOffset: 1.5d);
+            dashOffset: 1.5d,
+            strokeTransformMode: PenStrokeTransformMode.Fixed);
         var command = new RenderCommand
         {
             Type = RenderCommandType.DrawPath,
@@ -178,11 +179,39 @@ public sealed class SkPictureSerializationCompatibilityTests
         Assert.Equal(stops.Length, actualBrush.Stops.Length);
         Assert.Equal(pen.DashArray, actual.Pen!.DashArray);
         Assert.Equal(PenLineCap.Triangle, actual.Pen.DashCap);
+        Assert.Equal(PenStrokeTransformMode.Fixed, actual.Pen.StrokeTransformMode);
         Assert.Equal(FillRule.EvenOdd, actual.Path!.FillRule);
         Assert.False(Assert.Single(actual.Path.Figures).IsFilled);
         Assert.IsType<ArcSegment>(actual.Path.Figures[0].Segments[^1]);
         Assert.Same(actual.Path, actual.GeometryCache?.StrokePath);
         Assert.Same(actual.Path, actual.GeometryCache?.FillPath);
+    }
+
+    [Fact]
+    public void VersionTwoArchiveDefaultsPenStrokeTransformModeToNormal()
+    {
+        var command = new RenderCommand
+        {
+            Type = RenderCommandType.DrawLine,
+            Position = new Vector2(2f, 4f),
+            Position2 = new Vector2(18f, 4f),
+            Pen = new Pen(
+                new SolidColorBrush(Vector4.One),
+                3f,
+                strokeTransformMode: PenStrokeTransformMode.Fixed),
+            IsPenThicknessLocal = true
+        };
+        var picture = new GpuPicture([command], [], [], [], []);
+        var bytes = PictureArchive.Serialize(
+            picture,
+            new SKRect(0f, 0f, 24f, 8f),
+            archiveVersion: 2);
+
+        using var copy = SKPicture.Deserialize(bytes);
+
+        Assert.NotNull(copy);
+        var actual = Assert.Single(copy.Picture.Commands);
+        Assert.Equal(PenStrokeTransformMode.Normal, actual.Pen!.StrokeTransformMode);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/SkPictureSerializationCompatibilityTests.cs
+++ b/src/ProGPU.Tests/SkPictureSerializationCompatibilityTests.cs
@@ -9,7 +9,7 @@ namespace ProGPU.Tests;
 public sealed class SkPictureSerializationCompatibilityTests
 {
     [Fact]
-    public void ArchiveRebuildsRetainedStrokeGeometryCachesOnce()
+    public void ArchiveRebuildsOnlyIntrinsicStrokeGeometryCaches()
     {
         var recorder = new GpuPictureRecorder();
         var context = recorder.BeginRecording(new Rect(0f, 0f, 64f, 64f));
@@ -62,12 +62,12 @@ public sealed class SkPictureSerializationCompatibilityTests
         Assert.NotNull(commands[0].GeometryCache?.StrokePath);
         Assert.NotNull(commands[1].GeometryCache?.StrokePath);
         Assert.NotNull(commands[2].GeometryCache?.StrokePath);
-        Assert.NotNull(commands[3].GeometryCache?.StrokePath);
-        Assert.NotNull(commands[4].GeometryCache?.StrokePath);
+        Assert.Null(commands[3].GeometryCache);
+        Assert.Null(commands[4].GeometryCache);
         Assert.NotNull(commands[5].GeometryCache?.StrokePath);
         Assert.Same(commands[5].Path, commands[5].GeometryCache?.StrokePath);
 
-        for (var index = 0; index < 6; index++)
+        foreach (var index in new[] { 0, 1, 2, 5 })
         {
             var cache = Assert.IsType<RenderCommandGeometryCache>(commands[index].GeometryCache);
             Assert.True(cache.TryGetDashedStrokePath(

--- a/src/ProGPU.Tests/SkiaHairlineRenderingTests.cs
+++ b/src/ProGPU.Tests/SkiaHairlineRenderingTests.cs
@@ -323,7 +323,7 @@ public sealed class SkiaHairlineRenderingTests
         Assert.Equal(arcMax.X + 2f, vertexMax.X, 3);
         Assert.Equal(arcMax.Y + 2f, vertexMax.Y, 3);
         Assert.Contains(
-            "2.0 / directStrokeScales.y - 2.0",
+            "retainedPadding / directStrokeScales.y - retainedPadding",
             Shaders.VectorShader);
     }
 

--- a/src/ProGPU.Tests/SkiaHairlineRenderingTests.cs
+++ b/src/ProGPU.Tests/SkiaHairlineRenderingTests.cs
@@ -1,0 +1,803 @@
+using System;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class SkiaHairlineRenderingTests
+{
+    private const int SurfaceSize = 128;
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void AnisotropicDirectLineRemainsOneDevicePixel(
+        bool vertical,
+        bool useStaticBuffer)
+    {
+        var transform = ScaleAboutCenter(2f, 0.5f);
+        var pixels = useStaticBuffer
+            ? RenderStatic(CreateLineCommand(vertical), transform)
+            : RenderDynamic(CreateGpuLineCommand(vertical, transform));
+        var crossSection = vertical
+            ? CountPaintedColumns(pixels, y: SurfaceSize / 2)
+            : CountPaintedRows(pixels, x: SurfaceSize / 2);
+
+        Assert.InRange(crossSection, 1, 2);
+    }
+
+    [Theory]
+    [InlineData(HairlinePrimitiveKind.Quadratic)]
+    [InlineData(HairlinePrimitiveKind.Cubic)]
+    [InlineData(HairlinePrimitiveKind.Rectangle)]
+    [InlineData(HairlinePrimitiveKind.Ellipse)]
+    [InlineData(HairlinePrimitiveKind.RoundedRectangle)]
+    [InlineData(HairlinePrimitiveKind.Arc)]
+    public void DynamicGpuHairlineMatchesCpuBakedReference(
+        HairlinePrimitiveKind kind)
+    {
+        var transform = ScaleAndShearAboutCenter(1.75f, 0.55f, 0.4f);
+        var actual = CreatePrimitiveCommand(kind);
+        actual.UseGpuTransforms = true;
+        actual.CameraView = transform;
+        var expected = CreatePrimitiveCommand(kind);
+        expected.Transform = transform;
+        expected.IsPenThicknessLocal = true;
+
+        AssertImagesNear(RenderDynamic(expected), RenderDynamic(actual));
+    }
+
+    [Fact]
+    public void HairlineRoundedRectangleNeverEntersFillOnlySolidSpecialization()
+    {
+        using var window = new HeadlessWindow(SurfaceSize, SurfaceSize);
+        window.Content = new RoundedSpecializationPrimerVisual();
+        window.Render();
+
+        var hairline = CreatePrimitiveCommand(
+            HairlinePrimitiveKind.RoundedRectangle);
+        window.Content = new CommandVisual(hairline);
+        window.Render();
+        var pixels = window.ReadPixels();
+
+        Assert.True(CountPaintedPixels(pixels) > 0);
+        var center = pixels[((64 * SurfaceSize + 64) * 4) + 2];
+        var background = pixels[((8 * SurfaceSize + 8) * 4) + 2];
+        Assert.InRange(Math.Abs(center - background), 0, 1);
+    }
+
+    [Fact]
+    public void DynamicGpuPathHairlineRegeneratesRoundCapsAndJoinInDeviceSpace()
+    {
+        var transform = ScaleAndShearAboutCenter(2f, 0.5f, 0.45f);
+        var actual = CreateJoinedPathCommand();
+        actual.UseGpuTransforms = true;
+        actual.CameraView = transform;
+        var expected = CreateJoinedPathCommand();
+        expected.Transform = transform;
+        expected.IsPenThicknessLocal = true;
+
+        var actualPixels = RenderDynamic(actual);
+        var expectedPixels = RenderDynamic(expected);
+
+        Assert.True(CountPaintedPixels(expectedPixels) > 0);
+        AssertImagesNear(expectedPixels, actualPixels, maximumDifferentPixels: 0);
+    }
+
+    [Fact]
+    public void DynamicGpuPictureRegeneratesNestedHairlinePathInDeviceSpace()
+    {
+        var transform = ScaleAndShearAboutCenter(1.9f, 0.55f, 0.3f);
+        using var picture = new GpuPicture(
+            [CreateJoinedPathCommand()],
+            [],
+            [],
+            [],
+            []);
+        var actual = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPicture,
+            Picture = picture,
+            UseGpuTransforms = true,
+            CameraView = transform
+        };
+        var expected = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPicture,
+            Picture = picture,
+            Transform = transform
+        };
+
+        AssertImagesNear(
+            RenderDynamic(expected),
+            RenderDynamic(actual),
+            maximumDifferentPixels: 0);
+    }
+
+    [Fact]
+    public void StaticLateAffineArcHairlineMatchesDynamicDeviceHairline()
+    {
+        var transform = ScaleAndShearAboutCenter(1.8f, 0.6f, 0.35f);
+        var staticPixels = RenderStatic(
+            CreatePrimitiveCommand(HairlinePrimitiveKind.Arc),
+            transform);
+        var dynamicCommand = CreatePrimitiveCommand(HairlinePrimitiveKind.Arc);
+        dynamicCommand.UseGpuTransforms = true;
+        dynamicCommand.CameraView = transform;
+        var dynamicPixels = RenderDynamic(dynamicCommand);
+
+        Assert.True(CountPaintedPixels(staticPixels) > 0);
+        AssertImagesNear(
+            dynamicPixels,
+            staticPixels,
+            maximumDifferentPixels: 48);
+    }
+
+    [Fact]
+    public void StaticLateDownscaledArcHairlineRetainsDevicePixelHalo()
+    {
+        var transform = ScaleAndShearAboutCenter(0.22f, 0.12f, 0.35f);
+        var staticPixels = RenderStatic(
+            CreatePrimitiveCommand(HairlinePrimitiveKind.Arc),
+            transform);
+        var dynamicCommand = CreatePrimitiveCommand(HairlinePrimitiveKind.Arc);
+        dynamicCommand.Transform = transform;
+        dynamicCommand.IsPenThicknessLocal = true;
+        var dynamicPixels = RenderDynamic(dynamicCommand);
+
+        Assert.True(CountPaintedPixels(dynamicPixels) > 0);
+        AssertImagesNear(
+            dynamicPixels,
+            staticPixels,
+            maximumDifferentPixels: 0);
+    }
+
+    [Theory]
+    [InlineData(PenLineCap.Flat)]
+    [InlineData(PenLineCap.Square)]
+    [InlineData(PenLineCap.Round)]
+    [InlineData(PenLineCap.Triangle)]
+    public void StaticLateHairlineCapMatchesDeviceSpaceReference(
+        PenLineCap lineCap)
+    {
+        var transform = ScaleAndShearAboutCenter(1.9f, 0.45f, 0.55f);
+        var command = CreateCappedPathCommand(lineCap);
+        var expected = command;
+        expected.Transform = transform;
+        expected.IsPenThicknessLocal = true;
+
+        var staticPixels = RenderStatic(command, transform);
+        var expectedPixels = RenderDynamic(expected);
+
+        Assert.True(CountPaintedPixels(expectedPixels) > 0);
+        AssertImagesNear(expectedPixels, staticPixels, maximumDifferentPixels: 0);
+    }
+
+    [Theory]
+    [InlineData(PenLineCap.Flat)]
+    [InlineData(PenLineCap.Square)]
+    [InlineData(PenLineCap.Round)]
+    [InlineData(PenLineCap.Triangle)]
+    public void IdentityHairlineCapMatchesOrdinaryOnePixelGeometry(
+        PenLineCap lineCap)
+    {
+        var hairlinePixels = RenderDynamic(CreateCappedPathCommand(lineCap));
+        var onePixelPixels = RenderDynamic(CreateCappedPathCommand(
+            lineCap,
+            thickness: 1f));
+
+        AssertImagesNear(
+            onePixelPixels,
+            hairlinePixels,
+            maximumDifferentPixels: 12);
+    }
+
+    [Theory]
+    [InlineData(PenLineJoin.Miter)]
+    [InlineData(PenLineJoin.Bevel)]
+    [InlineData(PenLineJoin.Round)]
+    public void StaticLateHairlineJoinMatchesDeviceSpaceReference(
+        PenLineJoin lineJoin)
+    {
+        var transform = ScaleAndShearAboutCenter(1.85f, 0.5f, 0.5f);
+        var command = CreateJoinedPathCommand(lineJoin, PenLineCap.Flat);
+        var expected = command;
+        expected.Transform = transform;
+        expected.IsPenThicknessLocal = true;
+
+        var staticPixels = RenderStatic(command, transform);
+        var expectedPixels = RenderDynamic(expected);
+
+        Assert.True(CountPaintedPixels(expectedPixels) > 0);
+        AssertImagesNear(expectedPixels, staticPixels, maximumDifferentPixels: 0);
+    }
+
+    [Theory]
+    [InlineData(PenLineJoin.Miter)]
+    [InlineData(PenLineJoin.Bevel)]
+    [InlineData(PenLineJoin.Round)]
+    public void IdentityHairlineJoinMatchesOrdinaryOnePixelGeometry(
+        PenLineJoin lineJoin)
+    {
+        var hairlinePixels = RenderDynamic(CreateAxisAlignedJoinedPathCommand(
+            lineJoin,
+            thickness: Pen.HairlineThickness));
+        var onePixelPixels = RenderDynamic(CreateAxisAlignedJoinedPathCommand(
+            lineJoin,
+            thickness: 1f));
+
+        AssertImagesNear(
+            onePixelPixels,
+            hairlinePixels,
+            maximumDifferentPixels: 12);
+    }
+
+    [Fact]
+    public void DynamicGpuDashedHairlineRegeneratesDashCapsInDeviceSpace()
+    {
+        var transform = ScaleAndShearAboutCenter(2f, 0.5f, 0.4f);
+        var actual = CreateDashedPathCommand();
+        actual.UseGpuTransforms = true;
+        actual.CameraView = transform;
+        var expected = CreateDashedPathCommand();
+        expected.Transform = transform;
+        expected.IsPenThicknessLocal = true;
+
+        AssertImagesNear(
+            RenderDynamic(expected),
+            RenderDynamic(actual),
+            maximumDifferentPixels: 0);
+    }
+
+    [Fact]
+    public void DynamicGpuUnequalRoundedRectangleHairlineUsesExactPathFallback()
+    {
+        var transform = ScaleAndShearAboutCenter(1.8f, 0.5f, 0.45f);
+        var actual = new RenderCommand
+        {
+            Type = RenderCommandType.DrawRoundedRect,
+            Rect = new Rect(28f, 34f, 72f, 58f),
+            RadiusX = 16f,
+            RadiusY = 9f,
+            Pen = CreateHairlinePen(),
+            IsPenThicknessLocal = true,
+            UseGpuTransforms = true,
+            CameraView = transform
+        };
+        var expected = actual;
+        expected.UseGpuTransforms = false;
+        expected.CameraView = default;
+        expected.Transform = transform;
+
+        AssertImagesNear(
+            RenderDynamic(expected),
+            RenderDynamic(actual),
+            maximumDifferentPixels: 0);
+    }
+
+    [Fact]
+    public void StaticHairlineArcRecordsTwoUnitHaloAndLateScaleExpansion()
+    {
+        var command = CreatePrimitiveCommand(HairlinePrimitiveKind.Arc);
+        var figure = Assert.Single(command.Path!.Figures);
+        var arc = Assert.IsType<ArcSegment>(Assert.Single(figure.Segments));
+        Assert.True(ArcSegmentGeometry.TryGetArcBounds(
+            figure.StartPoint,
+            arc,
+            out var arcMin,
+            out var arcMax));
+
+        using var window = new HeadlessWindow(SurfaceSize, SurfaceSize);
+        var context = new DrawingContext();
+        context.Commands.Add(command);
+        using var buffer = window.Compositor.CompileStaticDxf(context);
+        var vertexMin = new Vector2(float.PositiveInfinity);
+        var vertexMax = new Vector2(float.NegativeInfinity);
+        var arcVertexCount = 0;
+        foreach (var vertex in buffer.VectorVertices)
+        {
+            var shapeType = vertex.ShapeType >= 195f
+                ? vertex.ShapeType - 200f
+                : vertex.ShapeType;
+            if (MathF.Abs(shapeType - 12f) > 0.01f)
+            {
+                continue;
+            }
+
+            Assert.Equal(Pen.HairlineThickness, vertex.StrokeThickness);
+            vertexMin = Vector2.Min(vertexMin, vertex.Position);
+            vertexMax = Vector2.Max(vertexMax, vertex.Position);
+            arcVertexCount++;
+        }
+
+        Assert.Equal(4, arcVertexCount);
+        Assert.Equal(arcMin.X - 2f, vertexMin.X, 3);
+        Assert.Equal(arcMin.Y - 2f, vertexMin.Y, 3);
+        Assert.Equal(arcMax.X + 2f, vertexMax.X, 3);
+        Assert.Equal(arcMax.Y + 2f, vertexMax.Y, 3);
+        Assert.Contains(
+            "2.0 / directStrokeScales.y - 2.0",
+            Shaders.VectorShader);
+    }
+
+    [Fact]
+    public void HairlineRoundCapsAndJoinUseOneFixedQuadPerAdornment()
+    {
+        var command = CreateJoinedPathCommand();
+        using var window = new HeadlessWindow(SurfaceSize, SurfaceSize);
+        var context = new DrawingContext();
+        context.Commands.Add(command);
+        using var buffer = window.Compositor.CompileStaticDxf(context);
+        var capVertexCount = 0;
+        var joinVertexCount = 0;
+        foreach (var vertex in buffer.VectorVertices)
+        {
+            var shapeType = vertex.ShapeType >= 195f
+                ? vertex.ShapeType - 200f
+                : vertex.ShapeType;
+            if (MathF.Abs(shapeType - 22f) <= 0.01f)
+            {
+                capVertexCount++;
+            }
+            else if (MathF.Abs(shapeType - 23f) <= 0.01f)
+            {
+                joinVertexCount++;
+            }
+        }
+
+        Assert.Equal(8, capVertexCount);
+        Assert.Equal(4, joinVertexCount);
+    }
+
+    [Fact]
+    public void NegativePolygonPayloadCoordinateDoesNotBecomeHairlineSentinel()
+    {
+        Assert.Contains(
+            "(isAnalyticSdf || isDirect2DStroke) &&\n        input.strokeThickness == -1.0;",
+            Shaders.VectorShader);
+
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(-24f, -12f));
+        figure.Segments.Add(new LineSegment(new Vector2(0f, -38f)));
+        figure.Segments.Add(new LineSegment(new Vector2(26f, -8f)));
+        path.Figures.Add(figure);
+        var transform = Matrix4x4.CreateScale(1.6f, 0.7f, 1f) *
+            Matrix4x4.CreateTranslation(64f, 64f, 0f);
+        var actual = new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(
+                CreateBrush(),
+                8f,
+                PenLineJoin.Round,
+                startLineCap: PenLineCap.Round,
+                endLineCap: PenLineCap.Round),
+            IsPenThicknessLocal = true,
+            UseGpuTransforms = true,
+            CameraView = transform
+        };
+        var expected = actual;
+        expected.UseGpuTransforms = false;
+        expected.CameraView = default;
+        expected.Transform = transform;
+
+        var actualPixels = RenderDynamic(actual);
+        Assert.True(CountPaintedPixels(actualPixels) > 0);
+        AssertImagesNear(
+            RenderDynamic(expected),
+            actualPixels,
+            maximumDifferentPixels: 256);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GpuHitTestHairlineUsesOnePixelScreenSpaceWidth(bool vertical)
+    {
+        var transform = Matrix4x4.CreateScale(4f, 0.5f, 1f);
+        var command = CreateLineCommand(vertical);
+        var builder = new GpuRenderCommandHitTestCacheBuilder();
+        builder.AddCommand(command, transform, id: 41);
+        var index = builder.BuildIndex();
+
+        using var context = new WgpuContext();
+        context.Initialize(null);
+        var center = vertical
+            ? Vector2.Transform(new Vector2(64f, 64f), transform)
+            : Vector2.Transform(new Vector2(64f, 64f), transform);
+        var inside = center + (vertical
+            ? new Vector2(0.49f, 0f)
+            : new Vector2(0f, 0.49f));
+        var outside = center + (vertical
+            ? new Vector2(0.75f, 0f)
+            : new Vector2(0f, 0.75f));
+
+        Assert.True(GpuHitTestEngine.TryHitTestPoint(
+            context,
+            index,
+            inside,
+            out var result));
+        Assert.Equal(41, result.Id);
+        Assert.False(GpuHitTestEngine.TryHitTestPoint(
+            context,
+            index,
+            outside,
+            out _));
+    }
+
+    [Fact]
+    public void OrdinaryZeroAndNegativePensRemainNonRenderingAndNonHittable()
+    {
+        foreach (var thickness in new[] { 0f, -2f })
+        {
+            var command = new RenderCommand
+            {
+                Type = RenderCommandType.DrawLine,
+                Position = new Vector2(16f, 64f),
+                Position2 = new Vector2(112f, 64f),
+                Pen = new Pen(CreateBrush(), thickness),
+                IsPenThicknessLocal = true
+            };
+            Assert.Equal(0, CountPaintedPixels(RenderDynamic(command)));
+
+            var builder = new GpuRenderCommandHitTestCacheBuilder();
+            builder.AddCommand(command, Matrix4x4.Identity);
+            Assert.Equal(0, builder.PrimitiveCount);
+        }
+    }
+
+    private static RenderCommand CreateLineCommand(bool vertical)
+    {
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawLine,
+            Position = vertical
+                ? new Vector2(64f, 20f)
+                : new Vector2(20f, 64f),
+            Position2 = vertical
+                ? new Vector2(64f, 108f)
+                : new Vector2(108f, 64f),
+            Pen = CreateHairlinePen(),
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static RenderCommand CreateGpuLineCommand(
+        bool vertical,
+        Matrix4x4 transform)
+    {
+        var command = CreateLineCommand(vertical);
+        command.UseGpuTransforms = true;
+        command.CameraView = transform;
+        return command;
+    }
+
+    private static RenderCommand CreatePrimitiveCommand(HairlinePrimitiveKind kind)
+    {
+        var command = new RenderCommand
+        {
+            Pen = CreateHairlinePen(),
+            IsPenThicknessLocal = true
+        };
+        switch (kind)
+        {
+            case HairlinePrimitiveKind.Quadratic:
+                command.Type = RenderCommandType.DrawBezier;
+                command.Position = new Vector2(24f, 76f);
+                command.Position2 = new Vector2(64f, 24f);
+                command.Position3 = new Vector2(104f, 76f);
+                break;
+            case HairlinePrimitiveKind.Cubic:
+                command.Type = RenderCommandType.DrawCubicBezier;
+                command.Position = new Vector2(24f, 80f);
+                command.Position2 = new Vector2(40f, 18f);
+                command.Position3 = new Vector2(88f, 110f);
+                command.Position4 = new Vector2(104f, 48f);
+                break;
+            case HairlinePrimitiveKind.Rectangle:
+                command.Type = RenderCommandType.DrawRect;
+                command.Rect = new Rect(30f, 34f, 68f, 56f);
+                break;
+            case HairlinePrimitiveKind.Ellipse:
+                command.Type = RenderCommandType.DrawEllipse;
+                command.Position2 = new Vector2(64f, 64f);
+                command.RadiusX = 34f;
+                command.RadiusY = 25f;
+                break;
+            case HairlinePrimitiveKind.RoundedRectangle:
+                command.Type = RenderCommandType.DrawRoundedRect;
+                command.Rect = new Rect(30f, 34f, 68f, 56f);
+                command.RadiusX = 12f;
+                command.RadiusY = 12f;
+                break;
+            case HairlinePrimitiveKind.Arc:
+                var path = new PathGeometry();
+                var figure = new PathFigure(new Vector2(32f, 64f));
+                figure.Segments.Add(new ArcSegment(
+                    new Vector2(96f, 64f),
+                    new Vector2(32f, 26f),
+                    rotationAngle: 18f,
+                    isLargeArc: false,
+                    SweepDirection.Clockwise));
+                path.Figures.Add(figure);
+                command.Type = RenderCommandType.DrawPath;
+                command.Path = path;
+                command.GeometryCache = RenderCommandGeometryCache.ForPath(path);
+                break;
+        }
+
+        return command;
+    }
+
+    private static RenderCommand CreateCappedPathCommand(
+        PenLineCap lineCap,
+        float thickness = Pen.HairlineThickness)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(30f, 64f));
+        figure.Segments.Add(new LineSegment(new Vector2(98f, 64f)));
+        path.Figures.Add(figure);
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(
+                CreateBrush(),
+                thickness,
+                startLineCap: lineCap,
+                endLineCap: lineCap),
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static RenderCommand CreateJoinedPathCommand(
+        PenLineJoin lineJoin = PenLineJoin.Round,
+        PenLineCap lineCap = PenLineCap.Round,
+        float thickness = Pen.HairlineThickness)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(26f, 82f));
+        figure.Segments.Add(new LineSegment(new Vector2(62f, 34f)));
+        figure.Segments.Add(new LineSegment(new Vector2(102f, 78f)));
+        path.Figures.Add(figure);
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(
+                CreateBrush(),
+                thickness,
+                lineJoin,
+                startLineCap: lineCap,
+                endLineCap: lineCap),
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static RenderCommand CreateDashedPathCommand()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(18f, 64f));
+        figure.Segments.Add(new LineSegment(new Vector2(110f, 64f)));
+        path.Figures.Add(figure);
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(
+                CreateBrush(),
+                Pen.HairlineThickness,
+                dashCap: PenLineCap.Round,
+                dashArray: new double[] { 7d, 4d }),
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static RenderCommand CreateAxisAlignedJoinedPathCommand(
+        PenLineJoin lineJoin,
+        float thickness)
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(28f, 64f));
+        figure.Segments.Add(new LineSegment(new Vector2(64f, 64f)));
+        figure.Segments.Add(new LineSegment(new Vector2(64f, 28f)));
+        path.Figures.Add(figure);
+        return new RenderCommand
+        {
+            Type = RenderCommandType.DrawPath,
+            Path = path,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
+            Pen = new Pen(
+                CreateBrush(),
+                thickness,
+                lineJoin,
+                startLineCap: PenLineCap.Flat,
+                endLineCap: PenLineCap.Flat),
+            IsPenThicknessLocal = true
+        };
+    }
+
+    private static byte[] RenderDynamic(RenderCommand command)
+    {
+        using var window = new HeadlessWindow(SurfaceSize, SurfaceSize);
+        window.Content = new CommandVisual(command);
+        window.Render();
+        return window.ReadPixels();
+    }
+
+    private static byte[] RenderStatic(RenderCommand command, Matrix4x4 transform)
+    {
+        using var window = new HeadlessWindow(SurfaceSize, SurfaceSize);
+        var context = new DrawingContext();
+        context.Commands.Add(command);
+        using var buffer = window.Compositor.CompileStaticDxf(context);
+        window.Content = new StaticVisual(buffer, transform);
+        window.Render();
+        return window.ReadPixels();
+    }
+
+    private static Matrix4x4 ScaleAboutCenter(float scaleX, float scaleY)
+    {
+        return Matrix4x4.CreateTranslation(-64f, -64f, 0f) *
+            Matrix4x4.CreateScale(scaleX, scaleY, 1f) *
+            Matrix4x4.CreateTranslation(64f, 64f, 0f);
+    }
+
+    private static Matrix4x4 ScaleAndShearAboutCenter(
+        float scaleX,
+        float scaleY,
+        float shearX)
+    {
+        var shear = Matrix4x4.Identity;
+        shear.M21 = shearX;
+        return Matrix4x4.CreateTranslation(-64f, -64f, 0f) *
+            Matrix4x4.CreateScale(scaleX, scaleY, 1f) *
+            shear *
+            Matrix4x4.CreateTranslation(64f, 64f, 0f);
+    }
+
+    private static Pen CreateHairlinePen() => new(
+        CreateBrush(),
+        Pen.HairlineThickness);
+
+    private static SolidColorBrush CreateBrush() => new(
+        new Vector4(0f, 0f, 1f, 1f));
+
+    private static int CountPaintedRows(byte[] pixels, int x)
+    {
+        var count = 0;
+        for (var y = 0; y < SurfaceSize; y++)
+        {
+            if (pixels[(y * SurfaceSize + x) * 4 + 2] > 128)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int CountPaintedColumns(byte[] pixels, int y)
+    {
+        var count = 0;
+        for (var x = 0; x < SurfaceSize; x++)
+        {
+            if (pixels[(y * SurfaceSize + x) * 4 + 2] > 128)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int CountPaintedPixels(byte[] pixels)
+    {
+        var count = 0;
+        for (var index = 2; index < pixels.Length; index += 4)
+        {
+            if (pixels[index] > 128)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static void AssertImagesNear(
+        byte[] expected,
+        byte[] actual,
+        int maximumDifferentPixels = 24)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var differentPixels = 0;
+        for (var index = 2; index < expected.Length; index += 4)
+        {
+            if (Math.Abs(expected[index] - actual[index]) > 8)
+            {
+                differentPixels++;
+            }
+        }
+
+        Assert.True(
+            differentPixels <= maximumDifferentPixels,
+            $"Hairline render mismatch: {differentPixels} pixels differ.");
+    }
+
+    private sealed class CommandVisual : FrameworkElement
+    {
+        private readonly RenderCommand _command;
+
+        public CommandVisual(RenderCommand command)
+        {
+            _command = command;
+            Width = SurfaceSize;
+            Height = SurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.Commands.Add(_command);
+    }
+
+    private sealed class StaticVisual : FrameworkElement
+    {
+        private readonly DxfStaticBuffer _buffer;
+
+        public StaticVisual(DxfStaticBuffer buffer, Matrix4x4 transform)
+        {
+            _buffer = buffer;
+            Transform = transform;
+            Width = SurfaceSize;
+            Height = SurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawStaticDxf(_buffer);
+    }
+
+    private sealed class RoundedSpecializationPrimerVisual : FrameworkElement
+    {
+        private readonly Pen _pen = new(CreateBrush(), 2f);
+
+        public RoundedSpecializationPrimerVisual()
+        {
+            Width = SurfaceSize;
+            Height = SurfaceSize;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            for (var index = 0; index < 40; index++)
+            {
+                var column = index % 8;
+                var row = index / 8;
+                context.DrawRoundedRectangle(
+                    null,
+                    _pen,
+                    new Rect(4f + column * 15f, 4f + row * 15f, 10f, 10f),
+                    3f,
+                    3f);
+            }
+        }
+    }
+
+    public enum HairlinePrimitiveKind
+    {
+        Quadratic,
+        Cubic,
+        Rectangle,
+        Ellipse,
+        RoundedRectangle,
+        Arc
+    }
+}

--- a/src/ProGPU.Tests/StaticCommandTransformTests.cs
+++ b/src/ProGPU.Tests/StaticCommandTransformTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class StaticCommandTransformTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StaticCompilationAppliesRecordedLineTransformOnce(bool useCommandList)
+    {
+        using var window = new HeadlessWindow(64, 64);
+        var command = new RenderCommand
+        {
+            Type = RenderCommandType.DrawLine,
+            Pen = new Pen(
+                new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                12f),
+            Position = new Vector2(4f, 16f),
+            Position2 = new Vector2(12f, 16f),
+            Transform = Matrix4x4.CreateScale(2f, 2f, 1f),
+            IsPenThicknessLocal = true
+        };
+
+        using var buffer = useCommandList
+            ? window.Compositor.CompileStaticDxf(new List<RenderCommand> { command })
+            : CompileContext(window.Compositor, command);
+
+        var vertices = buffer.VectorVertices
+            .Where(static vertex => MathF.Abs(vertex.ShapeType - 203f) < 0.01f)
+            .ToArray();
+        Assert.Equal(4, vertices.Length);
+        Assert.All(vertices, static vertex => Assert.Equal(24f, vertex.StrokeThickness, 3));
+        Assert.Equal(8f, vertices.Min(static vertex => vertex.Position.X), 3);
+        Assert.Equal(24f, vertices.Max(static vertex => vertex.Position.X), 3);
+        Assert.All(vertices, static vertex => Assert.Equal(32f, vertex.Position.Y, 3));
+    }
+
+    [Fact]
+    public void DiagnosticCompilationAppliesRecordedLineTransformOnce()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new EmptyVisual();
+        window.Compositor.RenderDiagnostics = (context, _, _) =>
+            context.Commands.Add(new RenderCommand
+            {
+                Type = RenderCommandType.DrawLine,
+                Pen = new Pen(
+                    new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                    12f),
+                Position = new Vector2(4f, 16f),
+                Position2 = new Vector2(12f, 16f),
+                Transform = Matrix4x4.CreateScale(2f, 2f, 1f),
+                IsPenThicknessLocal = true
+            });
+
+        window.Render();
+
+        var vertices = window.Compositor.VectorVertices
+            .Where(static vertex => MathF.Abs(vertex.ShapeType - 3f) < 0.01f)
+            .ToArray();
+        Assert.Equal(4, vertices.Length);
+        Assert.All(vertices, static vertex => Assert.Equal(24f, vertex.StrokeThickness, 3));
+        Assert.Equal(8f, vertices.Min(static vertex => vertex.Position.X), 3);
+        Assert.Equal(24f, vertices.Max(static vertex => vertex.Position.X), 3);
+        Assert.All(vertices, static vertex => Assert.Equal(32f, vertex.Position.Y, 3));
+    }
+
+    [Fact]
+    public void StaticSplineExtensionAppliesRecordedTransformOnce()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        var context = new DrawingContext();
+        context.DrawSpline(
+            new Pen(
+                new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                12f),
+            [new Vector2(4f, 16f), new Vector2(12f, 16f)],
+            [0d, 0d, 1d, 1d],
+            degree: 1);
+        var command = context.Commands[0];
+        command.Transform = Matrix4x4.CreateScale(2f, 2f, 1f);
+        command.IsPenThicknessLocal = true;
+        context.Commands[0] = command;
+
+        using var buffer = window.Compositor.CompileStaticDxf(context);
+
+        var vertices = buffer.VectorVertices
+            .Where(static vertex => MathF.Abs(vertex.ShapeType - 203f) < 0.01f)
+            .ToArray();
+        Assert.NotEmpty(vertices);
+        Assert.All(vertices, static vertex => Assert.Equal(24f, vertex.StrokeThickness, 3));
+        Assert.Equal(8f, vertices.Min(static vertex => vertex.Position.X), 3);
+        Assert.Equal(24f, vertices.Max(static vertex => vertex.Position.X), 3);
+        Assert.All(vertices, static vertex => Assert.Equal(32f, vertex.Position.Y, 3));
+    }
+
+    private static DxfStaticBuffer CompileContext(
+        Compositor compositor,
+        RenderCommand command)
+    {
+        var context = new DrawingContext();
+        context.Commands.Add(command);
+        return compositor.CompileStaticDxf(context);
+    }
+
+    private sealed class EmptyVisual : FrameworkElement
+    {
+        public EmptyVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+    }
+}

--- a/src/ProGPU.Tests/StaticDxfRenderTests.cs
+++ b/src/ProGPU.Tests/StaticDxfRenderTests.cs
@@ -186,6 +186,27 @@ public sealed class StaticDxfRenderTests
     }
 
     [Fact]
+    public void CompileStaticDxfBakesExplicitTransformForQuadExtensions()
+    {
+        var context = new DrawingContext();
+        context.DrawExtension(
+            CompositorBuiltInExtensions.ShaderToy,
+            dataParam: new ProGPU.Scene.Extensions.ShaderToyParams
+            {
+                Rect = new Rect(2f, 4f, 10f, 12f)
+            },
+            transform: Matrix4x4.CreateTranslation(20f, 30f, 0f));
+
+        using var buffer = HeadlessWindow.Shared.Compositor.CompileStaticDxf(context);
+
+        Assert.NotEmpty(buffer.VectorVertices);
+        Assert.Equal(22f, buffer.VectorVertices.Min(vertex => vertex.Position.X));
+        Assert.Equal(32f, buffer.VectorVertices.Max(vertex => vertex.Position.X));
+        Assert.Equal(34f, buffer.VectorVertices.Min(vertex => vertex.Position.Y));
+        Assert.Equal(46f, buffer.VectorVertices.Max(vertex => vertex.Position.Y));
+    }
+
+    [Fact]
     public void DrawStaticDxfSplineHonorsActiveBlendMode()
     {
         var window = HeadlessWindow.Shared;

--- a/src/ProGPU.Tests/StaticDxfRenderTests.cs
+++ b/src/ProGPU.Tests/StaticDxfRenderTests.cs
@@ -133,6 +133,59 @@ public sealed class StaticDxfRenderTests
     }
 
     [Fact]
+    public void AppendedStaticDxfTranslationIsAppliedExactlyOnce()
+    {
+        using var window = new HeadlessWindow(72, 40);
+        using var buffer = CreateStaticRect(window.Compositor, new Rect(0, 8, 16, 24));
+        window.Content = new AppendedStaticDxfVisual(buffer, new Vector2(20f, 0f));
+
+        window.Render();
+
+        var pixels = window.ReadPixels();
+        var translated = ReadPixel(pixels, window.Width, x: 28, y: 20);
+        var doubleTranslated = ReadPixel(pixels, window.Width, x: 48, y: 20);
+        Assert.True(translated.R >= 220, $"Expected the appended DXF at one translation, found {translated}.");
+        Assert.True(translated.G <= 35 && translated.B <= 35, $"Expected red appended DXF content, found {translated}.");
+        Assert.True(doubleTranslated.R <= 35, $"Expected no double-translated DXF content, found {doubleTranslated}.");
+    }
+
+    [Fact]
+    public void CompileStaticDxfAppliesAppendedLineAndHatchTransforms()
+    {
+        var compositor = HeadlessWindow.Shared.Compositor;
+        var translation = new Vector2(20f, 30f);
+        var pen = new Pen(new SolidColorBrush(Vector4.One), 2f);
+
+        var sourceLine = new DrawingContext();
+        sourceLine.DrawLine3D(
+            pen,
+            new Vector3(0f, 0f, 0f),
+            new Vector3(10f, 0f, 0f));
+        var appendedLine = new DrawingContext();
+        appendedLine.Append(sourceLine, translation);
+        using var lineBuffer = compositor.CompileStaticDxf(appendedLine);
+
+        Assert.NotEmpty(lineBuffer.VectorVertices);
+        Assert.Equal(20f, lineBuffer.VectorVertices.Min(vertex => vertex.Position.X));
+        Assert.Equal(30f, lineBuffer.VectorVertices.Max(vertex => vertex.Position.X));
+        Assert.All(lineBuffer.VectorVertices, vertex => Assert.Equal(30f, vertex.Position.Y));
+
+        var sourceHatch = new DrawingContext();
+        sourceHatch.DrawHatch(
+            new SolidColorBrush(Vector4.One),
+            PrimitivePathGeometry.CreateRectangle(0f, 0f, 10f, 12f));
+        var appendedHatch = new DrawingContext();
+        appendedHatch.Append(sourceHatch, translation);
+        using var hatchBuffer = compositor.CompileStaticDxf(appendedHatch);
+
+        Assert.NotEmpty(hatchBuffer.VectorVertices);
+        Assert.Equal(20f, hatchBuffer.VectorVertices.Min(vertex => vertex.Position.X));
+        Assert.Equal(30f, hatchBuffer.VectorVertices.Max(vertex => vertex.Position.X));
+        Assert.Equal(30f, hatchBuffer.VectorVertices.Min(vertex => vertex.Position.Y));
+        Assert.Equal(42f, hatchBuffer.VectorVertices.Max(vertex => vertex.Position.Y));
+    }
+
+    [Fact]
     public void DrawStaticDxfSplineHonorsActiveBlendMode()
     {
         var window = HeadlessWindow.Shared;
@@ -466,6 +519,27 @@ public sealed class StaticDxfRenderTests
         public override void OnRender(DrawingContext context)
         {
             context.DrawStaticDxf(_buffer);
+        }
+    }
+
+    private sealed class AppendedStaticDxfVisual : FrameworkElement
+    {
+        private readonly DxfStaticBuffer _buffer;
+        private readonly Vector2 _translation;
+
+        public AppendedStaticDxfVisual(DxfStaticBuffer buffer, Vector2 translation)
+        {
+            _buffer = buffer;
+            _translation = translation;
+            Width = 72f;
+            Height = 40f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var source = new DrawingContext();
+            source.DrawStaticDxf(_buffer);
+            context.Append(source, _translation);
         }
     }
 

--- a/src/ProGPU.Tests/StrokeTransformProvenanceTests.cs
+++ b/src/ProGPU.Tests/StrokeTransformProvenanceTests.cs
@@ -155,6 +155,47 @@ public sealed class StrokeTransformProvenanceTests
     }
 
     [Fact]
+    public void AffineBezierSubdivisionAdaptsToDeviceSpaceCurvature()
+    {
+        var quadraticStart = Vector2.Zero;
+        var quadraticControl = new Vector2(1f, 100f);
+        var quadraticEnd = new Vector2(2f, 0f);
+        var cubicControl1 = new Vector2(1f, 100f);
+        var cubicControl2 = new Vector2(2f, -100f);
+        var cubicEnd = new Vector2(3f, 0f);
+
+        int quadraticBase = Compositor.GetAffineQuadraticSegmentCount(
+            quadraticStart,
+            quadraticControl,
+            quadraticEnd,
+            Matrix4x4.Identity);
+        int quadraticMagnified = Compositor.GetAffineQuadraticSegmentCount(
+            quadraticStart,
+            quadraticControl,
+            quadraticEnd,
+            Matrix4x4.CreateScale(1f, 100f, 1f));
+        int cubicBase = Compositor.GetAffineCubicSegmentCount(
+            quadraticStart,
+            cubicControl1,
+            cubicControl2,
+            cubicEnd,
+            Matrix4x4.Identity);
+        int cubicMagnified = Compositor.GetAffineCubicSegmentCount(
+            quadraticStart,
+            cubicControl1,
+            cubicControl2,
+            cubicEnd,
+            Matrix4x4.CreateScale(1f, 100f, 1f));
+
+        Assert.InRange(quadraticBase, 24, 1024);
+        Assert.InRange(cubicBase, 24, 1024);
+        Assert.True(quadraticMagnified > quadraticBase);
+        Assert.True(cubicMagnified > cubicBase);
+        Assert.InRange(quadraticMagnified, 25, 1024);
+        Assert.InRange(cubicMagnified, 25, 1024);
+    }
+
+    [Fact]
     public void WpfGeometryKeepsRawPenAcrossComposedTransforms()
     {
         var nativeContext = new DrawingContext();

--- a/src/ProGPU.Tests/StrokeTransformProvenanceTests.cs
+++ b/src/ProGPU.Tests/StrokeTransformProvenanceTests.cs
@@ -80,7 +80,7 @@ public sealed class StrokeTransformProvenanceTests
     }
 
     [Fact]
-    public void DashedCurveAndIndexedStrokeRecordersRetainGeometryCaches()
+    public void DashedCurvesRetainCachesWhileIndexedRecordersStayCacheFree()
     {
         var context = new DrawingContext();
         var pen = new Pen(
@@ -109,9 +109,49 @@ public sealed class StrokeTransformProvenanceTests
             degree: 1);
 
         Assert.Equal(4, context.Commands.Count);
-        Assert.All(
-            context.Commands,
-            static command => Assert.NotNull(command.GeometryCache?.StrokePath));
+        Assert.NotNull(context.Commands[0].GeometryCache?.StrokePath);
+        Assert.NotNull(context.Commands[1].GeometryCache?.StrokePath);
+        Assert.Null(context.Commands[2].GeometryCache);
+        Assert.Null(context.Commands[3].GeometryCache);
+    }
+
+    [Fact]
+    public void IndexedStrokeRecordingIsAllocationFreeAfterWarmup()
+    {
+        var context = new DrawingContext();
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            thickness: 2f,
+            lineJoin: PenLineJoin.Round,
+            startLineCap: PenLineCap.Round,
+            endLineCap: PenLineCap.Triangle);
+        Vector2[] polylinePoints =
+        [
+            Vector2.Zero,
+            new Vector2(4f, 8f),
+            new Vector2(12f, 2f)
+        ];
+        Vector2[] splinePoints =
+        [
+            Vector2.Zero,
+            new Vector2(4f, 8f),
+            new Vector2(8f, -2f),
+            new Vector2(12f, 2f)
+        ];
+        double[] knots = [0d, 0d, 0d, 1d, 2d, 2d, 2d];
+
+        RecordIndexedStrokes(context, pen, polylinePoints, splinePoints, knots);
+        context.Clear();
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (int iteration = 0; iteration < 256; iteration++)
+        {
+            RecordIndexedStrokes(context, pen, polylinePoints, splinePoints, knots);
+            context.Clear();
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.Equal(0, allocated);
     }
 
     [Fact]
@@ -285,6 +325,17 @@ public sealed class StrokeTransformProvenanceTests
         Assert.Equal(PenLineJoin.Bevel, command.Pen.LineJoin);
         Assert.Equal(3f, command.Pen.Thickness);
         Assert.True(command.IsPenThicknessLocal);
+    }
+
+    private static void RecordIndexedStrokes(
+        DrawingContext context,
+        Pen pen,
+        Vector2[] polylinePoints,
+        Vector2[] splinePoints,
+        double[] knots)
+    {
+        context.DrawPolyline(pen, polylinePoints);
+        context.DrawSpline(pen, splinePoints, knots, degree: 2);
     }
 
     private static PathGeometry CreatePath()

--- a/src/ProGPU.Tests/StrokeTransformProvenanceTests.cs
+++ b/src/ProGPU.Tests/StrokeTransformProvenanceTests.cs
@@ -1,0 +1,298 @@
+using System.Numerics;
+using ProGPU.Scene;
+using ProGPU.Vector;
+using Xunit;
+using WpfBrushes = System.Windows.Media.Brushes;
+using WpfDrawingContext = System.Windows.Media.DrawingContext;
+using WpfMatrix = System.Windows.Media.Matrix;
+using WpfMatrixTransform = System.Windows.Media.MatrixTransform;
+using WpfPen = System.Windows.Media.Pen;
+using WpfRect = System.Windows.Rect;
+using WpfRectangleGeometry = System.Windows.Media.RectangleGeometry;
+using GdiColor = System.Drawing.Color;
+using GdiGraphics = System.Drawing.Graphics;
+using GdiGraphicsPath = System.Drawing.Drawing2D.GraphicsPath;
+using GdiLineCap = System.Drawing.Drawing2D.LineCap;
+using GdiLineJoin = System.Drawing.Drawing2D.LineJoin;
+using GdiPen = System.Drawing.Pen;
+using GdiPoint = System.Drawing.Point;
+using GdiPointF = System.Drawing.PointF;
+
+namespace ProGPU.Tests;
+
+public sealed class StrokeTransformProvenanceTests
+{
+    [Fact]
+    public void SceneTransformOverloadsMarkRawPenThicknessAsLocal()
+    {
+        var context = new DrawingContext();
+        var pen = new Pen(new SolidColorBrush(Vector4.One), 2f);
+        var path = CreatePath();
+        var cache = RenderCommandGeometryCache.ForPath(path);
+        var transform = Matrix4x4.CreateScale(2f, 3f, 1f);
+
+        context.DrawRectangle(null, pen, new Rect(1f, 2f, 3f, 4f), transform);
+        context.DrawPath(null, pen, path, transform);
+        context.DrawPath(null, pen, path, transform, cache);
+        context.DrawEllipse(null, pen, new Vector2(5f, 6f), 7f, 8f, transform);
+        context.DrawRoundedRectangle(
+            null,
+            pen,
+            new Rect(1f, 2f, 30f, 40f),
+            3f,
+            4f,
+            transform);
+        context.PushOpacityMask(path, pen, new Rect(0f, 0f, 20f, 20f), transform);
+
+        Assert.Equal(6, context.Commands.Count);
+        Assert.All(
+            context.Commands,
+            command =>
+            {
+                Assert.Same(pen, command.Pen);
+                Assert.Equal(transform, command.Transform);
+                Assert.True(command.IsPenThicknessLocal);
+            });
+    }
+
+    [Fact]
+    public void TransformOverloadsDoNotTagFillOnlyCommandsAsLocalStrokes()
+    {
+        var context = new DrawingContext();
+        var brush = new SolidColorBrush(Vector4.One);
+        var path = CreatePath();
+        var transform = Matrix4x4.CreateScale(2f, 3f, 1f);
+
+        context.DrawRectangle(brush, null, new Rect(1f, 2f, 3f, 4f), transform);
+        context.DrawPath(brush, null, path, transform);
+        context.DrawEllipse(brush, null, new Vector2(5f, 6f), 7f, 8f, transform);
+        context.DrawRoundedRectangle(
+            brush,
+            null,
+            new Rect(1f, 2f, 30f, 40f),
+            3f,
+            4f,
+            transform);
+
+        Assert.All(
+            context.Commands,
+            command => Assert.False(command.IsPenThicknessLocal));
+    }
+
+    [Fact]
+    public void DashedCurveAndIndexedStrokeRecordersRetainGeometryCaches()
+    {
+        var context = new DrawingContext();
+        var pen = new Pen(
+            new SolidColorBrush(Vector4.One),
+            2f,
+            dashArray: [2d, 1d]);
+
+        context.DrawQuadraticBezier(
+            pen,
+            Vector2.Zero,
+            new Vector2(5f, 0f),
+            new Vector2(10f, 0f));
+        context.DrawCubicBezier(
+            pen,
+            Vector2.Zero,
+            new Vector2(3f, 0f),
+            new Vector2(7f, 0f),
+            new Vector2(10f, 0f));
+        context.DrawPolyline(
+            pen,
+            [Vector2.Zero, new Vector2(10f, 0f)]);
+        context.DrawSpline(
+            pen,
+            [Vector2.Zero, new Vector2(10f, 0f)],
+            [0d, 0d, 1d, 1d],
+            degree: 1);
+
+        Assert.Equal(4, context.Commands.Count);
+        Assert.All(
+            context.Commands,
+            static command => Assert.NotNull(command.GeometryCache?.StrokePath));
+    }
+
+    [Fact]
+    public void WpfGeometryKeepsRawPenAcrossComposedTransforms()
+    {
+        var nativeContext = new DrawingContext();
+        using var context = new WpfDrawingContext(nativeContext);
+        var outerTransform = new WpfMatrix
+        {
+            M11 = 3,
+            M22 = 3
+        };
+        var geometryTransform = new WpfMatrix
+        {
+            M11 = 2,
+            M22 = 2
+        };
+        var geometry = new WpfRectangleGeometry(
+            new WpfRect(0, 0, 20, 10),
+            0,
+            0,
+            new WpfMatrixTransform(geometryTransform));
+
+        context.PushTransform(new WpfMatrixTransform(outerTransform));
+        context.DrawGeometry(
+            brush: null,
+            pen: new WpfPen(WpfBrushes.Black, 2),
+            geometry);
+
+        RenderCommand command = Assert.Single(nativeContext.Commands);
+        Assert.Equal(RenderCommandType.DrawPath, command.Type);
+        Assert.Equal(2f, command.Pen!.Thickness);
+        Assert.Equal(Matrix4x4.CreateScale(6f, 6f, 1f), command.Transform);
+        Assert.True(command.IsPenThicknessLocal);
+    }
+
+    [Fact]
+    public void SystemDrawingPathKeepsRawPenAcrossAnisotropicTransform()
+    {
+        var nativeContext = new DrawingContext();
+        using var graphics = GdiGraphics.FromProGpuDrawingContext(
+            nativeContext,
+            Matrix4x4.Identity);
+        using var pen = new GdiPen(GdiColor.Red, 2f);
+        using var path = new GdiGraphicsPath();
+        path.AddLine(1f, 2f, 5f, 2f);
+
+        graphics.ScaleTransform(4f, 1f);
+        graphics.DrawPath(pen, path);
+
+        RenderCommand command = Assert.Single(nativeContext.Commands);
+        Assert.Equal(RenderCommandType.DrawPath, command.Type);
+        Assert.Equal(2f, command.Pen!.Thickness);
+        Assert.Equal(Matrix4x4.CreateScale(4f, 1f, 1f), command.Transform);
+        Assert.True(command.IsPenThicknessLocal);
+    }
+
+    [Fact]
+    public void SystemDrawingAnalyticStrokesUseLocalPathsUnderAnisotropicTransform()
+    {
+        var nativeContext = new DrawingContext();
+        using var graphics = GdiGraphics.FromProGpuDrawingContext(
+            nativeContext,
+            Matrix4x4.Identity);
+        using var pen = new GdiPen(GdiColor.Red, 2f);
+
+        graphics.ScaleTransform(4f, 1f);
+        graphics.DrawRectangle(pen, 1f, 2f, 10f, 8f);
+        graphics.DrawEllipse(pen, 3f, 4f, 12f, 6f);
+
+        Assert.Collection(
+            nativeContext.Commands,
+            command => AssertLocalPathStroke(command, pen.Width),
+            command => AssertLocalPathStroke(command, pen.Width));
+    }
+
+    [Fact]
+    public void SystemDrawingLineKeepsLocalEndpointsAndRawPenUnderShear()
+    {
+        var nativeContext = new DrawingContext();
+        using var graphics = GdiGraphics.FromProGpuDrawingContext(
+            nativeContext,
+            Matrix4x4.Identity);
+        using var pen = new GdiPen(GdiColor.Red, 2f);
+        using var transform = new System.Drawing.Drawing2D.Matrix(
+            2f,
+            0.5f,
+            0.75f,
+            1f,
+            8f,
+            9f);
+        graphics.Transform = transform;
+
+        graphics.DrawLine(pen, 1f, 2f, 5f, 7f);
+
+        var command = Assert.Single(nativeContext.Commands);
+        Assert.Equal(RenderCommandType.DrawLine, command.Type);
+        Assert.Equal(new Vector2(1f, 2f), command.Position);
+        Assert.Equal(new Vector2(5f, 7f), command.Position2);
+        Assert.Equal(2f, command.Pen!.Thickness);
+        Assert.Equal(
+            new Matrix4x4(
+                2f, 0.5f, 0f, 0f,
+                0.75f, 1f, 0f, 0f,
+                0f, 0f, 1f, 0f,
+                8f, 9f, 0f, 1f),
+            command.Transform);
+        Assert.True(command.IsPenThicknessLocal);
+    }
+
+    [Fact]
+    public void SystemDrawingLinesRetainOneConnectedPathWithEndpointCapsAndJoins()
+    {
+        var nativeContext = new DrawingContext();
+        using var graphics = GdiGraphics.FromProGpuDrawingContext(
+            nativeContext,
+            Matrix4x4.Identity);
+        using var pen = new GdiPen(GdiColor.Red, 3f)
+        {
+            StartCap = GdiLineCap.Round,
+            EndCap = GdiLineCap.Triangle,
+            LineJoin = GdiLineJoin.Bevel
+        };
+        using var transform = new System.Drawing.Drawing2D.Matrix(
+            1.5f,
+            0.25f,
+            0.5f,
+            0.75f,
+            4f,
+            6f);
+        graphics.Transform = transform;
+
+        graphics.DrawLines(
+            pen,
+            [
+                new GdiPointF(1f, 2f),
+                new GdiPointF(5f, 8f),
+                new GdiPointF(11f, 3f)
+            ]);
+        graphics.DrawLines(
+            pen,
+            [
+                new GdiPoint(2, 3),
+                new GdiPoint(7, 9),
+                new GdiPoint(13, 4)
+            ]);
+
+        Assert.Collection(
+            nativeContext.Commands,
+            AssertConnectedSystemDrawingPolyline,
+            AssertConnectedSystemDrawingPolyline);
+    }
+
+    private static void AssertLocalPathStroke(RenderCommand command, float thickness)
+    {
+        Assert.Equal(RenderCommandType.DrawPath, command.Type);
+        Assert.NotNull(command.Path);
+        Assert.Equal(thickness, command.Pen!.Thickness);
+        Assert.Equal(Matrix4x4.CreateScale(4f, 1f, 1f), command.Transform);
+        Assert.True(command.IsPenThicknessLocal);
+    }
+
+    private static void AssertConnectedSystemDrawingPolyline(RenderCommand command)
+    {
+        Assert.Equal(RenderCommandType.DrawPath, command.Type);
+        var figure = Assert.Single(command.Path!.Figures);
+        Assert.Equal(2, figure.Segments.Count);
+        Assert.All(figure.Segments, static segment => Assert.IsType<LineSegment>(segment));
+        Assert.Equal(PenLineCap.Round, command.Pen!.StartLineCap);
+        Assert.Equal(PenLineCap.Triangle, command.Pen.EndLineCap);
+        Assert.Equal(PenLineJoin.Bevel, command.Pen.LineJoin);
+        Assert.Equal(3f, command.Pen.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
+    }
+
+    private static PathGeometry CreatePath()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(Vector2.Zero);
+        figure.Segments.Add(new LineSegment(new Vector2(10f, 0f)));
+        path.Figures.Add(figure);
+        return path;
+    }
+}

--- a/src/ProGPU.Tests/StrokeTransformRenderingTests.cs
+++ b/src/ProGPU.Tests/StrokeTransformRenderingTests.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Scene;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class StrokeTransformRenderingTests
+{
+    [Theory]
+    [InlineData(StrokeKind.Line)]
+    [InlineData(StrokeKind.Quadratic)]
+    [InlineData(StrokeKind.Cubic)]
+    [InlineData(StrokeKind.Polyline)]
+    [InlineData(StrokeKind.Spline)]
+    [InlineData(StrokeKind.Path)]
+    [InlineData(StrokeKind.DashedLine)]
+    [InlineData(StrokeKind.DashedQuadratic)]
+    [InlineData(StrokeKind.DashedCubic)]
+    [InlineData(StrokeKind.DashedPolyline)]
+    [InlineData(StrokeKind.DashedSpline)]
+    [InlineData(StrokeKind.PictureLine)]
+    public void VisualScaleAppliesOnceAcrossEquivalentStrokeCommands(StrokeKind kind)
+    {
+        using var window = new HeadlessWindow(64, 64);
+        using var visual = new StrokeVisual(kind, UniformScaleAboutCenter(0.5f));
+        window.Content = visual;
+
+        window.Render();
+
+        var paintedRows = CountPaintedRows(window.ReadPixels(), x: 32);
+        Assert.True(
+            paintedRows is >= 4 and <= 8,
+            $"{kind} painted {paintedRows} rows from {window.Compositor.VectorVertices.Count} vector vertices.");
+    }
+
+    [Theory]
+    [InlineData(0.5f, 4, 8)]
+    [InlineData(2f, 22, 26)]
+    [InlineData(4f, 46, 50)]
+    public void PictureStrokeScaleIsAppliedExactlyOnce(
+        float scale,
+        int minimumRows,
+        int maximumRows)
+    {
+        using var window = new HeadlessWindow(64, 64);
+        using var visual = new StrokeVisual(
+            StrokeKind.PictureLine,
+            UniformScaleAboutCenter(scale));
+        window.Content = visual;
+
+        window.Render();
+
+        Assert.InRange(
+            CountPaintedRows(window.ReadPixels(), x: 32),
+            minimumRows,
+            maximumRows);
+    }
+
+    [Fact]
+    public void NonUniformScaleTransformsHorizontalStrokeOutlineInLocalSpace()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        using var visual = new StrokeVisual(
+            StrokeKind.Line,
+            ScaleAboutCenter(scaleX: 2f, scaleY: 0.5f));
+        window.Content = visual;
+
+        window.Render();
+
+        Assert.InRange(CountPaintedRows(window.ReadPixels(), x: 32), 4, 8);
+    }
+
+    [Fact]
+    public void NonUniformScaleTransformsVerticalStrokeOutlineInLocalSpace()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        using var visual = new VerticalStrokeVisual(
+            ScaleAboutCenter(scaleX: 2f, scaleY: 0.5f));
+        window.Content = visual;
+
+        window.Render();
+
+        Assert.InRange(CountPaintedColumns(window.ReadPixels(), y: 32), 22, 26);
+    }
+
+    [Theory]
+    [InlineData(true, 12f)]
+    [InlineData(false, 24f)]
+    public void LocalAndLegacyRecordedWidthsComposeCommandAndVisualScaleOnce(
+        bool isLocal,
+        float recordedThickness)
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new ProvenanceStrokeVisual(isLocal, recordedThickness);
+
+        window.Render();
+
+        var lineVertex = Assert.Single(
+            window.Compositor.VectorVertices
+                .Where(static vertex => MathF.Abs(vertex.ShapeType - 3f) < 0.01f)
+                .Select(static vertex => vertex.StrokeThickness)
+                .Distinct());
+        Assert.Equal(12f, lineVertex, precision: 3);
+    }
+
+    [Fact]
+    public void NonFiniteStrokeTransformDoesNotEmitDirectStrokeVertices()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new NonFiniteStrokeVisual();
+
+        window.Render();
+
+        Assert.DoesNotContain(
+            window.Compositor.VectorVertices,
+            static vertex => MathF.Abs(vertex.ShapeType - 3f) < 0.01f);
+    }
+
+    [Fact]
+    public void CollapsedStrokeTransformDoesNotEmitDirectStrokeVertices()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new CollapsedStrokeVisual();
+
+        window.Render();
+
+        Assert.DoesNotContain(
+            window.Compositor.VectorVertices,
+            static vertex => MathF.Abs(vertex.ShapeType - 3f) < 0.01f);
+    }
+
+    [Fact]
+    public void InvalidStrokeWidthDoesNotSuppressIndependentFill()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new InvalidStrokeWidthVisual();
+
+        window.Render();
+
+        var rectangleVertices = window.Compositor.VectorVertices
+            .Where(static vertex => MathF.Abs(vertex.ShapeType) < 0.01f)
+            .ToArray();
+        Assert.Equal(4, rectangleVertices.Length);
+        Assert.All(
+            rectangleVertices,
+            static vertex => Assert.Equal(0f, vertex.StrokeThickness));
+        var pixels = window.ReadPixels();
+        Assert.True(pixels[(32 * 64 + 32) * 4 + 2] > 128);
+    }
+
+    private static Matrix4x4 UniformScaleAboutCenter(float scale) =>
+        ScaleAboutCenter(scale, scale);
+
+    private static Matrix4x4 ScaleAboutCenter(float scaleX, float scaleY) =>
+        Matrix4x4.CreateTranslation(-32f, -32f, 0f) *
+        Matrix4x4.CreateScale(scaleX, scaleY, 1f) *
+        Matrix4x4.CreateTranslation(32f, 32f, 0f);
+
+    private static Pen CreatePen(bool dashed = false) => new(
+        new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+        12f,
+        dashArray: dashed ? [1000d, 1d] : null);
+
+    private static PathGeometry CreateHorizontalPath()
+    {
+        var path = new PathGeometry();
+        var figure = new PathFigure(new Vector2(0f, 32f));
+        figure.Segments.Add(new LineSegment(new Vector2(64f, 32f)));
+        path.Figures.Add(figure);
+        return path;
+    }
+
+    private static int CountPaintedRows(byte[] pixels, int x)
+    {
+        var count = 0;
+        for (var y = 0; y < 64; y++)
+        {
+            if (pixels[(y * 64 + x) * 4 + 2] > 128)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountPaintedColumns(byte[] pixels, int y)
+    {
+        var count = 0;
+        for (var x = 0; x < 64; x++)
+        {
+            if (pixels[(y * 64 + x) * 4 + 2] > 128)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private sealed class StrokeVisual : FrameworkElement, IDisposable
+    {
+        private readonly StrokeKind _kind;
+        private readonly GpuPicture? _picture;
+
+        public StrokeVisual(StrokeKind kind, Matrix4x4 transform)
+        {
+            _kind = kind;
+            Width = 64f;
+            Height = 64f;
+            Transform = transform;
+            if (kind == StrokeKind.PictureLine)
+            {
+                _picture = new GpuPicture(
+                    [
+                        new RenderCommand
+                        {
+                            Type = RenderCommandType.DrawLine,
+                            Pen = CreatePen(),
+                            Position = new Vector2(0f, 32f),
+                            Position2 = new Vector2(64f, 32f)
+                        }
+                    ],
+                    [],
+                    [],
+                    [],
+                    []);
+            }
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var pen = CreatePen(_kind is
+                StrokeKind.DashedLine or
+                StrokeKind.DashedQuadratic or
+                StrokeKind.DashedCubic or
+                StrokeKind.DashedPolyline or
+                StrokeKind.DashedSpline);
+            switch (_kind)
+            {
+                case StrokeKind.Line:
+                case StrokeKind.DashedLine:
+                    context.DrawLine(pen, new Vector2(0f, 32f), new Vector2(64f, 32f));
+                    break;
+                case StrokeKind.Quadratic:
+                case StrokeKind.DashedQuadratic:
+                    context.DrawQuadraticBezier(
+                        pen,
+                        new Vector2(0f, 32f),
+                        new Vector2(32f, 32f),
+                        new Vector2(64f, 32f));
+                    break;
+                case StrokeKind.Cubic:
+                case StrokeKind.DashedCubic:
+                    context.DrawCubicBezier(
+                        pen,
+                        new Vector2(0f, 32f),
+                        new Vector2(20f, 32f),
+                        new Vector2(44f, 32f),
+                        new Vector2(64f, 32f));
+                    break;
+                case StrokeKind.Polyline:
+                case StrokeKind.DashedPolyline:
+                    context.DrawPolyline(
+                        pen,
+                        [new Vector2(0f, 32f), new Vector2(64f, 32f)]);
+                    break;
+                case StrokeKind.Spline:
+                case StrokeKind.DashedSpline:
+                    context.DrawSpline(
+                        pen,
+                        [new Vector2(0f, 32f), new Vector2(64f, 32f)],
+                        [0d, 0d, 1d, 1d],
+                        degree: 1);
+                    break;
+                case StrokeKind.Path:
+                    context.DrawPath(null, pen, CreateHorizontalPath());
+                    break;
+                case StrokeKind.PictureLine:
+                    context.DrawPicture(_picture!);
+                    break;
+            }
+        }
+
+        public void Dispose() => _picture?.Dispose();
+    }
+
+    private sealed class VerticalStrokeVisual : FrameworkElement, IDisposable
+    {
+        public VerticalStrokeVisual(Matrix4x4 transform)
+        {
+            Width = 64f;
+            Height = 64f;
+            Transform = transform;
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawLine(CreatePen(), new Vector2(32f, 0f), new Vector2(32f, 64f));
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ProvenanceStrokeVisual : FrameworkElement
+    {
+        private readonly bool _isLocal;
+        private readonly float _recordedThickness;
+
+        public ProvenanceStrokeVisual(bool isLocal, float recordedThickness)
+        {
+            _isLocal = isLocal;
+            _recordedThickness = recordedThickness;
+            Width = 64f;
+            Height = 64f;
+            Transform = UniformScaleAboutCenter(0.5f);
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.Commands.Add(new RenderCommand
+            {
+                Type = RenderCommandType.DrawLine,
+                Pen = new Pen(
+                    new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                    _recordedThickness),
+                Position = new Vector2(0f, 32f),
+                Position2 = new Vector2(32f, 32f),
+                Transform = Matrix4x4.CreateScale(2f, 2f, 1f),
+                IsPenThicknessLocal = _isLocal
+            });
+        }
+    }
+
+    private sealed class NonFiniteStrokeVisual : FrameworkElement
+    {
+        public NonFiniteStrokeVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var transform = Matrix4x4.Identity;
+            transform.M11 = float.NaN;
+            context.Commands.Add(new RenderCommand
+            {
+                Type = RenderCommandType.DrawLine,
+                Pen = CreatePen(),
+                Position = new Vector2(0f, 32f),
+                Position2 = new Vector2(64f, 32f),
+                Transform = transform,
+                IsPenThicknessLocal = true
+            });
+        }
+    }
+
+    private sealed class CollapsedStrokeVisual : FrameworkElement
+    {
+        public CollapsedStrokeVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.Commands.Add(new RenderCommand
+            {
+                Type = RenderCommandType.DrawLine,
+                Pen = CreatePen(),
+                Position = new Vector2(0f, 32f),
+                Position2 = new Vector2(64f, 32f),
+                Transform = Matrix4x4.CreateScale(0f, 1f, 1f),
+                IsPenThicknessLocal = true
+            });
+        }
+    }
+
+    private sealed class InvalidStrokeWidthVisual : FrameworkElement
+    {
+        public InvalidStrokeWidthVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                new SolidColorBrush(new Vector4(0f, 0f, 1f, 1f)),
+                new Pen(
+                    new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+                    float.NaN),
+                new Rect(8f, 8f, 48f, 48f));
+        }
+    }
+
+    public enum StrokeKind
+    {
+        Line,
+        Quadratic,
+        Cubic,
+        Polyline,
+        Spline,
+        Path,
+        DashedLine,
+        DashedQuadratic,
+        DashedCubic,
+        DashedPolyline,
+        DashedSpline,
+        PictureLine
+    }
+}

--- a/src/ProGPU.Tests/WinUiCompositionTests.cs
+++ b/src/ProGPU.Tests/WinUiCompositionTests.cs
@@ -1672,6 +1672,54 @@ public sealed class WinUiCompositionTests
     }
 
     [Fact]
+    public void NonScalingStrokeKeepsDeviceWidthUnderAnisotropicShapeScale()
+    {
+        using var window = new HeadlessWindow(96, 48);
+        var host = new FrameworkElement
+        {
+            Width = 96f,
+            Height = 48f
+        };
+        window.Content = host;
+
+        try
+        {
+            window.Render();
+            Compositor compositor = ElementCompositionPreview
+                .GetElementVisual(host)
+                .Compositor;
+            ShapeVisual visual = compositor.CreateShapeVisual();
+            visual.Size = new Vector2(96f, 48f);
+            CompositionLineGeometry line = compositor.CreateLineGeometry();
+            line.Start = new Vector2(10f, 8f);
+            line.End = new Vector2(10f, 40f);
+            CompositionSpriteShape shape = compositor.CreateSpriteShape(line);
+            shape.Scale = new Vector2(4f, 1f);
+            shape.StrokeBrush = compositor.CreateColorBrush(
+                Color.FromArgb(255, 0, 0, 255));
+            shape.StrokeThickness = 4f;
+            shape.IsStrokeNonScaling = true;
+            visual.Shapes.Add(shape);
+            ElementCompositionPreview.SetElementChildVisual(host, visual);
+
+            window.Render();
+            byte[] pixels = window.ReadPixels();
+            AssertBlue(ReadPixel(pixels, window.Width, 41, 24));
+            AssertDark(ReadPixel(pixels, window.Width, 44, 24));
+
+            shape.IsStrokeNonScaling = false;
+            window.Render();
+            pixels = window.ReadPixels();
+            AssertBlue(ReadPixel(pixels, window.Width, 44, 24));
+        }
+        finally
+        {
+            ElementCompositionPreview.SetElementChildVisual(host, null);
+            window.Content = null;
+        }
+    }
+
+    [Fact]
     public void PathAndRoundedRectangleFactoriesPreserveTypedContracts()
     {
         using var compositor = new Compositor();

--- a/src/ProGPU.Tests/WpfDrawingContextStrokeTransformTests.cs
+++ b/src/ProGPU.Tests/WpfDrawingContextStrokeTransformTests.cs
@@ -15,7 +15,7 @@ namespace ProGPU.Tests;
 public sealed class WpfDrawingContextStrokeTransformTests
 {
     [Fact]
-    public void PushTransformScalesRectanglePenThickness()
+    public void PushTransformRetainsRectanglePenThicknessInLocalSpace()
     {
         var nativeContext = new DrawingContext();
         using var context = new WpfDrawingContext(nativeContext);
@@ -34,12 +34,13 @@ public sealed class WpfDrawingContextStrokeTransformTests
         var command = Assert.Single(nativeContext.Commands);
         Assert.Equal(RenderCommandType.DrawRect, command.Type);
         Assert.NotNull(command.Pen);
-        AssertNear(6f, command.Pen!.Thickness);
+        AssertNear(2f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
         AssertMatrixNear(Matrix4x4.CreateScale(3f, 3f, 1f), command.Transform);
     }
 
     [Fact]
-    public void PushTransformScalesLinePenThickness()
+    public void PushTransformRetainsLinePenThicknessInLocalSpace()
     {
         var nativeContext = new DrawingContext();
         using var context = new WpfDrawingContext(nativeContext);
@@ -58,12 +59,13 @@ public sealed class WpfDrawingContextStrokeTransformTests
         var command = Assert.Single(nativeContext.Commands);
         Assert.Equal(RenderCommandType.DrawLine, command.Type);
         Assert.NotNull(command.Pen);
-        AssertNear(7.5f, command.Pen!.Thickness);
+        AssertNear(1.5f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
         AssertMatrixNear(ToMatrix4x4(transform), command.Transform);
     }
 
     [Fact]
-    public void PushTransformScalesGeometryPenThickness()
+    public void PushTransformRetainsGeometryPenThicknessInLocalSpace()
     {
         var nativeContext = new DrawingContext();
         using var context = new WpfDrawingContext(nativeContext);
@@ -82,7 +84,8 @@ public sealed class WpfDrawingContextStrokeTransformTests
         var command = Assert.Single(nativeContext.Commands);
         Assert.Equal(RenderCommandType.DrawPath, command.Type);
         Assert.NotNull(command.Pen);
-        AssertNear(3f, command.Pen!.Thickness);
+        AssertNear(0.75f, command.Pen!.Thickness);
+        Assert.True(command.IsPenThicknessLocal);
         AssertMatrixNear(Matrix4x4.CreateScale(4f, 4f, 1f), command.Transform);
     }
 

--- a/src/ProGPU.Text/TtfFont.cs
+++ b/src/ProGPU.Text/TtfFont.cs
@@ -1957,7 +1957,12 @@ public partial class TtfFont
             foreach (var figure in rawOutline.Figures)
             {
                 var startPt = new Vector2(figure.StartPoint.X, -figure.StartPoint.Y);
-                var newFigure = new PathFigure(startPt, figure.IsClosed) { IsFilled = figure.IsFilled };
+                var newFigure = new PathFigure(startPt, figure.IsClosed)
+                {
+                    IsFilled = figure.IsFilled,
+                    StrokeStartLineCap = figure.StrokeStartLineCap,
+                    StrokeEndLineCap = figure.StrokeEndLineCap
+                };
                 foreach (var segment in figure.Segments)
                 {
                     if (segment is LineSegment line)

--- a/src/ProGPU.Vector/Brush.cs
+++ b/src/ProGPU.Vector/Brush.cs
@@ -200,6 +200,18 @@ public enum PenLineCap
     Triangle = 3
 }
 
+/// <summary>
+/// Selects the coordinate space used to expand a positive-width stroke.
+/// </summary>
+public enum PenStrokeTransformMode
+{
+    /// <summary>The stroke is expanded in source space and follows the complete transform.</summary>
+    Normal = 0,
+
+    /// <summary>The centerline is transformed first and the positive width is expanded in device space.</summary>
+    Fixed = 1
+}
+
 public class Pen
 {
     /// <summary>
@@ -221,7 +233,9 @@ public class Pen
     public PenLineCap StartLineCap { get; set; }
     public PenLineCap EndLineCap { get; set; }
     public PenLineCap DashCap { get; set; }
+    public PenStrokeTransformMode StrokeTransformMode { get; set; }
     public bool IsHairline => Thickness == HairlineThickness;
+    public bool IsFixed => !IsHairline && StrokeTransformMode == PenStrokeTransformMode.Fixed;
     public bool HasDashPattern => _dashArray is { Length: > 0 };
     public double[]? DashArray
     {
@@ -240,7 +254,8 @@ public class Pen
         PenLineCap endLineCap = PenLineCap.Flat,
         PenLineCap dashCap = PenLineCap.Flat,
         double[]? dashArray = null,
-        double dashOffset = 0.0)
+        double dashOffset = 0.0,
+        PenStrokeTransformMode strokeTransformMode = PenStrokeTransformMode.Normal)
     {
         Brush = brush;
         Thickness = thickness;
@@ -251,6 +266,7 @@ public class Pen
         DashCap = dashCap;
         DashArray = dashArray;
         DashOffset = double.IsFinite(dashOffset) ? dashOffset : 0.0;
+        StrokeTransformMode = strokeTransformMode;
     }
 }
 

--- a/src/ProGPU.Vector/Brush.cs
+++ b/src/ProGPU.Vector/Brush.cs
@@ -202,6 +202,16 @@ public enum PenLineCap
 
 public class Pen
 {
+    /// <summary>
+    /// Retained sentinel for an explicit one-device-pixel hairline.
+    /// </summary>
+    /// <remarks>
+    /// Ordinary zero or negative widths remain non-rendering. The negative
+    /// sentinel survives picture serialization without adding another mutable
+    /// command flag and is interpreted only by the stroke compiler.
+    /// </remarks>
+    public const float HairlineThickness = -1f;
+
     private double[]? _dashArray;
 
     public Brush Brush { get; set; }
@@ -211,12 +221,14 @@ public class Pen
     public PenLineCap StartLineCap { get; set; }
     public PenLineCap EndLineCap { get; set; }
     public PenLineCap DashCap { get; set; }
+    public bool IsHairline => Thickness == HairlineThickness;
     public bool HasDashPattern => _dashArray is { Length: > 0 };
     public double[]? DashArray
     {
         get => _dashArray is null ? null : (double[])_dashArray.Clone();
         set => _dashArray = value is null ? null : (double[])value.Clone();
     }
+    internal double[]? DashArrayStorage => _dashArray;
     public double DashOffset { get; set; }
 
     public Pen(

--- a/src/ProGPU.Vector/GpuHitTesting.cs
+++ b/src/ProGPU.Vector/GpuHitTesting.cs
@@ -339,6 +339,33 @@ public readonly struct GpuHitTestPrimitive
         Matrix4x4 transform,
         float zIndex = 0f)
     {
+        return PathStroke(
+            id,
+            min,
+            max,
+            startSegment,
+            segmentCount,
+            strokeThickness,
+            tolerance,
+            LineGeometryCap.Round,
+            LineGeometryCap.Round,
+            transform,
+            zIndex);
+    }
+
+    public static GpuHitTestPrimitive PathStroke(
+        int id,
+        Vector2 min,
+        Vector2 max,
+        uint startSegment,
+        uint segmentCount,
+        float strokeThickness,
+        float tolerance,
+        LineGeometryCap startCap,
+        LineGeometryCap endCap,
+        Matrix4x4 transform,
+        float zIndex = 0f)
+    {
         float padding = MathF.Max(0f, (MathF.Abs(strokeThickness) * 0.5f) + MathF.Max(0f, tolerance));
         Vector2 paddedMin = min - new Vector2(padding);
         Vector2 paddedMax = max + new Vector2(padding);
@@ -349,7 +376,7 @@ public readonly struct GpuHitTestPrimitive
             TransformBoundsMax(paddedMin, paddedMax, transform),
             new Vector4(min.X, min.Y, max.X, max.Y),
             new Vector4(startSegment, segmentCount, strokeThickness, tolerance),
-            Vector4.Zero,
+            new Vector4((uint)startCap, (uint)endCap, 0f, 0f),
             CreateInverseTransformRow0(transform),
             CreateInverseTransformRow1(transform),
             zIndex);

--- a/src/ProGPU.Vector/PathGeometry.cs
+++ b/src/ProGPU.Vector/PathGeometry.cs
@@ -205,6 +205,24 @@ class PathFigure
     public bool IsClosed { get; set; }
     public bool IsFilled { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets the optional stroke-cap override for the beginning of this figure.
+    /// </summary>
+    /// <remarks>
+    /// A null value inherits the start cap from the pen. Retained geometry lowering uses
+    /// this neutral metadata when one logical stroke contains figures with different caps.
+    /// </remarks>
+    public PenLineCap? StrokeStartLineCap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional stroke-cap override for the end of this figure.
+    /// </summary>
+    /// <remarks>
+    /// A null value inherits the end cap from the pen. Closed figures ignore both cap
+    /// overrides because their first and last stroked segments meet at a join.
+    /// </remarks>
+    public PenLineCap? StrokeEndLineCap { get; set; }
+
     public PathFigure() { }
 
     public PathFigure(Vector2 startPoint, bool isClosed = false)
@@ -321,7 +339,9 @@ class PathGeometry : IGeometrySource2D
             {
                 StartPoint = Vector2.Transform(figure.StartPoint, transform),
                 IsClosed = figure.IsClosed,
-                IsFilled = figure.IsFilled
+                IsFilled = figure.IsFilled,
+                StrokeStartLineCap = figure.StrokeStartLineCap,
+                StrokeEndLineCap = figure.StrokeEndLineCap
             };
 
             var figureSegments = figure.Segments;

--- a/src/ProGPU.Vector/PathOpGeometrySolver.cs
+++ b/src/ProGPU.Vector/PathOpGeometrySolver.cs
@@ -817,7 +817,12 @@ namespace ProGPU.Vector
             for (int figureIndex = 0; figureIndex < src.Count; figureIndex++)
             {
                 var figure = src[figureIndex];
-                var newFigure = new PathFigure(figure.StartPoint, figure.IsClosed) { IsFilled = figure.IsFilled };
+                var newFigure = new PathFigure(figure.StartPoint, figure.IsClosed)
+                {
+                    IsFilled = figure.IsFilled,
+                    StrokeStartLineCap = figure.StrokeStartLineCap,
+                    StrokeEndLineCap = figure.StrokeEndLineCap
+                };
                 var figureSegments = figure.Segments;
                 for (int segmentIndex = 0; segmentIndex < figureSegments.Count; segmentIndex++)
                 {

--- a/src/ProGPU.Vector/Shaders/GpuHitTesting.wgsl
+++ b/src/ProGPU.Vector/Shaders/GpuHitTesting.wgsl
@@ -703,6 +703,126 @@ fn stroked_segment_intersects_ellipse_region(start: vec2<f32>, end: vec2<f32>, h
     return distance_squared_to_segment(vec2<f32>(0.0, 0.0), normalized_start, normalized_end) <= hit_radius * hit_radius;
 }
 
+fn quad_intersects_ellipse_region(
+    a: vec2<f32>,
+    b: vec2<f32>,
+    c: vec2<f32>,
+    d: vec2<f32>,
+    query_center: vec2<f32>,
+    query_inverse_radii: vec2<f32>) -> bool {
+    if (contains_ellipse_from_inverse_radii(a, query_center, query_inverse_radii) ||
+        contains_ellipse_from_inverse_radii(b, query_center, query_inverse_radii) ||
+        contains_ellipse_from_inverse_radii(c, query_center, query_inverse_radii) ||
+        contains_ellipse_from_inverse_radii(d, query_center, query_inverse_radii) ||
+        point_in_quad(query_center, a, b, c, d)) {
+        return true;
+    }
+
+    return segment_intersects_ellipse_region(a, b, query_center, query_inverse_radii) ||
+        segment_intersects_ellipse_region(b, c, query_center, query_inverse_radii) ||
+        segment_intersects_ellipse_region(c, d, query_center, query_inverse_radii) ||
+        segment_intersects_ellipse_region(d, a, query_center, query_inverse_radii);
+}
+
+fn triangle_cap_intersects_ellipse_region(
+    center: vec2<f32>,
+    direction: vec2<f32>,
+    half_stroke: f32,
+    query_center: vec2<f32>,
+    query_inverse_radii: vec2<f32>) -> bool {
+    let normal = vec2<f32>(-direction.y, direction.x);
+    let a = center - normal * half_stroke;
+    let b = center + normal * half_stroke;
+    let c = center + direction * half_stroke;
+    if (contains_ellipse_from_inverse_radii(a, query_center, query_inverse_radii) ||
+        contains_ellipse_from_inverse_radii(b, query_center, query_inverse_radii) ||
+        contains_ellipse_from_inverse_radii(c, query_center, query_inverse_radii) ||
+        point_in_triangle(query_center, a, b, c)) {
+        return true;
+    }
+
+    return segment_intersects_ellipse_region(a, b, query_center, query_inverse_radii) ||
+        segment_intersects_ellipse_region(b, c, query_center, query_inverse_radii) ||
+        segment_intersects_ellipse_region(c, a, query_center, query_inverse_radii);
+}
+
+fn capped_line_stroke_intersects_ellipse_region(
+    start: vec2<f32>,
+    end: vec2<f32>,
+    half_stroke: f32,
+    start_cap: u32,
+    end_cap: u32,
+    query_center: vec2<f32>,
+    query_inverse_radii: vec2<f32>) -> bool {
+    if (half_stroke <= 0.0 || query_inverse_radii.x <= 0.0 || query_inverse_radii.y <= 0.0) {
+        return false;
+    }
+
+    let delta = end - start;
+    let segment_length = length(delta);
+    if (segment_length <= 0.0001) {
+        if (start_cap == CAP_FLAT && end_cap == CAP_FLAT) {
+            return false;
+        }
+
+        let cap_inverse_radii = vec2<f32>(1.0 / half_stroke, 1.0 / half_stroke);
+        return ellipses_may_intersect(
+            query_center,
+            query_inverse_radii,
+            start,
+            cap_inverse_radii);
+    }
+
+    let direction = delta / segment_length;
+    let normal = vec2<f32>(-direction.y, direction.x);
+    let start_extension = select(0.0, half_stroke, start_cap == CAP_SQUARE);
+    let end_extension = select(0.0, half_stroke, end_cap == CAP_SQUARE);
+    let body_start = start - direction * start_extension;
+    let body_end = end + direction * end_extension;
+    let a = body_start + normal * half_stroke;
+    let b = body_end + normal * half_stroke;
+    let c = body_end - normal * half_stroke;
+    let d = body_start - normal * half_stroke;
+    if (quad_intersects_ellipse_region(
+            a,
+            b,
+            c,
+            d,
+            query_center,
+            query_inverse_radii)) {
+        return true;
+    }
+
+    let cap_inverse_radii = vec2<f32>(1.0 / half_stroke, 1.0 / half_stroke);
+    if (start_cap == CAP_ROUND &&
+        ellipses_may_intersect(query_center, query_inverse_radii, start, cap_inverse_radii)) {
+        return true;
+    }
+
+    if (end_cap == CAP_ROUND &&
+        ellipses_may_intersect(query_center, query_inverse_radii, end, cap_inverse_radii)) {
+        return true;
+    }
+
+    if (start_cap == CAP_TRIANGLE &&
+        triangle_cap_intersects_ellipse_region(
+            start,
+            -direction,
+            half_stroke,
+            query_center,
+            query_inverse_radii)) {
+        return true;
+    }
+
+    return end_cap == CAP_TRIANGLE &&
+        triangle_cap_intersects_ellipse_region(
+            end,
+            direction,
+            half_stroke,
+            query_center,
+            query_inverse_radii);
+}
+
 fn line_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_radii: vec2<f32>, primitive: HitTestPrimitive) -> bool {
     let stroke = abs(primitive.data1.x);
     if (stroke <= 0.0 || query_inverse_radii.x <= 0.0 || query_inverse_radii.y <= 0.0) {
@@ -712,24 +832,14 @@ fn line_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_
     let half_stroke = (stroke * 0.5) + max(0.0, primitive.data1.y);
     let start_cap = u32(primitive.data1.z);
     let end_cap = u32(primitive.data1.w);
-    let direction = primitive.data2.xy;
-    let segment_length = primitive.data2.z;
-    let normalized_stroke_radius = half_stroke * max(query_inverse_radii.x, query_inverse_radii.y);
-    let hit_radius = 1.0 + normalized_stroke_radius;
-    if (segment_length <= 0.0001) {
-        if (start_cap == CAP_FLAT && end_cap == CAP_FLAT) {
-            return false;
-        }
-
-        let normalized_point = (primitive.data0.xy - query_center) * query_inverse_radii;
-        return dot(normalized_point, normalized_point) <= hit_radius * hit_radius;
-    }
-
-    let start_extension = select(half_stroke, 0.0, start_cap == CAP_FLAT);
-    let end_extension = select(half_stroke, 0.0, end_cap == CAP_FLAT);
-    let start = (primitive.data0.xy - (direction * start_extension) - query_center) * query_inverse_radii;
-    let end = (primitive.data0.zw + (direction * end_extension) - query_center) * query_inverse_radii;
-    return distance_squared_to_segment(vec2<f32>(0.0, 0.0), start, end) <= hit_radius * hit_radius;
+    return capped_line_stroke_intersects_ellipse_region(
+        primitive.data0.xy,
+        primitive.data0.zw,
+        half_stroke,
+        start_cap,
+        end_cap,
+        query_center,
+        query_inverse_radii);
 }
 
 fn distance_squared_to_rect(point: vec2<f32>, rect_min: vec2<f32>, rect_max: vec2<f32>) -> f32 {
@@ -856,23 +966,20 @@ fn triangle_cap_intersects_rect(center: vec2<f32>, direction: vec2<f32>, half_st
         segment_intersects_rect(c, a, rect_min, rect_max);
 }
 
-fn line_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primitive: HitTestPrimitive) -> bool {
-    let start = primitive.data0.xy;
-    let end = primitive.data0.zw;
-    let stroke = abs(primitive.data1.x);
-    if (stroke <= 0.0) {
-        return false;
-    }
-
-    let half_stroke = (stroke * 0.5) + max(0.0, primitive.data1.y);
+fn capped_line_stroke_intersects_rect(
+    start: vec2<f32>,
+    end: vec2<f32>,
+    half_stroke: f32,
+    start_cap: u32,
+    end_cap: u32,
+    rect_min: vec2<f32>,
+    rect_max: vec2<f32>) -> bool {
     if (half_stroke <= 0.0) {
         return false;
     }
 
-    let start_cap = u32(primitive.data1.z);
-    let end_cap = u32(primitive.data1.w);
-    let direction = primitive.data2.xy;
-    let segment_length = primitive.data2.z;
+    let delta = end - start;
+    let segment_length = length(delta);
     if (segment_length <= 0.0001) {
         if (start_cap == CAP_FLAT && end_cap == CAP_FLAT) {
             return false;
@@ -881,6 +988,7 @@ fn line_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
         return distance_squared_to_rect(start, rect_min, rect_max) <= half_stroke * half_stroke;
     }
 
+    let direction = delta / segment_length;
     let normal = vec2<f32>(-direction.y, direction.x);
     let start_extension = select(0.0, half_stroke, start_cap == CAP_SQUARE);
     let end_extension = select(0.0, half_stroke, end_cap == CAP_SQUARE);
@@ -894,23 +1002,44 @@ fn line_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
         return true;
     }
 
-    if (start_cap == CAP_ROUND && distance_squared_to_rect(start, rect_min, rect_max) <= half_stroke * half_stroke) {
+    if (start_cap == CAP_ROUND &&
+        distance_squared_to_rect(start, rect_min, rect_max) <= half_stroke * half_stroke) {
         return true;
     }
 
-    if (end_cap == CAP_ROUND && distance_squared_to_rect(end, rect_min, rect_max) <= half_stroke * half_stroke) {
+    if (end_cap == CAP_ROUND &&
+        distance_squared_to_rect(end, rect_min, rect_max) <= half_stroke * half_stroke) {
         return true;
     }
 
-    if (start_cap == CAP_TRIANGLE && triangle_cap_intersects_rect(start, -direction, half_stroke, rect_min, rect_max)) {
+    if (start_cap == CAP_TRIANGLE &&
+        triangle_cap_intersects_rect(start, -direction, half_stroke, rect_min, rect_max)) {
         return true;
     }
 
-    if (end_cap == CAP_TRIANGLE && triangle_cap_intersects_rect(end, direction, half_stroke, rect_min, rect_max)) {
-        return true;
+    return end_cap == CAP_TRIANGLE &&
+        triangle_cap_intersects_rect(end, direction, half_stroke, rect_min, rect_max);
+}
+
+fn line_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primitive: HitTestPrimitive) -> bool {
+    let start = primitive.data0.xy;
+    let end = primitive.data0.zw;
+    let stroke = abs(primitive.data1.x);
+    if (stroke <= 0.0) {
+        return false;
     }
 
-    return false;
+    let half_stroke = (stroke * 0.5) + max(0.0, primitive.data1.y);
+    let start_cap = u32(primitive.data1.z);
+    let end_cap = u32(primitive.data1.w);
+    return capped_line_stroke_intersects_rect(
+        start,
+        end,
+        half_stroke,
+        start_cap,
+        end_cap,
+        rect_min,
+        rect_max);
 }
 
 fn evaluate_quadratic(start: vec2<f32>, control: vec2<f32>, end: vec2<f32>, t: f32) -> vec2<f32> {
@@ -1300,8 +1429,175 @@ fn classify_path_fill_ellipse_region_intersection_detail(query_center: vec2<f32>
     return classify_path_fill_ellipse_region_intersection_detail_range(query_center, query_inverse_radii, start_segment, segment_count, fill_rule);
 }
 
-fn path_stroke_line_hit(point: vec2<f32>, start: vec2<f32>, end: vec2<f32>, half_stroke: f32) -> bool {
-    return distance_squared_to_segment(point, start, end) <= half_stroke * half_stroke;
+fn path_stroke_line_hit(
+    point: vec2<f32>,
+    start: vec2<f32>,
+    end: vec2<f32>,
+    half_stroke: f32,
+    start_cap: u32,
+    end_cap: u32,
+    is_first_piece: bool,
+    is_last_piece: bool) -> bool {
+    let delta = end - start;
+    let segment_length = length(delta);
+    if (segment_length <= 0.0001) {
+        let effective_start_cap = select(CAP_ROUND, start_cap, is_first_piece);
+        let effective_end_cap = select(CAP_ROUND, end_cap, is_last_piece);
+        if (effective_start_cap == CAP_FLAT && effective_end_cap == CAP_FLAT) {
+            return false;
+        }
+
+        let point_delta = point - start;
+        return dot(point_delta, point_delta) <= half_stroke * half_stroke;
+    }
+
+    let direction = delta / segment_length;
+    let offset = point - start;
+    let along = dot(offset, direction);
+    let signed_distance = cross2(offset, direction);
+    if (along >= 0.0 && along <= segment_length && abs(signed_distance) <= half_stroke) {
+        return true;
+    }
+
+    if (along < 0.0) {
+        let cap = select(CAP_ROUND, start_cap, is_first_piece);
+        return contains_line_cap(point, start, direction, signed_distance, along, half_stroke, cap, true);
+    }
+
+    let cap = select(CAP_ROUND, end_cap, is_last_piece);
+    return contains_line_cap(point, end, direction, signed_distance, along - segment_length, half_stroke, cap, false);
+}
+
+fn path_segment_end_point(segment: PathSegment) -> vec2<f32> {
+    if (segment.segment_type == SEGMENT_QUADRATIC) {
+        return segment.p2;
+    }
+
+    if (segment.segment_type == SEGMENT_CUBIC) {
+        return segment.p3;
+    }
+
+    return segment.p1;
+}
+
+fn evaluate_arc_tangent(segment: PathSegment, t: f32) -> vec2<f32> {
+    let theta_start = bitcast<f32>(segment.pad0);
+    let delta_theta = bitcast<f32>(segment.pad1);
+    let rotation = bitcast<f32>(segment.pad2);
+    let theta = theta_start + delta_theta * t;
+    let local = vec2<f32>(
+        -sin(theta) * segment.p3.x,
+        cos(theta) * segment.p3.y) * delta_theta;
+    let c = cos(rotation);
+    let s = sin(rotation);
+    return vec2<f32>(
+        (local.x * c) - (local.y * s),
+        (local.x * s) + (local.y * c));
+}
+
+fn path_segment_start_tangent(segment: PathSegment) -> vec2<f32> {
+    if (segment.segment_type == SEGMENT_LINE) {
+        return segment.p1 - segment.p0;
+    }
+
+    if (segment.segment_type == SEGMENT_QUADRATIC) {
+        let first = segment.p1 - segment.p0;
+        return select(segment.p2 - segment.p0, first, dot(first, first) > 0.000000000001);
+    }
+
+    if (segment.segment_type == SEGMENT_CUBIC) {
+        let first = segment.p1 - segment.p0;
+        if (dot(first, first) > 0.000000000001) {
+            return first;
+        }
+
+        let second = segment.p2 - segment.p0;
+        return select(segment.p3 - segment.p0, second, dot(second, second) > 0.000000000001);
+    }
+
+    let tangent = evaluate_arc_tangent(segment, 0.0);
+    return select(segment.p1 - segment.p0, tangent, dot(tangent, tangent) > 0.000000000001);
+}
+
+fn path_segment_end_tangent(segment: PathSegment) -> vec2<f32> {
+    if (segment.segment_type == SEGMENT_LINE) {
+        return segment.p1 - segment.p0;
+    }
+
+    if (segment.segment_type == SEGMENT_QUADRATIC) {
+        let last = segment.p2 - segment.p1;
+        return select(segment.p2 - segment.p0, last, dot(last, last) > 0.000000000001);
+    }
+
+    if (segment.segment_type == SEGMENT_CUBIC) {
+        let last = segment.p3 - segment.p2;
+        if (dot(last, last) > 0.000000000001) {
+            return last;
+        }
+
+        let previous = segment.p3 - segment.p1;
+        return select(segment.p3 - segment.p0, previous, dot(previous, previous) > 0.000000000001);
+    }
+
+    let tangent = evaluate_arc_tangent(segment, 1.0);
+    return select(segment.p1 - segment.p0, tangent, dot(tangent, tangent) > 0.000000000001);
+}
+
+fn point_passes_path_endpoint_caps(
+    point: vec2<f32>,
+    half_stroke: f32,
+    start_segment: u32,
+    end_segment: u32,
+    start_cap: u32,
+    end_cap: u32) -> bool {
+    if (start_cap != CAP_ROUND) {
+        let first = path_segments[start_segment];
+        let direction_delta = path_segment_start_tangent(first);
+        let direction_length = length(direction_delta);
+        if (direction_length > 0.000001) {
+            let direction = direction_delta / direction_length;
+            let offset = point - first.p0;
+            let along = dot(offset, direction);
+            if (along < 0.0 &&
+                !contains_line_cap(
+                    point,
+                    first.p0,
+                    direction,
+                    cross2(offset, direction),
+                    along,
+                    half_stroke,
+                    start_cap,
+                    true)) {
+                return false;
+            }
+        }
+    }
+
+    if (end_cap != CAP_ROUND) {
+        let last = path_segments[end_segment - 1u];
+        let end_point = path_segment_end_point(last);
+        let direction_delta = path_segment_end_tangent(last);
+        let direction_length = length(direction_delta);
+        if (direction_length > 0.000001) {
+            let direction = direction_delta / direction_length;
+            let offset = point - end_point;
+            let along = dot(offset, direction);
+            if (along > 0.0 &&
+                !contains_line_cap(
+                    point,
+                    end_point,
+                    direction,
+                    cross2(offset, direction),
+                    along,
+                    half_stroke,
+                    end_cap,
+                    false)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
@@ -1313,7 +1609,19 @@ fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
     }
 
     let half_stroke = (stroke * 0.5) + max(0.0, primitive.data1.w);
+    let start_cap = u32(primitive.data2.x + 0.5);
+    let end_cap = u32(primitive.data2.y + 0.5);
     let end_segment = min(start_segment + segment_count, query.path_segment_count);
+    if (!point_passes_path_endpoint_caps(
+            point,
+            half_stroke,
+            start_segment,
+            end_segment,
+            start_cap,
+            end_cap)) {
+        return false;
+    }
+
     var segment_index = start_segment;
     loop {
         if (segment_index >= end_segment) {
@@ -1322,7 +1630,15 @@ fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
 
         let segment = path_segments[segment_index];
         if (segment.segment_type == SEGMENT_LINE) {
-            if (path_stroke_line_hit(point, segment.p0, segment.p1, half_stroke)) {
+            if (path_stroke_line_hit(
+                    point,
+                    segment.p0,
+                    segment.p1,
+                    half_stroke,
+                    start_cap,
+                    end_cap,
+                    segment_index == start_segment,
+                    segment_index + 1u == end_segment)) {
                 return true;
             }
         } else if (segment.segment_type == SEGMENT_QUADRATIC) {
@@ -1334,7 +1650,15 @@ fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
                 }
 
                 let next_point = evaluate_quadratic(segment.p0, segment.p1, segment.p2, f32(step) / f32(PATH_QUADRATIC_STEPS));
-                if (path_stroke_line_hit(point, previous, next_point, half_stroke)) {
+                if (path_stroke_line_hit(
+                        point,
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_QUADRATIC_STEPS)) {
                     return true;
                 }
 
@@ -1350,7 +1674,15 @@ fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
                 }
 
                 let next_point = evaluate_cubic(segment.p0, segment.p1, segment.p2, segment.p3, f32(step) / f32(PATH_CUBIC_STEPS));
-                if (path_stroke_line_hit(point, previous, next_point, half_stroke)) {
+                if (path_stroke_line_hit(
+                        point,
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_CUBIC_STEPS)) {
                     return true;
                 }
 
@@ -1366,7 +1698,15 @@ fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
                 }
 
                 let next_point = evaluate_arc(segment, f32(step) / f32(PATH_ARC_STEPS));
-                if (path_stroke_line_hit(point, previous, next_point, half_stroke)) {
+                if (path_stroke_line_hit(
+                        point,
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_ARC_STEPS)) {
                     return true;
                 }
 
@@ -1379,6 +1719,26 @@ fn contains_path_stroke(point: vec2<f32>, primitive: HitTestPrimitive) -> bool {
     }
 
     return false;
+}
+
+fn path_stroke_piece_intersects_rect(
+    start: vec2<f32>,
+    end: vec2<f32>,
+    half_stroke: f32,
+    start_cap: u32,
+    end_cap: u32,
+    is_first_piece: bool,
+    is_last_piece: bool,
+    rect_min: vec2<f32>,
+    rect_max: vec2<f32>) -> bool {
+    return capped_line_stroke_intersects_rect(
+        start,
+        end,
+        half_stroke,
+        select(CAP_ROUND, start_cap, is_first_piece),
+        select(CAP_ROUND, end_cap, is_last_piece),
+        rect_min,
+        rect_max);
 }
 
 fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primitive: HitTestPrimitive) -> bool {
@@ -1390,6 +1750,8 @@ fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
     }
 
     let half_stroke = (stroke * 0.5) + max(0.0, primitive.data1.w);
+    let start_cap = u32(primitive.data2.x + 0.5);
+    let end_cap = u32(primitive.data2.y + 0.5);
     let end_segment = min(start_segment + segment_count, query.path_segment_count);
     var segment_index = start_segment;
     loop {
@@ -1399,7 +1761,16 @@ fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
 
         let segment = path_segments[segment_index];
         if (segment.segment_type == SEGMENT_LINE) {
-            if (stroked_segment_intersects_rect(segment.p0, segment.p1, rect_min, rect_max, half_stroke)) {
+            if (path_stroke_piece_intersects_rect(
+                    segment.p0,
+                    segment.p1,
+                    half_stroke,
+                    start_cap,
+                    end_cap,
+                    segment_index == start_segment,
+                    segment_index + 1u == end_segment,
+                    rect_min,
+                    rect_max)) {
                 return true;
             }
         } else if (segment.segment_type == SEGMENT_QUADRATIC) {
@@ -1411,7 +1782,16 @@ fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
                 }
 
                 let next_point = evaluate_quadratic(segment.p0, segment.p1, segment.p2, f32(step) / f32(PATH_QUADRATIC_STEPS));
-                if (stroked_segment_intersects_rect(previous, next_point, rect_min, rect_max, half_stroke)) {
+                if (path_stroke_piece_intersects_rect(
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_QUADRATIC_STEPS,
+                        rect_min,
+                        rect_max)) {
                     return true;
                 }
 
@@ -1427,7 +1807,16 @@ fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
                 }
 
                 let next_point = evaluate_cubic(segment.p0, segment.p1, segment.p2, segment.p3, f32(step) / f32(PATH_CUBIC_STEPS));
-                if (stroked_segment_intersects_rect(previous, next_point, rect_min, rect_max, half_stroke)) {
+                if (path_stroke_piece_intersects_rect(
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_CUBIC_STEPS,
+                        rect_min,
+                        rect_max)) {
                     return true;
                 }
 
@@ -1443,7 +1832,16 @@ fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
                 }
 
                 let next_point = evaluate_arc(segment, f32(step) / f32(PATH_ARC_STEPS));
-                if (stroked_segment_intersects_rect(previous, next_point, rect_min, rect_max, half_stroke)) {
+                if (path_stroke_piece_intersects_rect(
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_ARC_STEPS,
+                        rect_min,
+                        rect_max)) {
                     return true;
                 }
 
@@ -1458,6 +1856,26 @@ fn path_stroke_intersects_rect(rect_min: vec2<f32>, rect_max: vec2<f32>, primiti
     return false;
 }
 
+fn path_stroke_piece_intersects_ellipse_region(
+    start: vec2<f32>,
+    end: vec2<f32>,
+    half_stroke: f32,
+    start_cap: u32,
+    end_cap: u32,
+    is_first_piece: bool,
+    is_last_piece: bool,
+    query_center: vec2<f32>,
+    query_inverse_radii: vec2<f32>) -> bool {
+    return capped_line_stroke_intersects_ellipse_region(
+        start,
+        end,
+        half_stroke,
+        select(CAP_ROUND, start_cap, is_first_piece),
+        select(CAP_ROUND, end_cap, is_last_piece),
+        query_center,
+        query_inverse_radii);
+}
+
 fn path_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_radii: vec2<f32>, primitive: HitTestPrimitive) -> bool {
     let start_segment = u32(primitive.data1.x + 0.5);
     let segment_count = u32(primitive.data1.y + 0.5);
@@ -1467,6 +1885,8 @@ fn path_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_
     }
 
     let half_stroke = (stroke * 0.5) + max(0.0, primitive.data1.w);
+    let start_cap = u32(primitive.data2.x + 0.5);
+    let end_cap = u32(primitive.data2.y + 0.5);
     let end_segment = min(start_segment + segment_count, query.path_segment_count);
     var segment_index = start_segment;
     loop {
@@ -1476,7 +1896,16 @@ fn path_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_
 
         let segment = path_segments[segment_index];
         if (segment.segment_type == SEGMENT_LINE) {
-            if (stroked_segment_intersects_ellipse_region(segment.p0, segment.p1, half_stroke, query_center, query_inverse_radii)) {
+            if (path_stroke_piece_intersects_ellipse_region(
+                    segment.p0,
+                    segment.p1,
+                    half_stroke,
+                    start_cap,
+                    end_cap,
+                    segment_index == start_segment,
+                    segment_index + 1u == end_segment,
+                    query_center,
+                    query_inverse_radii)) {
                 return true;
             }
         } else if (segment.segment_type == SEGMENT_QUADRATIC) {
@@ -1488,7 +1917,16 @@ fn path_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_
                 }
 
                 let next_point = evaluate_quadratic(segment.p0, segment.p1, segment.p2, f32(step) / f32(PATH_QUADRATIC_STEPS));
-                if (stroked_segment_intersects_ellipse_region(previous, next_point, half_stroke, query_center, query_inverse_radii)) {
+                if (path_stroke_piece_intersects_ellipse_region(
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_QUADRATIC_STEPS,
+                        query_center,
+                        query_inverse_radii)) {
                     return true;
                 }
 
@@ -1504,7 +1942,16 @@ fn path_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_
                 }
 
                 let next_point = evaluate_cubic(segment.p0, segment.p1, segment.p2, segment.p3, f32(step) / f32(PATH_CUBIC_STEPS));
-                if (stroked_segment_intersects_ellipse_region(previous, next_point, half_stroke, query_center, query_inverse_radii)) {
+                if (path_stroke_piece_intersects_ellipse_region(
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_CUBIC_STEPS,
+                        query_center,
+                        query_inverse_radii)) {
                     return true;
                 }
 
@@ -1520,7 +1967,16 @@ fn path_stroke_intersects_ellipse_region(query_center: vec2<f32>, query_inverse_
                 }
 
                 let next_point = evaluate_arc(segment, f32(step) / f32(PATH_ARC_STEPS));
-                if (stroked_segment_intersects_ellipse_region(previous, next_point, half_stroke, query_center, query_inverse_radii)) {
+                if (path_stroke_piece_intersects_ellipse_region(
+                        previous,
+                        next_point,
+                        half_stroke,
+                        start_cap,
+                        end_cap,
+                        segment_index == start_segment && step == 1u,
+                        segment_index + 1u == end_segment && step == PATH_ARC_STEPS,
+                        query_center,
+                        query_inverse_radii)) {
                     return true;
                 }
 

--- a/src/ProGPU.Vector/TransformMetrics.cs
+++ b/src/ProGPU.Vector/TransformMetrics.cs
@@ -15,15 +15,65 @@ static class TransformMetrics
 {
     public static float GetStrokeScale(Matrix4x4 transform)
     {
-        var a = transform.M11;
-        var b = transform.M12;
-        var c = transform.M21;
-        var d = transform.M22;
+        return TryGetStrokeScale(transform, out var scale) ? scale : 1f;
+    }
+
+    public static bool TryGetStrokeScale(Matrix4x4 transform, out float scale)
+    {
+        return TryGetStrokeScales(transform, out scale, out _);
+    }
+
+    /// <summary>
+    /// Computes the maximum and minimum singular values of the transform's
+    /// two-dimensional linear component.
+    /// </summary>
+    /// <remarks>
+    /// The singular values are the exact maximum and minimum scale factors of
+    /// the affine transform over all unit directions. The calculation performs
+    /// fixed <c>O(1)</c> work without allocation and uses double-precision
+    /// intermediates to avoid overflow and cancellation in finite float input.
+    /// </remarks>
+    public static bool TryGetStrokeScales(
+        Matrix4x4 transform,
+        out float maximumScale,
+        out float minimumScale)
+    {
+        var a = (double)transform.M11;
+        var b = (double)transform.M12;
+        var c = (double)transform.M21;
+        var d = (double)transform.M22;
+        if (!double.IsFinite(a) ||
+            !double.IsFinite(b) ||
+            !double.IsFinite(c) ||
+            !double.IsFinite(d))
+        {
+            maximumScale = 0f;
+            minimumScale = 0f;
+            return false;
+        }
+
         var sum = a * a + b * b + c * c + d * d;
         var determinant = (a * d) - (b * c);
-        var discriminant = MathF.Max(0f, (sum * sum) - (4f * determinant * determinant));
-        var scale = MathF.Sqrt(MathF.Max(0f, (sum + MathF.Sqrt(discriminant)) * 0.5f));
+        var discriminant = Math.Max(
+            0d,
+            (sum * sum) - (4d * determinant * determinant));
+        var maximum = Math.Sqrt(Math.Max(
+            0d,
+            (sum + Math.Sqrt(discriminant)) * 0.5d));
+        var minimum = Math.Abs(determinant) / maximum;
 
-        return float.IsFinite(scale) && scale > 0f ? scale : 1f;
+        maximumScale = (float)maximum;
+        minimumScale = (float)minimum;
+        if (float.IsFinite(maximumScale) &&
+            maximumScale > 0f &&
+            float.IsFinite(minimumScale) &&
+            minimumScale > 0f)
+        {
+            return true;
+        }
+
+        maximumScale = 0f;
+        minimumScale = 0f;
+        return false;
     }
 }

--- a/src/ProGPU.WinUI/Composition/CompositionPaths.cs
+++ b/src/ProGPU.WinUI/Composition/CompositionPaths.cs
@@ -95,9 +95,9 @@ public sealed class CompositionPathGeometry : CompositionGeometry
             _trimmedPath = _path.Data.CreateTrimmed(
                 TrimOrigin,
                 TrimLength);
-            _trimmedCache = RenderCommandGeometryCache.ForPath(
-                _trimmedPath);
         }
+        _trimmedCache ??= RenderCommandGeometryCache.ForPath(
+            _trimmedPath);
         context.DrawPath(
             fill,
             stroke,
@@ -219,9 +219,9 @@ public sealed class CompositionRoundedRectangleGeometry : CompositionGeometry
             _trimmedPath = _pathData!.CreateTrimmed(
                 TrimOrigin,
                 TrimLength);
-            _trimmedCache = RenderCommandGeometryCache.ForPath(
-                _trimmedPath);
         }
+        _trimmedCache ??= RenderCommandGeometryCache.ForPath(
+            _trimmedPath);
         context.DrawPath(
             fill,
             stroke,

--- a/src/ProGPU.WinUI/Composition/CompositionShapes.cs
+++ b/src/ProGPU.WinUI/Composition/CompositionShapes.cs
@@ -259,9 +259,9 @@ public sealed class CompositionEllipseGeometry : CompositionGeometry
         if (_trimmedPath is null)
         {
             _trimmedPath = CreateTrimmedPath();
-            _trimmedCache = RenderCommandGeometryCache.ForPath(
-                _trimmedPath);
         }
+        _trimmedCache ??= RenderCommandGeometryCache.ForPath(
+            _trimmedPath);
         context.DrawPath(
             fill,
             stroke,
@@ -389,9 +389,9 @@ public sealed class CompositionRectangleGeometry : CompositionGeometry
         if (_trimmedPath is null)
         {
             _trimmedPath = CreateTrimmedPath();
-            _trimmedCache = RenderCommandGeometryCache.ForPath(
-                _trimmedPath);
         }
+        _trimmedCache ??= RenderCommandGeometryCache.ForPath(
+            _trimmedPath);
         context.DrawPath(
             fill,
             stroke,
@@ -530,8 +530,8 @@ public sealed class CompositionLineGeometry : CompositionGeometry
         if (_path is null)
         {
             _path = CreatePath();
-            _pathCache = RenderCommandGeometryCache.ForPath(_path);
         }
+        _pathCache ??= RenderCommandGeometryCache.ForPath(_path);
         context.DrawPath(
             null,
             stroke,
@@ -748,6 +748,10 @@ public sealed class CompositionSpriteShape : CompositionShape,
     private readonly Pen _strokePen;
     private readonly SolidColorBrush _opaqueTextureMaskBrush;
     private double[]? _appliedDashArray;
+    private PathGeometry? _nonScalingStrokePath;
+    private PathGeometry? _nonScalingStrokeSource;
+    private RenderCommandGeometryCache? _nonScalingStrokeCache;
+    private Matrix4x4 _nonScalingStrokeTransform;
     private bool _isStrokeNonScaling;
     private CompositionStrokeCap _strokeDashCap;
     private float _strokeDashOffset;
@@ -787,6 +791,7 @@ public sealed class CompositionSpriteShape : CompositionShape,
             _geometry?.RemoveOwner(this);
             _geometry = value;
             _geometry?.AddOwner(this);
+            InvalidateNonScalingStrokeCache();
             NotifyShapeChanged();
         }
     }
@@ -850,8 +855,11 @@ public sealed class CompositionSpriteShape : CompositionShape,
     void ICompositionBrushOwner.NotifyBrushValueChanged() =>
         NotifyShapeChanged();
 
-    void ICompositionGeometryOwner.NotifyGeometryChanged() =>
+    void ICompositionGeometryOwner.NotifyGeometryChanged()
+    {
+        InvalidateNonScalingStrokeCache();
         NotifyShapeChanged();
+    }
 
     internal override void Record(
         DrawingContext context,
@@ -874,7 +882,7 @@ public sealed class CompositionSpriteShape : CompositionShape,
         Brush? fill = _fillBrush is null ? null : _fillSceneBrush;
         _strokeBrush?.UpdateSceneBrush(brushBounds, ref _strokeSceneBrush);
         Pen? stroke = UpdateStrokePen(_strokeSceneBrush, transform);
-        _geometry.Record(context, fill, stroke, transform);
+        RecordGeometry(context, fill, stroke, transform);
     }
 
     internal override void OnDisposed()
@@ -887,6 +895,7 @@ public sealed class CompositionSpriteShape : CompositionShape,
         _strokeBrush = null;
         _strokeSceneBrush = null;
         _geometry = null;
+        InvalidateNonScalingStrokeCache();
         StrokeDashArray.Dispose();
         base.OnDisposed();
     }
@@ -932,7 +941,7 @@ public sealed class CompositionSpriteShape : CompositionShape,
                         transform);
                 }
                 else if (fill is not null)
-                    _geometry!.Record(context, fill, null, transform);
+                    RecordGeometry(context, fill, null, transform);
             }
             finally
             {
@@ -964,7 +973,7 @@ public sealed class CompositionSpriteShape : CompositionShape,
                 {
                     Pen? stroke = UpdateStrokePen(strokeBrush, transform);
                     if (stroke is not null)
-                    _geometry!.Record(context, null, stroke, transform);
+                        RecordGeometry(context, null, stroke, transform);
                 }
             }
             finally
@@ -1000,7 +1009,21 @@ public sealed class CompositionSpriteShape : CompositionShape,
             transform);
         if (path is null || maskPen is null)
             return;
-        context.PushOpacityMask(path, maskPen, brushBounds, transform);
+        if (_isStrokeNonScaling)
+        {
+            path = GetNonScalingStrokePath(path, transform);
+            var transformedBounds = new GeneralTransform(transform)
+                .TransformBounds(brushBounds);
+            context.PushOpacityMask(
+                path,
+                maskPen,
+                transformedBounds,
+                Matrix4x4.Identity);
+        }
+        else
+        {
+            context.PushOpacityMask(path, maskPen, brushBounds, transform);
+        }
         context.DrawRectangle(textureBrush, null, brushBounds);
         context.PopOpacityMask();
     }
@@ -1013,10 +1036,7 @@ public sealed class CompositionSpriteShape : CompositionShape,
             return null;
 
         _strokePen.Brush = strokeBrush;
-        _strokePen.Thickness = _isStrokeNonScaling
-            ? _strokeThickness /
-              TransformMetrics.GetStrokeScale(transform)
-            : _strokeThickness;
+        _strokePen.Thickness = _strokeThickness;
         _strokePen.LineJoin = ToLineJoin(_strokeLineJoin);
         _strokePen.MiterLimit = Math.Max(1f, _strokeMiterLimit);
         _strokePen.StartLineCap = ToLineCap(_strokeStartCap);
@@ -1030,6 +1050,62 @@ public sealed class CompositionSpriteShape : CompositionShape,
             _appliedDashArray = dashArray;
         }
         return _strokePen;
+    }
+
+    private void RecordGeometry(
+        DrawingContext context,
+        Brush? fill,
+        Pen? stroke,
+        in Matrix4x4 transform)
+    {
+        if (!_isStrokeNonScaling || stroke is null)
+        {
+            _geometry!.Record(context, fill, stroke, transform);
+            return;
+        }
+
+        if (fill is not null)
+        {
+            _geometry!.Record(context, fill, null, transform);
+        }
+
+        PathGeometry? source = _geometry!.GetClipPath();
+        if (source is null)
+            return;
+
+        PathGeometry path = GetNonScalingStrokePath(source, transform);
+        context.DrawPath(
+            null,
+            stroke,
+            path,
+            Matrix4x4.Identity,
+            _nonScalingStrokeCache!);
+    }
+
+    private PathGeometry GetNonScalingStrokePath(
+        PathGeometry source,
+        in Matrix4x4 transform)
+    {
+        if (!ReferenceEquals(_nonScalingStrokeSource, source) ||
+            _nonScalingStrokeTransform != transform ||
+            _nonScalingStrokePath is null)
+        {
+            _nonScalingStrokeSource = source;
+            _nonScalingStrokeTransform = transform;
+            _nonScalingStrokePath = source.CreateTransformed(transform);
+            _nonScalingStrokeCache = RenderCommandGeometryCache.ForPath(
+                _nonScalingStrokePath);
+        }
+
+        return _nonScalingStrokePath;
+    }
+
+    private void InvalidateNonScalingStrokeCache()
+    {
+        _nonScalingStrokeSource = null;
+        _nonScalingStrokePath = null;
+        _nonScalingStrokeCache = null;
+        _nonScalingStrokeTransform = default;
     }
 
     private void SetFinite(

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -25,6 +25,8 @@ public class SKCanvas : SKObject
     private static readonly byte[] s_identityColorTable = CreateIdentityColorTable();
     private static readonly PathGeometry s_unitRectangleGeometry =
         CreateRectGeometry(new SKRect(0f, 0f, 1f, 1f));
+    private static readonly SolidColorBrush s_opaqueStrokeMaskBrush =
+        new(Vector4.One);
     private static readonly DrawingContext s_emptyRetainedLayerResourceContext = new();
 
     private sealed class TextureColorSpace
@@ -4725,12 +4727,36 @@ public class SKCanvas : SKObject
                 pushedOpacity = true;
             }
 
+            bool hasHairlineStroke =
+                paint.Style != SKPaintStyle.Fill &&
+                paint.StrokeWidth == 0f;
             if (paint.Style == SKPaintStyle.Fill)
             {
                 DrawShaderLayer(shader!, clipGeometry, targetBounds, paint, drawAsFill: false);
             }
             else
             {
+                if (paint.Style == SKPaintStyle.StrokeAndFill &&
+                    hasHairlineStroke)
+                {
+                    DrawShaderLayer(
+                        shader!,
+                        clipGeometry,
+                        targetBounds,
+                        paint,
+                        drawAsFill: true);
+                }
+
+                if (hasHairlineStroke)
+                {
+                    DrawSpecialShaderHairline(
+                        shader!,
+                        clipGeometry,
+                        targetBounds,
+                        paint);
+                    return true;
+                }
+
                 using var sourcePath = new SKPath();
                 sourcePath.Geometry.FillRule = clipGeometry.FillRule;
                 foreach (var figure in clipGeometry.Figures)
@@ -4756,6 +4782,54 @@ public class SKCanvas : SKObject
         }
 
         return true;
+    }
+
+    private void DrawSpecialShaderHairline(
+        SKShader shader,
+        PathGeometry strokePath,
+        SKRect targetBounds,
+        SKPaint paint)
+    {
+        Matrix4x4 transform = _currentMatrix.ToMatrix4x4();
+        float localPadding = 1f;
+        if (TransformMetrics.TryGetStrokeScales(
+                transform,
+                out _,
+                out float minimumScale))
+        {
+            localPadding = 2f / minimumScale;
+        }
+
+        var coverageBounds = SKRect.Inflate(
+            targetBounds,
+            localPadding,
+            localPadding);
+        var coverageGeometry = CreateRectGeometry(coverageBounds);
+        Pen maskPen = paint.ToLocalPen(
+            s_opaqueStrokeMaskBrush,
+            GetCurrentStrokeScale());
+        _context.PushOpacityMask(
+            strokePath,
+            maskPen,
+            new Rect(
+                coverageBounds.Left,
+                coverageBounds.Top,
+                coverageBounds.Width,
+                coverageBounds.Height),
+            transform);
+        try
+        {
+            DrawShaderLayer(
+                shader,
+                coverageGeometry,
+                coverageBounds,
+                paint,
+                drawAsFill: true);
+        }
+        finally
+        {
+            _context.PopOpacityMask();
+        }
     }
 
     private static bool HasSpecialShader(SKShader? shader)

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -4349,7 +4349,7 @@ public class SKCanvas : SKObject
         try
         {
             var brush = paint.ToRetainedBrush();
-            var pen = paint.ToRetainedPen(GetCurrentStrokeScale());
+            var pen = paint.ToLocalPen(GetCurrentStrokeScale());
 
             if (IsInverseFillType(path.FillType))
             {
@@ -4529,6 +4529,8 @@ public class SKCanvas : SKObject
             Pen = pen,
             Transform = transform,
             IsEdgeAliased = isEdgeAliased,
+            IsPenThicknessLocal = pen is not null,
+            GeometryCache = RenderCommandGeometryCache.ForPath(path),
             UseVectorGlyphRendering = textRasterization.HasValue,
             FontSize = textInfo.FontSize,
             FontTransform = textInfo.FontTransform,
@@ -4834,7 +4836,7 @@ public class SKCanvas : SKObject
                 var conicalFill = style == SKPaintStyle.Stroke ? null : conicalBrush;
                 var conicalPen = style == SKPaintStyle.Fill
                     ? null
-                    : paint.ToPen(conicalBrush, GetCurrentStrokeScale());
+                    : paint.ToLocalPen(conicalBrush, GetCurrentStrokeScale());
                 AddDrawPathCommand(
                     clipGeometry,
                     conicalFill,
@@ -4901,7 +4903,7 @@ public class SKCanvas : SKObject
         var fill = shaderStyle == SKPaintStyle.Stroke ? null : brush;
         var pen = shaderStyle == SKPaintStyle.Fill
             ? null
-            : paint.ToPen(brush, GetCurrentStrokeScale());
+            : paint.ToLocalPen(brush, GetCurrentStrokeScale());
         AddDrawPathCommand(
             clipGeometry,
             fill,

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -4028,6 +4028,13 @@ public class SKCanvas : SKObject
         DrawPoint(x, y, paint);
     }
 
+    private void AddAnalyticPrimitiveCommand(RenderCommand command)
+    {
+        command.GeometryCache =
+            RenderCommandGeometryCache.CreateForDashedPrimitive(command);
+        _context.Commands.Add(command);
+    }
+
     public void DrawRect(float x, float y, float w, float h, SKPaint paint)
     {
         var rect = new SKRect(x, y, x + w, y + h);
@@ -4042,7 +4049,7 @@ public class SKCanvas : SKObject
         {
             var brush = paint.ToRetainedBrush();
             var pen = paint.ToLocalPen(GetCurrentStrokeScale());
-            _context.Commands.Add(new RenderCommand
+            AddAnalyticPrimitiveCommand(new RenderCommand
             {
                 Type = RenderCommandType.DrawRect,
                 Rect = new Rect(x, y, w, h),
@@ -4097,7 +4104,7 @@ public class SKCanvas : SKObject
         {
             var brush = paint.ToRetainedBrush();
             var pen = paint.ToLocalPen(GetCurrentStrokeScale());
-            _context.Commands.Add(new RenderCommand
+            AddAnalyticPrimitiveCommand(new RenderCommand
             {
                 Type = RenderCommandType.DrawRoundedRect,
                 Rect = new Rect(rect.Left, rect.Top, rect.Width, rect.Height),
@@ -4223,7 +4230,7 @@ public class SKCanvas : SKObject
         {
             var brush = paint.ToRetainedBrush();
             var pen = paint.ToLocalPen(GetCurrentStrokeScale());
-            _context.Commands.Add(new RenderCommand
+            AddAnalyticPrimitiveCommand(new RenderCommand
             {
                 Type = RenderCommandType.DrawEllipse,
                 Position2 = new Vector2(rect.MidX, rect.MidY),
@@ -4266,7 +4273,7 @@ public class SKCanvas : SKObject
         {
             var brush = paint.ToRetainedBrush();
             var pen = paint.ToLocalPen(GetCurrentStrokeScale());
-            _context.Commands.Add(new RenderCommand
+            AddAnalyticPrimitiveCommand(new RenderCommand
             {
                 Type = RenderCommandType.DrawCircle,
                 Position2 = new Vector2(cx, cy),

--- a/src/SkiaSharp/SKForwardingCanvases.cs
+++ b/src/SkiaSharp/SKForwardingCanvases.cs
@@ -114,7 +114,8 @@ public class SKNWayCanvas : SKNoDrawCanvas
                 command.Pen.EndLineCap,
                 command.Pen.DashCap,
                 command.Pen.DashArray,
-                command.Pen.DashOffset);
+                command.Pen.DashOffset,
+                command.Pen.StrokeTransformMode);
         }
 
         destination.AppendCommand(DrawingContext, commandIndex, command);

--- a/src/SkiaSharp/SKPaint.cs
+++ b/src/SkiaSharp/SKPaint.cs
@@ -321,13 +321,10 @@ public partial class SKPaint : SKObject
     {
         if (Style == SKPaintStyle.Fill) return null;
 
-        var localStrokeWidth = StrokeWidth;
-        if (localStrokeWidth == 0f)
-        {
-            localStrokeWidth = float.IsFinite(strokeScale) && strokeScale > 0f
-                ? HairlineStrokeWidth / strokeScale
-                : HairlineStrokeWidth;
-        }
+        var isHairline = StrokeWidth == 0f;
+        var localStrokeWidth = isHairline
+            ? Pen.HairlineThickness
+            : StrokeWidth;
 
         if (TryGetRetainedSolidBrush(out var retainedBrush))
         {
@@ -354,7 +351,9 @@ public partial class SKPaint : SKObject
                 color.A / 255.0f));
         }
 
-        var (dashArray, dashOffset) = MapDashEffect(PathEffect, localStrokeWidth);
+        var (dashArray, dashOffset) = MapDashEffect(
+            PathEffect,
+            isHairline ? HairlineStrokeWidth : localStrokeWidth);
         penBrush = ApplyMaskFilter(penBrush);
         return new Pen(
             penBrush,
@@ -431,6 +430,28 @@ public partial class SKPaint : SKObject
         return new Pen(
             ApplyMaskFilter(brush),
             scaledStrokeWidth,
+            MapStrokeJoin(StrokeJoin),
+            StrokeMiter,
+            MapStrokeCap(StrokeCap),
+            MapStrokeCap(StrokeCap),
+            MapStrokeCap(StrokeCap),
+            dashArray,
+            dashOffset);
+    }
+
+    internal Pen ToLocalPen(Brush brush, float strokeScale)
+    {
+        var isHairline = StrokeWidth == 0f;
+        var localStrokeWidth = isHairline
+            ? Pen.HairlineThickness
+            : StrokeWidth;
+
+        var (dashArray, dashOffset) = MapDashEffect(
+            PathEffect,
+            isHairline ? HairlineStrokeWidth : localStrokeWidth);
+        return new Pen(
+            ApplyMaskFilter(brush),
+            localStrokeWidth,
             MapStrokeJoin(StrokeJoin),
             StrokeMiter,
             MapStrokeCap(StrokeCap),
@@ -796,7 +817,9 @@ public partial class SKPaint : SKObject
 
         var reversed = new PathFigure(current, source.IsClosed)
         {
-            IsFilled = source.IsFilled
+            IsFilled = source.IsFilled,
+            StrokeStartLineCap = source.StrokeEndLineCap,
+            StrokeEndLineCap = source.StrokeStartLineCap
         };
         for (var index = segments.Count - 1; index >= 0; index--)
         {

--- a/src/SkiaSharp/SKPath.Compatibility.cs
+++ b/src/SkiaSharp/SKPath.Compatibility.cs
@@ -934,7 +934,12 @@ public partial class SKPath
             current = GetSegmentEnd(source.Segments[index]);
         }
 
-        var reversed = new PathFigure(current, source.IsClosed) { IsFilled = source.IsFilled };
+        var reversed = new PathFigure(current, source.IsClosed)
+        {
+            IsFilled = source.IsFilled,
+            StrokeStartLineCap = source.StrokeEndLineCap,
+            StrokeEndLineCap = source.StrokeStartLineCap
+        };
         for (var index = source.Segments.Count - 1; index >= 0; index--)
         {
             if (TryFindConicGroup(source.Segments, index, out var conicStart, out var conic))

--- a/src/SkiaSharp/SKPath.cs
+++ b/src/SkiaSharp/SKPath.cs
@@ -639,7 +639,9 @@ public partial class SKPath : SKObject
     {
         var copy = new PathFigure(figure.StartPoint + offset, figure.IsClosed)
         {
-            IsFilled = figure.IsFilled
+            IsFilled = figure.IsFilled,
+            StrokeStartLineCap = figure.StrokeStartLineCap,
+            StrokeEndLineCap = figure.StrokeEndLineCap
         };
         foreach (var segment in figure.Segments)
         {

--- a/src/SkiaSharp/SKPicture.Serialization.cs
+++ b/src/SkiaSharp/SKPicture.Serialization.cs
@@ -310,6 +310,14 @@ internal static class PictureArchive
             return;
         }
 
+        var primitiveCache =
+            RenderCommandGeometryCache.CreateForDashedPrimitive(command);
+        if (primitiveCache != null)
+        {
+            command.GeometryCache = primitiveCache;
+            return;
+        }
+
         PathGeometry? strokePath = command.Type switch
         {
             RenderCommandType.DrawLine when RequiresStrokePath(pen) =>

--- a/src/SkiaSharp/SKPicture.Serialization.cs
+++ b/src/SkiaSharp/SKPicture.Serialization.cs
@@ -140,7 +140,8 @@ public partial class SKPicture
 internal static class PictureArchive
 {
     private const ulong Magic = 0x314349504B534750UL;
-    private const int Version = 1;
+    private const int Version = 2;
+    private const int MinimumSupportedVersion = 1;
     private const int MaxDepth = 64;
     private const int MaxCommands = 1_000_000;
     private const int MaxArrayElements = 16_000_000;
@@ -172,16 +173,27 @@ internal static class PictureArchive
         Arc,
     }
 
-    public static byte[] Serialize(GpuPicture picture, SKRect cullRect)
+    public static byte[] Serialize(GpuPicture picture, SKRect cullRect) =>
+        Serialize(picture, cullRect, Version);
+
+    internal static byte[] Serialize(
+        GpuPicture picture,
+        SKRect cullRect,
+        int archiveVersion)
     {
         ArgumentNullException.ThrowIfNull(picture);
+        if (archiveVersion < MinimumSupportedVersion || archiveVersion > Version)
+        {
+            throw new ArgumentOutOfRangeException(nameof(archiveVersion));
+        }
+
         using var output = new MemoryStream();
         using (var writer = new BinaryWriter(output, Encoding.UTF8, leaveOpen: true))
         {
             writer.Write(Magic);
-            writer.Write(Version);
+            writer.Write(archiveVersion);
             WriteRect(writer, cullRect);
-            WritePicture(writer, picture, 0);
+            WritePicture(writer, picture, 0, archiveVersion);
         }
 
         if (output.Length > MaxArchiveBytes)
@@ -207,13 +219,19 @@ internal static class PictureArchive
         {
             using var input = new MemoryStream(data.ToArray(), writable: false);
             using var reader = new BinaryReader(input, Encoding.UTF8, leaveOpen: false);
-            if (reader.ReadUInt64() != Magic || reader.ReadInt32() != Version)
+            if (reader.ReadUInt64() != Magic)
+            {
+                return false;
+            }
+
+            var version = reader.ReadInt32();
+            if (version < MinimumSupportedVersion || version > Version)
             {
                 return false;
             }
 
             cullRect = ReadRect(reader);
-            picture = ReadPicture(reader, 0);
+            picture = ReadPicture(reader, 0, version);
             if (input.Position != input.Length)
             {
                 picture.Dispose();
@@ -240,7 +258,11 @@ internal static class PictureArchive
         }
     }
 
-    private static void WritePicture(BinaryWriter writer, GpuPicture picture, int depth)
+    private static void WritePicture(
+        BinaryWriter writer,
+        GpuPicture picture,
+        int depth,
+        int version)
     {
         EnsureDepth(depth);
         WriteVector2Array(writer, picture.PointBuffer);
@@ -250,11 +272,11 @@ internal static class PictureArchive
         WriteCount(writer, picture.RetainedCommands.Length, MaxCommands, "commands");
         foreach (var command in picture.RetainedCommands)
         {
-            WriteCommand(writer, command, depth);
+            WriteCommand(writer, command, depth, version);
         }
     }
 
-    private static GpuPicture ReadPicture(BinaryReader reader, int depth)
+    private static GpuPicture ReadPicture(BinaryReader reader, int depth, int version)
     {
         EnsureDepth(depth);
         var points = ReadVector2Array(reader);
@@ -265,12 +287,123 @@ internal static class PictureArchive
         var commands = new RenderCommand[count];
         for (var index = 0; index < commands.Length; index++)
         {
-            commands[index] = ReadCommand(reader, depth);
+            commands[index] = ReadCommand(reader, depth, version);
+            RestoreGeometryCache(ref commands[index], points, doubles);
         }
         return new GpuPicture(commands, points, doubles, lines, floats);
     }
 
-    private static void WriteCommand(BinaryWriter writer, RenderCommand command, int depth)
+    private static void RestoreGeometryCache(
+        ref RenderCommand command,
+        Vector2[] points,
+        double[] doubles)
+    {
+        if (command.Type == RenderCommandType.DrawPath && command.Path != null)
+        {
+            command.GeometryCache = RenderCommandGeometryCache.ForPath(command.Path);
+            return;
+        }
+
+        var pen = command.Pen;
+        if (pen == null)
+        {
+            return;
+        }
+
+        PathGeometry? strokePath = command.Type switch
+        {
+            RenderCommandType.DrawLine when RequiresStrokePath(pen) =>
+                RenderCommandGeometryCache.CreateLinePath(
+                    command.Position,
+                    command.Position2),
+            RenderCommandType.DrawBezier when RequiresStrokePath(pen) =>
+                RenderCommandGeometryCache.CreateQuadraticBezierPath(
+                    command.Position,
+                    command.Position2,
+                    command.Position3),
+            RenderCommandType.DrawCubicBezier when RequiresStrokePath(pen) =>
+                RenderCommandGeometryCache.CreateCubicBezierPath(
+                    command.Position,
+                    command.Position2,
+                    command.Position3,
+                    command.Position4),
+            RenderCommandType.PushOpacityMask when command.Path != null =>
+                command.Path,
+            _ => null
+        };
+
+        if (command.Type == RenderCommandType.DrawPolyline)
+        {
+            var polylinePoints = GetArchivePoints(command, points);
+            if (pen.HasDashPattern ||
+                command.IsClosed ||
+                polylinePoints.Length > 2 ||
+                RequiresStrokePath(pen))
+            {
+                strokePath = RenderCommandGeometryCache.CreatePolylinePath(
+                    polylinePoints,
+                    command.IsClosed);
+            }
+        }
+        else if (command.Type == RenderCommandType.DrawSpline ||
+            (command.Type == RenderCommandType.DrawExtension &&
+             command.ExtensionId == CompositorBuiltInExtensions.Spline))
+        {
+            var splinePoints = GetArchivePoints(command, points);
+            var knots = GetArchiveDoubles(
+                command.DoubleBufferOffset,
+                command.DoubleBufferCount,
+                command.SplineKnots,
+                doubles);
+            var weights = GetArchiveDoubles(
+                command.WeightBufferOffset,
+                command.WeightBufferCount,
+                command.SplineWeights,
+                doubles);
+            strokePath = RenderCommandGeometryCache.CreateSplinePath(
+                splinePoints,
+                knots,
+                weights,
+                command.SplineDegree,
+                command.IsClosed);
+        }
+
+        if (strokePath != null)
+        {
+            command.GeometryCache = RenderCommandGeometryCache.ForStrokePath(strokePath);
+        }
+    }
+
+    private static bool RequiresStrokePath(Pen pen) =>
+        pen.HasDashPattern ||
+        pen.StartLineCap != PenLineCap.Flat ||
+        pen.EndLineCap != PenLineCap.Flat;
+
+    private static ReadOnlySpan<Vector2> GetArchivePoints(
+        in RenderCommand command,
+        Vector2[] points) =>
+        command.PolylinePoints is { Length: > 0 } inlinePoints
+            ? inlinePoints
+            : points.AsSpan(
+                command.PointBufferOffset,
+                command.PointBufferCount);
+
+    private static ReadOnlySpan<double> GetArchiveDoubles(
+        int offset,
+        int count,
+        double[]? inlineValues,
+        double[] values) =>
+        inlineValues is { Length: > 0 }
+            ? inlineValues
+            : count > 0
+                ? values.AsSpan(offset, count)
+                : ReadOnlySpan<double>.Empty;
+
+    private static void WriteCommand(
+        BinaryWriter writer,
+        RenderCommand command,
+        int depth,
+        int version)
     {
         if (command.Texture is not null ||
             command.StaticBuffer is not null ||
@@ -286,7 +419,7 @@ internal static class PictureArchive
         WriteRect(writer, command.Rect);
         WriteBrush(writer, command.Brush);
         WritePen(writer, command.Pen);
-        WritePath(writer, command.Path, depth);
+        WritePath(writer, command.Path, depth, version);
         WriteString(writer, command.Text);
         WriteFont(writer, command.Font);
         writer.Write(command.FontSize);
@@ -343,7 +476,7 @@ internal static class PictureArchive
         writer.Write(command.Picture is not null);
         if (command.Picture is not null)
         {
-            WritePicture(writer, command.Picture, depth + 1);
+            WritePicture(writer, command.Picture, depth + 1, version);
         }
         WriteUShortArray(writer, command.GlyphIndices);
         WriteVector2Array(writer, command.GlyphPositions);
@@ -354,7 +487,7 @@ internal static class PictureArchive
         writer.Write(command.FloatParam);
     }
 
-    private static RenderCommand ReadCommand(BinaryReader reader, int depth)
+    private static RenderCommand ReadCommand(BinaryReader reader, int depth, int version)
     {
         var command = new RenderCommand
         {
@@ -363,7 +496,7 @@ internal static class PictureArchive
             Rect = ReadSceneRect(reader),
             Brush = ReadBrush(reader),
             Pen = ReadPen(reader),
-            Path = ReadPath(reader, depth),
+            Path = ReadPath(reader, depth, version),
             Text = ReadString(reader),
             Font = ReadFont(reader),
             FontSize = reader.ReadSingle(),
@@ -420,7 +553,7 @@ internal static class PictureArchive
         };
         if (reader.ReadBoolean())
         {
-            command.Picture = ReadPicture(reader, depth + 1);
+            command.Picture = ReadPicture(reader, depth + 1, version);
         }
         command.GlyphIndices = ReadNullableUShortArray(reader);
         command.GlyphPositions = ReadNullableVector2Array(reader);
@@ -731,7 +864,11 @@ internal static class PictureArchive
         };
     }
 
-    private static void WritePath(BinaryWriter writer, PathGeometry? path, int depth)
+    private static void WritePath(
+        BinaryWriter writer,
+        PathGeometry? path,
+        int depth,
+        int version)
     {
         writer.Write(path is not null);
         if (path is null)
@@ -744,8 +881,8 @@ internal static class PictureArchive
         writer.Write(path.Op);
         if (path.IsCombined)
         {
-            WritePath(writer, path.PathA, depth + 1);
-            WritePath(writer, path.PathB, depth + 1);
+            WritePath(writer, path.PathA, depth + 1, version);
+            WritePath(writer, path.PathB, depth + 1, version);
         }
         WriteCount(writer, path.Figures.Count, MaxArrayElements, "path figures");
         foreach (var figure in path.Figures)
@@ -753,6 +890,11 @@ internal static class PictureArchive
             WriteVector2(writer, figure.StartPoint);
             writer.Write(figure.IsClosed);
             writer.Write(figure.IsFilled);
+            if (version >= 2)
+            {
+                WriteNullableEnum(writer, figure.StrokeStartLineCap);
+                WriteNullableEnum(writer, figure.StrokeEndLineCap);
+            }
             WriteCount(writer, figure.Segments.Count, MaxArrayElements, "path segments");
             foreach (var segment in figure.Segments)
             {
@@ -794,7 +936,7 @@ internal static class PictureArchive
         }
     }
 
-    private static PathGeometry? ReadPath(BinaryReader reader, int depth)
+    private static PathGeometry? ReadPath(BinaryReader reader, int depth, int version)
     {
         if (!reader.ReadBoolean())
         {
@@ -809,8 +951,8 @@ internal static class PictureArchive
         };
         if (path.IsCombined)
         {
-            path.PathA = ReadPath(reader, depth + 1);
-            path.PathB = ReadPath(reader, depth + 1);
+            path.PathA = ReadPath(reader, depth + 1, version);
+            path.PathB = ReadPath(reader, depth + 1, version);
         }
         var figureCount = ReadCount(reader, MaxArrayElements, "path figures");
         for (var figureIndex = 0; figureIndex < figureCount; figureIndex++)
@@ -819,6 +961,11 @@ internal static class PictureArchive
             {
                 IsFilled = reader.ReadBoolean(),
             };
+            if (version >= 2)
+            {
+                figure.StrokeStartLineCap = ReadNullableEnum<PenLineCap>(reader);
+                figure.StrokeEndLineCap = ReadNullableEnum<PenLineCap>(reader);
+            }
             var segmentCount = ReadCount(reader, MaxArrayElements, "path segments");
             for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
             {
@@ -1304,6 +1451,20 @@ internal static class PictureArchive
         }
         return (TEnum)Enum.ToObject(typeof(TEnum), raw);
     }
+
+    private static void WriteNullableEnum<TEnum>(BinaryWriter writer, TEnum? value)
+        where TEnum : struct, Enum
+    {
+        writer.Write(value.HasValue);
+        if (value.HasValue)
+        {
+            writer.Write(Convert.ToInt32(value.Value));
+        }
+    }
+
+    private static TEnum? ReadNullableEnum<TEnum>(BinaryReader reader)
+        where TEnum : struct, Enum =>
+        reader.ReadBoolean() ? ReadEnum<TEnum>(reader) : null;
 
     private static void WriteRect(BinaryWriter writer, SKRect value)
     {

--- a/src/SkiaSharp/SKPicture.Serialization.cs
+++ b/src/SkiaSharp/SKPicture.Serialization.cs
@@ -140,7 +140,7 @@ public partial class SKPicture
 internal static class PictureArchive
 {
     private const ulong Magic = 0x314349504B534750UL;
-    private const int Version = 2;
+    private const int Version = 3;
     private const int MinimumSupportedVersion = 1;
     private const int MaxDepth = 64;
     private const int MaxCommands = 1_000_000;
@@ -367,7 +367,7 @@ internal static class PictureArchive
         writer.Write(command.HitTestId);
         WriteRect(writer, command.Rect);
         WriteBrush(writer, command.Brush);
-        WritePen(writer, command.Pen);
+        WritePen(writer, command.Pen, version);
         WritePath(writer, command.Path, depth, version);
         WriteString(writer, command.Text);
         WriteFont(writer, command.Font);
@@ -444,7 +444,7 @@ internal static class PictureArchive
             HitTestId = reader.ReadInt32(),
             Rect = ReadSceneRect(reader),
             Brush = ReadBrush(reader),
-            Pen = ReadPen(reader),
+            Pen = ReadPen(reader, version),
             Path = ReadPath(reader, depth, version),
             Text = ReadString(reader),
             Font = ReadFont(reader),
@@ -775,7 +775,7 @@ internal static class PictureArchive
             UseFallback = reader.ReadBoolean(),
         };
 
-    private static void WritePen(BinaryWriter writer, Pen? pen)
+    private static void WritePen(BinaryWriter writer, Pen? pen, int version)
     {
         writer.Write(pen is not null);
         if (pen is null)
@@ -791,16 +791,20 @@ internal static class PictureArchive
         writer.Write((int)pen.DashCap);
         WriteDoubleArray(writer, pen.DashArray);
         writer.Write(pen.DashOffset);
+        if (version >= 3)
+        {
+            writer.Write((int)pen.StrokeTransformMode);
+        }
     }
 
-    private static Pen? ReadPen(BinaryReader reader)
+    private static Pen? ReadPen(BinaryReader reader, int version)
     {
         if (!reader.ReadBoolean())
         {
             return null;
         }
         var brush = ReadBrush(reader) ?? throw new InvalidDataException("Pens require a brush.");
-        return new Pen(brush)
+        var pen = new Pen(brush)
         {
             Thickness = reader.ReadSingle(),
             LineJoin = ReadEnum<PenLineJoin>(reader),
@@ -811,6 +815,11 @@ internal static class PictureArchive
             DashArray = ReadNullableDoubleArray(reader),
             DashOffset = reader.ReadDouble(),
         };
+        if (version >= 3)
+        {
+            pen.StrokeTransformMode = ReadEnum<PenStrokeTransformMode>(reader);
+        }
+        return pen;
     }
 
     private static void WritePath(

--- a/src/SkiaSharp/SKPicture.Serialization.cs
+++ b/src/SkiaSharp/SKPicture.Serialization.cs
@@ -288,15 +288,12 @@ internal static class PictureArchive
         for (var index = 0; index < commands.Length; index++)
         {
             commands[index] = ReadCommand(reader, depth, version);
-            RestoreGeometryCache(ref commands[index], points, doubles);
+            RestoreGeometryCache(ref commands[index]);
         }
         return new GpuPicture(commands, points, doubles, lines, floats);
     }
 
-    private static void RestoreGeometryCache(
-        ref RenderCommand command,
-        Vector2[] points,
-        double[] doubles)
+    private static void RestoreGeometryCache(ref RenderCommand command)
     {
         if (command.Type == RenderCommandType.DrawPath && command.Path != null)
         {
@@ -340,42 +337,6 @@ internal static class PictureArchive
             _ => null
         };
 
-        if (command.Type == RenderCommandType.DrawPolyline)
-        {
-            var polylinePoints = GetArchivePoints(command, points);
-            if (pen.HasDashPattern ||
-                command.IsClosed ||
-                polylinePoints.Length > 2 ||
-                RequiresStrokePath(pen))
-            {
-                strokePath = RenderCommandGeometryCache.CreatePolylinePath(
-                    polylinePoints,
-                    command.IsClosed);
-            }
-        }
-        else if (command.Type == RenderCommandType.DrawSpline ||
-            (command.Type == RenderCommandType.DrawExtension &&
-             command.ExtensionId == CompositorBuiltInExtensions.Spline))
-        {
-            var splinePoints = GetArchivePoints(command, points);
-            var knots = GetArchiveDoubles(
-                command.DoubleBufferOffset,
-                command.DoubleBufferCount,
-                command.SplineKnots,
-                doubles);
-            var weights = GetArchiveDoubles(
-                command.WeightBufferOffset,
-                command.WeightBufferCount,
-                command.SplineWeights,
-                doubles);
-            strokePath = RenderCommandGeometryCache.CreateSplinePath(
-                splinePoints,
-                knots,
-                weights,
-                command.SplineDegree,
-                command.IsClosed);
-        }
-
         if (strokePath != null)
         {
             command.GeometryCache = RenderCommandGeometryCache.ForStrokePath(strokePath);
@@ -386,26 +347,6 @@ internal static class PictureArchive
         pen.HasDashPattern ||
         pen.StartLineCap != PenLineCap.Flat ||
         pen.EndLineCap != PenLineCap.Flat;
-
-    private static ReadOnlySpan<Vector2> GetArchivePoints(
-        in RenderCommand command,
-        Vector2[] points) =>
-        command.PolylinePoints is { Length: > 0 } inlinePoints
-            ? inlinePoints
-            : points.AsSpan(
-                command.PointBufferOffset,
-                command.PointBufferCount);
-
-    private static ReadOnlySpan<double> GetArchiveDoubles(
-        int offset,
-        int count,
-        double[]? inlineValues,
-        double[] values) =>
-        inlineValues is { Length: > 0 }
-            ? inlineValues
-            : count > 0
-                ? values.AsSpan(offset, count)
-                : ReadOnlySpan<double>.Empty;
 
     private static void WriteCommand(
         BinaryWriter writer,

--- a/src/System.Drawing.Common/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/System/Drawing/Graphics.cs
@@ -339,6 +339,37 @@ public class Graphics :
         Math.Abs(CombinedTransform.M12) > 1e-5f
         || Math.Abs(CombinedTransform.M21) > 1e-5f;
 
+    private bool RequiresTransformedStrokePath
+    {
+        get
+        {
+            if (HasRotationOrShear)
+            {
+                return true;
+            }
+
+            var xAxisLengthSquared =
+                (CombinedTransform.M11 * CombinedTransform.M11) +
+                (CombinedTransform.M12 * CombinedTransform.M12);
+            var yAxisLengthSquared =
+                (CombinedTransform.M21 * CombinedTransform.M21) +
+                (CombinedTransform.M22 * CombinedTransform.M22);
+            if (!float.IsFinite(xAxisLengthSquared) ||
+                !float.IsFinite(yAxisLengthSquared) ||
+                xAxisLengthSquared <= 1e-10f ||
+                yAxisLengthSquared <= 1e-10f)
+            {
+                return true;
+            }
+
+            var comparisonScale = MathF.Max(
+                1f,
+                MathF.Max(xAxisLengthSquared, yAxisLengthSquared));
+            return MathF.Abs(xAxisLengthSquared - yAxisLengthSquared) >
+                (comparisonScale * 1e-5f);
+        }
+    }
+
     private Rect TxRect(RectangleF rect)
     {
         var p1 = Tx(rect.X, rect.Y);
@@ -360,33 +391,10 @@ public class Graphics :
             m32.M31, m32.M32, 0f, 1f);
     }
 
-    private ProGPU.Vector.Pen TransformPen(Pen pen, Vector2 localStart, Vector2 localEnd)
-    {
-        float widthScale = GetStrokeWidthScale(localStart, localEnd);
-        return pen.ToProGpuPen(pen.Width * widthScale);
-    }
-
     private ProGPU.Vector.Pen TransformPen(Pen pen)
     {
         float widthScale = GetFallbackStrokeWidthScale();
         return pen.ToProGpuPen(pen.Width * widthScale);
-    }
-
-    private float GetStrokeWidthScale(Vector2 localStart, Vector2 localEnd)
-    {
-        var delta = localEnd - localStart;
-        if (delta.LengthSquared() > 1e-10f)
-        {
-            var normal = Vector2.Normalize(new Vector2(-delta.Y, delta.X));
-            var transformedNormal = Vector2.TransformNormal(normal, CombinedTransform);
-            float scale = transformedNormal.Length();
-            if (float.IsFinite(scale) && scale > 1e-5f)
-            {
-                return scale;
-            }
-        }
-
-        return GetFallbackStrokeWidthScale();
     }
 
     private float GetFallbackStrokeWidthScale()
@@ -415,27 +423,32 @@ public class Graphics :
 
     public void DrawLine(Pen pen, float x1, float y1, float x2, float y2)
     {
+        ArgumentNullException.ThrowIfNull(pen);
         var localStart = new Vector2(x1, y1);
         var localEnd = new Vector2(x2, y2);
-        _context.DrawLine(TransformPen(pen, localStart, localEnd), Tx(localStart), Tx(localEnd));
+        _context.DrawLine(
+            pen.ToProGpuPen(pen.Width),
+            localStart,
+            localEnd,
+            CurrentTransform4x4());
     }
 
     public void DrawLines(Pen pen, PointF[] points)
     {
         if (points == null || points.Length < 2) return;
-        for (int i = 0; i < points.Length - 1; i++)
-        {
-            DrawLine(pen, points[i], points[i + 1]);
-        }
+        ArgumentNullException.ThrowIfNull(pen);
+        using var path = new GraphicsPath();
+        path.AddLines(points);
+        DrawTransformedPath(pen, path.Geometry);
     }
 
     public void DrawLines(Pen pen, Point[] points)
     {
         if (points == null || points.Length < 2) return;
-        for (int i = 0; i < points.Length - 1; i++)
-        {
-            DrawLine(pen, points[i], points[i + 1]);
-        }
+        ArgumentNullException.ThrowIfNull(pen);
+        using var path = new GraphicsPath();
+        path.AddLines(points);
+        DrawTransformedPath(pen, path.Geometry);
     }
 
     public void DrawCurve(Pen pen, PointF[] points) =>
@@ -474,7 +487,7 @@ public class Graphics :
                 new Vector2(next.X, next.Y)));
         }
 
-        _context.DrawPath(null, TransformPen(pen), geometry, CurrentTransform4x4());
+        DrawTransformedPath(pen, geometry);
     }
 
     public void DrawCurve(Pen pen, Point[] points) =>
@@ -510,7 +523,7 @@ public class Graphics :
                 new Vector2(next.X, next.Y)));
         }
 
-        _context.DrawPath(null, TransformPen(pen), geometry, CurrentTransform4x4());
+        DrawTransformedPath(pen, geometry);
     }
 
     private static int GetCurveSegmentCount<TPoint>(TPoint[]? points)
@@ -538,7 +551,7 @@ public class Graphics :
 
     public void DrawRectangle(Pen pen, float x, float y, float width, float height)
     {
-        if (HasRotationOrShear)
+        if (RequiresTransformedStrokePath)
         {
             using var path = new GraphicsPath();
             path.AddRectangle(new RectangleF(x, y, width, height));
@@ -673,7 +686,7 @@ public class Graphics :
 
     public void DrawEllipse(Pen pen, float x, float y, float width, float height)
     {
-        if (HasRotationOrShear)
+        if (RequiresTransformedStrokePath)
         {
             using var path = new GraphicsPath();
             path.AddEllipse(x, y, width, height);
@@ -752,7 +765,16 @@ public class Graphics :
     public void DrawPath(Pen pen, GraphicsPath path)
     {
         if (path == null) return;
-        _context.DrawPath(null, TransformPen(pen), path.Geometry, CurrentTransform4x4());
+        DrawTransformedPath(pen, path.Geometry);
+    }
+
+    private void DrawTransformedPath(Pen pen, PathGeometry geometry)
+    {
+        _context.DrawPath(
+            null,
+            pen.ToProGpuPen(pen.Width),
+            geometry,
+            CurrentTransform4x4());
     }
 
     public void FillPath(Brush brush, GraphicsPath path)

--- a/tests/ProGPU.Avalonia.ContractTests/AvaloniaStrokeTransformContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/AvaloniaStrokeTransformContractTests.cs
@@ -1,0 +1,48 @@
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.ProGpu;
+using ProGPU.Scene;
+using Xunit;
+
+namespace Avalonia.ProGpu.ContractTests;
+
+[Collection(BackendContextCollection.Name)]
+public sealed class AvaloniaStrokeTransformContractTests
+{
+    [Fact]
+    public void TransformedPrimitiveStrokesRetainRawLocalPenThickness()
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(64, 48),
+                Dpi = new Vector(96, 96)
+            });
+        context.Transform = Matrix.CreateScale(2, 3);
+        var pen = new Avalonia.Media.Pen(Brushes.Red, 2);
+
+        context.DrawLine(pen, new Point(1, 2), new Point(10, 2));
+        context.DrawRectangle(
+            null,
+            pen,
+            new RoundedRect(new Rect(1, 2, 10, 12)));
+        context.DrawEllipse(null, pen, new Rect(2, 3, 12, 14));
+        context.DrawGeometry(
+            null,
+            pen,
+            AvaloniaGeometryFactory.Line(
+                new Point(1, 2),
+                new Point(10, 2)));
+
+        Assert.Equal(4, context.DrawingContext.Commands.Count);
+        Assert.All(
+            context.DrawingContext.Commands,
+            command =>
+            {
+                Assert.Equal(2f, command.Pen!.Thickness);
+                Assert.True(command.IsPenThicknessLocal);
+                Assert.Equal(2f, command.Transform.M11);
+                Assert.Equal(3f, command.Transform.M22);
+            });
+    }
+}

--- a/tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
+++ b/tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="AvaloniaCompositionLayoutClipContractTests.cs" />
     <Compile Include="AvaloniaRetainedCommandCacheContractTests.cs" />
     <Compile Include="AvaloniaStreamPathContractTests.cs" />
+    <Compile Include="AvaloniaStrokeTransformContractTests.cs" />
     <Compile Include="ColorGlyphMetricCacheContractTests.cs" />
     <Compile Include="DawnNativeWindowSourceTests.cs" />
     <Compile Include="OffscreenTextureCacheTests.cs" />


### PR DESCRIPTION
## Summary

This reviewed continuation subsumes #86 while retaining its exact contributor head (`bab4dbef993f2b2d722ff46689021604c2e9b947`) as an ancestor.

- preserves source-space pen thickness through Scene, Avalonia, WPF, System.Drawing, Skia, retained pictures, append/replay, static buffers, and GPU transforms;
- applies conformal scale exactly once and lowers anisotropic/sheared strokes through transformed local outlines;
- preserves Skia hairlines, caps, joins, dashes, hit testing, serialization, and retained cache ownership;
- implements exact WinUI `CompositionSpriteShape.IsStrokeNonScaling` via a cached device-space centerline;
- keeps indexed polyline/spline recording allocation-free and restores adaptive spline sampling;
- adapts affine Bézier and hairline-arc hit subdivisions to a 0.25-device-pixel error bound;
- makes Wavefront fallback transactional and ordering-safe;
- fixes static/dynamic extension transform ownership, dashed analytic primitives, the vector batch boundary, special-shader hairlines, and a machine-specific Markdown fixture.

## Review findings addressed

- Original scalar-width multiplication was not mathematically correct for anisotropic scale or shear.
- Width provenance was lost across several bridge, replay, and archive seams.
- WinUI non-scaling strokes used one inverse scalar and were directionally wrong under anisotropy/shear.
- Late GPU transforms, hairline caps/joins, and GPU hit testing did not share one exact contract.
- Fixed Bézier/arc subdivision could exceed subpixel error after magnification.
- The span-based polyline/spline APIs eagerly materialized managed geometry graphs and forced every spline to 100 segments.
- Special Skia shader hairlines disappeared through fill-path materialization.
- Mixed Wavefront/Atlas output could violate draw order, and Wavefront capacity/nonconformal cases could silently degrade.
- Appended/static extension transforms could be applied zero or two times.
- Analytic dashed primitives rendered and hit-tested as continuous strokes.
- A specialized rectangle fill could leave following path-stroke vertices in the wrong pipeline batch.

## Clean-room research

The implementation is original and is documented in `docs/STROKE_TRANSFORM_RESEARCH.md`. Primary contracts and architectures consulted:

- Skia canvas/paint: https://api.skia.org/classSkCanvas.html and https://api.skia.org/classSkPaint.html
- Direct2D transforms/stroke transform types: https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview and https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/ne-d2d1_1-d2d1_stroke_transform_type
- WinUI non-scaling strokes: https://learn.microsoft.com/en-us/uwp/api/windows.ui.composition.compositionspriteshape.isstrokenonscaling
- Win2D drawing sessions: https://microsoft.github.io/Win2D/WinUI3/html/T_Microsoft_Graphics_Canvas_CanvasDrawingSession.htm
- WebRender retained rendering overview: https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst
- Vello retained scene: https://github.com/linebender/vello/blob/main/vello/src/scene.rs
- SVG 2 vector effects: https://www.w3.org/TR/SVG2/painting.html#VectorEffects
- WGSL derivatives: https://www.w3.org/TR/WGSL/#derivative-builtin-functions
- SkParagraph, DirectWrite, Parley, and HarfBuzz rendering boundaries are compared in the research record.

No foreign implementation source, helper structure, shader, data encoding, or control flow was copied or adapted.

## Local validation on exact head `cb6fba97`

- Release core build: 0 warnings, 0 errors
- Core tests: 3,561/3,561
- Headless tests: 239/239
- Avalonia contract tests: 87/87
- Avalonia Silk.NET contract tests: 55/55
- Avalonia headless pixel tests: 1/1
- Focused stroke/hairline/hit-test matrix: 233/233 (154 + 79)
- Shader resource/source audits: 12/12
- GDI raw-local/final-output focused tests: 3/3; full GDI shim: 61/61
- Package manifest gate: 41 runtime, 4 integration, 15 non-shipping
- Documentation/package table gate and `git diff --check`: pass

The isolated GitHub package jobs are the authoritative package gates for this PR.



## Exact-head CI checkpoint

All 16 GitHub checks pass on exact head `cb6fba97e0a5cb215458853ff23a42a35ad0437b`: Ubuntu, macOS, and Windows build/test; portable and mobile packaging; native Dawn Ubuntu/Windows; Avalonia retained and upstream text; native/ProGPU SVG image parity; matched native/ProGPU CPU benchmarks on all three operating systems; official SkiaSharp and WinUI metadata; and release documentation. Both review threads are resolved.

## Manual validation hold

This PR is intentionally unmerged and must remain draft until hands-on rendering validation is complete. Exercise the Release desktop sample on macOS/Windows/Linux, especially Picture Caching, Vector Shapes, SkiaSharp Shim, WPF, and GDI pages. Check anisotropic scale, shear, rotation, reflection, caps, joins, dashes, positive non-scaling WinUI sprite strokes, zero-width shader hairlines, picture replay, resize/DPI changes, and stable-frame flicker/allocation behavior. Re-run the browser sample where available to confirm WebGPU output and responsive resizing.
