### PR TITLE
Expose WebGPU adapter selection diagnostics

### DIFF
--- a/src/ProGPU.Backend/WgpuAdapterSelectionDiagnostics.cs
+++ b/src/ProGPU.Backend/WgpuAdapterSelectionDiagnostics.cs
@@ -1,0 +1,37 @@
+using Silk.NET.WebGPU;
+
+namespace ProGPU.Backend;
+
+/// <summary>
+/// Describes the WebGPU adapter selected for a context and the constraints
+/// that produced that selection.
+/// </summary>
+public sealed record WgpuAdapterSelectionDiagnostics(
+    string Name,
+    BackendType BackendType,
+    AdapterType AdapterType,
+    string DriverDescription,
+    uint VendorId,
+    uint DeviceId,
+    bool RequiredCompatibleSurface,
+    WgpuAdapterSelectionReason SelectionReason)
+{
+    public static WgpuAdapterSelectionDiagnostics Unknown { get; } = new(
+        string.Empty,
+        BackendType.Undefined,
+        AdapterType.Unknown,
+        string.Empty,
+        0,
+        0,
+        false,
+        WgpuAdapterSelectionReason.Unknown);
+}
+
+public enum WgpuAdapterSelectionReason
+{
+    Unknown,
+    HighPerformance,
+    HighPerformanceSurfaceCompatible,
+    ExternalBrowserHost,
+    ExternalNativeHost
+}

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -50,6 +50,8 @@ public unsafe class WgpuContext : IDisposable
     public bool SupportsTextureFormatsTier1 { get; private set; }
     public BackendType AdapterBackendType { get; private set; } = BackendType.Undefined;
     public string AdapterName { get; private set; } = string.Empty;
+    public WgpuAdapterSelectionDiagnostics AdapterSelectionDiagnostics { get; private set; } =
+        WgpuAdapterSelectionDiagnostics.Unknown;
     public IProGpuExternalTextureImporter?
         ExternalTextureImporter { get; private set; }
     internal WgpuDeviceResourceDomain DeviceResourceDomain =>
@@ -866,9 +868,29 @@ public unsafe class WgpuContext : IDisposable
 
         var adapterProperties = new AdapterProperties();
         Wgpu.AdapterGetProperties(Adapter, &adapterProperties);
-        AdapterBackendType = adapterProperties.BackendType;
-        AdapterName = adapterProperties.Name == null ? string.Empty : ReadNativeMessage(adapterProperties.Name);
-        SafeLog($"[WGPUCONTEXT] Adapter '{AdapterName}', backend={AdapterBackendType}\n");
+        SetAdapterSelectionDiagnostics(new WgpuAdapterSelectionDiagnostics(
+            adapterProperties.Name == null ? string.Empty : ReadNativeMessage(adapterProperties.Name),
+            adapterProperties.BackendType,
+            adapterProperties.AdapterType,
+            adapterProperties.DriverDescription == null
+                ? string.Empty
+                : ReadNativeMessage(adapterProperties.DriverDescription),
+            adapterProperties.VendorID,
+            adapterProperties.DeviceID,
+            Surface != null,
+            Surface != null
+                ? WgpuAdapterSelectionReason.HighPerformanceSurfaceCompatible
+                : WgpuAdapterSelectionReason.HighPerformance));
+        string adapterDiagnostic =
+            $"[WGPUCONTEXT] Adapter '{AdapterName}', backend={AdapterBackendType}, " +
+            $"type={AdapterSelectionDiagnostics.AdapterType}, " +
+            $"driver='{AdapterSelectionDiagnostics.DriverDescription}', " +
+            $"vendor=0x{AdapterSelectionDiagnostics.VendorId:X4}, " +
+            $"device=0x{AdapterSelectionDiagnostics.DeviceId:X4}, " +
+            $"surfaceCompatible={AdapterSelectionDiagnostics.RequiredCompatibleSurface}, " +
+            $"reason={AdapterSelectionDiagnostics.SelectionReason}";
+        SafeLog(adapterDiagnostic + "\n");
+        ProGpuBackendDiagnostics.WriteLine(adapterDiagnostic);
         if (OperatingSystem.IsAndroid() && AdapterBackendType != BackendType.Vulkan)
         {
             ReleaseAdapterInitializationResources();
@@ -1296,6 +1318,15 @@ public unsafe class WgpuContext : IDisposable
         _isSurfaceConfigured = true;
         _lastWidth = 1;
         _lastHeight = 1;
+        SetAdapterSelectionDiagnostics(new WgpuAdapterSelectionDiagnostics(
+            string.Empty,
+            BackendType.Undefined,
+            AdapterType.Unknown,
+            string.Empty,
+            0,
+            0,
+            true,
+            WgpuAdapterSelectionReason.ExternalBrowserHost));
 
         lock (_activeContexts)
         {
@@ -1328,7 +1359,11 @@ public unsafe class WgpuContext : IDisposable
         bool supportsReadOnlyAndReadWriteStorageTextures = false,
         bool supportsTextureFormatsTier1 = false,
         BackendType adapterBackendType = BackendType.Undefined,
-        string? adapterName = null)
+        string? adapterName = null,
+        AdapterType adapterType = AdapterType.Unknown,
+        string? adapterDriverDescription = null,
+        uint adapterVendorId = 0,
+        uint adapterDeviceId = 0)
     {
         ArgumentNullException.ThrowIfNull(api);
         ArgumentNullException.ThrowIfNull(lifetime);
@@ -1357,8 +1392,15 @@ public unsafe class WgpuContext : IDisposable
             supportsReadOnlyAndReadWriteStorageTextures;
         SupportsTextureFormatsTier1 =
             supportsTextureFormatsTier1;
-        AdapterBackendType = adapterBackendType;
-        AdapterName = adapterName ?? string.Empty;
+        SetAdapterSelectionDiagnostics(new WgpuAdapterSelectionDiagnostics(
+            adapterName ?? string.Empty,
+            adapterBackendType,
+            adapterType,
+            adapterDriverDescription ?? string.Empty,
+            adapterVendorId,
+            adapterDeviceId,
+            false,
+            WgpuAdapterSelectionReason.ExternalNativeHost));
         _externalDeviceLifetime = lifetime;
         _deviceResourceDomain = new WgpuDeviceResourceDomain(Api, Device);
 
@@ -1453,8 +1495,7 @@ public unsafe class WgpuContext : IDisposable
         SupportsReadOnlyAndReadWriteStorageTextures = deviceOwner.SupportsReadOnlyAndReadWriteStorageTextures;
         SupportsTextureFormatsTier1 =
             deviceOwner.SupportsTextureFormatsTier1;
-        AdapterBackendType = deviceOwner.AdapterBackendType;
-        AdapterName = deviceOwner.AdapterName;
+        SetAdapterSelectionDiagnostics(deviceOwner.AdapterSelectionDiagnostics);
         _deviceResourceDomain = deviceOwner._deviceResourceDomain;
         _sharedDeviceLifetime = sharedDeviceLifetime;
         RenderLock = deviceOwner.RenderLock;
@@ -1488,6 +1529,14 @@ public unsafe class WgpuContext : IDisposable
         }
 
         return window is INativeWindowSource { Native: not null };
