### PR TITLE
Stabilize Dawn native presentation on Linux

### DIFF
--- a/docs/DAWN_LINUX_VM_RENDERING.md
+++ b/docs/DAWN_LINUX_VM_RENDERING.md
@@ -1,0 +1,187 @@
+# Dawn Linux VM rendering investigation
+
+Date: 2026-08-20  
+ProGPU baseline: `eab6754b` (`0.1.0-preview.53`)  
+WebGPUSharp: `0.5.5`, Dawn aligned with Chromium M150
+
+## Outcome
+
+Dawn is a viable native WebGPU backend for ProGPU, and it removes the need for
+a locally modified wgpu-native binary. It does not, however, provide hardware
+acceleration on the measured Linux ARM64 virtual machine. Dawn selects the
+Vulkan CPU adapter (`llvmpipe`) because the VM exposes no hardware Vulkan
+adapter. The virtual OpenGL adapter cannot be used by the current package or by
+the Core WebGPU renderer:
+
+- WebGPUSharp's Linux Dawn binary is built with Vulkan enabled and desktop GL
+  and GLES disabled;
+- Dawn's GL backends support WebGPU Compatibility mode, whereas ProGPU's
+  renderer currently requires Core mode;
+- current Dawn requires desktop OpenGL 4.4 or OpenGL ES 3.1, while this VM
+  exposes virgl OpenGL 4.0 and OpenGL ES 3.0.
+
+The investigation did find and fix a real Dawn presentation lifetime defect.
+After the fix, the bounded sample renders and presents correctly for the entire
+measurement instead of losing its surface after the first frame.
+
+## Test system
+
+| Component | Observed value |
+| --- | --- |
+| Guest | Ubuntu 24.04 ARM64, kernel 7.0.0-29 |
+| VM | Parallels on Apple silicon |
+| Session | GNOME Wayland with XWayland presentation |
+| Virtual OpenGL | virgl, desktop GL 4.0, GLES 3.0 |
+| Vulkan | Mesa `llvmpipe`, CPU adapter only |
+| Guest logical processors | 4 |
+| Bounded process RSS | 327-346 MB |
+
+No long renderer suite was run in this constrained desktop session. Validation
+used single-threaded project builds and one 60-frame warmup plus 120-frame
+measurement process with a 30-second hard timeout.
+
+## Runtime and package audit
+
+The WebGPUSharp 0.5.5 Linux ARM64 native object is
+`webgpu_dawn.so`. Its dynamic runtime closure includes:
+
+- `libc++.so.1`;
+- `libc++abi.so.1`;
+- `libunwind.so.1`.
+
+Those libraries were not present in the clean guest runtime closure. The
+current [WebGPUSharp Dawn build script](https://github.com/EmilSV/webgpu-dawn-build/blob/main/build_dawn.ps1)
+explicitly selects libc++ and enables only Vulkan on Linux:
+
+```text
+DAWN_ENABLE_DESKTOP_GL=OFF
+DAWN_ENABLE_OPENGLES=OFF
+DAWN_ENABLE_VULKAN=ON
+CMAKE_CXX_FLAGS=-stdlib=libc++
+```
+
+Consequently, selecting `BackendType.OpenGL` or `BackendType.OpenGLES` cannot
+discover an adapter with the distributed Linux binary. Merely changing ProGPU
+adapter preference cannot change that result.
+
+Upstream Dawn does build Vulkan, desktop GL, and GLES implementations on Linux
+when enabled. Its current GL implementation validates a minimum of OpenGL 4.4
+or GLES 3.1 and reports support for WebGPU Compatibility feature level. See
+[Dawn's Linux backend defaults](https://github.com/google/dawn/blob/main/CMakeLists.txt)
+and [the GL physical-device validation](https://github.com/google/dawn/blob/main/src/dawn/native/opengl/PhysicalDeviceGL.cpp).
+
+## Presentation failure and fix
+
+### Root cause
+
+`DawnNativeWindowSource.CreateXlib` opens and owns a dedicated X display
+connection. The desktop context factory attaches a Dawn surface inside a
+`using` scope and then disposes the source. Before this change,
+`DawnNativeWindowSource.Dispose` immediately called `XCloseDisplay`, even
+though the Dawn presentation surface still referred to that display.
+
+The first swapchain acquisition succeeded because it had already been created.
+Every acquisition after the first present returned `Lost`, triggering a
+reconfiguration attempt on every frame. A debugger changed teardown timing
+enough for the process to exit normally, but did not restore presentation.
+
+### Implementation
+
+Each surface creation now acquires an idempotent lifetime lease from its native
+window source. Disposing the source prevents new surfaces but defers release of
+owned native resources until the last surface lease is disposed. A presentation
+surface releases its Dawn surface before releasing the native-resource lease.
+
+This ordering applies to Xlib display ownership and Cocoa layer ownership while
+remaining harmless for borrowed Win32, Wayland, Android, and Metal handles.
+
+The Dawn-created `WgpuContext` now also carries the actual adapter name, backend,
+type, vendor/device identifiers, driver description, and compatible-surface
+requirement. An opt-in `PROGPU_DAWN_PRESENTATION_DIAGNOSTICS=1` trace reports at
+most the first 32 acquisitions and configurations, so diagnostics cannot create
+an unbounded log in the frame loop.
+
+## Bounded measurement
+
+Both measurements used the same 1280x800 Basic Input page, 60 warmup frames,
+120 measured frames, uncapped application scheduling, and Dawn FIFO
+presentation.
+
+| Metric | Before lifetime fix | After lifetime fix |
+| --- | ---: | ---: |
+| Adapter | Vulkan `llvmpipe` CPU | Vulkan `llvmpipe` CPU |
+| First acquisition | `SuccessOptimal` | `SuccessOptimal` |
+| Following sampled acquisitions | `Lost` | `SuccessOptimal` |
+| Measured surface configurations | 119 | 0 |
+| Scene-cache hits | 0 / 120 | 115 / 120 |
+| Present time | 0.0000 ms (no presentation) | 16.7075 ms |
+| Render time | invalid workload | 1.7242 ms |
+| Compositor time | invalid workload | 1.7819 ms |
+| Total frame time | invalid workload | 18.9176 ms |
+| Wall throughput | invalid 686.99 FPS | 49.92 FPS |
+| Process RSS | 327.4 MB | 346.0 MB |
+| Exit | timing-dependent failure/false completion | normal, exit 0 |
+
+The pre-fix throughput is explicitly invalid: almost every frame skipped GPU
+rendering after swapchain acquisition failed. The post-fix value is the first
+valid Dawn result on this VM. FIFO present dominates the steady frame time, and
+all rendering is performed by a CPU Vulkan implementation.
+
+## Can Dawn improve GPU rendering in this VM?
+
+Not with the VM's currently exposed graphics capabilities.
+
+| Candidate | Result | Reason |
+| --- | --- | --- |
+| Distributed Dawn Vulkan | Functional but CPU-rendered | Only `llvmpipe` Vulkan is exposed |
+| Dawn desktop GL enabled upstream | Adapter still unsuitable | VM GL 4.0 is below Dawn's 4.4 minimum; GL is Compatibility-only |
+| Dawn GLES enabled upstream | Adapter still unsuitable | VM GLES 3.0 is below Dawn's 3.1 minimum; GLES is Compatibility-only |
+| ANGLE over guest Vulkan | CPU-rendered | Guest Vulkan resolves to `llvmpipe` |
+| Hardware Vulkan exposed by VM | Preferred future path | Dawn can select a Core hardware adapter without renderer changes |
+
+The bottleneck is therefore the guest graphics contract, not the managed
+WebGPU bridge. Dawn can improve correctness, diagnostics, portability, and
+packaging, but no adapter-selection policy can synthesize the missing guest GPU
+features.
+
+## Recommended work
+
+### ProGPU
+
+1. Keep the surface lifetime lease and actual adapter diagnostics.
+2. Add an explicit hardware-adapter policy at application integration points:
+   reject `AdapterType.Cpu` when hardware acceleration is required, then use the
+   application's supported software renderer instead of silently running a
+   complex GPU renderer on `llvmpipe`.
+3. Keep the renderer on WebGPU Core. A Compatibility renderer would require a
+   separate shader/resource design and should only be considered after a
+   representative feature and performance study.
+4. Allow FIFO/Immediate/Mailbox selection only after querying supported present
+   modes. The measured 16.7 ms FIFO wait is expected presentation throttling,
+   not renderer CPU cost.
+
+### WebGPUSharp / Dawn packaging
+
+1. Make the Linux native package self-contained or use the standard distro C++
+   runtime. The current undeclared libc++ dependency prevents clean deployment.
+2. If Compatibility workloads are desired, publish Linux binaries with desktop
+   GL and GLES enabled and generate the
+   `RequestAdapterOptionsGetGLProc` binding. This does not unblock ProGPU Core
+   on the measured VM.
+3. Record the exact Dawn commit and CMake feature matrix in package metadata so
+   backend availability is auditable without reverse engineering the binary.
+
+### VM qualification
+
+The useful acceptance gate for future VM updates is:
+
+1. `vulkaninfo` reports a non-CPU adapter;
+2. Dawn adapter diagnostics report `Vulkan` and an integrated/discrete/virtual
+   GPU rather than `Cpu`;
+3. 180 bounded frames complete with zero unexpected surface reconfigurations;
+4. warmed scene-cache hits are retained;
+5. matched wall time and RSS improve over the supported software-renderer
+   fallback.
+
+Until the first two conditions pass, additional renderer micro-optimization
+cannot produce real GPU acceleration in this guest.

--- a/docs/DAWN_LINUX_VM_RENDERING.md
+++ b/docs/DAWN_LINUX_VM_RENDERING.md
@@ -127,6 +127,22 @@ rendering after swapchain acquisition failed. The post-fix value is the first
 valid Dawn result on this VM. FIFO present dominates the steady frame time, and
 all rendering is performed by a CPU Vulkan implementation.
 
+## Downstream WPF presenter audit
+
+The consuming WPF presenter had two independent backend-integration defects:
+
+- it called the concrete `Wgpu` object for acquire, view creation, present, and
+  release instead of the context's backend-neutral `Api` abstraction;
+- it released the acquired texture view but never released the acquired surface
+  texture handle.
+
+The downstream Dawn branch routes those calls through `IWebGpuApi` and balances
+both the texture-view and texture references, including the non-success
+acquisition path. This removes a per-frame native reference leak for the current
+backend and makes the hot presentation path compatible with `DawnWebGpuApi`.
+It intentionally does not add Dawn as a shipping WPF dependency while the Linux
+native runtime closure and hardware-adapter gate remain unresolved.
+
 ## Can Dawn improve GPU rendering in this VM?
 
 Not with the VM's currently exposed graphics capabilities.

--- a/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
+++ b/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
@@ -38,13 +38,16 @@ public sealed unsafe partial class DawnGpuContext
         }
 
         SurfaceHandle compatibilitySurface = SurfaceHandle.Null;
+        IDisposable? compatibilitySurfaceLease = null;
         AdapterHandle adapter = AdapterHandle.Null;
         DeviceHandle device = DeviceHandle.Null;
         QueueHandle queue = QueueHandle.Null;
         WgpuContext? context = null;
         try
         {
-            compatibilitySurface = source.CreateSurface(instance);
+            compatibilitySurface = source.CreateSurface(
+                instance,
+                out compatibilitySurfaceLease);
             if (compatibilitySurface == SurfaceHandle.Null)
             {
                 throw new NotSupportedException(
@@ -56,6 +59,7 @@ public sealed unsafe partial class DawnGpuContext
                 source.BackendType,
                 compatibilitySurface,
                 source.BackendName);
+            W.AdapterInfo? adapterInfo = adapter.GetInfo();
             NativeSurfaceCapabilities capabilities =
                 QuerySurfaceCapabilities(
                     compatibilitySurface,
@@ -197,8 +201,24 @@ public sealed unsafe partial class DawnGpuContext
                 supportsTextureFormatsTier1:
                     supportsTextureFormatsTier1,
                 adapterBackendType:
-                    ToSilkBackendType(source.BackendType),
-                adapterName: source.BackendName);
+                    ToSilkBackendType(
+                        adapterInfo?.BackendType ??
+                        source.BackendType),
+                adapterName:
+                    adapterInfo?.Description ??
+                    adapterInfo?.Device ??
+                    source.BackendName,
+                adapterType:
+                    ToSilkAdapterType(
+                        adapterInfo?.AdapterType ??
+                        W.AdapterType.Unknown),
+                adapterDriverDescription:
+                    DescribeAdapterDriver(adapterInfo),
+                adapterVendorId:
+                    adapterInfo?.VendorID ?? 0,
+                adapterDeviceId:
+                    adapterInfo?.DeviceID ?? 0,
+                requiredCompatibleSurface: true);
 
             InstanceHandle ownedInstance = instance;
             AdapterHandle ownedAdapter = adapter;
@@ -245,7 +265,9 @@ public sealed unsafe partial class DawnGpuContext
             if (compatibilitySurface != SurfaceHandle.Null)
             {
                 compatibilitySurface.Release();
+                compatibilitySurface = SurfaceHandle.Null;
             }
+            compatibilitySurfaceLease?.Dispose();
         }
     }
 
@@ -264,14 +286,16 @@ public sealed unsafe partial class DawnGpuContext
                 "The native surface backend does not match the Dawn adapter.");
         }
 
