### PR TITLE
Route portable popups across WPF windows

### DIFF
--- a/src/ProGPU.Tests/PortableWpfServiceRegistryTests.cs
+++ b/src/ProGPU.Tests/PortableWpfServiceRegistryTests.cs
@@ -1,0 +1,161 @@
+using ProGPU.Wpf.Interop;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class PortableWpfServiceRegistryTests
+{
+    private static readonly PortableWpfServiceKey ServiceKey =
+        new($"PopupTests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void PopupRouterKeepsMultipleWindowServicesAndRoutesByOwner()
+    {
+        object firstOwner = new();
+        object secondOwner = new();
+        var first = new TestPopupService(ServiceKey, firstOwner);
+        var second = new TestPopupService(ServiceKey, secondOwner);
+
+        using IDisposable firstRegistration = PortableWpfServiceRegistry.RegisterPopupService(first);
+        Assert.True(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out var cachedRouter));
+        using IDisposable secondRegistration = PortableWpfServiceRegistry.RegisterPopupService(second);
+        Assert.True(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out var currentRouter));
+        Assert.Same(cachedRouter, currentRouter);
+
+        PortablePopupCreateRequest firstRequest = CreateRequest(firstOwner);
+        Assert.True(currentRouter.TryCreatePopup(firstRequest, out object? firstPopup));
+        Assert.NotNull(firstPopup);
+        Assert.Equal(1, second.CreateAttempts);
+        Assert.Equal(1, first.CreateAttempts);
+
+        PortablePopupCreateRequest secondRequest = CreateRequest(secondOwner);
+        Assert.True(currentRouter.TryCreatePopup(secondRequest, out object? secondPopup));
+        Assert.NotNull(secondPopup);
+        Assert.Equal(2, second.CreateAttempts);
+        Assert.Equal(1, first.CreateAttempts);
+
+        Assert.True(currentRouter.TrySetPopupPosition(firstPopup!, 12, 34));
+        Assert.True(currentRouter.TrySetPopupSize(secondPopup!, 320, 180));
+        Assert.True(currentRouter.TryShowPopup(firstPopup));
+        Assert.True(currentRouter.TryHidePopup(secondPopup));
+        Assert.True(currentRouter.TrySetPopupHitTestable(firstPopup, false));
+        Assert.True(currentRouter.TryDestroyPopup(secondPopup));
+
+        Assert.Equal(3, first.OperationCount);
+        Assert.Equal(3, second.OperationCount);
+    }
+
+    [Fact]
+    public void CachedPopupRouterFallsBackAfterNewerWindowServiceIsDisposed()
+    {
+        object firstOwner = new();
+        object secondOwner = new();
+        var first = new TestPopupService(ServiceKey, firstOwner);
+        var second = new TestPopupService(ServiceKey, secondOwner);
+
+        using IDisposable firstRegistration = PortableWpfServiceRegistry.RegisterPopupService(first);
+        using IDisposable secondRegistration = PortableWpfServiceRegistry.RegisterPopupService(second);
+        Assert.True(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out var cachedRouter));
+
+        secondRegistration.Dispose();
+
+        Assert.True(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out var currentRouter));
+        Assert.Same(cachedRouter, currentRouter);
+        Assert.True(cachedRouter.TryCreatePopup(CreateRequest(firstOwner), out object? popup));
+        Assert.NotNull(popup);
+        Assert.Equal(0, second.CreateAttempts);
+        Assert.Equal(1, first.CreateAttempts);
+    }
+
+    [Fact]
+    public void PopupRouterSurvivesAWindowGapForPreviouslyCachedConsumers()
+    {
+        object firstOwner = new();
+        var first = new TestPopupService(ServiceKey, firstOwner);
+        using IDisposable firstRegistration = PortableWpfServiceRegistry.RegisterPopupService(first);
+        Assert.True(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out var cachedRouter));
+
+        firstRegistration.Dispose();
+        Assert.False(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out _));
+        Assert.False(cachedRouter.TryCreatePopup(CreateRequest(firstOwner), out _));
+
+        object secondOwner = new();
+        var second = new TestPopupService(ServiceKey, secondOwner);
+        using IDisposable secondRegistration = PortableWpfServiceRegistry.RegisterPopupService(second);
+
+        Assert.True(PortableWpfServiceRegistry.TryGetPopupService(ServiceKey, out var currentRouter));
+        Assert.Same(cachedRouter, currentRouter);
+        Assert.True(cachedRouter.TryCreatePopup(CreateRequest(secondOwner), out object? popup));
+        Assert.NotNull(popup);
+        Assert.Equal(1, second.CreateAttempts);
+    }
+
+    private static PortablePopupCreateRequest CreateRequest(object owner)
+    {
+        return new PortablePopupCreateRequest(
+            placementTarget: null,
+            ownerPresentationSource: owner,
+            ownerHandle: IntPtr.Zero,
+            x: 0,
+            y: 0,
+            isTransparent: true,
+            isChildPopup: false);
+    }
+
+    private sealed class TestPopupService(
+        PortableWpfServiceKey serviceKey,
+        object owner) : IPortablePopupServiceRegistrar
+    {
+        private readonly HashSet<object> _popups = new(ReferenceEqualityComparer.Instance);
+
+        public PortableWpfServiceKey ServiceKey { get; } = serviceKey;
+
+        public int CreateAttempts { get; private set; }
+
+        public int OperationCount { get; private set; }
+
+        public bool TryCreatePopup(PortablePopupCreateRequest request, out object? presentationSource)
+        {
+            CreateAttempts++;
+            if (!ReferenceEquals(request.OwnerPresentationSource, owner))
+            {
+                presentationSource = null;
+                return false;
+            }
+
+            presentationSource = new object();
+            _popups.Add(presentationSource);
+            return true;
+        }
+
+        public bool TrySetPopupPosition(object presentationSource, int x, int y) =>
+            RecordOperation(presentationSource);
+
+        public bool TrySetPopupSize(object presentationSource, int width, int height) =>
+            RecordOperation(presentationSource);
+
+        public bool TryShowPopup(object presentationSource) => RecordOperation(presentationSource);
+
+        public bool TryHidePopup(object presentationSource) => RecordOperation(presentationSource);
+
+        public bool TrySetPopupHitTestable(object presentationSource, bool hitTestable) =>
+            RecordOperation(presentationSource);
+
+        public bool TryDestroyPopup(object presentationSource)
+        {
+            OperationCount++;
+            return _popups.Remove(presentationSource);
+        }
+
+        public void Clear()
+        {
+            _popups.Clear();
+        }
+
+        private bool RecordOperation(object presentationSource)
+        {
+            OperationCount++;
+            return _popups.Contains(presentationSource);
+        }
+    }
+}

