### PR TITLE
Reuse compiled scenes with empty drawing visuals

### DIFF
--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -5080,7 +5080,12 @@ SceneStateUploadComplete:
         bool includeLocalTransform,
         bool includeLocalVisualState)
     {
-        if (node is DrawingVisual)
+        // DrawingContext command storage can change without invalidating its owning
+        // visual, so populated drawing visuals cannot participate in compiled-scene
+        // reuse. An empty drawing visual contributes no command data and is safe to
+        // cache; this is common for hosts that keep an optional overlay visual.
+        if (node is DrawingVisual drawingVisual
+            && drawingVisual.Context.Commands.Count != 0)
         {
             _compiledSceneContainsDrawingVisual = true;
         }

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -554,6 +554,26 @@ public sealed class LayerRenderTests
     }
 
     [Fact]
+    public void EmptyDrawingVisualAllowsCompiledSceneReuse()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new EmptyDrawingVisualHost();
+
+        try
+        {
+            window.Render();
+            window.Render();
+
+            Assert.True(window.Compositor.Metrics.SceneCacheHit);
+            Assert.Null(window.Compositor.Metrics.SceneCacheMissReason);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
     public void CachedLayerCompositeIncludesVisualLocalTransform()
     {
         var window = HeadlessWindow.Shared;
@@ -878,6 +898,16 @@ public sealed class LayerRenderTests
                 null,
                 new Rect(0f, 0f, 64f, 64f));
             AddChild(drawing);
+        }
+    }
+
+    private sealed class EmptyDrawingVisualHost : FrameworkElement
+    {
+        public EmptyDrawingVisualHost()
+        {
+            Width = 64f;
+            Height = 64f;
+            AddChild(new DrawingVisual { Size = new Vector2(64f, 64f) });
         }
     }
 


### PR DESCRIPTION
## Summary
- allow compiled-scene reuse when a `DrawingVisual` has no recorded commands
- preserve the conservative cache bypass for populated mutable drawing contexts
- cover both empty and populated drawing-visual behavior with regression tests

## Motivation
A host may retain an optional empty overlay drawing visual. Its presence alone does not contribute mutable command data, but previously disabled scene-cache reuse for the entire surface. This caused repeated scene compilation in a private cross-platform validation workload.

## Validation
- `LayerRenderTests.EmptyDrawingVisualAllowsCompiledSceneReuse`
- `LayerRenderTests.MutableDrawingVisualDisablesCompiledSceneReuse`
- complete `LayerRenderTests` class: 24 passed, 0 failed
- Release compilation succeeded

The first test attempt was environment-blocked because the test output had no native WebGPU library. Rerunning with the repository-compatible native runtime passed.