### PR TITLE
Harden Linux WebGPU adapter selection and EGL startup

### DIFF
--- a/eng/build-wgpu-native-linux.sh
+++ b/eng/build-wgpu-native-linux.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the exact wgpu-native ABI consumed by Silk.NET.WebGPU 2.23.0 with
+# ProGPU's reviewed Linux EGL compatibility patch. Upstream sources and Cargo
+# caches remain external build inputs under artifacts/.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source_dir="${WGPU_NATIVE_SOURCE:-${repo_root}/artifacts/wgpu-native-linux-src}"
+output_dir="${WGPU_NATIVE_LINUX_OUTPUT:-${repo_root}/artifacts/wgpu-native-linux}"
+target_dir="${WGPU_NATIVE_LINUX_TARGET:-${repo_root}/artifacts/wgpu-native-linux-build}"
+cargo_home="${WGPU_NATIVE_LINUX_CARGO_HOME:-${repo_root}/artifacts/wgpu-native-linux-cargo}"
+patch_file="${repo_root}/eng/patches/wgpu-0.19-linux-egl-fallback.patch"
+
+native_commit="33133da4ec5a0174cb21539ef2d3346f75200411"
+wgpu_commit="87576b72b37c6b78b41104eb25fc31893af94092"
+upstream_url="https://github.com/gfx-rs/wgpu-native.git"
+
+for required_tool in cargo gcc git nm readelf rustc strip; do
+  if ! command -v "${required_tool}" >/dev/null 2>&1; then
+    echo "Required tool not found: ${required_tool}" >&2
+    exit 1
+  fi
+done
+
+case "${output_dir}" in
+  ""|/|"${repo_root}"|"${source_dir}"|"${target_dir}"|"${cargo_home}")
+    echo "Unsafe WGPU_NATIVE_LINUX_OUTPUT: ${output_dir}" >&2
+    exit 2
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64) runtime_id="linux-x64" ;;
+  aarch64|arm64) runtime_id="linux-arm64" ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -d "${source_dir}/.git" ]]; then
+  git clone --filter=blob:none "${upstream_url}" "${source_dir}"
+fi
+
+if [[ -n "$(git -C "${source_dir}" status --porcelain --untracked-files=no)" ]]; then
+  echo "Refusing to change a modified external wgpu-native checkout: ${source_dir}" >&2
+  exit 1
+fi
+
+git -C "${source_dir}" fetch --depth 1 origin "${native_commit}"
+if [[ "$(git -C "${source_dir}" rev-parse HEAD)" != "${native_commit}" ]]; then
+  git -C "${source_dir}" checkout --detach "${native_commit}"
+fi
+git -C "${source_dir}" submodule update --init --depth 1 ffi/webgpu-headers
+
+mkdir -p "${cargo_home}" "${target_dir}"
+export CARGO_HOME="${cargo_home}"
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+export CARGO_TARGET_DIR="${target_dir}"
+export CARGO_INCREMENTAL=0
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+export CARGO_PROFILE_RELEASE_LTO=thin
+
+cargo fetch --manifest-path "${source_dir}/Cargo.toml" --locked
+
+wgpu_checkout=""
+while IFS= read -r candidate; do
+  if [[ "$(git -C "${candidate}" rev-parse HEAD 2>/dev/null || true)" == "${wgpu_commit}" ]]; then
+    wgpu_checkout="${candidate}"
+    break
+  fi
+done < <(find "${cargo_home}/git/checkouts" -mindepth 2 -maxdepth 2 -type d -name "${wgpu_commit:0:7}" -print)
+
+if [[ -z "${wgpu_checkout}" ]]; then
+  echo "Cargo did not fetch the pinned wgpu checkout ${wgpu_commit}." >&2
+  exit 1
+fi
+
+if git -C "${wgpu_checkout}" apply --check "${patch_file}"; then
+  git -C "${wgpu_checkout}" apply "${patch_file}"
+elif ! git -C "${wgpu_checkout}" apply --reverse --check "${patch_file}"; then
+  echo "The pinned wgpu checkout contains changes other than the reviewed EGL patch." >&2
+  exit 1
+fi
+
+gcc_include="$(gcc -print-file-name=include)"
+target_include="/usr/include/$(gcc -dumpmachine)"
+bindgen_args="-I${gcc_include} -I/usr/include"
+if [[ -d "${target_include}" ]]; then
+  bindgen_args+=" -I${target_include}"
+fi
+export BINDGEN_EXTRA_CLANG_ARGS="${BINDGEN_EXTRA_CLANG_ARGS:-${bindgen_args}}"
+
+if [[ -z "${LIBCLANG_PATH:-}" ]]; then
+  for candidate in /usr/lib/llvm-*/lib; do
+    if [[ -e "${candidate}/libclang.so" || -e "${candidate}/libclang.so.1" ]]; then
+      export LIBCLANG_PATH="${candidate}"
+      break
+    fi
+  done
+fi
+
+base_rustflags="--remap-path-prefix=${source_dir}=wgpu-native --remap-path-prefix=${wgpu_checkout}=wgpu -C link-arg=-Wl,--build-id=sha1 -C link-arg=-Wl,-soname,libwgpu_native.so"
+export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }${base_rustflags}"
+export SOURCE_DATE_EPOCH="$(git -C "${source_dir}" show -s --format=%ct "${native_commit}")"
+export TZ=UTC
+
+cargo build \
+  --manifest-path "${source_dir}/Cargo.toml" \
+  --release \
+  --locked \
+  --no-default-features \
+  --features wgsl
+
+source_library="${target_dir}/release/libwgpu_native.so"
+destination_dir="${output_dir}/runtimes/${runtime_id}/native"
+destination_library="${destination_dir}/libwgpu_native.so"
+if [[ ! -f "${source_library}" ]]; then
+  echo "Cargo completed without producing ${source_library}." >&2
+  exit 1
+fi
+
+mkdir -p "${destination_dir}" "${output_dir}/include" "${output_dir}/licenses"
+install -m 0755 "${source_library}" "${destination_library}"
+strip --strip-unneeded "${destination_library}"
+install -m 0644 "${source_dir}/ffi/wgpu.h" "${output_dir}/include/wgpu.h"
+install -m 0644 "${source_dir}/ffi/webgpu-headers/webgpu.h" "${output_dir}/include/webgpu.h"
+install -m 0644 "${source_dir}/LICENSE.APACHE" "${output_dir}/licenses/LICENSE.APACHE"
+install -m 0644 "${source_dir}/LICENSE.MIT" "${output_dir}/licenses/LICENSE.MIT"
+
+if ! nm -D --defined-only "${destination_library}" |
+    awk '$NF == "wgpuCreateInstance" { found = 1 } END { exit !found }'; then
+  echo "Packaged library does not export the WebGPU C ABI." >&2
+  exit 1
+fi
+if ! readelf -d "${destination_library}" |
+    awk '/\(SONAME\)/ && /\[libwgpu_native\.so\]/ { found = 1 } END { exit !found }'; then
+  echo "Packaged library has no libwgpu_native.so SONAME." >&2
+  exit 1
+fi
+
+patch_sha256="$(sha256sum "${patch_file}" | awk '{print $1}')"
+rust_version="$(rustc --version)"
+{
+  printf 'wgpu-native-commit=%s\n' "${native_commit}"
+  printf 'wgpu-commit=%s\n' "${wgpu_commit}"
+  printf 'egl-patch-sha256=%s\n' "${patch_sha256}"
+  printf 'silk-net-webgpu-abi=2.23.0\n'
+  printf 'runtime-id=%s\n' "${runtime_id}"
+  printf 'cargo-features=wgsl\n'
+  printf 'rust-version=%s\n' "${rust_version}"
+} > "${output_dir}/BUILD-MANIFEST.txt"
+
+checksum_file="${output_dir}/SHA256SUMS"
+checksum_temp="${checksum_file}.tmp"
+: > "${checksum_temp}"
+while IFS= read -r relative_path; do
+  digest="$(sha256sum "${output_dir}/${relative_path}" | awk '{print $1}')"
+  printf '%s  %s\n' "${digest}" "${relative_path}" >> "${checksum_temp}"
+done < <(
+  cd "${output_dir}"
+  find BUILD-MANIFEST.txt include licenses runtimes -type f -print | LC_ALL=C sort
+)
+mv "${checksum_temp}" "${checksum_file}"
+
+echo "Created Linux wgpu-native package at ${output_dir} from ${native_commit}."
+echo "Runtime: ${runtime_id}; wgpu patch: ${patch_sha256}"