-        SurfaceHandle surface = source.CreateSurface(Instance);
-        if (surface == SurfaceHandle.Null)
-        {
-            throw new NotSupportedException(
-                "Dawn could not create the native presentation surface.");
-        }
+        SurfaceHandle surface = source.CreateSurface(
+            Instance,
+            out IDisposable surfaceLifetimeLease);
         try
         {
+            if (surface == SurfaceHandle.Null)
+            {
+                throw new NotSupportedException(
+                    "Dawn could not create the native presentation surface.");
+            }
             NativeSurfaceCapabilities capabilities =
                 QuerySurfaceCapabilities(surface, Adapter);
             W.TextureFormat format =
@@ -289,11 +313,16 @@ public sealed unsafe partial class DawnGpuContext
                 this,
                 surface,
                 format,
-                alphaMode);
+                alphaMode,
+                surfaceLifetimeLease);
         }
         catch
         {
-            surface.Release();
+            if (surface != SurfaceHandle.Null)
+            {
+                surface.Release();
+            }
+            surfaceLifetimeLease.Dispose();
             throw;
         }
     }
@@ -518,6 +547,33 @@ public sealed unsafe partial class DawnGpuContext
                 $"Unsupported Dawn presentation backend {backendType}.")
         };
 
+    private static SW.AdapterType ToSilkAdapterType(
+        W.AdapterType adapterType) =>
+        adapterType switch
+        {
+            W.AdapterType.DiscreteGPU => SW.AdapterType.DiscreteGpu,
+            W.AdapterType.IntegratedGPU => SW.AdapterType.IntegratedGpu,
+            W.AdapterType.CPU => SW.AdapterType.Cpu,
+            _ => SW.AdapterType.Unknown
+        };
+
+    private static string DescribeAdapterDriver(
+        W.AdapterInfo? adapterInfo)
+    {
+        if (adapterInfo is null)
+        {
+            return string.Empty;
+        }
+
+        string vendor = adapterInfo.Vendor ?? string.Empty;
+        string architecture = adapterInfo.Architecture ?? string.Empty;
+        return string.IsNullOrWhiteSpace(vendor)
+            ? architecture
+            : string.IsNullOrWhiteSpace(architecture)
+                ? vendor
+                : $"{vendor} / {architecture}";
+    }
+
     internal readonly record struct NativeSurfaceCapabilities(
         W.TextureFormat[] Formats,
         W.CompositeAlphaMode[] AlphaModes);
