### PR TITLE
Add portable display metrics service

### DIFF
--- a/src/ProGPU.Tests/PortableWpfServiceRegistryTests.cs
+++ b/src/ProGPU.Tests/PortableWpfServiceRegistryTests.cs
@@ -90,6 +90,43 @@ public sealed class PortableWpfServiceRegistryTests
         Assert.Equal(1, second.CreateAttempts);
     }
 
+    [Fact]
+    public void DisplayMetricsSourceReplacementAndDisposalKeepCurrentRegistration()
+    {
+        PortableWpfServiceKey serviceKey = new($"DisplayTests-{Guid.NewGuid():N}");
+        var first = new TestDisplayMetricsSource(serviceKey, 1920, 1080);
+        var second = new TestDisplayMetricsSource(serviceKey, 2560, 1440);
+        int changeCount = 0;
+        EventHandler handler = (_, _) => changeCount++;
+        PortableWpfServiceRegistry.DisplayMetricsChanged += handler;
+
+        try
+        {
+            using IDisposable firstRegistration = PortableWpfServiceRegistry.RegisterDisplayMetricsSource(first);
+            Assert.True(PortableWpfServiceRegistry.TryGetDisplayMetricsSource(serviceKey, out var current));
+            Assert.Same(first, current);
+            first.RaiseChanged();
+
+            using IDisposable secondRegistration = PortableWpfServiceRegistry.RegisterDisplayMetricsSource(second);
+            Assert.True(PortableWpfServiceRegistry.TryGetDisplayMetricsSource(serviceKey, out current));
+            Assert.Same(second, current);
+            first.RaiseChanged();
+            second.RaiseChanged();
+
+            firstRegistration.Dispose();
+            Assert.True(PortableWpfServiceRegistry.TryGetDisplayMetricsSource(serviceKey, out current));
+            Assert.Same(second, current);
+
+            secondRegistration.Dispose();
+            Assert.False(PortableWpfServiceRegistry.TryGetDisplayMetricsSource(serviceKey, out _));
+            Assert.Equal(5, changeCount);
+        }
+        finally
+        {
+            PortableWpfServiceRegistry.DisplayMetricsChanged -= handler;
+        }
+    }
+
     private static PortablePopupCreateRequest CreateRequest(object owner)
     {
         return new PortablePopupCreateRequest(
@@ -156,6 +193,28 @@ public sealed class PortableWpfServiceRegistryTests
         {
             OperationCount++;
             return _popups.Contains(presentationSource);
+        }
+    }
+
+    private sealed class TestDisplayMetricsSource(
+        PortableWpfServiceKey serviceKey,
+        double width,
+        double height) : IPortableDisplayMetricsSource
+    {
+        public PortableWpfServiceKey ServiceKey { get; } = serviceKey;
+
+        public event EventHandler? DisplayMetricsChanged;
+
+        public bool TryGetDisplayMetrics(out PortableDisplayMetrics metrics)
+        {
+            PortableRect screen = new(0, 0, width, height);
+            metrics = new PortableDisplayMetrics(screen, screen, screen);
+            return true;
+        }
+
+        public void RaiseChanged()
+        {
+            DisplayMetricsChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/ProGPU.Wpf.Interop/PortableDisplayMetrics.cs
+++ b/src/ProGPU.Wpf.Interop/PortableDisplayMetrics.cs
@@ -1,0 +1,23 @@
+namespace ProGPU.Wpf.Interop;
+
+/// <summary>
+/// Describes logical desktop geometry reported by a portable windowing backend.
+/// All coordinates and dimensions are expressed in device-independent units.
+/// </summary>
+public readonly record struct PortableDisplayMetrics(
+    PortableRect PrimaryScreen,
+    PortableRect PrimaryWorkArea,
+    PortableRect VirtualScreen);
+
+/// <summary>
+/// Supplies desktop geometry without coupling retained UI code to a specific
+/// windowing backend or native monitor API.
+/// </summary>
+public interface IPortableDisplayMetricsSource
+{
+    PortableWpfServiceKey ServiceKey { get; }
+
+    bool TryGetDisplayMetrics(out PortableDisplayMetrics metrics);
+
+    event EventHandler? DisplayMetricsChanged;
+}

--- a/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
+++ b/src/ProGPU.Wpf.Interop/PortableWpfServiceRegistry.cs
@@ -680,6 +680,7 @@ public static class PortableWpfServiceRegistry
     private static readonly Dictionary<PortableWpfServiceKey, IPortableFontDialogServiceRegistrar> FontDialogServices = new();
     private static readonly Dictionary<PortableWpfServiceKey, PopupServiceRouter> PopupServiceRouters = new();
     private static readonly Dictionary<PortableWpfServiceKey, IPortableSystemThemeSource> SystemThemeSources = new();
+    private static readonly Dictionary<PortableWpfServiceKey, IPortableDisplayMetricsSource> DisplayMetricsSources = new();
 
     public static event Action<IPortableClipboardServiceRegistrar>? ClipboardServiceRegistered;
 
@@ -696,6 +697,12 @@ public static class PortableWpfServiceRegistry
     /// or when the active source for a service key is replaced or removed.
     /// </summary>
     public static event EventHandler? SystemThemeChanged;
+
+    /// <summary>
+    /// Raised when a registered platform display source reports a geometry change,
+    /// or when the active source for a service key is replaced or removed.
+    /// </summary>
+    public static event EventHandler? DisplayMetricsChanged;
 
     public static IDisposable RegisterWindowActivationService(IPortableWindowActivationServiceRegistrar service)
     {
@@ -953,6 +960,44 @@ public static class PortableWpfServiceRegistry
     private static void OnSystemThemeSourceChanged(object? sender, EventArgs e)
     {
         SystemThemeChanged?.Invoke(sender, e);
+    }
+
+    public static IDisposable RegisterDisplayMetricsSource(IPortableDisplayMetricsSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ValidateServiceKey(source.ServiceKey, nameof(source));
+
+        IPortableDisplayMetricsSource? replacedSource = null;
+        lock (SyncRoot)
+        {
+            if (DisplayMetricsSources.TryGetValue(source.ServiceKey, out replacedSource))
+            {
+                replacedSource.DisplayMetricsChanged -= OnDisplayMetricsSourceChanged;
+            }
+
+            DisplayMetricsSources[source.ServiceKey] = source;
+            source.DisplayMetricsChanged += OnDisplayMetricsSourceChanged;
+        }
+
+        DisplayMetricsChanged?.Invoke(source, EventArgs.Empty);
+        return new DisplayMetricsSourceRegistration(source);
+    }
+
+    public static bool TryGetDisplayMetricsSource(
+        PortableWpfServiceKey serviceKey,
+        out IPortableDisplayMetricsSource source)
+    {
+        ValidateServiceKey(serviceKey, nameof(serviceKey));
+
+        lock (SyncRoot)
+        {
+            return DisplayMetricsSources.TryGetValue(serviceKey, out source!);
+        }
+    }
+
+    private static void OnDisplayMetricsSourceChanged(object? sender, EventArgs e)
+    {
+        DisplayMetricsChanged?.Invoke(sender, e);
     }
 
     private static void ValidateServiceKey(PortableWpfServiceKey serviceKey, string parameterName)
@@ -1285,6 +1330,42 @@ public static class PortableWpfServiceRegistry
             if (removed)
             {
                 SystemThemeChanged?.Invoke(source, EventArgs.Empty);
+            }
+        }
+    }
+
+    private sealed class DisplayMetricsSourceRegistration : IDisposable
+    {
+        private IPortableDisplayMetricsSource? _source;
+
+        public DisplayMetricsSourceRegistration(IPortableDisplayMetricsSource source)
+        {
+            _source = source;
+        }
+
+        public void Dispose()
+        {
+            IPortableDisplayMetricsSource? source = Interlocked.Exchange(ref _source, null);
+            if (source is null)
+            {
+                return;
+            }
+
+            bool removed = false;
+            lock (SyncRoot)
+            {
+                if (DisplayMetricsSources.TryGetValue(source.ServiceKey, out IPortableDisplayMetricsSource? current) &&
+                    ReferenceEquals(current, source))
+                {
+                    source.DisplayMetricsChanged -= OnDisplayMetricsSourceChanged;
+                    DisplayMetricsSources.Remove(source.ServiceKey);
+                    removed = true;
+                }
+            }
+
+            if (removed)
+            {
+                DisplayMetricsChanged?.Invoke(source, EventArgs.Empty);
             }
         }
     }


### PR DESCRIPTION
## Summary

- add a typed `IPortableDisplayMetricsSource` contract for logical primary-screen, work-area, and virtual-screen geometry
- add keyed registration, lookup, replacement, removal, and change forwarding to `PortableWpfServiceRegistry`
- cover source replacement, stale registration disposal, notifications, and final removal

This is the interop boundary needed for LibreWPF to replace unavailable Win32 `SystemParameters` display metrics on non-Windows hosts.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj --no-restore --filter FullyQualifiedName~PortableWpfServiceRegistryTests` — 4 passed