--- a/eng/patches/wgpu-0.19-linux-egl-fallback.patch
+++ b/eng/patches/wgpu-0.19-linux-egl-fallback.patch
@@ -1,0 +1,72 @@
+diff --git a/wgpu-hal/src/gles/egl.rs b/wgpu-hal/src/gles/egl.rs
+index 8b2eb49d6..9d9e10056 100644
+--- a/wgpu-hal/src/gles/egl.rs
++++ b/wgpu-hal/src/gles/egl.rs
+@@ -520,6 +520,8 @@ impl Inner {
+                 log::debug!("\tEGL context: -debug");
+             }
+         }
++        let robustness_attribute_index = context_attributes.len();
++        let mut requested_robustness = false;
+         if needs_robustness {
+             //Note: the core version can fail if robustness is not supported
+             // (regardless of whether the extension is supported!).
+@@ -528,10 +530,12 @@ impl Inner {
+                 log::debug!("\tEGL context: +robust access");
+                 context_attributes.push(khronos_egl::CONTEXT_OPENGL_ROBUST_ACCESS);
+                 context_attributes.push(khronos_egl::TRUE as _);
++                requested_robustness = true;
+             } else if display_extensions.contains("EGL_EXT_create_context_robustness") {
+                 log::debug!("\tEGL context: +robust access EXT");
+                 context_attributes.push(EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT);
+                 context_attributes.push(khronos_egl::TRUE as _);
++                requested_robustness = true;
+             } else {
+                 //Note: we aren't trying `EGL_CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR`
+                 // because it's for desktop GL only, not GLES.
+@@ -547,6 +551,23 @@ impl Inner {
+         context_attributes.push(khronos_egl::NONE);
+         let context = match egl.create_context(display, config, None, &context_attributes) {
+             Ok(context) => context,
++            Err(
++                khronos_egl::Error::BadAttribute
++                | khronos_egl::Error::BadMatch
++                | khronos_egl::Error::BadConfig,
++            ) if requested_robustness => {
++                log::warn!("\tEGL context: robust access rejected, retrying without it");
++                context_attributes.drain(
++                    robustness_attribute_index..robustness_attribute_index + 2,
++                );
++                egl.create_context(display, config, None, &context_attributes)
++                    .map_err(|e| {
++                        crate::InstanceError::with_source(
++                            String::from("unable to create GLES 3.x context"),
++                            e,
++                        )
++                    })?
++            }
+             Err(e) => {
+                 return Err(crate::InstanceError::with_source(
+                     String::from("unable to create GLES 3.x context"),
+@@ -709,9 +730,19 @@ impl crate::Instance<super::Api> for Instance {
+-        let wayland_library = if client_ext_str.contains("EGL_EXT_platform_wayland") {
++        let requested_platform = std::env::var("WGPU_EGL_PLATFORM")
++            .ok()
++            .map(|value| value.to_ascii_lowercase());
++        let allow_wayland = requested_platform.as_deref() != Some("x11");
++        let allow_x11 = requested_platform.as_deref() != Some("wayland");
++
++        let wayland_library = if allow_wayland
++            && client_ext_str.contains("EGL_EXT_platform_wayland")
++        {
+             test_wayland_display()
+         } else {
+             None
+         };
+-        let x11_display_library = if client_ext_str.contains("EGL_EXT_platform_x11") {
++        let x11_display_library = if allow_x11
++            && client_ext_str.contains("EGL_EXT_platform_x11")
++        {
+             open_x_display()
+         } else {
+             None

--- a/eng/run-linux-gpu-benchmark.sh
+++ b/eng/run-linux-gpu-benchmark.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dotnet="${DOTNET:-dotnet}"
+iterations="${PROGPU_LINUX_GPU_BENCHMARK_ITERATIONS:-5}"
+warmup_frames="${PROGPU_LINUX_GPU_BENCHMARK_WARMUP_FRAMES:-180}"
+measure_frames="${PROGPU_LINUX_GPU_BENCHMARK_MEASURE_FRAMES:-600}"
+timeout_seconds="${PROGPU_LINUX_GPU_BENCHMARK_TIMEOUT_SECONDS:-240}"
+page="${PROGPU_LINUX_GPU_BENCHMARK_PAGE:-Basic Input}"
+webgpu_implementation="${PROGPU_LINUX_GPU_BENCHMARK_WEBGPU_IMPLEMENTATION:-silk}"
+output_dir="${PROGPU_LINUX_GPU_BENCHMARK_OUTPUT:-${repo_root}/artifacts/performance/linux-gpu-benchmark}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "The Linux GPU benchmark must run on Linux." >&2
+  exit 2
+fi
+
+for value_name in iterations warmup_frames measure_frames timeout_seconds; do
+  value="${!value_name}"
+  if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${value_name} must be a positive integer, got '${value}'." >&2
+    exit 2
+  fi
+done
+
+case "${webgpu_implementation}" in
+  dawn|silk|wgpu) ;;
+  *)
+    echo "PROGPU_LINUX_GPU_BENCHMARK_WEBGPU_IMPLEMENTATION must be dawn, silk, or wgpu." >&2
+    exit 2
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64) runtime_id="linux-x64" ;;
+  aarch64|arm64) runtime_id="linux-arm64" ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)" >&2
+    exit 2
+    ;;
+esac
+
+sample_project="${repo_root}/src/ProGPU.Samples.Desktop/ProGPU.Samples.Desktop.csproj"
+sample_output="${repo_root}/src/ProGPU.Samples.Desktop/bin/Release/net10.0"
+sample_assembly="${sample_output}/ProGPU.Samples.Desktop.dll"
+sample_native="${sample_output}/runtimes/${runtime_id}/native"
+patched_native="${repo_root}/artifacts/wgpu-native-linux/runtimes/${runtime_id}/native"
+
+if [[ "${webgpu_implementation}" != "dawn" &&
+      ! -f "${patched_native}/libwgpu_native.so" ]]; then
+  echo "Missing reviewed wgpu-native build under ${patched_native}." >&2
+  echo "Run eng/build-wgpu-native-linux.sh first." >&2
+  exit 1
+fi
+
+if [[ "${PROGPU_LINUX_GPU_BENCHMARK_SKIP_BUILD:-0}" != "1" ]]; then
+  "${dotnet}" build "${sample_project}" \
+    -c Release \
+    -p:ProGpuDesktopLinuxOnly=true \
+    -v:minimal
+fi
+if [[ ! -f "${sample_assembly}" ]]; then
+  echo "Missing Release benchmark assembly: ${sample_assembly}" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+metadata="${output_dir}/environment.txt"
+summary="${output_dir}/results.txt"
+{
+  printf 'commit=%s\n' "$(git -C "${repo_root}" rev-parse HEAD)"
+  printf 'dirty=%s\n' "$(git -C "${repo_root}" status --porcelain | wc -l)"
+  printf 'os=%s\n' "$(. /etc/os-release && printf '%s' "${PRETTY_NAME}")"
+  printf 'kernel=%s\n' "$(uname -srvm)"
+  printf 'architecture=%s\n' "$(uname -m)"
+  printf 'processor_count=%s\n' "$(nproc)"
+  printf 'dotnet=%s\n' "$("${dotnet}" --version)"
+  printf 'runtime_id=%s\n' "${runtime_id}"
+  printf 'page=%s\n' "${page}"
+  printf 'iterations=%s\n' "${iterations}"
+  printf 'warmup_frames=%s\n' "${warmup_frames}"
+  printf 'measure_frames=%s\n' "${measure_frames}"
+  printf 'vsync=false\n'
+  printf 'webgpu_implementation=%s\n' "${webgpu_implementation}"
+  printf 'wgpu_backend_override=%s\n' "${WGPU_BACKEND:-automatic}"
+  printf 'display=%s\n' "${DISPLAY:-unset}"
+  printf 'wayland_display=%s\n' "${WAYLAND_DISPLAY:-unset}"
+  if [[ "${webgpu_implementation}" == "dawn" ]]; then
+    printf 'ld_library_path=%s%s\n' \
+      "${sample_native}" \
+      "${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  else
+    printf 'ld_library_path=%s:%s%s\n' \
+      "${patched_native}" \
+      "${sample_native}" \
+      "${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  fi
+} > "${metadata}"
+: > "${summary}"
+
+for ((iteration = 1; iteration <= iterations; iteration++)); do
+  run_log="${output_dir}/run-${iteration}.log"
+  echo "Running Linux GPU benchmark ${iteration}/${iterations}..."
+  benchmark_library_path="${sample_native}"
+  if [[ "${webgpu_implementation}" != "dawn" ]]; then
+    benchmark_library_path="${patched_native}:${benchmark_library_path}"
+  fi
+  if ! timeout --signal=INT --kill-after=5s "${timeout_seconds}s" \
+      env \
+        LD_LIBRARY_PATH="${benchmark_library_path}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+        PROGPU_SAMPLE_WEBGPU_IMPLEMENTATION="${webgpu_implementation}" \
+        PROGPU_SAMPLE_BENCHMARK_PAGE="${page}" \
+        PROGPU_SAMPLE_BENCHMARK_WARMUP_FRAMES="${warmup_frames}" \
+        PROGPU_SAMPLE_BENCHMARK_MEASURE_FRAMES="${measure_frames}" \
+        PROGPU_SAMPLE_BENCHMARK_VSYNC=false \
+        "${dotnet}" "${sample_assembly}" > "${run_log}" 2>&1; then
+    echo "Benchmark iteration ${iteration} failed; see ${run_log}." >&2
+    tail -n 80 "${run_log}" >&2
+    exit 1
+  fi
+
+  result="$(grep -F '[SampleBenchmark] RESULT' "${run_log}" | tail -n 1 || true)"
+  if [[ -z "${result}" ]]; then
+    echo "Benchmark iteration ${iteration} produced no result; see ${run_log}." >&2
+    exit 1
+  fi
+  printf 'run=%d %s\n' "${iteration}" "${result}" | tee -a "${summary}"
+done
+
+echo "Linux GPU benchmark results: ${summary}"

--- a/src/ProGPU.Backend/LinuxWebGpuBackendPreference.cs
+++ b/src/ProGPU.Backend/LinuxWebGpuBackendPreference.cs
@@ -1,0 +1,45 @@
+using Silk.NET.WebGPU;
+
+namespace ProGPU.Backend;
+
+internal readonly record struct LinuxWebGpuAdapterCandidate(
+    AdapterType AdapterType,
+    BackendType BackendType);
+
+internal static class LinuxWebGpuBackendPreference
+{
+    internal static BackendType Choose(
+        ReadOnlySpan<LinuxWebGpuAdapterCandidate> candidates)
+    {
+        int bestScore = int.MinValue;
+        BackendType bestBackend = BackendType.Undefined;
+        foreach (LinuxWebGpuAdapterCandidate candidate in candidates)
+        {
+            if (candidate.BackendType is not (
+                BackendType.Vulkan or BackendType.OpenGL))
+            {
+                continue;
+            }
+
+            int score = candidate.AdapterType switch
+            {
+                AdapterType.DiscreteGpu => 400,
+                AdapterType.IntegratedGpu => 300,
+                AdapterType.Unknown => 200,
+                AdapterType.Cpu => 100,
+                _ => 0
+            };
+            if (candidate.BackendType == BackendType.Vulkan)
+            {
+                score += 10;
+            }
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestBackend = candidate.BackendType;
+            }
+        }
+
+        return bestBackend;
+    }
+}

--- a/src/ProGPU.Backend/ProGPU.Backend.csproj
+++ b/src/ProGPU.Backend/ProGPU.Backend.csproj
@@ -6,6 +6,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="ProGPU.Tests, PublicKey=$(ProGPUPublicKey)" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Silk.NET.WebGPU" />
     <PackageReference Include="Silk.NET.WebGPU.Native.WGPU" />
     <PackageReference Include="Silk.NET.Windowing.Common" />

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -769,12 +769,13 @@ public unsafe class WgpuContext : IDisposable
 
         SafeLog($"[WGPUCONTEXT] Initialize started, window exists={window != null}\n");
         _window = window;
+        ConfigureLinuxEglPlatform(window);
         Wgpu = CreateNativeWebGpuApi();
         Api = new SilkWebGpuApi(Wgpu);
         
         // 1. Create WebGPU Instance (isolated per context)
         SafeLog("[WGPUCONTEXT] Creating WebGPU Instance\n");
-        var instanceExtras = CreateNativeInstanceExtras();
+        var instanceExtras = CreateNativeInstanceExtras(Wgpu);
         var instanceDesc = new InstanceDescriptor
         {
             NextInChain = instanceExtras.Chain.SType == 0 ? null : &instanceExtras.Chain
@@ -1100,19 +1101,24 @@ public unsafe class WgpuContext : IDisposable
         _hasSurfaceConfigurationCapabilities = false;
     }
 
-    private static NativeInstanceExtras CreateNativeInstanceExtras()
+    private static NativeInstanceExtras CreateNativeInstanceExtras(WebGPU wgpu)
     {
         uint backends = OperatingSystem.IsAndroid()
             ? NativeInstanceExtras.VulkanBackend
             : OperatingSystem.IsIOS()
                 ? NativeInstanceExtras.MetalBackend
-                : 0u;
+                : OperatingSystem.IsLinux()
+                    ? SelectLinuxInstanceBackend(wgpu)
+                    : 0u;
         return backends == 0u
             ? default
             : new NativeInstanceExtras
             {
                 Chain = new ChainedStruct { SType = (SType)NativeInstanceExtras.STypeValue },
-                Backends = backends
+                Backends = backends,
+                Gles3MinorVersion = backends == NativeInstanceExtras.OpenGlBackend
+                    ? NativeInstanceExtras.Gles3MinorVersion1
+                    : NativeInstanceExtras.Gles3MinorVersionAutomatic
             };
     }
 
@@ -1124,7 +1130,10 @@ public unsafe class WgpuContext : IDisposable
     {
         public const uint STypeValue = 0x00030006;
         public const uint VulkanBackend = 1u << 0;
+        public const uint OpenGlBackend = 1u << 1;
         public const uint MetalBackend = 1u << 2;
+        public const int Gles3MinorVersionAutomatic = 0;
+        public const int Gles3MinorVersion1 = 2;
 
         public ChainedStruct Chain;
         public uint Backends;
@@ -1133,6 +1142,195 @@ public unsafe class WgpuContext : IDisposable
         public int Gles3MinorVersion;
         public byte* DxilPath;
         public byte* DxcPath;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeInstanceEnumerateAdapterOptions
+    {
+        public ChainedStruct* NextInChain;
+        public uint Backends;
+    }
+
+    private static void ConfigureLinuxEglPlatform(IWindow? window)
+    {
+        if (!OperatingSystem.IsLinux() ||
+            window is not INativeWindowSource nativeWindowSource ||
+            nativeWindowSource.Native is null)
+        {
+            return;
+        }
+
+        if (nativeWindowSource.Native.X11.HasValue)
+        {
+            Environment.SetEnvironmentVariable("WGPU_EGL_PLATFORM", "x11");
+        }
+        else if (nativeWindowSource.Native.Wayland.HasValue)
+        {
+            Environment.SetEnvironmentVariable("WGPU_EGL_PLATFORM", "wayland");
+        }
+    }
+
+    private static uint SelectLinuxInstanceBackend(WebGPU wgpu)
+    {
+        string? requestedBackend = Environment.GetEnvironmentVariable("WGPU_BACKEND");
+        string? requestedBackendName = null;
+        uint candidateBackends;
+        if (string.Equals(requestedBackend, "gl", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(requestedBackend, "opengl", StringComparison.OrdinalIgnoreCase))
+        {
+            requestedBackendName = "OpenGL";
+            candidateBackends = NativeInstanceExtras.OpenGlBackend;
+        }
+        else if (string.Equals(requestedBackend, "vulkan", StringComparison.OrdinalIgnoreCase))
+        {
+            requestedBackendName = "Vulkan";
+            candidateBackends = NativeInstanceExtras.VulkanBackend;
+        }
+        else
+        {
+            candidateBackends =
+                NativeInstanceExtras.VulkanBackend |
+                NativeInstanceExtras.OpenGlBackend;
+        }
+
+        var probeExtras = new NativeInstanceExtras
+        {
+            Chain = new ChainedStruct
+            {
+                SType = (SType)NativeInstanceExtras.STypeValue
+            },
+            Backends = candidateBackends,
+            // ProGPU relies on compute shaders and vertex/storage buffers. Request
+            // the GLES 3.1 feature floor while probing so an accelerated adapter is
+            // considered only when it can support the renderer's required pipelines.
+            Gles3MinorVersion =
+                (candidateBackends & NativeInstanceExtras.OpenGlBackend) != 0
+                    ? NativeInstanceExtras.Gles3MinorVersion1
+                    : NativeInstanceExtras.Gles3MinorVersionAutomatic
+        };
+        var probeDescriptor = new InstanceDescriptor
+        {
+            NextInChain = &probeExtras.Chain
+        };
+        Instance* probeInstance = wgpu.CreateInstance(&probeDescriptor);
+        if (probeInstance == null)
+        {
+            return LinuxBackendUnavailable(
+                requestedBackendName,
+                "the probe instance could not be created");
+        }
+
+        try
+        {
+            nint enumerateAddress = ResolveLinuxWebGpuSymbol(
+                "wgpuInstanceEnumerateAdapters");
+            if (enumerateAddress == 0)
+            {
+                return LinuxBackendUnavailable(
+                    requestedBackendName,
+                    "wgpuInstanceEnumerateAdapters is unavailable");
+            }
+
+            var enumerate =
+                (delegate* unmanaged[Cdecl]<
+                    Instance*,
+                    NativeInstanceEnumerateAdapterOptions*,
+                    WgpuAdapter**,
+                    nuint>)enumerateAddress;
+            var options = new NativeInstanceEnumerateAdapterOptions
+            {
+                Backends = candidateBackends
+            };
+            nuint count = enumerate(probeInstance, &options, null);
+            if (count == 0 || count > 32)
+            {
+                return LinuxBackendUnavailable(
+                    requestedBackendName,
+                    count == 0
+                        ? "no compatible adapter met the renderer feature floor"
+                        : $"the adapter count {count} is invalid");
+            }
+
+            WgpuAdapter** adapters = stackalloc WgpuAdapter*[checked((int)count)];
+            nuint written = enumerate(probeInstance, &options, adapters);
+            Span<LinuxWebGpuAdapterCandidate> candidates =
+                stackalloc LinuxWebGpuAdapterCandidate[checked((int)written)];
+            try
+            {
+                for (nuint index = 0; index < written; index++)
+                {
+                    var properties = new AdapterProperties();
+                    wgpu.AdapterGetProperties(adapters[index], &properties);
+                    candidates[checked((int)index)] = new LinuxWebGpuAdapterCandidate(
+                        properties.AdapterType,
+                        properties.BackendType);
+                }
+            }
+            finally
+            {
+                for (nuint index = 0; index < written; index++)
+                {
+                    if (adapters[index] != null)
+                    {
+                        wgpu.AdapterRelease(adapters[index]);
+                    }
+                }
+            }
+
+            BackendType selectedBackend =
+                LinuxWebGpuBackendPreference.Choose(candidates);
+            uint selectedMask = selectedBackend switch
+            {
+                BackendType.Vulkan => NativeInstanceExtras.VulkanBackend,
+                BackendType.OpenGL => NativeInstanceExtras.OpenGlBackend,
+                _ => 0u
+            };
+            if (selectedMask == 0)
+            {
+                return LinuxBackendUnavailable(
+                    requestedBackendName,
+                    "no compatible Vulkan or OpenGL adapter was enumerated");
+            }
+
+            ProGpuBackendDiagnostics.WriteLine(
+                $"[WebGPU Context] Linux probe selected {selectedBackend} " +
+                $"from {written} compatible adapter(s); " +
+                $"override={requestedBackendName ?? "automatic"}.");
+            return selectedMask;
+        }
+        catch (DllNotFoundException)
+        {
+            return LinuxBackendUnavailable(
+                requestedBackendName,
+                "libwgpu_native.so could not be loaded");
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return LinuxBackendUnavailable(
+                requestedBackendName,
+                "the native adapter-enumeration entry point is unavailable");
+        }
+        finally
+        {
+            wgpu.InstanceRelease(probeInstance);
+        }
+    }
+
+    private static uint LinuxBackendUnavailable(
+        string? requestedBackendName,
+        string reason)
+    {
+        if (requestedBackendName is not null)
+        {
+            throw new PlatformNotSupportedException(
+                $"The requested Linux WebGPU backend {requestedBackendName} " +
+                $"is unavailable: {reason}.");
+        }
+
+        ProGpuBackendDiagnostics.WriteLine(
+            $"[WebGPU Context] Linux backend probe was inconclusive: {reason}; " +
+            "using native default discovery.");
+        return 0;
     }
 
     // wgpu-native 0.19 surface extension ABI. An Apple frame latency of one
@@ -1164,6 +1362,32 @@ public unsafe class WgpuContext : IDisposable
 
     private static readonly object s_androidWebGpuLibraryLock = new();
     private static nint s_androidWebGpuLibrary;
+    private static readonly object s_linuxWebGpuLibraryLock = new();
+    private static nint s_linuxWebGpuLibrary;
+
+    private static nint ResolveLinuxWebGpuSymbol(string symbol)
+    {
+        if (s_linuxWebGpuLibrary == 0)
+        {
+            lock (s_linuxWebGpuLibraryLock)
+            {
+                if (s_linuxWebGpuLibrary == 0 &&
+                    !NativeLibrary.TryLoad(
+                        "libwgpu_native.so",
+                        out s_linuxWebGpuLibrary))
+                {
+                    return 0;
+                }
+            }
+        }
+
+        return NativeLibrary.TryGetExport(
+            s_linuxWebGpuLibrary,
+            symbol,
+            out nint address)
+                ? address
+                : 0;
+    }
 
     private static nint ResolveAndroidWebGpuSymbol(string symbol)
     {

--- a/src/ProGPU.Samples.Desktop/ProGPU.Samples.Desktop.csproj
+++ b/src/ProGPU.Samples.Desktop/ProGPU.Samples.Desktop.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net10.0;net10.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProGpuDesktopLinuxOnly)' == 'true'">net10.0</TargetFrameworks>
     <ApplicationId Condition="'$(TargetFramework)' == 'net10.0-macos'">org.progpu.samples.desktop</ApplicationId>
     <ApplicationTitle Condition="'$(TargetFramework)' == 'net10.0-macos'">ProGPU Samples Desktop</ApplicationTitle>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/ProGPU.Samples.Desktop/Program.cs
+++ b/src/ProGPU.Samples.Desktop/Program.cs
@@ -24,6 +24,9 @@ namespace ProGPU.Samples.Desktop;
 
 public static class Program
 {
+    private const string WebGpuBackendVariable =
+        "PROGPU_SAMPLE_WEBGPU_IMPLEMENTATION";
+
 #if MACOS
     private const string MediaColorEffectId =
         "ProGPU.Sample.Desktop.VideoColor";
@@ -80,12 +83,28 @@ public static class Program
 #endif
         GlfwWindowing.Use();
         GlfwInput.RegisterPlatform();
-        AppBuilder<App>.Configure()
+        AppBuilder<App> builder = AppBuilder<App>.Configure()
             .WithTitle("ProGPU Substrate - High-Performance WinUI Gallery Dashboard")
-            .WithSize(1280, 800)
-            .WithGpuContextFactory(CreateDesktopGpuContext)
-            .Build()
-            .Run(args);
+            .WithSize(1280, 800);
+        if (!UseSilkWebGpuImplementation())
+        {
+            builder.WithGpuContextFactory(CreateDesktopGpuContext);
+        }
+        builder.Build().Run(args);
+    }
+
+    private static bool UseSilkWebGpuImplementation()
+    {
+        string? value =
+            Environment.GetEnvironmentVariable(WebGpuBackendVariable);
+        return string.Equals(
+            value,
+            "silk",
+            StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(
+                value,
+                "wgpu",
+                StringComparison.OrdinalIgnoreCase);
     }
 
     private static WgpuContext CreateDesktopGpuContext(

--- a/src/ProGPU.Samples/SamplePerformanceBenchmark.cs
+++ b/src/ProGPU.Samples/SamplePerformanceBenchmark.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
+using ProGPU.Backend;
 using Silk.NET.Maths;
 using Silk.NET.Windowing;
 
@@ -48,6 +49,12 @@ internal static class SamplePerformanceBenchmark
     private static double s_presentMilliseconds;
     private static double s_totalFrameMilliseconds;
     private static double s_maximumFrameMilliseconds;
+    private static readonly double[] s_totalFrameSamples =
+        new double[s_measureFrames];
+    private static readonly double[] s_renderSamples =
+        new double[s_measureFrames];
+    private static readonly double[] s_presentSamples =
+        new double[s_measureFrames];
     private static int s_framesOverBudget;
     private static Microsoft.UI.Xaml.Window? s_window;
     private static IWindow? s_resizeWindow;
@@ -244,6 +251,7 @@ internal static class SamplePerformanceBenchmark
         }
 
         s_deltaSeconds += deltaSeconds;
+        int sampleIndex = s_frame - s_warmupFrames - 1;
         if (s_window is { } window)
         {
             var frameMetrics = window.FrameMetrics;
@@ -252,6 +260,11 @@ internal static class SamplePerformanceBenchmark
             s_surfaceAcquireMilliseconds += frameMetrics.SurfaceAcquireTimeMs;
             s_presentMilliseconds += frameMetrics.PresentTimeMs;
             s_totalFrameMilliseconds += frameMetrics.TotalTimeMs;
+            if ((uint)sampleIndex < (uint)s_totalFrameSamples.Length)
+            {
+                s_totalFrameSamples[sampleIndex] = frameMetrics.TotalTimeMs;
+                s_presentSamples[sampleIndex] = frameMetrics.PresentTimeMs;
+            }
             s_maximumFrameMilliseconds = Math.Max(s_maximumFrameMilliseconds, frameMetrics.TotalTimeMs);
             if (frameMetrics.TotalTimeMs > 16.667d) s_framesOverBudget++;
         }
@@ -276,6 +289,10 @@ internal static class SamplePerformanceBenchmark
             }
             s_uploadMilliseconds += metrics.GpuUploadTimeMs;
             s_renderMilliseconds += metrics.RenderPassTimeMs;
+            if ((uint)sampleIndex < (uint)s_renderSamples.Length)
+            {
+                s_renderSamples[sampleIndex] = metrics.RenderPassTimeMs;
+            }
             s_compositorMilliseconds += metrics.FrameTimeMs;
             if (metrics.SceneCacheHit) s_sceneCacheHitFrames++;
         }
@@ -296,6 +313,15 @@ internal static class SamplePerformanceBenchmark
             ? measuredFrames / s_wallClock.Elapsed.TotalSeconds
             : 0d;
         double divisor = Math.Max(1, measuredFrames);
+        double totalFrameP50 = Percentile(s_totalFrameSamples, measuredFrames, 0.50d);
+        double totalFrameP95 = Percentile(s_totalFrameSamples, measuredFrames, 0.95d);
+        double totalFrameP99 = Percentile(s_totalFrameSamples, measuredFrames, 0.99d);
+        double renderP50 = Percentile(s_renderSamples, measuredFrames, 0.50d);
+        double renderP95 = Percentile(s_renderSamples, measuredFrames, 0.95d);
+        double renderP99 = Percentile(s_renderSamples, measuredFrames, 0.99d);
+        double presentP50 = Percentile(s_presentSamples, measuredFrames, 0.50d);
+        double presentP95 = Percentile(s_presentSamples, measuredFrames, 0.95d);
+        double presentP99 = Percentile(s_presentSamples, measuredFrames, 0.99d);
         long allocatedBytes = Math.Max(0, GC.GetTotalAllocatedBytes(precise: false) - s_allocatedBytesAtStart);
         int gen0Collections = GC.CollectionCount(0) - s_gen0CollectionsAtStart;
         int gen1Collections = GC.CollectionCount(1) - s_gen1CollectionsAtStart;
@@ -317,6 +343,9 @@ internal static class SamplePerformanceBenchmark
         ProcessMemorySnapshot processMemory =
             ProcessMemorySnapshot.CaptureCurrent();
         var finalMetrics = AppState._screenCompositor?.Metrics;
+        WgpuAdapterSelectionDiagnostics adapterDiagnostics =
+            AppState._wgpuContext?.AdapterSelectionDiagnostics ??
+            WgpuAdapterSelectionDiagnostics.Unknown;
         var finalResizeMetrics = s_window?.ResizeMetrics ?? default;
         ulong resizeEvents = finalResizeMetrics.LogicalResizeEvents - s_resizeMetricsAtStart.LogicalResizeEvents;
         ulong framebufferResizeEvents = finalResizeMetrics.FramebufferResizeEvents - s_resizeMetricsAtStart.FramebufferResizeEvents;
@@ -448,6 +477,11 @@ internal static class SamplePerformanceBenchmark
 
         Console.WriteLine(
             $"[SampleBenchmark] RESULT page=\"{RequestedPage}\" frames={measuredFrames}" +
+            $" adapter=\"{adapterDiagnostics.Name}\"" +
+            $" adapterBackend={adapterDiagnostics.BackendType}" +
+            $" adapterType={adapterDiagnostics.AdapterType}" +
+            $" adapterDriver=\"{adapterDiagnostics.DriverDescription}\"" +
+            $" adapterReason={adapterDiagnostics.SelectionReason}" +
             $" deltaFps={deltaFps:F2} wallFps={wallFps:F2}" +
             $" compileMs={s_compileMilliseconds / divisor:F4}" +
             $" maxCompileMs={s_maxCompileMilliseconds:F4}" +
@@ -466,6 +500,15 @@ internal static class SamplePerformanceBenchmark
             $" acquireMs={s_surfaceAcquireMilliseconds / divisor:F4}" +
             $" presentMs={s_presentMilliseconds / divisor:F4}" +
             $" totalFrameMs={s_totalFrameMilliseconds / divisor:F4}" +
+            $" renderP50Ms={renderP50:F4}" +
+            $" renderP95Ms={renderP95:F4}" +
+            $" renderP99Ms={renderP99:F4}" +
+            $" presentP50Ms={presentP50:F4}" +
+            $" presentP95Ms={presentP95:F4}" +
+            $" presentP99Ms={presentP99:F4}" +
+            $" totalFrameP50Ms={totalFrameP50:F4}" +
+            $" totalFrameP95Ms={totalFrameP95:F4}" +
+            $" totalFrameP99Ms={totalFrameP99:F4}" +
             $" maxFrameMs={s_maximumFrameMilliseconds:F4}" +
             $" framesOverBudget={s_framesOverBudget}" +
             $" resizeRequests={s_resizeRequests - s_resizeRequestsAtStart}" +
@@ -549,6 +592,30 @@ internal static class SamplePerformanceBenchmark
         }
 
         AppState._window?.Close();
+    }
+
+    private static double Percentile(
+        double[] samples,
+        int count,
+        double percentile)
+    {
+        if (count <= 0)
+        {
+            return 0d;
+        }
+
+        double[] ordered = samples.AsSpan(0, count).ToArray();
+        Array.Sort(ordered);
+        double rank = (ordered.Length - 1) * percentile;
+        int lower = (int)Math.Floor(rank);
+        int upper = (int)Math.Ceiling(rank);
+        if (lower == upper)
+        {
+            return ordered[lower];
+        }
+
+        double weight = rank - lower;
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * weight;
     }
 
     private static void AdvanceResizeWorkload(double _)

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -11,6 +11,45 @@ namespace ProGPU.Tests;
 public sealed class WgpuContextTests
 {
     [Fact]
+    public void LinuxBackendPreferenceChoosesAcceleratedGlOverCpuVulkan()
+    {
+        LinuxWebGpuAdapterCandidate[] candidates =
+        [
+            new(AdapterType.Cpu, BackendType.Vulkan),
+            new(AdapterType.IntegratedGpu, BackendType.OpenGL)
+        ];
+
+        Assert.Equal(
+            BackendType.OpenGL,
+            LinuxWebGpuBackendPreference.Choose(candidates));
+    }
+
+    [Fact]
+    public void LinuxBackendPreferenceKeepsAcceleratedVulkan()
+    {
+        LinuxWebGpuAdapterCandidate[] candidates =
+        [
+            new(AdapterType.IntegratedGpu, BackendType.OpenGL),
+            new(AdapterType.IntegratedGpu, BackendType.Vulkan)
+        ];
+
+        Assert.Equal(
+            BackendType.Vulkan,
+            LinuxWebGpuBackendPreference.Choose(candidates));
+    }
+
+    [Fact]
+    public void LinuxBackendPreferenceUsesCpuVulkanAsLastResort()
+    {
+        LinuxWebGpuAdapterCandidate[] candidates =
+        [new(AdapterType.Cpu, BackendType.Vulkan)];
+
+        Assert.Equal(
+            BackendType.Vulkan,
+            LinuxWebGpuBackendPreference.Choose(candidates));
+    }
+
+    [Fact]
     public void DeviceLossInvalidatesExistingContextsButNotReplacements()
     {
         var existing = new WgpuContext();


### PR DESCRIPTION
## Summary

- build the exact pinned wgpu-native ABI with a reviewed Linux EGL compatibility patch
- select the concrete X11 or Wayland EGL platform and retry rejected robust contexts without robustness
- probe Vulkan and OpenGL adapters at the renderer feature floor, prefer accelerated adapters, and fail explicit unsupported overrides before surface creation
- add adapter-aware, percentile-based Release window benchmarking with repeatable environment capture

## Evidence

On the ARM64 Parallels VM, the patch restores discovery of accelerated virgl OpenGL, but the virtual adapter exposes only GLES 3.0 / desktop GL 4.0. It cannot provide the compute and vertex/storage-buffer features used by the renderer, so automatic selection correctly retains CPU Vulkan instead of creating invalid pipelines. Five independent windowed runs have a median 24.7293 ms frame time (37.43 FPS), with presentation the larger average stage.

Dawn was also qualified. Its current Linux presentation path is Vulkan-only and the live loader selects libvulkan_lvp.so / llvmpipe on this VM. Its Linux ARM64 runtime closure and surface lifecycle require separate fixes before it is a valid replacement.

## Validation

- Release desktop sample build: 0 warnings, 0 errors
- backend preference tests: 3 passed
- headless rendering suite with reviewed native runtime: 240 passed
- automatic windowed smoke: passed on diagnosed CPU Vulkan fallback
- explicit OpenGL negative test: managed feature-floor diagnostic before surface creation
- native package ABI export, SONAME, manifest, licenses, and checksums: verified
- full renderer suite: not completed in this memory-constrained VM; it grows to about 2.7-3.0 GiB RSS and destabilizes the desktop session

## Primary references

- pinned wgpu: https://github.com/gfx-rs/wgpu/commit/87576b72b37c6b78b41104eb25fc31893af94092
- upstream robustness retry: https://github.com/gfx-rs/wgpu/commit/68a10a01d9dc210ce92cc7f3e40cdb7bccf60ba5
- upstream BadMatch/BadConfig correction: https://github.com/gfx-rs/wgpu/commit/e66813a88e351dbb66088b7cadd45c87f5328e0a
- OpenGL ES 3.1 registry: https://registry.khronos.org/OpenGL/specs/es/3.1/