--- a/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
@@ -678,7 +678,7 @@ public static class PortableWpfServiceRegistry
     private static readonly Dictionary<PortableWpfServiceKey, IPortableFileDialogServiceRegistrar> FileDialogServices = new();
     private static readonly Dictionary<PortableWpfServiceKey, IPortableColorDialogServiceRegistrar> ColorDialogServices = new();
     private static readonly Dictionary<PortableWpfServiceKey, IPortableFontDialogServiceRegistrar> FontDialogServices = new();
-    private static readonly Dictionary<PortableWpfServiceKey, IPortablePopupServiceRegistrar> PopupServices = new();
+    private static readonly Dictionary<PortableWpfServiceKey, PopupServiceRouter> PopupServiceRouters = new();
     private static readonly Dictionary<PortableWpfServiceKey, IPortableSystemThemeSource> SystemThemeSources = new();
 
     public static event Action<IPortableClipboardServiceRegistrar>? ClipboardServiceRegistered;
@@ -882,12 +882,19 @@ public static class PortableWpfServiceRegistry
         ArgumentNullException.ThrowIfNull(service);
         ValidateServiceKey(service.ServiceKey, nameof(service));
 
+        PopupServiceRouter router;
         lock (SyncRoot)
         {
-            PopupServices[service.ServiceKey] = service;
+            if (!PopupServiceRouters.TryGetValue(service.ServiceKey, out router!))
+            {
+                router = new PopupServiceRouter(service.ServiceKey);
+                PopupServiceRouters.Add(service.ServiceKey, router);
+            }
+
+            router.Add(service);
         }
 