@@ -533,25 +589,34 @@ public sealed unsafe partial class DawnGpuContext
 /// </remarks>
 public sealed unsafe class DawnNativePresentationSurface : IDisposable
 {
+    private const string PresentationDiagnosticsVariable =
+        "PROGPU_DAWN_PRESENTATION_DIAGNOSTICS";
+    private static readonly bool s_tracePresentation =
+        IsPresentationDiagnosticsEnabled();
     private readonly DawnGpuContext _owner;
     private SurfaceHandle _surface;
     private readonly W.TextureFormat _format;
     private readonly W.CompositeAlphaMode _alphaMode;
+    private IDisposable? _surfaceLifetimeLease;
     private uint _width;
     private uint _height;
     private bool _configured;
     private bool _reconfigureAfterPresent;
+    private int _diagnosticAcquisitionCount;
+    private int _diagnosticConfigurationCount;
 
     internal DawnNativePresentationSurface(
         DawnGpuContext owner,
         SurfaceHandle surface,
         W.TextureFormat format,
-        W.CompositeAlphaMode alphaMode)
+        W.CompositeAlphaMode alphaMode,
+        IDisposable surfaceLifetimeLease)
     {
         _owner = owner;
         _surface = surface;
         _format = format;
         _alphaMode = alphaMode;
+        _surfaceLifetimeLease = surfaceLifetimeLease;
     }
 
     public SW.TextureFormat Format =>
