### PR TITLE
Bound Linux dependency installation in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: Install Linux X11 and Vulkan software adapter
         if: runner.os == 'Linux'
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          ./eng/progpu-install-linux-packages.sh \
             libc++1 \
             libvulkan1 \
             mesa-vulkan-drivers \
@@ -173,9 +173,9 @@ jobs:
 
       - name: Install Linux WebGPU dependencies
         if: runner.os == 'Linux'
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          ./eng/progpu-install-linux-packages.sh \
             libvulkan1 \
             mesa-vulkan-drivers \
             libx11-xcb1 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
           submodules: recursive
 
       - name: Install Linux WebGPU dependencies
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          ./eng/progpu-install-linux-packages.sh \
             libvulkan1 \
             mesa-vulkan-drivers \
             libx11-xcb1 \

--- a/eng/progpu-install-linux-packages.sh
+++ b/eng/progpu-install-linux-packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# == 0 )); then
+  echo "No Linux packages were requested." >&2
+  exit 2
+fi
+
+missing_packages=()
+for package in "$@"; do
+  status="$(dpkg-query -W -f='${Status}' "${package}" 2>/dev/null || true)"
+  if [[ "${status}" != "install ok installed" ]]; then
+    missing_packages+=("${package}")
+  fi
+done
+
+if (( ${#missing_packages[@]} == 0 )); then
+  echo "All requested Linux packages are already installed; skipping apt."
+  exit 0
+fi
+
+echo "Installing missing Linux packages: ${missing_packages[*]}"
+if sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
+  -o Acquire::Retries=3 \
+  -o Dpkg::Use-Pty=0 \
+  "${missing_packages[@]}"; then
+  exit 0
+fi
+
+echo "The cached package indexes could not satisfy the request; refreshing once."
+sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update \
+  -o Acquire::Retries=3 \
+  -o Dpkg::Use-Pty=0
+sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
+  -o Acquire::Retries=3 \
+  -o Dpkg::Use-Pty=0 \
+  "${missing_packages[@]}"


### PR DESCRIPTION
## Summary
- skip `apt` entirely when all requested Linux graphics packages are already installed on the hosted image
- run any required installation noninteractively, retry transient downloads, and disable the apt pseudo-TTY
- cap dependency-install steps at 10 minutes in build and release workflows

## Validation
- `bash -n eng/progpu-install-linux-packages.sh`
- local installed-package fast path
- `git diff --check`

This addresses repeated Ubuntu jobs hanging indefinitely in `Install Linux WebGPU dependencies` before any ProGPU build work started.