+    }
+
+    private void SetAdapterSelectionDiagnostics(
+        WgpuAdapterSelectionDiagnostics diagnostics)
+    {
+        AdapterSelectionDiagnostics = diagnostics;
+        AdapterBackendType = diagnostics.BackendType;
+        AdapterName = diagnostics.Name;
     }
 
     /// <summary>

--- a/src/ProGPU.Tests/BrowserWebGpuApiTests.cs
+++ b/src/ProGPU.Tests/BrowserWebGpuApiTests.cs
@@ -23,6 +23,11 @@ public unsafe sealed class BrowserWebGpuApiTests
 
         Assert.True(context.IsInitialized);
         Assert.Same(context, WgpuContext.Current);
+        Assert.Equal(
+            WgpuAdapterSelectionReason.ExternalBrowserHost,
+            context.AdapterSelectionDiagnostics.SelectionReason);
+        Assert.True(
+            context.AdapterSelectionDiagnostics.RequiredCompatibleSurface);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -47,12 +47,27 @@ public sealed class WgpuContextTests
             TextureFormat.Bgra8Unorm,
             supportsTextureFormatsTier1: true,
             adapterBackendType: BackendType.Metal,
-            adapterName: "Test Dawn Metal");
+            adapterName: "Test Dawn Metal",
+            adapterType: AdapterType.IntegratedGPU,
+            adapterDriverDescription: "Test Metal Driver",
+            adapterVendorId: 0x106B,
+            adapterDeviceId: 0x1234);
 
         Assert.True(context.IsInitialized);
         Assert.Equal(WgpuBackendKind.DawnNative, context.BackendKind);
         Assert.Equal(BackendType.Metal, context.AdapterBackendType);
         Assert.Equal("Test Dawn Metal", context.AdapterName);
+        Assert.Equal(
+            new WgpuAdapterSelectionDiagnostics(
+                "Test Dawn Metal",
+                BackendType.Metal,
+                AdapterType.IntegratedGPU,
+                "Test Metal Driver",
+                0x106B,
+                0x1234,
+                false,
+                WgpuAdapterSelectionReason.ExternalNativeHost),
+            context.AdapterSelectionDiagnostics);
         Assert.True(context.SupportsTextureFormatsTier1);
 
         context.PollDevice(wait: false);

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -48,7 +48,7 @@ public sealed class WgpuContextTests
             supportsTextureFormatsTier1: true,
             adapterBackendType: BackendType.Metal,
             adapterName: "Test Dawn Metal",
-            adapterType: AdapterType.IntegratedGPU,
+            adapterType: AdapterType.IntegratedGpu,
             adapterDriverDescription: "Test Metal Driver",
             adapterVendorId: 0x106B,
             adapterDeviceId: 0x1234);
@@ -61,7 +61,7 @@ public sealed class WgpuContextTests
             new WgpuAdapterSelectionDiagnostics(
                 "Test Dawn Metal",
                 BackendType.Metal,
-                AdapterType.IntegratedGPU,
+                AdapterType.IntegratedGpu,
                 "Test Metal Driver",
                 0x106B,
                 0x1234,


### PR DESCRIPTION
## Summary

- expose an immutable adapter-selection diagnostic snapshot from `WgpuContext`
- report adapter type, driver description, vendor/device IDs, surface constraint, and selection reason
- populate diagnostics for Silk native, external native, browser-hosted, and shared-device contexts while preserving the existing adapter name/backend API
- emit the complete native selection through opt-in backend diagnostics

This is the first independent follow-up from LibreWPF's Linux rendering investigation. It adds the evidence needed to verify later adapter-ranking and backend-selection changes without changing selection policy in this PR.

## Validation

- `dotnet build src/ProGPU.Tests/ProGPU.Tests.csproj --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false` (0 warnings, 0 errors)
- focused adapter-diagnostics tests: 2 passed, 0 failed
- GitHub Actions: all nine Windows, Ubuntu, macOS, packaging, and Avalonia contract jobs passed