@@ -582,6 +647,7 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
             ConfigureIfNeeded(width, height);
             SurfaceTextureFFI acquired = default;
             _surface.GetCurrentTexture(ref acquired);
+            TraceAcquisition("owned", acquired);
             if (acquired.Status is
                 W.SurfaceGetCurrentTextureStatus.Outdated or
                 W.SurfaceGetCurrentTextureStatus.Lost)
@@ -682,6 +748,7 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
                 this);
             SurfaceTextureFFI acquired = default;
             _surface.GetCurrentTexture(ref acquired);
+            TraceAcquisition("external", acquired);
             bool acquiredTexture =
                 acquired.Texture != TextureHandle.Null;
             *target = new SW.SurfaceTexture
@@ -760,9 +827,43 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
             AlphaMode = _alphaMode
         };
         _surface.Configure(configuration);
+        if (s_tracePresentation &&
+            _diagnosticConfigurationCount++ < 32)
+        {
+            Console.WriteLine(
+                $"[Dawn Presentation] configure " +
+                $"size={width}x{height} " +
+                $"format={_format} mode={configuration.PresentMode} " +
+                $"alpha={_alphaMode}.");
+        }
         _width = width;
         _height = height;
         _configured = true;
+    }
+
+    private void TraceAcquisition(
+        string path,
+        SurfaceTextureFFI acquired)
+    {
+        if (!s_tracePresentation ||
+            _diagnosticAcquisitionCount++ >= 32)
+        {
+            return;
+        }
+
+        Console.WriteLine(
+            $"[Dawn Presentation] acquire path={path} " +
+            $"status={acquired.Status} " +
+            $"texture={(acquired.Texture == TextureHandle.Null ? "null" : "valid")} " +
+            $"configured={_configured} size={_width}x{_height}.");
+    }
+
+    private static bool IsPresentationDiagnosticsEnabled()
+    {
+        string? value = Environment.GetEnvironmentVariable(
+            PresentationDiagnosticsVariable);
+        return string.Equals(value, "1", StringComparison.Ordinal) ||
+            string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()
@@ -771,6 +872,7 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
         {
             return;
         }
+        IDisposable? surfaceLifetimeLease;
         lock (_owner.Context.RenderLock)
         {
             if (_configured)
@@ -780,7 +882,10 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
             _surface.Release();
             _surface = SurfaceHandle.Null;
             _configured = false;
+            surfaceLifetimeLease = _surfaceLifetimeLease;
+            _surfaceLifetimeLease = null;
         }
+        surfaceLifetimeLease?.Dispose();
     }
 }
 

