### PR TITLE
Add portable WPF window icon contract

### DIFF
--- a/src/ProGPU.Tests/PortableWindowIconContractTests.cs
+++ b/src/ProGPU.Tests/PortableWindowIconContractTests.cs
@@ -1,0 +1,49 @@
+using ProGPU.Wpf.Interop;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class PortableWindowIconContractTests
+{
+    [Fact]
+    public void PortableWindowStateCarriesOpaqueIconSource()
+    {
+        object icon = new();
+        var state = new PortableWindowState
+        {
+            HasIcon = true,
+            Icon = icon
+        };
+
+        Assert.True(state.HasIcon);
+        Assert.Same(icon, state.Icon);
+    }
+
+    [Fact]
+    public void ActivationCallbacksForwardIconUpdatesIncludingClear()
+    {
+        object activation = new();
+        object icon = new();
+        object? receivedActivation = null;
+        object? receivedIcon = null;
+        int updateCount = 0;
+        var callbacks = new PortableWindowActivationCallbacks(
+            activate: _ => activation,
+            setIcon: (value, source) =>
+            {
+                receivedActivation = value;
+                receivedIcon = source;
+                updateCount++;
+            });
+
+        callbacks.SetIcon!(activation, icon);
+
+        Assert.Same(activation, receivedActivation);
+        Assert.Same(icon, receivedIcon);
+
+        callbacks.SetIcon(activation, null);
+
+        Assert.Equal(2, updateCount);
+        Assert.Null(receivedIcon);
+    }
+}

--- a/src/ProGPU.Wpf.Interop/PortableWindowState.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWindowState.cs
@@ -11,6 +11,20 @@ public sealed class PortableWindowState
 
     public string? Title { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether <see cref="Icon"/> contains the window icon source.
+    /// </summary>
+    public bool HasIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets the framework-owned window icon source.
+    /// </summary>
+    /// <remarks>
+    /// The interop assembly deliberately keeps this value opaque so portable hosts can
+    /// adapt the source without taking a dependency on a particular UI framework.
+    /// </remarks>
+    public object? Icon { get; set; }
+
     public bool HasWidth { get; set; }
 
     public double Width { get; set; }

--- a/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
@@ -476,7 +476,8 @@ public sealed class PortableWindowActivationCallbacks
         Func<object, bool>? dragMove = null,
         Func<object, IntPtr>? getHandle = null,
         Func<IntPtr, PortableWindowRegion, bool>? setWindowRegion = null,
-        Func<object, bool>? requestActivation = null)
+        Func<object, bool>? requestActivation = null,
+        Action<object, object?>? setIcon = null)
     {
         Activate = activate ?? throw new ArgumentNullException(nameof(activate));
         Show = show;
@@ -494,6 +495,7 @@ public sealed class PortableWindowActivationCallbacks
         GetHandle = getHandle;
         SetWindowRegion = setWindowRegion;
         RequestActivation = requestActivation;
+        SetIcon = setIcon;
     }
 
     public Func<object, object?> Activate { get; }
@@ -535,6 +537,12 @@ public sealed class PortableWindowActivationCallbacks
     /// when the native platform accepted the foreground request.
     /// </remarks>
     public Func<object, bool>? RequestActivation { get; }
+
+    /// <summary>
+    /// Updates the framework-owned icon source for an existing portable window host.
+    /// A <see langword="null"/> source clears the native window icon.
+    /// </summary>
+    public Action<object, object?>? SetIcon { get; }
 }
 
 public sealed class PortableWindowInputEvent


### PR DESCRIPTION
## Summary

- carry a framework-owned icon source through `PortableWindowState` without introducing a WPF dependency
- expose an optional activation callback for updating or clearing an existing native window icon
- add focused contract tests for initial state and runtime updates

## Why

LibreWPF's portable WPF host currently has no contract through which `Window.Icon` or the resolved application icon can reach the native Silk.NET window. This keeps the ProGPU interop layer framework-neutral while enabling the LibreWPF adapter to perform the actual conversion.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj --no-restore --filter FullyQualifiedName~PortableWindowIconContractTests` (2 passed)