-        return new Registration<IPortablePopupServiceRegistrar>(service, PopupServices);
+        return new PopupServiceRegistration(router, service);
     }
 
     public static bool TryGetPopupService(
@@ -898,7 +905,15 @@ public static class PortableWpfServiceRegistry
 
         lock (SyncRoot)
         {
-            return PopupServices.TryGetValue(serviceKey, out service!);
+            if (PopupServiceRouters.TryGetValue(serviceKey, out PopupServiceRouter? router) &&
+                router.HasServices)
+            {
+                service = router;
+                return true;
+            }
+
+            service = null!;
+            return false;
         }
     }
 
@@ -995,6 +1010,246 @@ public static class PortableWpfServiceRegistry
                 IPortablePopupServiceRegistrar popupService => popupService.ServiceKey,
                 _ => throw new InvalidOperationException("Unsupported portable WPF service registrar.")
             };
+        }
+    }
+
+    private sealed class PopupServiceRegistration : IDisposable
+    {
+        private PopupServiceRouter? _router;
+        private IPortablePopupServiceRegistrar? _service;
+
+        public PopupServiceRegistration(
+            PopupServiceRouter router,
+            IPortablePopupServiceRegistrar service)
+        {
+            _router = router;
+            _service = service;
+        }
+
+        public void Dispose()
+        {
+            IPortablePopupServiceRegistrar? service = Interlocked.Exchange(ref _service, null);
+            PopupServiceRouter? router = Interlocked.Exchange(ref _router, null);
+            if (service != null && router != null)
+            {
+                router.Remove(service);
+            }
+        }
+    }
+
+    private sealed class PopupServiceRouter : IPortablePopupServiceRegistrar
+    {
+        private readonly object _gate = new();
+        private readonly List<IPortablePopupServiceRegistrar> _services = new();
+        private readonly Dictionary<object, IPortablePopupServiceRegistrar> _popupOwners =
+            new(ReferenceEqualityComparer.Instance);
+
+        public PopupServiceRouter(PortableWpfServiceKey serviceKey)
+        {
+            ServiceKey = serviceKey;
+        }
+
+        public PortableWpfServiceKey ServiceKey { get; }
+
+        public bool HasServices
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _services.Count != 0;
+                }
+            }
+        }
+
+        public void Add(IPortablePopupServiceRegistrar service)
+        {
+            lock (_gate)
+            {
+                _services.Add(service);
+            }
+        }
+
+        public void Remove(IPortablePopupServiceRegistrar service)
+        {
+            lock (_gate)
+            {
+                for (int index = _services.Count - 1; index >= 0; index--)
+                {
+                    if (ReferenceEquals(_services[index], service))
+                    {
+                        _services.RemoveAt(index);
+                        break;
+                    }
+                }
+
+                if (_popupOwners.Count == 0)
+                {
+                    return;
+                }
+
+                object[] ownedPopups = _popupOwners
+                    .Where(pair => ReferenceEquals(pair.Value, service))
+                    .Select(static pair => pair.Key)
+                    .ToArray();
+                foreach (object popup in ownedPopups)
+                {
+                    _popupOwners.Remove(popup);
+                }
+            }
+        }
+
+        public bool TryCreatePopup(PortablePopupCreateRequest request, out object? presentationSource)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            IPortablePopupServiceRegistrar[] services = GetServicesNewestFirst();
+            foreach (IPortablePopupServiceRegistrar service in services)
+            {
+                if (!service.TryCreatePopup(request, out presentationSource))
+                {
+                    continue;
+                }
+
+                if (presentationSource != null)
+                {
+                    lock (_gate)
+                    {
+                        _popupOwners[presentationSource] = service;
+                    }
+                }
+
+                return true;
+            }
+
+            presentationSource = null;
+            return false;
+        }
+
+        public bool TrySetPopupPosition(object presentationSource, int x, int y)
+        {
+            ArgumentNullException.ThrowIfNull(presentationSource);
+            return TryRoute(
+                presentationSource,
+                service => service.TrySetPopupPosition(presentationSource, x, y));
+        }
+
+        public bool TrySetPopupSize(object presentationSource, int width, int height)
+        {
+            ArgumentNullException.ThrowIfNull(presentationSource);
+            return TryRoute(
+                presentationSource,
+                service => service.TrySetPopupSize(presentationSource, width, height));
+        }
+
+        public bool TryShowPopup(object presentationSource)
+        {
+            ArgumentNullException.ThrowIfNull(presentationSource);
+            return TryRoute(presentationSource, service => service.TryShowPopup(presentationSource));
+        }
+
+        public bool TryHidePopup(object presentationSource)
+        {
+            ArgumentNullException.ThrowIfNull(presentationSource);
+            return TryRoute(presentationSource, service => service.TryHidePopup(presentationSource));
+        }
+
+        public bool TrySetPopupHitTestable(object presentationSource, bool hitTestable)
+        {
+            ArgumentNullException.ThrowIfNull(presentationSource);
+            return TryRoute(
+                presentationSource,
+                service => service.TrySetPopupHitTestable(presentationSource, hitTestable));
+        }
+
+        public bool TryDestroyPopup(object presentationSource)
+        {
+            ArgumentNullException.ThrowIfNull(presentationSource);
+
+            IPortablePopupServiceRegistrar? owner = GetPopupOwner(presentationSource);
+            if (owner != null)
+            {
+                bool destroyed = owner.TryDestroyPopup(presentationSource);
+                if (destroyed)
+                {
+                    lock (_gate)
+                    {
+                        _popupOwners.Remove(presentationSource);
+                    }
+                }
+
+                return destroyed;
+            }
+
+            foreach (IPortablePopupServiceRegistrar service in GetServicesNewestFirst())
+            {
+                if (service.TryDestroyPopup(presentationSource))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void Clear()
+        {
+            IPortablePopupServiceRegistrar[] services = GetServicesNewestFirst();
+            lock (_gate)
+            {
+                _popupOwners.Clear();
+            }
+
+            foreach (IPortablePopupServiceRegistrar service in services)
+            {
+                service.Clear();
+            }
+        }
+
+        private bool TryRoute(
+            object presentationSource,
+            Func<IPortablePopupServiceRegistrar, bool> operation)
+        {
+            IPortablePopupServiceRegistrar? owner = GetPopupOwner(presentationSource);
+            if (owner != null)
+            {
+                return operation(owner);
+            }
+
+            foreach (IPortablePopupServiceRegistrar service in GetServicesNewestFirst())
+            {
+                if (operation(service))
+                {
+                    lock (_gate)
+                    {
+                        _popupOwners[presentationSource] = service;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private IPortablePopupServiceRegistrar? GetPopupOwner(object presentationSource)
+        {
+            lock (_gate)
+            {
+                return _popupOwners.TryGetValue(presentationSource, out IPortablePopupServiceRegistrar? owner)
+                    ? owner
+                    : null;
+            }
+        }
+
+        private IPortablePopupServiceRegistrar[] GetServicesNewestFirst()
+        {
+            lock (_gate)
+            {
+                IPortablePopupServiceRegistrar[] services = _services.ToArray();
+                Array.Reverse(services);
+                return services;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- replace the single-value portable popup registry with a stable per-key router
- keep every live window-specific popup service and select the service that owns each popup request
- route the popup lifecycle back to the service that created its presentation source
- preserve cached router instances when newer windows close or when all windows temporarily disappear
- add focused multi-window, disposal, and cached-consumer regression coverage

## Root cause

Each ProGPU WPF window registers its own popup service under the shared `PresentationFramework` key. Opening a second window replaced the first registration; disposing it then removed the key. Menus and ComboBoxes in the original window either resolved the wrong service or no service at all.

The router keeps the process-wide lookup stable while retaining window-local ownership.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj --no-restore --filter FullyQualifiedName~PortableWpfServiceRegistryTests`
  - 3 passed
- `dotnet build src/ProGPU.Wpf.Interop/ProGPU.Wpf.Interop.csproj --no-restore --configuration Release`
  - 0 warnings, 0 errors
- `git diff --check`

LibreWPF issue: https://github.com/wieslawsoltes/LibreWPF/issues/64