--- a/src/ProGPU.Backend.Dawn/DawnNativeWindowSource.cs
+++ b/src/ProGPU.Backend.Dawn/DawnNativeWindowSource.cs
@@ -23,14 +23,18 @@ public enum DawnNativeWindowKind
 /// <remarks>
 /// Construction and surface creation are O(1). The Xlib lane owns one display
 /// connection for its lifetime; the Win32 lane borrows the HWND and process
-/// module handle. No pixel storage or presentation texture is allocated here.
+/// module handle. Disposing the source prevents new surfaces and defers owned
+/// native-resource release until existing surfaces release their lifetime
+/// leases. No pixel storage or presentation texture is allocated here.
 /// </remarks>
 public sealed unsafe partial class DawnNativeWindowSource : IDisposable
 {
+    private readonly object _lifetimeGate = new();
     private readonly bool _ownsDisplay;
     private readonly bool _ownsWindow;
     private nint _displayOrInstance;
     private nint _window;
+    private int _surfaceLeaseCount;
     private bool _disposed;
 
     private DawnNativeWindowSource(
@@ -295,9 +299,10 @@ public sealed unsafe partial class DawnNativeWindowSource : IDisposable
         return false;
     }
 
-    internal SurfaceHandle CreateSurface(InstanceHandle instance)
+    internal SurfaceHandle CreateSurface(
+        InstanceHandle instance,
+        out IDisposable lifetimeLease)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
         if (instance == InstanceHandle.Null)
         {
             throw new ArgumentException(
@@ -305,21 +310,36 @@ public sealed unsafe partial class DawnNativeWindowSource : IDisposable
                 nameof(instance));
         }
 
-        return Kind switch
+        lock (_lifetimeGate)
         {
-            DawnNativeWindowKind.Win32 =>
-                CreateWin32Surface(instance),
-            DawnNativeWindowKind.Xlib =>
-                CreateXlibSurface(instance),
-            DawnNativeWindowKind.Wayland =>
-                CreateWaylandSurface(instance),
-            DawnNativeWindowKind.Android =>
-                CreateAndroidSurface(instance),
-            DawnNativeWindowKind.MetalLayer =>
-                CreateMetalLayerSurface(instance),
-            _ => throw new NotSupportedException(
-                $"Unsupported Dawn window kind {Kind}.")
-        };
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _surfaceLeaseCount++;
+            try
+            {
+                SurfaceHandle surface = Kind switch
+                {
+                    DawnNativeWindowKind.Win32 =>
+                        CreateWin32Surface(instance),
+                    DawnNativeWindowKind.Xlib =>
+                        CreateXlibSurface(instance),
+                    DawnNativeWindowKind.Wayland =>
+                        CreateWaylandSurface(instance),
+                    DawnNativeWindowKind.Android =>
+                        CreateAndroidSurface(instance),
+                    DawnNativeWindowKind.MetalLayer =>
+                        CreateMetalLayerSurface(instance),
+                    _ => throw new NotSupportedException(
+                        $"Unsupported Dawn window kind {Kind}.")
+                };
+                lifetimeLease = new SurfaceLifetimeLease(this);
+                return surface;
+            }
+            catch
+            {
+                _surfaceLeaseCount--;
+                throw;
+            }
+        }
     }
 
     private SurfaceHandle CreateWin32Surface(InstanceHandle instance)
