### PR TITLE
Export the native Dawn CMake target

### DIFF
--- a/eng/build-progpu-native-windows.ps1
+++ b/eng/build-progpu-native-windows.ps1
@@ -208,6 +208,7 @@ if (-not $SkipExtendedIntegration) {
     $SdkPackageStage = Join-Path $PackageStage "sdk"
     New-Item -ItemType Directory -Force -Path $SdkPackageStage | Out-Null
     $SdkLibraries = @(
+        "progpu_native_dawn.lib",
         "progpu_native_compression.lib",
         "progpu_native_hit_testing.lib",
         "progpu_native_image.lib",

--- a/eng/progpu-verify-native-package.sh
+++ b/eng/progpu-verify-native-package.sh
@@ -55,6 +55,8 @@ for rid in linux-x64 linux-arm64 osx-x64 osx-arm64; do
   done
 done
 for rid in win-x64 win-arm64; do
+  required_entries+=(
+    "runtimes/${rid}/native/sdk/progpu_native_dawn.lib")
   for library in compression hit_testing image text scene_builder; do
     required_entries+=(
       "runtimes/${rid}/native/sdk/progpu_native_${library}.lib")

--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -1438,12 +1438,19 @@ if(NOT EMSCRIPTEN)
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     install(FILES
         include/progpu_native.h
+        include/progpu_native_dawn.h
         include/progpu_native_compression.hpp
         include/progpu_native_hit_testing.hpp
         include/progpu_native_image.hpp
         include/progpu_native_scene_builder.hpp
         include/progpu_native_text.hpp
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    if(TARGET progpu_native_dawn)
+        install(TARGETS progpu_native_dawn
+            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    endif()
     install(FILES
         src/Compression/progpu_native_compression.cppm
         src/HitTesting/progpu_native_hit_testing.cppm

--- a/src/ProGPU.Native/cmake/ProGPUNativeConfig.cmake
+++ b/src/ProGPU.Native/cmake/ProGPUNativeConfig.cmake
@@ -3,10 +3,6 @@
 # layout. Module interface sources are shipped separately because compiled C++
 # module artifacts are intentionally compiler-specific.
 
-if(TARGET ProGPU::native_scene_builder)
-    return()
-endif()
-
 get_filename_component(_progpu_native_root
     "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
 
@@ -35,9 +31,12 @@ if(EXISTS "${_progpu_native_root}/build/native/include")
     endif()
     set(_progpu_native_library_dir
         "${_progpu_native_root}/runtimes/${_progpu_native_rid}/native/sdk")
+    set(_progpu_native_runtime_dir
+        "${_progpu_native_root}/runtimes/${_progpu_native_rid}/native")
 else()
     set(_progpu_native_include "${_progpu_native_root}/include")
     set(_progpu_native_library_dir "${_progpu_native_root}/lib")
+    set(_progpu_native_runtime_dir "${_progpu_native_library_dir}")
     if(WIN32)
         set(_progpu_native_prefix "")
         set(_progpu_native_suffix ".lib")
@@ -48,6 +47,9 @@ else()
 endif()
 
 function(_progpu_native_import component)
+    if(TARGET "ProGPU::native_${component}")
+        return()
+    endif()
     set(_location
         "${_progpu_native_library_dir}/${_progpu_native_prefix}progpu_native_${component}${_progpu_native_suffix}")
     if(NOT EXISTS "${_location}")
@@ -67,6 +69,43 @@ _progpu_native_import(image)
 _progpu_native_import(text)
 _progpu_native_import(scene_builder)
 
+if(NOT TARGET ProGPU::native_dawn AND WIN32)
+    set(_progpu_native_dawn_location
+        "${_progpu_native_runtime_dir}/progpu_native_dawn.dll")
+    set(_progpu_native_dawn_implib
+        "${_progpu_native_library_dir}/progpu_native_dawn.lib")
+    if(EXISTS "${_progpu_native_dawn_location}" AND
+       EXISTS "${_progpu_native_dawn_implib}")
+        add_library(ProGPU::native_dawn SHARED IMPORTED)
+        set_target_properties(ProGPU::native_dawn PROPERTIES
+            IMPORTED_LOCATION "${_progpu_native_dawn_location}"
+            IMPORTED_IMPLIB "${_progpu_native_dawn_implib}"
+            INTERFACE_INCLUDE_DIRECTORIES "${_progpu_native_include}")
+    endif()
+elseif(NOT TARGET ProGPU::native_dawn AND APPLE)
+    set(_progpu_native_dawn_location
+        "${_progpu_native_runtime_dir}/libprogpu_native_dawn.dylib")
+    if(EXISTS "${_progpu_native_dawn_location}")
+        add_library(ProGPU::native_dawn SHARED IMPORTED)
+        set_target_properties(ProGPU::native_dawn PROPERTIES
+            IMPORTED_LOCATION "${_progpu_native_dawn_location}"
+            INTERFACE_INCLUDE_DIRECTORIES "${_progpu_native_include}")
+    endif()
+elseif(NOT TARGET ProGPU::native_dawn AND UNIX)
+    set(_progpu_native_dawn_location
+        "${_progpu_native_runtime_dir}/libprogpu_native_dawn.so")
+    if(EXISTS "${_progpu_native_dawn_location}")
+        add_library(ProGPU::native_dawn SHARED IMPORTED)
+        set_target_properties(ProGPU::native_dawn PROPERTIES
+            IMPORTED_LOCATION "${_progpu_native_dawn_location}"
+            INTERFACE_INCLUDE_DIRECTORIES "${_progpu_native_include}")
+    endif()
+endif()
+if(TARGET ProGPU::native_dawn)
+    set_property(TARGET ProGPU::native_dawn PROPERTY
+        INTERFACE_COMPILE_FEATURES cxx_std_20)
+endif()
+
 set_property(TARGET ProGPU::native_image PROPERTY
     INTERFACE_LINK_LIBRARIES ProGPU::native_compression)
 set_property(TARGET ProGPU::native_text PROPERTY
@@ -77,6 +116,9 @@ set_property(TARGET ProGPU::native_scene_builder PROPERTY
 unset(_progpu_native_root)
 unset(_progpu_native_include)
 unset(_progpu_native_library_dir)
+unset(_progpu_native_runtime_dir)
+unset(_progpu_native_dawn_location)
+unset(_progpu_native_dawn_implib)
 unset(_progpu_native_arch)
 unset(_progpu_native_rid)
 unset(_progpu_native_prefix)

--- a/tests/ProGPU.Native.CppPackageConsumer/CMakeLists.txt
+++ b/tests/ProGPU.Native.CppPackageConsumer/CMakeLists.txt
@@ -7,5 +7,6 @@ add_executable(progpu_native_cpp_package_consumer main.cpp)
 target_compile_features(progpu_native_cpp_package_consumer PRIVATE cxx_std_20)
 target_link_libraries(progpu_native_cpp_package_consumer
     PRIVATE
+        ProGPU::native_dawn
         ProGPU::native_hit_testing
         ProGPU::native_scene_builder)

--- a/tests/ProGPU.Native.CppPackageConsumer/main.cpp
+++ b/tests/ProGPU.Native.CppPackageConsumer/main.cpp
@@ -1,11 +1,16 @@
 #include <progpu_native_scene_builder.hpp>
 #include <progpu_native_hit_testing.hpp>
+#include <progpu_native_dawn.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
 int main() {
+    if (progpu_native_dawn_get_adapter_abi_version() !=
+        PROGPU_NATIVE_DAWN_ADAPTER_ABI_VERSION) {
+        return 5;
+    }
     progpu::native::hit_testing::hit_test_index hit_test_index;
     if (!hit_test_index.nodes().empty()) {
         return 1;


### PR DESCRIPTION
## Summary

- export the installed provider-resolved Dawn renderer as `ProGPU::native_dawn`
- install the public Dawn adapter header and built library in regular CMake installs
- stage the Windows import library with the native C++ SDK
- exercise the Dawn ABI through the native package consumer

## Validation

- built `progpu_native_dawn` and `progpu_native_dawn_contract_tests` with AppleClang 21 in Release
- `progpu_native_dawn_contract_tests`: passed (1/1)
- installed the native SDK to a clean prefix
- configured, built, and ran `ProGPU.Native.CppPackageConsumer` against that installed prefix

The change is packaging-only; renderer algorithms and shaders are unchanged.