### PR TITLE
Distinguish portable MessageBox fallback registrations

### DIFF
--- a/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
@@ -33,6 +33,11 @@ public interface IPortableMessageBoxServiceRegistrar
 
     IDisposable Register(Func<PortableMessageBoxRequest, string?> show);
 
+    IDisposable RegisterFallback(Func<PortableMessageBoxRequest, string?> show)
+    {
+        return Register(show);
+    }
+
     void Clear();
 }
 


### PR DESCRIPTION
## Summary

- adds an explicit fallback-registration method to the portable WPF MessageBox registrar contract
- preserves source and binary compatibility through a default interface implementation that delegates to `Register`
- lets framework hosts distinguish custom override handlers from the built-in process-backed fallback

## Motivation

LibreWPF issue #62 adds an interactive WPF-rendered MessageBox on non-Windows platforms. Host/test handlers registered through `Register` must still override that dialog, while ProGPU's built-in process backend should run only when the interactive dialog cannot be shown. The shared contract previously could not express that distinction, causing the LibreWPF SDK `Application.Run` validation to block on an interactive dialog.

This is the standalone ProGPU API change required by wieslawsoltes/LibreWPF#86.

## Validation

- `dotnet build src/ProGPU.Wpf.Interop/ProGPU.Wpf.Interop.csproj -c Release --no-restore`
- `git diff --check`