@@ -417,11 +437,41 @@ public sealed unsafe partial class DawnNativeWindowSource : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        lock (_lifetimeGate)
         {
-            return;
-        }
+            if (_disposed)
+            {
+                return;
+            }
 
+            _disposed = true;
+            if (_surfaceLeaseCount == 0)
+            {
+                ReleaseNativeResources();
+            }
+        }
+    }
+
+    private void ReleaseSurfaceLease()
+    {
+        lock (_lifetimeGate)
+        {
+            if (_surfaceLeaseCount <= 0)
+            {
+                throw new InvalidOperationException(
+                    "The Dawn native surface lifetime lease is unbalanced.");
+            }
+
+            _surfaceLeaseCount--;
+            if (_disposed && _surfaceLeaseCount == 0)
+            {
+                ReleaseNativeResources();
+            }
+        }
+    }
+
+    private void ReleaseNativeResources()
+    {
         if (_ownsDisplay && _displayOrInstance != 0)
         {
             XCloseDisplay(_displayOrInstance);
@@ -432,7 +482,22 @@ public sealed unsafe partial class DawnNativeWindowSource : IDisposable
         }
         _displayOrInstance = 0;
         _window = 0;
-        _disposed = true;
+    }
+
+    private sealed class SurfaceLifetimeLease : IDisposable
+    {
+        private DawnNativeWindowSource? _owner;
+
+        internal SurfaceLifetimeLease(DawnNativeWindowSource owner)
+        {
+            _owner = owner;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _owner, null)?
+                .ReleaseSurfaceLease();
+        }
     }
 
     [LibraryImport(

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -1363,7 +1363,8 @@ public unsafe class WgpuContext : IDisposable
         AdapterType adapterType = AdapterType.Unknown,
         string? adapterDriverDescription = null,
         uint adapterVendorId = 0,
-        uint adapterDeviceId = 0)
+        uint adapterDeviceId = 0,
+        bool requiredCompatibleSurface = false)
     {
         ArgumentNullException.ThrowIfNull(api);
         ArgumentNullException.ThrowIfNull(lifetime);
@@ -1399,7 +1400,7 @@ public unsafe class WgpuContext : IDisposable
             adapterDriverDescription ?? string.Empty,
             adapterVendorId,
             adapterDeviceId,
-            false,
+            requiredCompatibleSurface,
             WgpuAdapterSelectionReason.ExternalNativeHost));
         _externalDeviceLifetime = lifetime;
         _deviceResourceDomain = new WgpuDeviceResourceDomain(Api, Device);

--- a/src/ProGPU.Samples/SamplePerformanceBenchmark.cs
+++ b/src/ProGPU.Samples/SamplePerformanceBenchmark.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
+using ProGPU.Backend;
 using Silk.NET.Maths;
 using Silk.NET.Windowing;
 
@@ -317,6 +318,9 @@ internal static class SamplePerformanceBenchmark
         ProcessMemorySnapshot processMemory =
             ProcessMemorySnapshot.CaptureCurrent();
         var finalMetrics = AppState._screenCompositor?.Metrics;
+        WgpuAdapterSelectionDiagnostics adapterDiagnostics =
+            AppState._wgpuContext?.AdapterSelectionDiagnostics ??
+            WgpuAdapterSelectionDiagnostics.Unknown;
         var finalResizeMetrics = s_window?.ResizeMetrics ?? default;
         ulong resizeEvents = finalResizeMetrics.LogicalResizeEvents - s_resizeMetricsAtStart.LogicalResizeEvents;
         ulong framebufferResizeEvents = finalResizeMetrics.FramebufferResizeEvents - s_resizeMetricsAtStart.FramebufferResizeEvents;
@@ -448,6 +452,11 @@ internal static class SamplePerformanceBenchmark
 
         Console.WriteLine(
             $"[SampleBenchmark] RESULT page=\"{RequestedPage}\" frames={measuredFrames}" +
+            $" adapter=\"{adapterDiagnostics.Name}\"" +
+            $" adapterBackend={adapterDiagnostics.BackendType}" +
+            $" adapterType={adapterDiagnostics.AdapterType}" +
+            $" adapterDriver=\"{adapterDiagnostics.DriverDescription}\"" +
+            $" adapterReason={adapterDiagnostics.SelectionReason}" +
             $" deltaFps={deltaFps:F2} wallFps={wallFps:F2}" +
             $" compileMs={s_compileMilliseconds / divisor:F4}" +
             $" maxCompileMs={s_maxCompileMilliseconds:F4}" +

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -51,7 +51,8 @@ public sealed class WgpuContextTests
             adapterType: AdapterType.IntegratedGpu,
             adapterDriverDescription: "Test Metal Driver",
             adapterVendorId: 0x106B,
-            adapterDeviceId: 0x1234);
+            adapterDeviceId: 0x1234,
+            requiredCompatibleSurface: true);
 
         Assert.True(context.IsInitialized);
         Assert.Equal(WgpuBackendKind.DawnNative, context.BackendKind);
@@ -65,7 +66,7 @@ public sealed class WgpuContextTests
                 "Test Metal Driver",
                 0x106B,
                 0x1234,
-                false,
+                true,
                 WgpuAdapterSelectionReason.ExternalNativeHost),
             context.AdapterSelectionDiagnostics);
         Assert.True(context.SupportsTextureFormatsTier1);


### PR DESCRIPTION
## Summary
- retain native window resources until all Dawn presentation surfaces release them
- report the actual Dawn adapter/backend/type instead of a synthetic backend label
- add bounded opt-in surface acquisition diagnostics and benchmark adapter output
- document the Linux VM capability and Dawn packaging findings

## Measured result
A bounded 60-warmup/120-measured-frame Linux ARM64 run now keeps every sampled acquisition at SuccessOptimal, records zero measured surface reconfigurations, reaches 115/120 scene-cache hits, and exits normally at about 346 MB RSS. Before the lifetime fix, only the first acquisition succeeded and 119 measured frames reconfigured a lost surface.

Dawn selects Vulkan llvmpipe on this VM, so the valid result is CPU-rendered at 49.92 wall FPS. The report explains why the distributed Linux Dawn binary and the guest GL/GLES feature levels cannot provide Core WebGPU hardware acceleration here.

## Validation
- ProGPU.Backend.Dawn Release build: passed, zero warnings/errors
- ProGPU.Samples.Desktop net10.0 Release build: passed, zero warnings/errors
- exact WgpuContext external-device diagnostics test: passed
- bounded Dawn live smoke: passed, exit 0
- broader WgpuContext class filter: 21 passed; 8 environment-dependent tests could not load the absent wgpu-native library
- Avalonia contract test project was not run because its configured external Avalonia source/assets were unavailable

This is intentionally a draft while the Dawn deployment/runtime policy is reviewed.