### PR TITLE
Add pure C++ WebGPU browser gallery with MotionMark

### DIFF
--- a/.github/workflows/browser-pages.yml
+++ b/.github/workflows/browser-pages.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: 4.0.18
+          actions-cache-folder: artifacts/emsdk-cache
+
       - name: Restore WebAssembly workload
         run: dotnet workload restore src/ProGPU.Samples.Browser/ProGPU.Samples.Browser.csproj
 
@@ -47,6 +53,11 @@ jobs:
           --no-restore
           --output artifacts/browser-aot
           -p:ContinuousIntegrationBuild=true
+
+      - name: Publish pure C++ WebAssembly AOT gallery
+        env:
+          PROGPU_NATIVE_BROWSER_GALLERY_PUBLISH_DIR: ${{ github.workspace }}/artifacts/browser-aot/wwwroot/native
+        run: ./eng/publish-progpu-native-browser-gallery.sh
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
           path: |
             artifacts/progpu-native/browser-evidence/progpu-native-browser-webgpu.png
             artifacts/progpu-native/browser-evidence/progpu-native-browser-contract.json
+            artifacts/progpu-native/browser-evidence/progpu-native-browser-gallery.png
+            artifacts/progpu-native/browser-evidence/progpu-native-browser-gallery.json
           if-no-files-found: warn
 
   native-cpp:

--- a/docs/NATIVE_CPP_BROWSER_GALLERY.md
+++ b/docs/NATIVE_CPP_BROWSER_GALLERY.md
@@ -47,7 +47,7 @@ produced by native C++; the DOM is not used as a rendering fallback.
 | Vello, Fluent, spectrum, and monochrome palettes | Identical color values and HSV conversion |
 | `pow(random, 5) * 20 + 1` stroke distribution | Identical width distribution |
 | Fixed 60 Hz update budget and 0.5% toggles per step | Identical bounded update cadence |
-| Retained grouped path recording | One retained geometry resource and one semantic draw command |
+| Retained grouped path recording | One retained geometry resource, one deduplicated brush table, and one semantic draw command |
 
 Changed-scene preparation is `O(N + G)` time and retained storage for `N`
 segments and `G` groups. Stable frames do not rebuild or recopy the semantic
@@ -55,6 +55,12 @@ stream. One changed generation crosses the internal native engine boundary
 once; each displayed frame performs one native render call and one GPU
 submission. The 1,000-segment local qualification produced one GPU draw and a
 roughly 132 KB retained scene stream.
+
+The geometry command carries an explicit deduplicated brush-index map, matching
+the managed native-scene compiler. This is required for exact curve rendering:
+quadratic and cubic GPU vertices use their inline color lanes for control-point
+metadata, while the shared brush table supplies their material. Lines, curves,
+caps, and joins therefore retain one group-end style without per-segment draws.
 
 ## WebGPU presentation and pixel quality
 
@@ -100,11 +106,11 @@ Local optimized artifact sizes on 2026-08-21:
 
 | Asset | Bytes |
 | --- | ---: |
-| `progpu_native_browser_gallery.wasm` | 626,456 |
+| `progpu_native_browser_gallery.wasm` | 628,799 |
 | `progpu_native_browser_gallery.js` | 61,784 |
 | `progpu_native_browser_gallery.html` | 5,638 |
 | shared `progpu-browser-host.js` | 4,042 |
-| Total | 697,920 |
+| Total | 700,263 |
 
 Sizes are uncompressed filesystem bytes. HTTP Brotli/gzip transfer sizes are
 expected to be lower and are server-dependent.

--- a/docs/NATIVE_CPP_BROWSER_GALLERY.md
+++ b/docs/NATIVE_CPP_BROWSER_GALLERY.md
@@ -37,6 +37,11 @@ The HTML shell provides accessible navigation and controls. MotionMark
 topology, animation, scene building, and all pixels inside the WebGPU canvas are
 produced by native C++; the DOM is not used as a rendering fallback.
 
+An explicitly destroyed `GPUDevice` is treated as graceful host teardown. Only
+an abnormal device-loss reason reaches the engine recovery callback. The real-
+browser gate changes MotionMark complexity and requires a later presented
+frame, so this lifecycle distinction cannot hide an unusable device.
+
 ## MotionMark parity and performance contract
 
 | Managed contract | Native implementation |
@@ -109,8 +114,8 @@ Local optimized artifact sizes on 2026-08-21:
 | `progpu_native_browser_gallery.wasm` | 628,799 |
 | `progpu_native_browser_gallery.js` | 61,784 |
 | `progpu_native_browser_gallery.html` | 5,638 |
-| shared `progpu-browser-host.js` | 4,042 |
-| Total | 700,263 |
+| shared `progpu-browser-host.js` | 4,153 |
+| Total | 700,374 |
 
 Sizes are uncompressed filesystem bytes. HTTP Brotli/gzip transfer sizes are
 expected to be lower and are server-dependent.

--- a/docs/NATIVE_CPP_BROWSER_GALLERY.md
+++ b/docs/NATIVE_CPP_BROWSER_GALLERY.md
@@ -1,0 +1,118 @@
+# Pure C++ browser gallery
+
+Status: MotionMark first slice implemented and locally qualified on 2026-08-21.
+
+## Purpose
+
+`progpu_native_browser_gallery` is the fully native counterpart of
+`ProGPU.Samples.Browser`. Clang/Emscripten compiles the ProGPU C++20 scene
+builder, renderer, text/font stack, and canonical production shaders directly
+to WebAssembly. The published application contains no CLR, Mono runtime,
+managed assembly, or managed-to-native boundary.
+
+The first gallery page is a direct cross-language port of the ProGPU-owned
+[`MotionMarkShowcaseVisual.cs`](../src/ProGPU.Samples/Views/MotionMarkShowcaseVisual.cs).
+Its native implementation records the exact source provenance in
+[`progpu_native_motion_mark.hpp`](../src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp)
+and has a matched native contract test. No third-party MotionMark source was
+used.
+
+## Shared managed/native browser architecture
+
+The native application is not a separate browser integration fork. Both hosts
+consume the canonical
+[`progpu-browser-host.js`](../src/ProGPU.Browser/BrowserAssets/progpu-browser-host.js)
+module:
+
+| Layer | Managed browser gallery | Native C++ browser gallery | Shared contract |
+| --- | --- | --- | --- |
+| Viewport and DPI | `ProGPU.Browser` dispatcher | `browser_window_host` | Visual viewport variables, `ResizeObserver`, logical size, and physical backing size |
+| Adapter/device | `BrowserGpuRuntime` | Emdawnwebgpu preinitialized device | High-performance adapter, Full/Portable feature selection, device-loss and uncaptured-error policy |
+| Frame scheduling | `BrowserWindowHost` | `emscripten_request_animation_frame_loop` | Browser vsync lifecycle and physical framebuffer metrics |
+| Canvas presentation | Managed WebGPU protocol | Stable WebGPU C API over Emdawnwebgpu | Preferred format, premultiplied alpha, current swapchain texture, direct render attachment |
+| Scene lifecycle | Managed retained compositor | C++ `semantic_scene_builder` | Immutable scene ID/generation, update only on change, render every presented frame |
+| GPU implementation | Managed backend | Native renderer | The same production `.wgsl` resources and semantic scene contracts |
+
+The HTML shell provides accessible navigation and controls. MotionMark
+topology, animation, scene building, and all pixels inside the WebGPU canvas are
+produced by native C++; the DOM is not used as a rendering fallback.
+
+## MotionMark parity and performance contract
+
+| Managed contract | Native implementation |
+| --- | --- |
+| 81 by 41 logical grid and four directional offsets | Identical grid and offset set |
+| Lines, quadratic Beziers, and cubic Beziers | One native geometry primitive per source segment |
+| Split-delimited paths with the style of the group-end element | Identical grouping and style selection |
+| Vello, Fluent, spectrum, and monochrome palettes | Identical color values and HSV conversion |
+| `pow(random, 5) * 20 + 1` stroke distribution | Identical width distribution |
+| Fixed 60 Hz update budget and 0.5% toggles per step | Identical bounded update cadence |
+| Retained grouped path recording | One retained geometry resource and one semantic draw command |
+
+Changed-scene preparation is `O(N + G)` time and retained storage for `N`
+segments and `G` groups. Stable frames do not rebuild or recopy the semantic
+stream. One changed generation crosses the internal native engine boundary
+once; each displayed frame performs one native render call and one GPU
+submission. The 1,000-segment local qualification produced one GPU draw and a
+roughly 132 KB retained scene stream.
+
+## WebGPU presentation and pixel quality
+
+The shared host measures the CSS canvas and assigns a backing width and height
+rounded from `logical extent * devicePixelRatio` (clamped to the engine's 1-4
+DPI contract). C++ configures the corresponding WebGPU surface, acquires its
+current texture once per animation frame, and passes that texture view directly
+to `progpu_native_engine_render_scene`. There is no texture mapping, CPU
+readback, BGRA/RGBA conversion, or 2D canvas copy.
+
+This follows the [WebGPU canvas presentation
+contract](https://gpuweb.github.io/gpuweb/#canvas-context) and Emscripten's
+[Emdawnwebgpu integration](https://emscripten.org/docs/porting/multimedia_and_graphics/WebGPU-support.html).
+The frame loop uses the documented
+[`emscripten_request_animation_frame_loop`](https://emscripten.org/docs/porting/emscripten-runtime-environment.html#implementing-an-asynchronous-main-loop-in-c-c)
+browser lifecycle. These sources confirmed the adopted swapchain and scheduling
+boundary; they did not supply implementation source.
+
+## Release AOT publish
+
+Run:
+
+```bash
+./eng/publish-progpu-native-browser-gallery.sh
+python3 -m http.server 8091 \
+  --directory artifacts/progpu-native/browser-gallery-aot
+```
+
+Then open
+`http://127.0.0.1:8091/progpu_native_browser_gallery.html`.
+
+The browser executable uses C++20, `Release`, `-O3`, and link-time optimization
+for its compile and link phases. This matches Emscripten's [optimized build
+guidance](https://emscripten.org/docs/compiling/Building-Projects.html#building-projects-with-optimizations).
+It emits a native `.wasm` ahead of time rather than performing .NET AOT.
+
+Local optimized artifact sizes on 2026-08-21:
+
+| Asset | Bytes |
+| --- | ---: |
+| `progpu_native_browser_gallery.wasm` | 626,456 |
+| `progpu_native_browser_gallery.js` | 61,784 |
+| `progpu_native_browser_gallery.html` | 5,638 |
+| shared `progpu-browser-host.js` | 4,042 |
+| Total | 697,920 |
+
+Sizes are uncompressed filesystem bytes. HTTP Brotli/gzip transfer sizes are
+expected to be lower and are server-dependent.
+
+## Automated gates
+
+- `progpu_native_motion_mark_tests` verifies the managed sample's retained
+  topology/group/update contracts with deterministic native data.
+- `eng/progpu-test-native-browser.sh` builds the Release Emscripten target and
+  drives a real Chromium WebGPU context.
+- The browser gate asserts the pure-C++ renderer identity, actual canvas
+  swapchain presentation, one GPU draw, UI control round-trip, and exact
+  physical-pixel backing dimensions, then uploads a screenshot and JSON
+  contract.
+- The existing Clang, GCC, and MSVC C++20 lanes compile the shared native sample
+  model through the normal CMake graph.

--- a/docs/NATIVE_CPP_BROWSER_GALLERY.md
+++ b/docs/NATIVE_CPP_BROWSER_GALLERY.md
@@ -86,6 +86,11 @@ python3 -m http.server 8091 \
 Then open
 `http://127.0.0.1:8091/progpu_native_browser_gallery.html`.
 
+On `main`, the Browser Pages workflow publishes the same four-file payload
+beside the managed AOT gallery under `/native/`. Both gallery variants therefore
+share one deployment origin and the same canonical browser host module while
+remaining independently compiled runtimes.
+
 The browser executable uses C++20, `Release`, `-O3`, and link-time optimization
 for its compile and link phases. This matches Emscripten's [optimized build
 guidance](https://emscripten.org/docs/compiling/Building-Projects.html#building-projects-with-optimizations).

--- a/docs/NATIVE_CPP_ENGINE_SPECIFICATION.md
+++ b/docs/NATIVE_CPP_ENGINE_SPECIFICATION.md
@@ -6,6 +6,9 @@ desktop/browser qualification and optional physical-device lifecycle evidence
 
 Initial implementation: `src/ProGPU.Native`
 
+Pure C++ browser gallery and AOT publish guide:
+[`NATIVE_CPP_BROWSER_GALLERY.md`](NATIVE_CPP_BROWSER_GALLERY.md)
+
 Managed baseline commit: `eab6754b` plus the exact ProGPU-owned source
 provenance recorded for each ported tranche
 Native ABI: `PROGPU_NATIVE_ABI_VERSION == 3`

--- a/eng/publish-progpu-native-browser-gallery.sh
+++ b/eng/publish-progpu-native-browser-gallery.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_dir="${PROGPU_NATIVE_BROWSER_GALLERY_BUILD_DIR:-${repo_root}/artifacts/progpu-native/build-browser-gallery}"
+publish_dir="${PROGPU_NATIVE_BROWSER_GALLERY_PUBLISH_DIR:-${repo_root}/artifacts/progpu-native/browser-gallery-aot}"
+
+command -v emcmake >/dev/null 2>&1 || {
+  echo "emcmake is required to publish the native C++ browser gallery." >&2
+  exit 1
+}
+
+emcmake cmake \
+  -S "${repo_root}/src/ProGPU.Native" \
+  -B "${build_dir}" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_TESTING=OFF \
+  -DPROGPU_NATIVE_BUILD_SAMPLE=OFF
+cmake --build "${build_dir}" \
+  --target progpu_native_browser_gallery \
+  --parallel
+
+cmake -E make_directory "${publish_dir}"
+for asset in \
+  progpu_native_browser_gallery.html \
+  progpu_native_browser_gallery.js \
+  progpu_native_browser_gallery.wasm \
+  progpu-browser-host.js; do
+  cmake -E copy_if_different \
+    "${build_dir}/${asset}" \
+    "${publish_dir}/${asset}"
+done
+
+echo "Published pure C++20/WebAssembly AOT gallery to ${publish_dir}"
+du -h "${publish_dir}"/*

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser-host.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser-host.js
@@ -1,0 +1,106 @@
+// Shared browser host contract for the managed and pure C++ ProGPU runtimes.
+// It owns only DOM/WebGPU platform integration; scene construction, rendering,
+// and presentation remain in the selected managed or native engine.
+
+export function measurePhysicalCanvas(
+  canvas, maximumScale = Number.POSITIVE_INFINITY) {
+  const scale = Math.max(1, Math.min(maximumScale,
+    Number(globalThis.devicePixelRatio) || 1));
+  const rect = canvas.getBoundingClientRect();
+  return Object.freeze({
+    width: Math.max(1, Math.round(rect.width * scale)),
+    height: Math.max(1, Math.round(rect.height * scale)),
+    scale,
+    logicalWidth: Math.max(1, rect.width),
+    logicalHeight: Math.max(1, rect.height)
+  });
+}
+
+export function resizePhysicalCanvas(
+  canvas, maximumScale = Number.POSITIVE_INFINITY) {
+  const metrics = measurePhysicalCanvas(canvas, maximumScale);
+  const changed = canvas.width !== metrics.width ||
+    canvas.height !== metrics.height;
+  if (changed) {
+    canvas.width = metrics.width;
+    canvas.height = metrics.height;
+  }
+  return Object.freeze({ ...metrics, changed });
+}
+
+export function updateProGpuVisualViewport() {
+  const viewport = globalThis.visualViewport;
+  const keyboardRect = navigator.virtualKeyboard?.boundingRect;
+  const keyboardInset = keyboardRect && keyboardRect.height > 0
+    ? keyboardRect.height
+    : 0;
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--progpu-viewport-left',
+    `${viewport?.offsetLeft || 0}px`);
+  rootStyle.setProperty('--progpu-viewport-top',
+    `${viewport?.offsetTop || 0}px`);
+  rootStyle.setProperty('--progpu-viewport-width',
+    `${viewport?.width || globalThis.innerWidth}px`);
+  rootStyle.setProperty('--progpu-viewport-height',
+    `${viewport?.height || globalThis.innerHeight}px`);
+  rootStyle.setProperty('--progpu-keyboard-inset', `${keyboardInset}px`);
+}
+
+export function installResponsiveCanvas(canvas, onResize,
+  maximumScale = Number.POSITIVE_INFINITY) {
+  const update = () => {
+    updateProGpuVisualViewport();
+    const metrics = resizePhysicalCanvas(canvas, maximumScale);
+    onResize?.(metrics);
+  };
+  const observer = new ResizeObserver(update);
+  observer.observe(canvas);
+  globalThis.visualViewport?.addEventListener('resize', update);
+  globalThis.visualViewport?.addEventListener('scroll', update);
+  globalThis.addEventListener('orientationchange', update);
+  navigator.virtualKeyboard?.addEventListener('geometrychange', update);
+  update();
+  return () => {
+    observer.disconnect();
+    globalThis.visualViewport?.removeEventListener('resize', update);
+    globalThis.visualViewport?.removeEventListener('scroll', update);
+    globalThis.removeEventListener('orientationchange', update);
+    navigator.virtualKeyboard?.removeEventListener('geometrychange', update);
+  };
+}
+
+export async function requestProGpuWebGpuDevice(options = {}) {
+  if (!globalThis.navigator?.gpu) {
+    throw new Error(
+      'navigator.gpu is unavailable. Enable WebGPU or use a current browser.');
+  }
+  const adapter = await navigator.gpu.requestAdapter({
+    powerPreference: options.powerPreference || 'high-performance'
+  });
+  if (!adapter) {
+    throw new Error('No WebGPU adapter matched the requested power preference.');
+  }
+
+  const supportsBgra8UnormStorage =
+    adapter.features.has('bgra8unorm-storage');
+  const wantsFullProfile = options.gpuProfile === 'Full';
+  const requiredFeatures = wantsFullProfile && supportsBgra8UnormStorage
+    ? ['bgra8unorm-storage']
+    : [];
+  const device = await adapter.requestDevice({ requiredFeatures });
+  device.addEventListener('uncapturederror', event => {
+    const detail = String(event.error?.message || event.error);
+    options.onUncapturedError?.(detail);
+  });
+  device.lost.then(info => options.onDeviceLost?.(info));
+
+  return Object.freeze({
+    adapter,
+    device,
+    format: navigator.gpu.getPreferredCanvasFormat(),
+    supportsBgra8UnormStorage,
+    activeProfile: wantsFullProfile && supportsBgra8UnormStorage
+      ? 'Full'
+      : 'Portable'
+  });
+}

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser-host.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser-host.js
@@ -92,7 +92,13 @@ export async function requestProGpuWebGpuDevice(options = {}) {
     const detail = String(event.error?.message || event.error);
     options.onUncapturedError?.(detail);
   });
-  device.lost.then(info => options.onDeviceLost?.(info));
+  device.lost.then(info => {
+    if (info.reason === 'destroyed') {
+      options.onDeviceDestroyed?.(info);
+      return;
+    }
+    options.onDeviceLost?.(info);
+  });
 
   return Object.freeze({
     adapter,

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -1,4 +1,9 @@
 import { dotnet } from './_framework/dotnet.js';
+import {
+  measurePhysicalCanvas,
+  requestProGpuWebGpuDevice,
+  updateProGpuVisualViewport
+} from './progpu-browser-host.js';
 
 const isDispatcherWorker = typeof WorkerGlobalScope !== 'undefined' && globalThis instanceof WorkerGlobalScope;
 let runtime = null;
@@ -344,10 +349,9 @@ function chooseExecutionMode(request, diagnostics) {
 }
 
 function resizeCanvas() {
-  const dpr = globalThis.devicePixelRatio || 1;
-  const rect = state.canvas.getBoundingClientRect();
-  const width = Math.max(1, Math.round(rect.width * dpr));
-  const height = Math.max(1, Math.round(rect.height * dpr));
+  const metrics = measurePhysicalCanvas(state.canvas);
+  const width = metrics.width;
+  const height = metrics.height;
   const changed = state.framebufferWidth !== width || state.framebufferHeight !== height;
   state.framebufferWidth = width;
   state.framebufferHeight = height;
@@ -363,15 +367,7 @@ function resizeCanvas() {
 
 function updateVisualViewport() {
   if (!state.canvas) return;
-  const viewport = globalThis.visualViewport;
-  const keyboardRect = navigator.virtualKeyboard?.boundingRect;
-  const keyboardInset = keyboardRect && keyboardRect.height > 0 ? keyboardRect.height : 0;
-  const rootStyle = document.documentElement.style;
-  rootStyle.setProperty('--progpu-viewport-left', `${viewport?.offsetLeft || 0}px`);
-  rootStyle.setProperty('--progpu-viewport-top', `${viewport?.offsetTop || 0}px`);
-  rootStyle.setProperty('--progpu-viewport-width', `${viewport?.width || globalThis.innerWidth}px`);
-  rootStyle.setProperty('--progpu-viewport-height', `${viewport?.height || globalThis.innerHeight}px`);
-  rootStyle.setProperty('--progpu-keyboard-inset', `${keyboardInset}px`);
+  updateProGpuVisualViewport();
   resizeCanvas();
   positionTextInput();
 }
@@ -2803,34 +2799,32 @@ async function initializeGpu(request, canvas, executionMode, diagnostics) {
   state.context = state.canvas.getContext('webgpu');
   if (!state.context) throw new Error('The selected canvas cannot create a WebGPU context.');
 
-  state.adapter = await navigator.gpu.requestAdapter({ powerPreference: request.powerPreference });
-  if (!state.adapter) throw new Error('No WebGPU adapter matched the requested power preference.');
-
-  const supportsBgraStorage = state.adapter.features.has('bgra8unorm-storage');
-  const requiredFeatures = [];
-  let activeProfile = request.gpuProfile === 'Full' ? 1 : 0;
-  if (request.gpuProfile === 'Full' && supportsBgraStorage) requiredFeatures.push('bgra8unorm-storage');
+  const webGpu = await requestProGpuWebGpuDevice({
+    powerPreference: request.powerPreference,
+    gpuProfile: request.gpuProfile,
+    onUncapturedError: detail => {
+      globalThis.console.error(`[ProGPU] WebGPU validation error: ${detail}`);
+      if (state.firstGpuError === null) {
+        state.firstGpuError = detail;
+        reportGpuStatus('WebGPU validation error', detail, true);
+      }
+    },
+    onDeviceLost: info => {
+      reportGpuStatus('WebGPU device lost', `${info.reason}: ${info.message}. Reloading the retained application to reconstruct GPU resources.`, true);
+      if (isDispatcherWorker) globalThis.postMessage({ type: 'device-lost' });
+      else globalThis.setTimeout(() => globalThis.location?.reload(), 250);
+    }
+  });
+  state.adapter = webGpu.adapter;
+  state.device = webGpu.device;
+  state.format = webGpu.format;
+  const supportsBgraStorage = webGpu.supportsBgra8UnormStorage;
+  let activeProfile = webGpu.activeProfile === 'Full' ? 1 : 0;
   if (request.gpuProfile === 'Full' && !supportsBgraStorage) {
     activeProfile = 0;
     diagnostics.push('Full profile downgraded: bgra8unorm-storage is unavailable; dependent Wavefront storage output is disabled.');
   }
-
-  state.device = await state.adapter.requestDevice({ requiredFeatures });
-  state.format = navigator.gpu.getPreferredCanvasFormat();
   state.context.configure({ device: state.device, format: state.format, alphaMode: 'premultiplied' });
-  state.device.addEventListener('uncapturederror', event => {
-    const detail = String(event.error?.message || event.error);
-    globalThis.console.error(`[ProGPU] WebGPU validation error: ${detail}`);
-    if (state.firstGpuError === null) {
-      state.firstGpuError = detail;
-      reportGpuStatus('WebGPU validation error', detail, true);
-    }
-  });
-  state.device.lost.then(info => {
-    reportGpuStatus('WebGPU device lost', `${info.reason}: ${info.message}. Reloading the retained application to reconstruct GPU resources.`, true);
-    if (isDispatcherWorker) globalThis.postMessage({ type: 'device-lost' });
-    else globalThis.setTimeout(() => globalThis.location?.reload(), 250);
-  });
 
   const adapterInfo = state.adapter.info;
   return {

--- a/src/ProGPU.Browser/ProGPU.Browser.csproj
+++ b/src/ProGPU.Browser/ProGPU.Browser.csproj
@@ -19,5 +19,8 @@
     <None Update="BrowserAssets/progpu-browser.js"
           Pack="true"
           PackagePath="contentFiles/any/any/wwwroot/progpu-browser.js" />
+    <None Update="BrowserAssets/progpu-browser-host.js"
+          Pack="true"
+          PackagePath="contentFiles/any/any/wwwroot/progpu-browser-host.js" />
   </ItemGroup>
 </Project>

--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -991,9 +991,43 @@ if(NOT EMSCRIPTEN AND PROGPU_NATIVE_DAWN_WEBGPU_INCLUDE_DIR)
     endif()
 endif()
 
+add_library(progpu_native_motion_mark_sample STATIC
+    samples/Views/progpu_native_motion_mark.cpp
+    samples/Views/progpu_native_motion_mark.hpp)
+target_compile_features(progpu_native_motion_mark_sample PUBLIC cxx_std_20)
+target_include_directories(progpu_native_motion_mark_sample PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}/samples/Views")
+target_link_libraries(progpu_native_motion_mark_sample PUBLIC
+    progpu_native_scene_builder)
+progpu_native_enable_warnings(progpu_native_motion_mark_sample)
+
 if(EMSCRIPTEN)
+    add_library(progpu_native_browser_renderer_objects OBJECT
+        ${PROGPU_NATIVE_RENDERER_SOURCES})
+    add_dependencies(
+        progpu_native_browser_renderer_objects
+        progpu_native_generated_shaders)
+    target_compile_features(
+        progpu_native_browser_renderer_objects PRIVATE cxx_std_20)
+    target_compile_definitions(
+        progpu_native_browser_renderer_objects PRIVATE
+        PROGPU_NATIVE_BUILD=1
+        PROGPU_NATIVE_DAWN_ABI=1
+        PROGPU_NATIVE_BROWSER=1)
+    target_include_directories(
+        progpu_native_browser_renderer_objects PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        ${PROGPU_NATIVE_INTERNAL_INCLUDE_DIRECTORIES}
+        "${CMAKE_CURRENT_SOURCE_DIR}/browser/include"
+        "${generated_directory}")
+    target_compile_options(
+        progpu_native_browser_renderer_objects PRIVATE
+        --use-port=emdawnwebgpu:cpp_bindings=false)
+    progpu_native_enable_warnings(progpu_native_browser_renderer_objects)
+
     add_executable(progpu_native_browser_smoke
-        ${PROGPU_NATIVE_RENDERER_SOURCES}
+        $<TARGET_OBJECTS:progpu_native_browser_renderer_objects>
         include/progpu_native_browser.h
         include/progpu_native_dawn.h
         browser/progpu_native_browser_evidence.cpp
@@ -1052,6 +1086,59 @@ if(EMSCRIPTEN)
         SUFFIX ".html"
         LINK_DEPENDS
             "${CMAKE_CURRENT_SOURCE_DIR}/browser/pre.js;${CMAKE_CURRENT_SOURCE_DIR}/browser/shell.html")
+
+    add_executable(progpu_native_browser_gallery
+        $<TARGET_OBJECTS:progpu_native_browser_renderer_objects>
+        include/progpu_native_browser.h
+        include/progpu_native_dawn.h
+        browser/Host/progpu_native_browser_window_host.cpp
+        browser/Host/progpu_native_browser_window_host.hpp
+        browser/progpu_native_browser_gallery.cpp)
+    add_dependencies(
+        progpu_native_browser_gallery
+        progpu_native_generated_shaders)
+    target_compile_features(progpu_native_browser_gallery PRIVATE cxx_std_20)
+    target_compile_definitions(progpu_native_browser_gallery PRIVATE
+        PROGPU_NATIVE_BUILD=1
+        PROGPU_NATIVE_DAWN_ABI=1
+        PROGPU_NATIVE_BROWSER=1)
+    target_include_directories(progpu_native_browser_gallery PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        ${PROGPU_NATIVE_INTERNAL_INCLUDE_DIRECTORIES}
+        "${CMAKE_CURRENT_SOURCE_DIR}/browser"
+        "${CMAKE_CURRENT_SOURCE_DIR}/browser/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/samples/Views"
+        "${generated_directory}")
+    target_link_libraries(progpu_native_browser_gallery PRIVATE
+        progpu_native_image
+        progpu_native_motion_mark_sample
+        progpu_native_scene_builder
+        progpu_native_text)
+    target_compile_options(progpu_native_browser_gallery PRIVATE
+        --use-port=emdawnwebgpu:cpp_bindings=false
+        $<$<CONFIG:Release>:-O3>
+        $<$<CONFIG:Release>:-flto>)
+    target_link_options(progpu_native_browser_gallery PRIVATE
+        --use-port=emdawnwebgpu:cpp_bindings=false
+        --pre-js=${CMAKE_CURRENT_SOURCE_DIR}/browser/gallery_pre.js
+        --shell-file=${CMAKE_CURRENT_SOURCE_DIR}/browser/gallery_shell.html
+        -sALLOW_MEMORY_GROWTH=1
+        -sEXIT_RUNTIME=0
+        -sENVIRONMENT=web
+        -sFILESYSTEM=0
+        $<$<CONFIG:Release>:-O3>
+        $<$<CONFIG:Release>:-flto>
+        $<$<CONFIG:Release>:-sASSERTIONS=0>)
+    progpu_native_enable_warnings(progpu_native_browser_gallery)
+    set_target_properties(progpu_native_browser_gallery PROPERTIES
+        SUFFIX ".html"
+        LINK_DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/browser/gallery_pre.js;${CMAKE_CURRENT_SOURCE_DIR}/browser/gallery_shell.html;${CMAKE_CURRENT_SOURCE_DIR}/../ProGPU.Browser/BrowserAssets/progpu-browser-host.js")
+    add_custom_command(TARGET progpu_native_browser_gallery POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/../ProGPU.Browser/BrowserAssets/progpu-browser-host.js"
+            "$<TARGET_FILE_DIR:progpu_native_browser_gallery>/progpu-browser-host.js"
+        VERBATIM)
 endif()
 
 if(NOT EMSCRIPTEN AND PROGPU_NATIVE_BUILD_WGPU_TARGET)
@@ -1256,6 +1343,22 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
         COMMAND progpu_native_internal_tests)
     set_tests_properties(
         progpu_native_internal_tests PROPERTIES TIMEOUT 60)
+
+    add_executable(progpu_native_motion_mark_tests
+        tests/progpu_native_motion_mark_tests.cpp)
+    target_compile_features(progpu_native_motion_mark_tests PRIVATE cxx_std_20)
+    target_include_directories(progpu_native_motion_mark_tests PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/samples/Views")
+    target_link_libraries(progpu_native_motion_mark_tests PRIVATE
+        progpu_native_motion_mark_sample)
+    progpu_native_enable_warnings(progpu_native_motion_mark_tests)
+    progpu_native_enable_sanitizers(progpu_native_motion_mark_tests)
+    add_test(
+        NAME progpu_native_motion_mark_tests
+        COMMAND progpu_native_motion_mark_tests)
+    set_tests_properties(
+        progpu_native_motion_mark_tests PROPERTIES TIMEOUT 60)
 
     if(PROGPU_NATIVE_BUILD_WGPU_TARGET)
     add_executable(progpu_native_text_interop_tests

--- a/src/ProGPU.Native/README.md
+++ b/src/ProGPU.Native/README.md
@@ -808,6 +808,18 @@ PROGPU_NATIVE_BROWSER_INSTALL_CHROMIUM=1 \
   ./eng/progpu-test-native-browser.sh
 ```
 
+The same browser lane also builds and exercises the production-style pure C++
+gallery with MotionMark as its first sample. Publish its optimized C++20/LTO
+WebAssembly files without a .NET runtime using:
+
+```sh
+./eng/publish-progpu-native-browser-gallery.sh
+```
+
+See [`docs/NATIVE_CPP_BROWSER_GALLERY.md`](../../docs/NATIVE_CPP_BROWSER_GALLERY.md)
+for the shared managed/native JavaScript host contract, architecture, AOT
+artifact sizes, source provenance, and qualification evidence.
+
 The Emscripten/Emdawnwebgpu lane compiles the shared renderer modules and WGSL,
 serves the generated page over HTTP, and runs a Playwright integration test.
 The gate validates the browser-specific ABI/capability identity and replays a

--- a/src/ProGPU.Native/browser/Host/progpu_native_browser_window_host.cpp
+++ b/src/ProGPU.Native/browser/Host/progpu_native_browser_window_host.cpp
@@ -1,0 +1,155 @@
+#include "progpu_native_browser_window_host.hpp"
+
+#include "progpu_native.h"
+
+#include <emscripten.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace progpu::native::browser {
+
+browser_window_host::~browser_window_host() {
+    if (surface_ != nullptr) {
+        wgpuSurfaceUnconfigure(surface_);
+        wgpuSurfaceRelease(surface_);
+    }
+    if (instance_ != nullptr) {
+        wgpuInstanceRelease(instance_);
+    }
+}
+
+bool browser_window_host::initialize(
+    WGPUDevice device,
+    const char* selector) noexcept {
+    if (device == nullptr || selector == nullptr || selector[0] == '\0') {
+        return false;
+    }
+    WGPUInstanceDescriptor instance_descriptor = WGPU_INSTANCE_DESCRIPTOR_INIT;
+    instance_ = wgpuCreateInstance(&instance_descriptor);
+    if (instance_ == nullptr) {
+        return false;
+    }
+    WGPUEmscriptenSurfaceSourceCanvasHTMLSelector source =
+        WGPU_EMSCRIPTEN_SURFACE_SOURCE_CANVAS_HTML_SELECTOR_INIT;
+    source.selector = {selector, WGPU_STRLEN};
+    WGPUSurfaceDescriptor surface_descriptor = WGPU_SURFACE_DESCRIPTOR_INIT;
+    surface_descriptor.nextInChain = &source.chain;
+    surface_ = wgpuInstanceCreateSurface(instance_, &surface_descriptor);
+    if (surface_ == nullptr) {
+        return false;
+    }
+    device_ = device;
+    const std::uint32_t preferred = static_cast<std::uint32_t>(EM_ASM_INT({
+        return Module.progpuBrowserCanvasFormat === 'rgba8unorm' ? 1 : 2;
+    }));
+    if (preferred == 1U) {
+        format_ = WGPUTextureFormat_RGBA8Unorm;
+        native_format_ = PROGPU_NATIVE_TEXTURE_FORMAT_RGBA8_UNORM;
+    } else {
+        format_ = WGPUTextureFormat_BGRA8Unorm;
+        native_format_ = PROGPU_NATIVE_TEXTURE_FORMAT_BGRA8_UNORM;
+    }
+    return configure_if_needed();
+}
+
+bool browser_window_host::begin_frame(browser_frame& frame) noexcept {
+    frame = {};
+    if (!configure_if_needed()) {
+        return false;
+    }
+    WGPUSurfaceTexture surface_texture = WGPU_SURFACE_TEXTURE_INIT;
+    wgpuSurfaceGetCurrentTexture(surface_, &surface_texture);
+    if ((surface_texture.status !=
+            WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal &&
+         surface_texture.status !=
+            WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal) ||
+        surface_texture.texture == nullptr) {
+        if (surface_texture.texture != nullptr) {
+            wgpuTextureRelease(surface_texture.texture);
+        }
+        return false;
+    }
+    WGPUTextureViewDescriptor view_descriptor =
+        WGPU_TEXTURE_VIEW_DESCRIPTOR_INIT;
+    view_descriptor.format = format_;
+    view_descriptor.dimension = WGPUTextureViewDimension_2D;
+    view_descriptor.mipLevelCount = 1U;
+    view_descriptor.arrayLayerCount = 1U;
+    view_descriptor.aspect = WGPUTextureAspect_All;
+    frame.view = wgpuTextureCreateView(
+        surface_texture.texture,
+        &view_descriptor);
+    if (frame.view == nullptr) {
+        wgpuTextureRelease(surface_texture.texture);
+        return false;
+    }
+    frame.texture = surface_texture.texture;
+    frame.width = width_;
+    frame.height = height_;
+    frame.dpi_scale = dpi_scale_;
+    frame.logical_width = logical_width_;
+    frame.logical_height = logical_height_;
+    return true;
+}
+
+void browser_window_host::end_frame(browser_frame& frame) noexcept {
+    if (frame.view != nullptr) {
+        wgpuTextureViewRelease(frame.view);
+    }
+    if (frame.texture != nullptr) {
+        wgpuTextureRelease(frame.texture);
+    }
+    frame = {};
+    // Emdawnwebgpu presents the current canvas texture when the active
+    // requestAnimationFrame callback returns. wgpuSurfacePresent intentionally
+    // is not called because that function is unsupported by this browser port.
+}
+
+WGPUTextureFormat browser_window_host::format() const noexcept {
+    return format_;
+}
+
+std::uint32_t browser_window_host::native_format() const noexcept {
+    return native_format_;
+}
+
+bool browser_window_host::configure_if_needed() noexcept {
+    if (surface_ == nullptr || device_ == nullptr) {
+        return false;
+    }
+    const double raw_scale = EM_ASM_DOUBLE({
+        return Number(Module.progpuBrowserMetrics?.scale || 1);
+    });
+    const auto width = static_cast<std::uint32_t>(std::max(
+        1,
+        EM_ASM_INT({ return Module.progpuBrowserMetrics?.width || 1; })));
+    const auto height = static_cast<std::uint32_t>(std::max(
+        1,
+        EM_ASM_INT({ return Module.progpuBrowserMetrics?.height || 1; })));
+    logical_width_ = static_cast<float>(EM_ASM_DOUBLE({
+        return Number(Module.progpuBrowserMetrics?.logicalWidth || 1);
+    }));
+    logical_height_ = static_cast<float>(EM_ASM_DOUBLE({
+        return Number(Module.progpuBrowserMetrics?.logicalHeight || 1);
+    }));
+    dpi_scale_ = static_cast<float>(std::clamp(raw_scale, 1.0, 4.0));
+    if (width == width_ && height == height_) {
+        return true;
+    }
+    width_ = width;
+    height_ = height;
+    WGPUSurfaceConfiguration configuration =
+        WGPU_SURFACE_CONFIGURATION_INIT;
+    configuration.device = device_;
+    configuration.format = format_;
+    configuration.usage = WGPUTextureUsage_RenderAttachment;
+    configuration.width = width_;
+    configuration.height = height_;
+    configuration.alphaMode = WGPUCompositeAlphaMode_Premultiplied;
+    configuration.presentMode = WGPUPresentMode_Fifo;
+    wgpuSurfaceConfigure(surface_, &configuration);
+    return true;
+}
+
+} // namespace progpu::native::browser

--- a/src/ProGPU.Native/browser/Host/progpu_native_browser_window_host.hpp
+++ b/src/ProGPU.Native/browser/Host/progpu_native_browser_window_host.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "webgpu.h"
+
+#include <cstdint>
+
+namespace progpu::native::browser {
+
+struct browser_frame final {
+    WGPUTexture texture = nullptr;
+    WGPUTextureView view = nullptr;
+    std::uint32_t width = 0U;
+    std::uint32_t height = 0U;
+    float dpi_scale = 1.0F;
+    float logical_width = 0.0F;
+    float logical_height = 0.0F;
+};
+
+/*
+ * Native counterpart to ProGPU.Browser.BrowserWindowHost. It consumes the
+ * same shared JavaScript canvas/device contract, owns a WebGPU surface, and
+ * exposes one physical-pixel swapchain view per requestAnimationFrame.
+ */
+class browser_window_host final {
+public:
+    browser_window_host() = default;
+    ~browser_window_host();
+
+    browser_window_host(const browser_window_host&) = delete;
+    browser_window_host& operator=(const browser_window_host&) = delete;
+
+    bool initialize(WGPUDevice device, const char* selector) noexcept;
+    bool begin_frame(browser_frame& frame) noexcept;
+    void end_frame(browser_frame& frame) noexcept;
+
+    WGPUTextureFormat format() const noexcept;
+    std::uint32_t native_format() const noexcept;
+
+private:
+    bool configure_if_needed() noexcept;
+
+    WGPUInstance instance_ = nullptr;
+    WGPUSurface surface_ = nullptr;
+    WGPUDevice device_ = nullptr;
+    WGPUTextureFormat format_ = WGPUTextureFormat_Undefined;
+    std::uint32_t native_format_ = 0U;
+    std::uint32_t width_ = 0U;
+    std::uint32_t height_ = 0U;
+    float dpi_scale_ = 1.0F;
+    float logical_width_ = 0.0F;
+    float logical_height_ = 0.0F;
+};
+
+} // namespace progpu::native::browser

--- a/src/ProGPU.Native/browser/gallery_pre.js
+++ b/src/ProGPU.Native/browser/gallery_pre.js
@@ -1,0 +1,43 @@
+Module.preRun = Module.preRun || [];
+Module.preRun.push(function () {
+  const dependency = 'progpu-native-gallery-webgpu';
+  addRunDependency(dependency);
+  import('./progpu-browser-host.js')
+    .then(async host => {
+      const canvas = document.querySelector('#progpu-canvas');
+      if (!(canvas instanceof HTMLCanvasElement)) {
+        throw new Error('The ProGPU native gallery canvas is unavailable.');
+      }
+      Module.progpuBrowserMetrics = host.resizePhysicalCanvas(canvas, 4);
+      Module.progpuBrowserDisposeResize = host.installResponsiveCanvas(
+        canvas,
+        metrics => {
+          Module.progpuBrowserMetrics = metrics;
+        },
+        4);
+      const webGpu = await host.requestProGpuWebGpuDevice({
+        powerPreference: 'high-performance',
+        gpuProfile: 'Full',
+        onUncapturedError: detail => {
+          console.error(`[ProGPU] WebGPU validation error: ${detail}`);
+          document.body.dataset.progpuNativeError = detail;
+        },
+        onDeviceLost: info => {
+          const detail = `${info.reason}: ${info.message}`;
+          console.error(`[ProGPU] WebGPU device lost: ${detail}`);
+          document.body.dataset.progpuNative = 'device-lost';
+          document.body.dataset.progpuNativeError = detail;
+        }
+      });
+      Module.preinitializedWebGPUDevice = webGpu.device;
+      Module.progpuBrowserCanvasFormat = webGpu.format;
+      document.body.dataset.progpuNativeProfile = webGpu.activeProfile;
+      removeRunDependency(dependency);
+    })
+    .catch(error => {
+      document.body.dataset.progpuNative = 'failed';
+      document.body.dataset.progpuNativeError = String(error);
+      document.querySelector('#status-message').textContent = String(error);
+      removeRunDependency(dependency);
+    });
+});

--- a/src/ProGPU.Native/browser/gallery_shell.html
+++ b/src/ProGPU.Native/browser/gallery_shell.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="dark">
+  <link rel="icon" href="data:,">
+  <title>ProGPU Native C++ Gallery</title>
+  <style>
+    :root { font: 15px Inter, ui-sans-serif, system-ui, sans-serif; color: #f4f6ff; background: #070911; }
+    * { box-sizing: border-box; }
+    html, body { width: 100%; min-height: 100%; margin: 0; }
+    body { min-height: 100dvh; background: radial-gradient(circle at 70% 0%, #182244 0, #090b15 36%, #05060b 100%); }
+    button, select { font: inherit; }
+    .app { min-height: 100dvh; display: grid; grid-template-rows: auto 1fr; }
+    header { min-height: 68px; display: flex; align-items: center; gap: 18px; padding: 14px clamp(18px, 3vw, 44px); border-bottom: 1px solid #ffffff14; background: #090a11d9; backdrop-filter: blur(18px); }
+    .mark { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 10px; background: linear-gradient(145deg, #168fff, #6559ff); font-weight: 900; }
+    .title { min-width: 0; }
+    h1 { margin: 0; font-size: clamp(18px, 2vw, 24px); letter-spacing: -.03em; }
+    .subtitle { margin-top: 3px; color: #9098ae; font-size: 12px; }
+    .badge { margin-left: auto; padding: 7px 10px; border: 1px solid #65a9ff4a; border-radius: 999px; color: #9bc8ff; background: #1164bd20; font: 700 11px ui-monospace, monospace; white-space: nowrap; }
+    .workspace { min-height: 0; display: grid; grid-template-columns: 224px minmax(0, 1fr); }
+    nav { padding: 24px 14px; border-right: 1px solid #ffffff12; background: #0d0f18d9; }
+    .nav-label { padding: 0 12px 10px; color: #666f87; font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+    .nav-item { width: 100%; display: flex; gap: 10px; align-items: center; padding: 11px 12px; border: 1px solid #4c7fd33d; border-radius: 10px; color: #eef4ff; background: #24487948; text-align: left; }
+    .nav-item span { color: #7bbcff; }
+    main { min-width: 0; padding: clamp(18px, 3vw, 38px); overflow: auto; }
+    .intro { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 18px; }
+    h2 { margin: 0; font-size: clamp(25px, 4vw, 40px); letter-spacing: -.045em; }
+    .intro p { max-width: 720px; margin: 7px 0 0; color: #8f98b0; line-height: 1.5; }
+    .controls { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; }
+    .control { min-height: 40px; padding: 0 14px; border: 1px solid #ffffff19; border-radius: 9px; color: #edf1ff; background: #202431; }
+    button.control { cursor: pointer; }
+    button.control:hover { border-color: #4d98ff; background: #293044; }
+    .stage { position: relative; overflow: hidden; min-height: 340px; height: min(68vh, 720px); border: 1px solid #ffffff1b; border-radius: 16px; background: #05060a; box-shadow: 0 28px 90px #0008; }
+    #progpu-canvas { display: block; width: 100%; height: 100%; touch-action: none; }
+    .metrics { position: absolute; left: 14px; right: 14px; bottom: 14px; display: flex; flex-wrap: wrap; gap: 8px; pointer-events: none; }
+    .metric { padding: 7px 10px; border: 1px solid #ffffff1c; border-radius: 8px; background: #080b14d9; color: #9fa8be; font: 11px ui-monospace, monospace; backdrop-filter: blur(10px); }
+    .metric strong { color: #62adff; }
+    #status-message { color: #7f899f; font: 12px ui-monospace, monospace; }
+    @media (max-width: 760px) {
+      .badge { display: none; }
+      .workspace { grid-template-columns: 1fr; }
+      nav { display: none; }
+      main { padding: 16px; }
+      .intro { align-items: start; flex-direction: column; }
+      .stage { height: 58vh; min-height: 360px; }
+    }
+  </style>
+</head>
+<body data-progpu-native="loading">
+  <div class="app">
+    <header>
+      <div class="mark">P</div>
+      <div class="title"><h1>ProGPU Native C++ Gallery</h1><div class="subtitle">The shared ProGPU architecture compiled directly to WebAssembly</div></div>
+      <div class="badge">C++20 · WASM AOT · WEBGPU</div>
+    </header>
+    <div class="workspace">
+      <nav><div class="nav-label">Native samples</div><button class="nav-item"><span>◉</span> MotionMark</button></nav>
+      <main>
+        <section class="intro">
+          <div><h2>MotionMark</h2><p>Mixed line, quadratic, and cubic paths animated through one immutable native semantic stream and the production ProGPU GPU pipeline.</p></div>
+          <div id="status-message">Initializing native WebGPU…</div>
+        </section>
+        <div class="controls">
+          <select id="complexity" class="control" aria-label="Shape count">
+            <option value="250">250 segments</option><option value="1000" selected>1,000 segments</option><option value="2500">2,500 segments</option><option value="5000">5,000 segments</option>
+          </select>
+          <select id="palette" class="control" aria-label="Color palette">
+            <option value="0">Vello palette</option><option value="1">Fluent palette</option><option value="2">Spectrum</option><option value="3">Monochrome</option>
+          </select>
+          <button id="pause" class="control">Pause</button>
+          <button id="regenerate" class="control">Regenerate</button>
+        </div>
+        <div class="stage">
+          <canvas id="progpu-canvas" aria-label="Pure C++ ProGPU MotionMark rendering surface"></canvas>
+          <div class="metrics">
+            <div class="metric">FPS <strong id="metric-fps">0</strong></div>
+            <div class="metric">segments <strong id="metric-elements">0</strong></div>
+            <div class="metric">groups <strong id="metric-groups">0</strong></div>
+            <div class="metric">GPU draws <strong id="metric-draws">0</strong></div>
+            <div class="metric">scene <strong id="metric-bytes">0 B</strong></div>
+            <div class="metric">DPR <strong id="metric-dpr">1</strong></div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+  <script>
+    addEventListener('load', () => {
+      const complexity = document.querySelector('#complexity');
+      const palette = document.querySelector('#palette');
+      const pause = document.querySelector('#pause');
+      const regenerate = document.querySelector('#regenerate');
+
+      complexity.addEventListener('change', event => Module._progpu_native_gallery_set_element_count(Number(event.target.value)));
+      palette.addEventListener('change', event => Module._progpu_native_gallery_set_color_mode(Number(event.target.value)));
+      pause.addEventListener('click', () => {
+        const paused = Module._progpu_native_gallery_toggle_paused() !== 0;
+        pause.textContent = paused ? 'Resume' : 'Pause';
+      });
+      regenerate.addEventListener('click', () => Module._progpu_native_gallery_regenerate());
+    });
+  </script>
+  {{{ SCRIPT }}}
+</body>
+</html>

--- a/src/ProGPU.Native/browser/gallery_shell.html
+++ b/src/ProGPU.Native/browser/gallery_shell.html
@@ -32,7 +32,7 @@
     .control { min-height: 40px; padding: 0 14px; border: 1px solid #ffffff19; border-radius: 9px; color: #edf1ff; background: #202431; }
     button.control { cursor: pointer; }
     button.control:hover { border-color: #4d98ff; background: #293044; }
-    .stage { position: relative; overflow: hidden; min-height: 340px; height: min(68vh, 720px); border: 1px solid #ffffff1b; border-radius: 16px; background: #05060a; box-shadow: 0 28px 90px #0008; }
+    .stage { position: relative; overflow: hidden; min-height: 340px; height: min(68vh, 720px); border: 1px solid #ffffff1b; border-radius: 16px; background: #202026; box-shadow: 0 28px 90px #0008; }
     #progpu-canvas { display: block; width: 100%; height: 100%; touch-action: none; }
     .metrics { position: absolute; left: 14px; right: 14px; bottom: 14px; display: flex; flex-wrap: wrap; gap: 8px; pointer-events: none; }
     .metric { padding: 7px 10px; border: 1px solid #ffffff1c; border-radius: 8px; background: #080b14d9; color: #9fa8be; font: 11px ui-monospace, monospace; backdrop-filter: blur(10px); }

--- a/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
+++ b/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
@@ -1,0 +1,263 @@
+#include "Host/progpu_native_browser_window_host.hpp"
+#include "progpu_native_browser.h"
+#include "progpu_native_motion_mark.hpp"
+
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <vector>
+
+namespace {
+
+using progpu::native::browser::browser_frame;
+using progpu::native::browser::browser_window_host;
+using progpu::native::samples::motion_mark_scene;
+using progpu::native::samples::motion_mark_scene_metrics;
+
+struct gallery_application final {
+    browser_window_host host{};
+    motion_mark_scene sample{};
+    motion_mark_scene_metrics sample_metrics{};
+    std::vector<std::byte> scene_stream{};
+    progpu_native_engine* engine = nullptr;
+    WGPUDevice device = nullptr;
+    WGPUQueue queue = nullptr;
+    std::uint64_t frame_count = 0U;
+    std::uint32_t regeneration = 1U;
+    double previous_timestamp = 0.0;
+    double metrics_timestamp = 0.0;
+    double fps_timestamp = 0.0;
+    double scene_update_milliseconds = 0.0;
+    std::uint64_t fps_frame = 0U;
+    float fps = 0.0F;
+    bool paused = false;
+};
+
+gallery_application* application = nullptr;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
+void fail(const char* message) noexcept {
+    EM_ASM({
+        const message = UTF8ToString($0);
+        document.body.dataset.progpuNative = 'failed';
+        document.body.dataset.progpuNativeError = message;
+        document.querySelector('#status-message').textContent = message;
+        console.error('[ProGPU] ' + message);
+    }, message);
+}
+#pragma clang diagnostic pop
+
+bool update_scene(gallery_application& app) noexcept {
+    if (!app.sample.dirty()) {
+        return true;
+    }
+    const double start = emscripten_get_now();
+    if (!app.sample.compile(app.scene_stream, app.sample_metrics)) {
+        return false;
+    }
+    progpu_native_scene_metrics metrics{};
+    metrics.struct_size = sizeof(metrics);
+    const auto status = progpu_native_engine_update_scene(
+        app.engine,
+        app.scene_stream.data(),
+        app.scene_stream.size(),
+        &metrics);
+    app.scene_update_milliseconds = emscripten_get_now() - start;
+    return status == PROGPU_NATIVE_STATUS_SUCCESS &&
+        metrics.scene_id != 0U && metrics.generation != 0U;
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
+void publish_metrics(
+    const gallery_application& app,
+    const browser_frame& frame,
+    const progpu_native_scene_frame_metrics& render) noexcept {
+    EM_ASM({
+        const set = (id, value) => {
+          const element = document.querySelector(id);
+          if (element) element.textContent = value;
+        };
+        set('#metric-fps', Number($0).toFixed(0));
+        set('#metric-elements', Number($1).toLocaleString());
+        set('#metric-groups', Number($2).toLocaleString());
+        set('#metric-draws', Number($3).toLocaleString());
+        set('#metric-bytes', Number($4).toLocaleString() + ' B');
+        set('#metric-dpr', Number($5).toFixed(2));
+        const status = document.querySelector('#status-message');
+        if (status) status.textContent =
+          'native update ' + Number($6).toFixed(3) + ' ms / ' +
+          Number($7).toLocaleString() + ' submissions';
+        document.body.dataset.progpuNative = 'running';
+        document.body.dataset.progpuNativeRenderer = 'pure-cpp-webgpu';
+        document.body.dataset.progpuNativePresentation = 'canvas-swapchain';
+        document.body.dataset.progpuNativeAot = 'emscripten-wasm';
+        document.body.dataset.progpuNativeElements = String($1);
+        document.body.dataset.progpuNativeGroups = String($2);
+        document.body.dataset.progpuNativeDraws = String($3);
+        document.body.dataset.progpuNativeStreamBytes = String($4);
+        document.body.dataset.progpuNativeBackingWidth = String($8);
+        document.body.dataset.progpuNativeBackingHeight = String($9);
+        document.body.dataset.progpuNativeDpiScale = String($5);
+        document.body.dataset.progpuNativeFrames = String($10);
+    },
+        static_cast<double>(app.fps),
+        app.sample_metrics.element_count,
+        app.sample_metrics.group_count,
+        render.draw_call_count,
+        static_cast<double>(app.sample_metrics.stream_bytes),
+        static_cast<double>(frame.dpi_scale),
+        app.scene_update_milliseconds,
+        static_cast<double>(render.submission_count),
+        frame.width,
+        frame.height,
+        static_cast<double>(app.frame_count));
+}
+#pragma clang diagnostic pop
+
+EM_BOOL render_frame(double timestamp, void*) noexcept {
+    auto& app = *application;
+    const float delta = app.previous_timestamp > 0.0
+        ? static_cast<float>(std::clamp(
+            (timestamp - app.previous_timestamp) / 1000.0,
+            0.0,
+            0.1))
+        : 1.0F / 60.0F;
+    app.previous_timestamp = timestamp;
+
+    browser_frame frame{};
+    if (!app.host.begin_frame(frame)) {
+        return EM_TRUE;
+    }
+    app.sample.resize(frame.logical_width, frame.logical_height);
+    if (!app.paused) {
+        app.sample.advance(delta);
+    }
+    if (!update_scene(app)) {
+        app.host.end_frame(frame);
+        fail("The pure C++ MotionMark scene update failed.");
+        return EM_FALSE;
+    }
+
+    progpu_native_scene_frame native_frame{};
+    native_frame.struct_size = sizeof(native_frame);
+    native_frame.width = frame.width;
+    native_frame.height = frame.height;
+    native_frame.dpi_scale = frame.dpi_scale;
+    native_frame.target_view =
+        reinterpret_cast<std::uintptr_t>(frame.view);
+    native_frame.clear_color = {0.018F, 0.022F, 0.035F, 1.0F};
+    native_frame.scene_id = 0x4D4F54494F4E4D4BULL;
+    native_frame.generation = app.sample.generation();
+
+    progpu_native_scene_frame_metrics render_metrics{};
+    render_metrics.struct_size = sizeof(render_metrics);
+    const auto status = progpu_native_engine_render_scene(
+        app.engine,
+        &native_frame,
+        &render_metrics);
+    const browser_frame presented_frame = frame;
+    app.host.end_frame(frame);
+    if (status != PROGPU_NATIVE_STATUS_SUCCESS) {
+        fail("The pure C++ ProGPU browser render failed.");
+        return EM_FALSE;
+    }
+
+    ++app.frame_count;
+    if (app.fps_timestamp == 0.0) {
+        app.fps_timestamp = timestamp;
+        app.fps_frame = app.frame_count;
+    } else if (timestamp - app.fps_timestamp >= 500.0) {
+        app.fps = static_cast<float>(
+            (app.frame_count - app.fps_frame) * 1000.0 /
+            (timestamp - app.fps_timestamp));
+        app.fps_timestamp = timestamp;
+        app.fps_frame = app.frame_count;
+    }
+    if (timestamp - app.metrics_timestamp >= 200.0) {
+        app.metrics_timestamp = timestamp;
+        publish_metrics(app, presented_frame, render_metrics);
+    }
+    return EM_TRUE;
+}
+
+} // namespace
+
+extern "C" {
+
+EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_set_element_count(
+    std::uint32_t count) noexcept {
+    if (application != nullptr) {
+        application->sample.set_element_count(count);
+    }
+}
+
+EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_set_color_mode(
+    std::uint32_t mode) noexcept {
+    if (application != nullptr) {
+        application->sample.set_color_mode(mode);
+    }
+}
+
+EMSCRIPTEN_KEEPALIVE std::int32_t
+progpu_native_gallery_toggle_paused() noexcept {
+    if (application == nullptr) {
+        return 0;
+    }
+    application->paused = !application->paused;
+    return application->paused ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_regenerate() noexcept {
+    if (application != nullptr) {
+        application->sample.regenerate(
+            0x50A7C0DEU + application->regeneration++ * 0x9E3779B9U);
+    }
+}
+
+} // extern "C"
+
+int main() {
+    auto* app = new (std::nothrow) gallery_application{};
+    if (app == nullptr) {
+        fail("The native gallery could not allocate its application state.");
+        return 1;
+    }
+    application = app;
+    app->device = emscripten_webgpu_get_device();
+    if (app->device == nullptr ||
+        !app->host.initialize(app->device, "#progpu-canvas")) {
+        fail("The shared browser host could not create a WebGPU canvas surface.");
+        return 1;
+    }
+    app->queue = wgpuDeviceGetQueue(app->device);
+    if (app->queue == nullptr) {
+        fail("The browser WebGPU queue is unavailable.");
+        return 1;
+    }
+
+    progpu_native_browser_engine_options options{};
+    options.struct_size = sizeof(options);
+    options.native_abi_version = PROGPU_NATIVE_ABI_VERSION;
+    options.adapter_abi_version =
+        PROGPU_NATIVE_BROWSER_ADAPTER_ABI_VERSION;
+    options.target_format = app->host.native_format();
+    options.device = reinterpret_cast<std::uintptr_t>(app->device);
+    options.queue = reinterpret_cast<std::uintptr_t>(app->queue);
+    if (progpu_native_browser_engine_create(&options, &app->engine) !=
+            PROGPU_NATIVE_STATUS_SUCCESS ||
+        app->engine == nullptr) {
+        fail("The ProGPU pure C++ browser engine could not be created.");
+        return 1;
+    }
+    app->scene_stream.reserve(1024U * 1024U);
+    emscripten_request_animation_frame_loop(render_frame, nullptr);
+    return 0;
+}

--- a/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
+++ b/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
@@ -153,7 +153,11 @@ EM_BOOL render_frame(double timestamp, void*) noexcept {
     native_frame.dpi_scale = frame.dpi_scale;
     native_frame.target_view =
         reinterpret_cast<std::uintptr_t>(frame.view);
-    native_frame.clear_color = {0.018F, 0.022F, 0.035F, 1.0F};
+    // Match the managed gallery's dark ControlBackground contrast. The default
+    // Vello palette deliberately contains near-black strokes, which disappear
+    // against the shell chrome's almost-black background and make connected
+    // curves look like isolated blocks.
+    native_frame.clear_color = {0.125F, 0.125F, 0.15F, 1.0F};
     native_frame.scene_id = 0x4D4F54494F4E4D4BULL;
     native_frame.generation = app.sample.generation();
 

--- a/src/ProGPU.Native/browser/test.mjs
+++ b/src/ProGPU.Native/browser/test.mjs
@@ -193,6 +193,93 @@ try {
     `${contract.semanticDraws} GPU draws, exact per-draw vector/glyph/image ` +
     `masks, retained rounded/vector, picture, and composite brush/stroked-geometry ` +
     `masks, coverage masks, and direct image sampling verified.\n`);
+
+  const galleryUrl = new URL(
+    "progpu_native_browser_gallery.html",
+    testUrl);
+  await page.goto(galleryUrl.toString(), { waitUntil: "domcontentloaded" });
+  try {
+    await page.waitForFunction(
+      () => document.body.dataset.progpuNative === "running" &&
+        Number(document.body.dataset.progpuNativeFrames) >= 3,
+      undefined,
+      { timeout: 120_000 });
+  } catch (error) {
+    const diagnostics = await page.evaluate(() => ({
+      status: document.body.dataset.progpuNative,
+      error: document.body.dataset.progpuNativeError ?? ""
+    }));
+    throw new Error(
+      `Native gallery did not present its MotionMark scene: ` +
+      `${JSON.stringify(diagnostics)}; ${errors.join(" | ")}`, {
+      cause: error
+    });
+  }
+  const galleryContract = await page.evaluate(() => {
+    const canvas = document.querySelector("#progpu-canvas");
+    const rect = canvas.getBoundingClientRect();
+    return {
+      status: document.body.dataset.progpuNative,
+      renderer: document.body.dataset.progpuNativeRenderer,
+      presentation: document.body.dataset.progpuNativePresentation,
+      aot: document.body.dataset.progpuNativeAot,
+      elements: Number(document.body.dataset.progpuNativeElements),
+      groups: Number(document.body.dataset.progpuNativeGroups),
+      draws: Number(document.body.dataset.progpuNativeDraws),
+      streamBytes: Number(document.body.dataset.progpuNativeStreamBytes),
+      width: Number(document.body.dataset.progpuNativeBackingWidth),
+      height: Number(document.body.dataset.progpuNativeBackingHeight),
+      dpiScale: Number(document.body.dataset.progpuNativeDpiScale),
+      frames: Number(document.body.dataset.progpuNativeFrames),
+      canvasWidth: canvas.width,
+      canvasHeight: canvas.height,
+      cssWidth: rect.width,
+      cssHeight: rect.height,
+      error: document.body.dataset.progpuNativeError ?? ""
+    };
+  });
+  assert.equal(galleryContract.status, "running");
+  assert.equal(galleryContract.renderer, "pure-cpp-webgpu");
+  assert.equal(galleryContract.presentation, "canvas-swapchain");
+  assert.equal(galleryContract.aot, "emscripten-wasm");
+  assert.equal(galleryContract.elements, 1000);
+  assert.ok(galleryContract.groups > 0 &&
+    galleryContract.groups <= galleryContract.elements);
+  assert.equal(galleryContract.draws, 1);
+  assert.ok(galleryContract.streamBytes > 0);
+  assert.equal(galleryContract.width, galleryContract.canvasWidth);
+  assert.equal(galleryContract.height, galleryContract.canvasHeight);
+  assert.equal(
+    galleryContract.width,
+    Math.round(galleryContract.cssWidth * galleryContract.dpiScale));
+  assert.equal(
+    galleryContract.height,
+    Math.round(galleryContract.cssHeight * galleryContract.dpiScale));
+  assert.ok(galleryContract.frames >= 3);
+  assert.equal(galleryContract.error, "");
+
+  await page.locator("#complexity").selectOption("250");
+  await page.waitForFunction(
+    () => document.body.dataset.progpuNativeElements === "250",
+    undefined,
+    { timeout: 30_000 });
+  galleryContract.controlledElements = Number(
+    await page.locator("body").getAttribute("data-progpu-native-elements"));
+  assert.equal(galleryContract.controlledElements, 250);
+  const galleryScreenshot = await page.locator(".stage").screenshot({
+    path: path.join(
+      evidenceDirectory,
+      "progpu-native-browser-gallery.png")
+  });
+  assert.ok(galleryScreenshot.length > 1000,
+    "The native gallery WebGPU screenshot is empty.");
+  await fs.writeFile(
+    path.join(evidenceDirectory, "progpu-native-browser-gallery.json"),
+    `${JSON.stringify(galleryContract, null, 2)}\n`);
+  assert.deepEqual(errors, []);
+  process.stdout.write(
+    `ProGPU pure C++ browser gallery presented MotionMark as one GPU draw ` +
+    `at ${galleryContract.width}x${galleryContract.height} physical pixels.\n`);
 } finally {
   await browser.close();
 }

--- a/src/ProGPU.Native/browser/test.mjs
+++ b/src/ProGPU.Native/browser/test.mjs
@@ -258,14 +258,25 @@ try {
   assert.ok(galleryContract.frames >= 3);
   assert.equal(galleryContract.error, "");
 
+  const framesBeforeControlChange = galleryContract.frames;
   await page.locator("#complexity").selectOption("250");
   await page.waitForFunction(
-    () => document.body.dataset.progpuNativeElements === "250",
-    undefined,
+    previousFrames =>
+      document.body.dataset.progpuNativeElements === "250" &&
+      Number(document.body.dataset.progpuNativeFrames) > previousFrames,
+    framesBeforeControlChange,
     { timeout: 30_000 });
   galleryContract.controlledElements = Number(
     await page.locator("body").getAttribute("data-progpu-native-elements"));
+  galleryContract.controlledFrames = Number(
+    await page.locator("body").getAttribute("data-progpu-native-frames"));
   assert.equal(galleryContract.controlledElements, 250);
+  assert.ok(galleryContract.controlledFrames > framesBeforeControlChange,
+    "The native gallery did not present after its scene changed.");
+  assert.equal(
+    await page.locator("body").getAttribute("data-progpu-native-error"),
+    null,
+    "The native gallery reported an error after its scene changed.");
   const galleryScreenshot = await page.locator(".stage").screenshot({
     path: path.join(
       evidenceDirectory,

--- a/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.cpp
+++ b/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.cpp
@@ -1,0 +1,404 @@
+#include "progpu_native_motion_mark.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
+namespace progpu::native::samples {
+namespace {
+
+constexpr std::array<std::array<std::int32_t, 2U>, 4U> offsets{{
+    {-4, 0}, {2, 0}, {1, -2}, {1, 2}}};
+
+constexpr std::array<progpu_native_color, 7U> vello_colors{{
+    {0.06F, 0.06F, 0.06F, 1.0F},
+    {0.50F, 0.50F, 0.50F, 1.0F},
+    {0.75F, 0.75F, 0.75F, 1.0F},
+    {0.06F, 0.06F, 0.06F, 1.0F},
+    {0.50F, 0.50F, 0.50F, 1.0F},
+    {0.75F, 0.75F, 0.75F, 1.0F},
+    {0.88F, 0.06F, 0.25F, 1.0F}}};
+
+constexpr std::array<progpu_native_color, 5U> fluent_colors{{
+    {0.0F, 0.47F, 0.83F, 1.0F},
+    {0.52F, 0.15F, 0.79F, 1.0F},
+    {0.91F, 0.11F, 0.38F, 1.0F},
+    {1.0F, 0.73F, 0.0F, 1.0F},
+    {0.06F, 0.69F, 0.32F, 1.0F}}};
+
+constexpr std::array<progpu_native_color, 4U> monochrome_colors{{
+    {0.12F, 0.12F, 0.12F, 1.0F},
+    {0.24F, 0.24F, 0.24F, 1.0F},
+    {0.60F, 0.60F, 0.60F, 1.0F},
+    {0.90F, 0.90F, 0.90F, 1.0F}}};
+
+constexpr progpu_native_affine_2d identity{
+    1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F};
+
+progpu_native_color hsv_to_rgb(float h, float s, float v) noexcept {
+    const float c = v * s;
+    const float x = c * (1.0F - std::abs(
+        std::fmod(h / 60.0F, 2.0F) - 1.0F));
+    const float m = v - c;
+    float r = 0.0F;
+    float g = 0.0F;
+    float b = 0.0F;
+    if (h < 60.0F) {
+        r = c;
+        g = x;
+    } else if (h < 120.0F) {
+        r = x;
+        g = c;
+    } else if (h < 180.0F) {
+        g = c;
+        b = x;
+    } else if (h < 240.0F) {
+        g = x;
+        b = c;
+    } else if (h < 300.0F) {
+        r = x;
+        b = c;
+    } else {
+        r = c;
+        b = x;
+    }
+    return {r + m, g + m, b + m, 1.0F};
+}
+
+} // namespace
+
+motion_mark_scene::motion_mark_scene(
+    std::uint32_t element_count,
+    std::uint32_t seed)
+    : random_state_(seed == 0U ? 0x50A7C0DEU : seed) {
+    elements_.reserve(5000U);
+    primitives_.reserve(10000U);
+    builder_.reserve(1U, 1U, 10000U *
+        sizeof(progpu_native_geometry_primitive));
+    resize(width_, height_);
+    rebuild_elements(std::clamp(element_count, 1U, 5000U));
+}
+
+bool motion_mark_scene::resize(float width, float height) noexcept {
+    if (!std::isfinite(width) || !std::isfinite(height) ||
+        width <= 0.0F || height <= 0.0F) {
+        return false;
+    }
+    if (width_ == width && height_ == height && !elements_.empty()) {
+        return false;
+    }
+    width_ = width;
+    height_ = height;
+    grid_scale_ = std::max(0.0F, std::min(width / 81.0F, height / 41.0F));
+    grid_offset_x_ = (width - grid_scale_ * 81.0F) * 0.5F;
+    grid_offset_y_ = (height - grid_scale_ * 41.0F) * 0.5F;
+    rebuild_primitives();
+    mark_dirty();
+    return true;
+}
+
+bool motion_mark_scene::set_element_count(std::uint32_t count) noexcept {
+    count = std::clamp(count, 1U, 5000U);
+    if (count == elements_.size()) {
+        return false;
+    }
+    if (count < elements_.size()) {
+        elements_.resize(count);
+    } else {
+        grid_point current = elements_.empty()
+            ? grid_point{40, 20}
+            : elements_.back().end;
+        while (elements_.size() < count) {
+            elements_.push_back(create_element(current));
+        }
+    }
+    rebuild_primitives();
+    mark_dirty();
+    return true;
+}
+
+bool motion_mark_scene::set_color_mode(std::uint32_t mode) noexcept {
+    mode = std::min(mode, 3U);
+    if (mode == color_mode_) {
+        return false;
+    }
+    color_mode_ = mode;
+    for (auto& value : elements_) {
+        value.color = random_color();
+    }
+    rebuild_primitives();
+    mark_dirty();
+    return true;
+}
+
+bool motion_mark_scene::regenerate(std::uint32_t seed) noexcept {
+    random_state_ = seed == 0U ? 0x50A7C0DEU : seed;
+    animation_budget_ = 0.0F;
+    split_toggle_budget_ = 0.0F;
+    rebuild_elements(static_cast<std::uint32_t>(elements_.size()));
+    return true;
+}
+
+bool motion_mark_scene::advance(float delta_seconds) noexcept {
+    if (elements_.empty() || !std::isfinite(delta_seconds) ||
+        delta_seconds <= 0.0F) {
+        return false;
+    }
+    constexpr float animation_step = 1.0F / 60.0F;
+    animation_budget_ += std::min(delta_seconds, 0.1F);
+    const auto step_count = static_cast<std::uint32_t>(
+        animation_budget_ / animation_step);
+    if (step_count == 0U) {
+        return false;
+    }
+    animation_budget_ -= static_cast<float>(step_count) * animation_step;
+    split_toggle_budget_ += static_cast<float>(elements_.size()) *
+        0.005F * static_cast<float>(step_count);
+    const auto toggle_count = std::min(
+        static_cast<std::uint32_t>(elements_.size()),
+        static_cast<std::uint32_t>(split_toggle_budget_));
+    if (toggle_count == 0U) {
+        return false;
+    }
+    split_toggle_budget_ -= static_cast<float>(toggle_count);
+    for (std::uint32_t index = 0U; index < toggle_count; ++index) {
+        auto& value = elements_[next_random() % elements_.size()];
+        value.split = !value.split;
+    }
+    rebuild_primitives();
+    mark_dirty();
+    return true;
+}
+
+bool motion_mark_scene::compile(
+    std::vector<std::byte>& stream,
+    motion_mark_scene_metrics& metrics) noexcept {
+    if (!dirty_ || primitives_.empty() ||
+        !builder_.reset(scene_id_, generation_) ||
+        !builder_.reserve(
+            1U,
+            1U,
+            primitives_.size() *
+                sizeof(progpu_native_geometry_primitive)) ||
+        !builder_.draw_geometry(
+            primitives_, {}, {0.0F, 0.0F, width_, height_})) {
+        return false;
+    }
+    const std::size_t required = builder_.required_stream_size();
+    if (required == 0U) {
+        return false;
+    }
+    try {
+        if (stream.capacity() < required) {
+            stream.reserve(required);
+        }
+        stream.resize(required);
+    } catch (...) {
+        return false;
+    }
+    std::size_t written = 0U;
+    scene_build_metrics build_metrics{};
+    if (!builder_.build_into(stream, written, &build_metrics) ||
+        written != required) {
+        return false;
+    }
+    metrics.element_count = static_cast<std::uint32_t>(elements_.size());
+    metrics.group_count = group_count_;
+    metrics.primitive_count = static_cast<std::uint32_t>(primitives_.size());
+    metrics.command_count = build_metrics.command_count;
+    metrics.resource_count = build_metrics.resource_count;
+    metrics.stream_bytes = build_metrics.stream_bytes;
+    metrics.generation = generation_;
+    dirty_ = false;
+    return true;
+}
+
+bool motion_mark_scene::dirty() const noexcept {
+    return dirty_;
+}
+
+std::uint64_t motion_mark_scene::generation() const noexcept {
+    return generation_;
+}
+
+std::uint32_t motion_mark_scene::element_count() const noexcept {
+    return static_cast<std::uint32_t>(elements_.size());
+}
+
+std::uint32_t motion_mark_scene::group_count() const noexcept {
+    return group_count_;
+}
+
+std::span<const progpu_native_geometry_primitive>
+motion_mark_scene::primitives() const noexcept {
+    return primitives_;
+}
+
+std::uint32_t motion_mark_scene::next_random() noexcept {
+    std::uint32_t value = random_state_;
+    value ^= value << 13U;
+    value ^= value >> 17U;
+    value ^= value << 5U;
+    random_state_ = value == 0U ? 0x50A7C0DEU : value;
+    return random_state_;
+}
+
+float motion_mark_scene::next_unit() noexcept {
+    return static_cast<float>(next_random() >> 8U) *
+        (1.0F / 16777216.0F);
+}
+
+motion_mark_scene::grid_point motion_mark_scene::random_point(
+    grid_point point) noexcept {
+    const auto& offset = offsets[next_random() % offsets.size()];
+    std::int32_t x = point.x + offset[0];
+    if (x < 0 || x > 80) {
+        x -= offset[0] * 2;
+    }
+    std::int32_t y = point.y + offset[1];
+    if (y < 0 || y > 40) {
+        y -= offset[1] * 2;
+    }
+    return {std::clamp(x, 0, 80), std::clamp(y, 0, 40)};
+}
+
+progpu_native_color motion_mark_scene::random_color() noexcept {
+    if (color_mode_ == 1U) {
+        return fluent_colors[next_random() % fluent_colors.size()];
+    }
+    if (color_mode_ == 2U) {
+        return hsv_to_rgb(next_unit() * 360.0F, 0.85F, 0.95F);
+    }
+    if (color_mode_ == 3U) {
+        return monochrome_colors[next_random() % monochrome_colors.size()];
+    }
+    return vello_colors[next_random() % vello_colors.size()];
+}
+
+motion_mark_scene::element motion_mark_scene::create_element(
+    grid_point& current) noexcept {
+    element value{};
+    value.start = current;
+    const std::uint32_t kind = next_random() % 3U;
+    if (kind == 0U) {
+        value.kind = motion_mark_segment_kind::line;
+        value.end = random_point(current);
+    } else if (kind == 1U) {
+        value.kind = motion_mark_segment_kind::quadratic;
+        value.control1 = random_point(current);
+        value.end = random_point(value.control1);
+    } else {
+        value.kind = motion_mark_segment_kind::cubic;
+        value.control1 = random_point(current);
+        value.control2 = random_point(value.control1);
+        value.end = random_point(value.control1);
+    }
+    current = value.end;
+    value.color = random_color();
+    value.width = std::pow(next_unit(), 5.0F) * 20.0F + 1.0F;
+    value.split = next_unit() < 0.5F;
+    return value;
+}
+
+progpu_native_point motion_mark_scene::map(grid_point point) const noexcept {
+    return {
+        grid_offset_x_ + (static_cast<float>(point.x) + 0.5F) * grid_scale_,
+        grid_offset_y_ + (static_cast<float>(point.y) + 0.5F) * grid_scale_};
+}
+
+progpu_native_point motion_mark_scene::incoming_tangent(
+    const element& value) const noexcept {
+    const auto end = map(value.end);
+    const auto previous = value.kind == motion_mark_segment_kind::line
+        ? map(value.start)
+        : value.kind == motion_mark_segment_kind::quadratic
+            ? map(value.control1)
+            : map(value.control2);
+    return {end.x - previous.x, end.y - previous.y};
+}
+
+progpu_native_point motion_mark_scene::outgoing_tangent(
+    const element& value) const noexcept {
+    const auto start = map(value.start);
+    const auto next = value.kind == motion_mark_segment_kind::line
+        ? map(value.end)
+        : map(value.control1);
+    return {next.x - start.x, next.y - start.y};
+}
+
+void motion_mark_scene::rebuild_elements(std::uint32_t count) noexcept {
+    elements_.clear();
+    grid_point current{40, 20};
+    for (std::uint32_t index = 0U; index < count; ++index) {
+        elements_.push_back(create_element(current));
+    }
+    animation_budget_ = 0.0F;
+    split_toggle_budget_ = 0.0F;
+    rebuild_primitives();
+    mark_dirty();
+}
+
+void motion_mark_scene::rebuild_primitives() noexcept {
+    primitives_.clear();
+    group_count_ = 0U;
+    std::size_t begin = 0U;
+    while (begin < elements_.size()) {
+        std::size_t end = begin;
+        while (end + 1U < elements_.size() && !elements_[end].split) {
+            ++end;
+        }
+        ++group_count_;
+        const auto& style = elements_[end];
+        for (std::size_t index = begin; index <= end; ++index) {
+            const auto& source = elements_[index];
+            progpu_native_geometry_primitive primitive{};
+            primitive.kind = source.kind == motion_mark_segment_kind::line
+                ? PROGPU_NATIVE_GEOMETRY_LINE
+                : source.kind == motion_mark_segment_kind::quadratic
+                    ? PROGPU_NATIVE_GEOMETRY_QUADRATIC_BEZIER
+                    : PROGPU_NATIVE_GEOMETRY_CUBIC_BEZIER;
+            primitive.p0 = map(source.start);
+            primitive.p1 = source.kind == motion_mark_segment_kind::line
+                ? map(source.end)
+                : map(source.control1);
+            if (source.kind == motion_mark_segment_kind::quadratic) {
+                primitive.p2 = map(source.end);
+            } else if (source.kind == motion_mark_segment_kind::cubic) {
+                primitive.p2 = map(source.control2);
+                primitive.p3 = map(source.end);
+            }
+            primitive.stroke_thickness = style.width;
+            primitive.color = style.color;
+            primitive.transform = identity;
+            primitives_.push_back(primitive);
+
+            if (index < end) {
+                progpu_native_geometry_primitive join{};
+                join.kind = PROGPU_NATIVE_GEOMETRY_PATH_JOIN;
+                join.flags = PROGPU_NATIVE_STROKE_JOIN_MITER <<
+                    PROGPU_NATIVE_PRIMITIVE_START_CAP_SHIFT;
+                join.p0 = map(source.end);
+                join.p1 = incoming_tangent(source);
+                join.p2 = outgoing_tangent(elements_[index + 1U]);
+                join.p3 = {10.0F, 0.0F};
+                join.stroke_thickness = style.width;
+                join.color = style.color;
+                join.transform = identity;
+                primitives_.push_back(join);
+            }
+        }
+        begin = end + 1U;
+    }
+}
+
+void motion_mark_scene::mark_dirty() noexcept {
+    if (!dirty_ && generation_ < std::numeric_limits<std::uint64_t>::max()) {
+        ++generation_;
+    } else if (dirty_ && generation_ == 0U) {
+        generation_ = 1U;
+    }
+    dirty_ = true;
+}
+
+} // namespace progpu::native::samples

--- a/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.cpp
+++ b/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cmath>
 #include <limits>
+#include <unordered_map>
 
 namespace progpu::native::samples {
 namespace {
@@ -35,6 +37,31 @@ constexpr std::array<progpu_native_color, 4U> monochrome_colors{{
 
 constexpr progpu_native_affine_2d identity{
     1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F};
+
+struct color_key final {
+    std::array<std::uint32_t, 4U> bits{};
+
+    bool operator==(const color_key&) const noexcept = default;
+};
+
+struct color_key_hash final {
+    std::size_t operator()(const color_key& value) const noexcept {
+        std::size_t hash = 0U;
+        for (const std::uint32_t bits : value.bits) {
+            hash ^= static_cast<std::size_t>(bits) + 0x9E3779B9U +
+                (hash << 6U) + (hash >> 2U);
+        }
+        return hash;
+    }
+};
+
+color_key key_for(progpu_native_color color) noexcept {
+    return {{
+        std::bit_cast<std::uint32_t>(color.r),
+        std::bit_cast<std::uint32_t>(color.g),
+        std::bit_cast<std::uint32_t>(color.b),
+        std::bit_cast<std::uint32_t>(color.a)}};
+}
 
 progpu_native_color hsv_to_rgb(float h, float s, float v) noexcept {
     const float c = v * s;
@@ -74,8 +101,10 @@ motion_mark_scene::motion_mark_scene(
     : random_state_(seed == 0U ? 0x50A7C0DEU : seed) {
     elements_.reserve(5000U);
     primitives_.reserve(10000U);
-    builder_.reserve(1U, 1U, 10000U *
-        sizeof(progpu_native_geometry_primitive));
+    brush_indices_.reserve(10000U);
+    builder_.reserve(1U, 2U, 10000U *
+        (sizeof(progpu_native_geometry_primitive) +
+            sizeof(std::uint32_t)));
     resize(width_, height_);
     rebuild_elements(std::clamp(element_count, 1U, 5000U));
 }
@@ -178,11 +207,40 @@ bool motion_mark_scene::compile(
         !builder_.reset(scene_id_, generation_) ||
         !builder_.reserve(
             1U,
-            1U,
+            2U,
             primitives_.size() *
-                sizeof(progpu_native_geometry_primitive)) ||
-        !builder_.draw_geometry(
-            primitives_, {}, {0.0F, 0.0F, width_, height_})) {
+                (sizeof(progpu_native_geometry_primitive) +
+                    sizeof(std::uint32_t)))) {
+        return false;
+    }
+    brush_indices_.clear();
+    std::unordered_map<color_key, std::uint32_t, color_key_hash> brushes{};
+    try {
+        brushes.reserve(std::min<std::size_t>(
+            primitives_.size(),
+            static_cast<std::size_t>(group_count_)));
+        for (const auto& primitive : primitives_) {
+            const color_key key = key_for(primitive.color);
+            auto found = brushes.find(key);
+            if (found == brushes.end()) {
+                std::uint32_t brush_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+                if (!builder_.add_solid_brush(
+                        primitive.color,
+                        1.0F,
+                        brush_index)) {
+                    return false;
+                }
+                found = brushes.emplace(key, brush_index).first;
+            }
+            brush_indices_.push_back(found->second);
+        }
+    } catch (...) {
+        return false;
+    }
+    if (!builder_.draw_geometry(
+            primitives_,
+            brush_indices_,
+            {0.0F, 0.0F, width_, height_})) {
         return false;
     }
     const std::size_t required = builder_.required_stream_size();
@@ -206,6 +264,7 @@ bool motion_mark_scene::compile(
     metrics.element_count = static_cast<std::uint32_t>(elements_.size());
     metrics.group_count = group_count_;
     metrics.primitive_count = static_cast<std::uint32_t>(primitives_.size());
+    metrics.brush_count = build_metrics.brush_count;
     metrics.command_count = build_metrics.command_count;
     metrics.resource_count = build_metrics.resource_count;
     metrics.stream_bytes = build_metrics.stream_bytes;

--- a/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp
+++ b/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp
@@ -20,6 +20,7 @@ struct motion_mark_scene_metrics final {
     std::uint32_t element_count = 0U;
     std::uint32_t group_count = 0U;
     std::uint32_t primitive_count = 0U;
+    std::uint32_t brush_count = 0U;
     std::uint32_t command_count = 0U;
     std::uint32_t resource_count = 0U;
     std::uint64_t stream_bytes = 0U;
@@ -92,6 +93,7 @@ private:
     semantic_scene_builder builder_{scene_id_, 1U};
     std::vector<element> elements_{};
     std::vector<progpu_native_geometry_primitive> primitives_{};
+    std::vector<std::uint32_t> brush_indices_{};
     std::uint32_t random_state_ = 0x50A7C0DEU;
     std::uint32_t color_mode_ = 0U;
     std::uint32_t group_count_ = 0U;

--- a/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp
+++ b/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "progpu_native.h"
+#include "progpu_native_scene_builder.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace progpu::native::samples {
+
+enum class motion_mark_segment_kind : std::uint8_t {
+    line,
+    quadratic,
+    cubic
+};
+
+struct motion_mark_scene_metrics final {
+    std::uint32_t element_count = 0U;
+    std::uint32_t group_count = 0U;
+    std::uint32_t primitive_count = 0U;
+    std::uint32_t command_count = 0U;
+    std::uint32_t resource_count = 0U;
+    std::uint64_t stream_bytes = 0U;
+    std::uint64_t generation = 0U;
+};
+
+/*
+ * Pure C++20 port of the ProGPU-owned managed MotionMark sample in
+ * src/ProGPU.Samples/Views/MotionMarkShowcaseVisual.cs. The element topology,
+ * fixed 60 Hz split cadence, grid mapping, grouping, palettes, and style-at-
+ * group-end contract are preserved. One changed scene is serialized into one
+ * retained geometry batch; stable frames reuse the immutable byte stream.
+ *
+ * Rebuild: O(N + G) time and O(N + G) retained storage for N segments and G
+ * groups. Stable replay is O(1) sample-side work with no scene serialization.
+ */
+class motion_mark_scene final {
+public:
+    explicit motion_mark_scene(
+        std::uint32_t element_count = 1000U,
+        std::uint32_t seed = 0x50A7C0DEU);
+
+    bool resize(float width, float height) noexcept;
+    bool set_element_count(std::uint32_t count) noexcept;
+    bool set_color_mode(std::uint32_t mode) noexcept;
+    bool regenerate(std::uint32_t seed) noexcept;
+    bool advance(float delta_seconds) noexcept;
+
+    bool compile(
+        std::vector<std::byte>& stream,
+        motion_mark_scene_metrics& metrics) noexcept;
+
+    bool dirty() const noexcept;
+    std::uint64_t generation() const noexcept;
+    std::uint32_t element_count() const noexcept;
+    std::uint32_t group_count() const noexcept;
+    std::span<const progpu_native_geometry_primitive> primitives() const
+        noexcept;
+
+private:
+    struct grid_point final {
+        std::int32_t x = 0;
+        std::int32_t y = 0;
+    };
+
+    struct element final {
+        motion_mark_segment_kind kind = motion_mark_segment_kind::line;
+        grid_point start{};
+        grid_point control1{};
+        grid_point control2{};
+        grid_point end{};
+        progpu_native_color color{};
+        float width = 1.0F;
+        bool split = false;
+    };
+
+    std::uint32_t next_random() noexcept;
+    float next_unit() noexcept;
+    grid_point random_point(grid_point point) noexcept;
+    progpu_native_color random_color() noexcept;
+    element create_element(grid_point& current) noexcept;
+    progpu_native_point map(grid_point point) const noexcept;
+    progpu_native_point incoming_tangent(const element& value) const noexcept;
+    progpu_native_point outgoing_tangent(const element& value) const noexcept;
+    void rebuild_elements(std::uint32_t count) noexcept;
+    void rebuild_primitives() noexcept;
+    void mark_dirty() noexcept;
+
+    static constexpr std::uint64_t scene_id_ = 0x4D4F54494F4E4D4BULL;
+    semantic_scene_builder builder_{scene_id_, 1U};
+    std::vector<element> elements_{};
+    std::vector<progpu_native_geometry_primitive> primitives_{};
+    std::uint32_t random_state_ = 0x50A7C0DEU;
+    std::uint32_t color_mode_ = 0U;
+    std::uint32_t group_count_ = 0U;
+    std::uint64_t generation_ = 1U;
+    float width_ = 960.0F;
+    float height_ = 540.0F;
+    float grid_scale_ = 1.0F;
+    float grid_offset_x_ = 0.0F;
+    float grid_offset_y_ = 0.0F;
+    float animation_budget_ = 0.0F;
+    float split_toggle_budget_ = 0.0F;
+    bool dirty_ = true;
+};
+
+} // namespace progpu::native::samples

--- a/src/ProGPU.Native/tests/progpu_native_motion_mark_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_motion_mark_tests.cpp
@@ -1,0 +1,69 @@
+#include "progpu_native_motion_mark.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+void require(bool condition) {
+    if (!condition) {
+        std::abort();
+    }
+}
+
+void managed_motion_mark_contract_is_preserved() {
+    using progpu::native::samples::motion_mark_scene;
+    using progpu::native::samples::motion_mark_scene_metrics;
+
+    motion_mark_scene scene{1000U, 0x12345678U};
+    require(scene.element_count() == 1000U);
+    require(scene.group_count() > 0U);
+    require(scene.group_count() <= scene.element_count());
+    require(scene.primitives().size() >= scene.element_count());
+    require(scene.primitives().size() < scene.element_count() * 2U);
+
+    std::vector<std::byte> stream{};
+    motion_mark_scene_metrics metrics{};
+    require(scene.compile(stream, metrics));
+    require(!stream.empty());
+    require(metrics.element_count == 1000U);
+    require(metrics.group_count == scene.group_count());
+    require(metrics.primitive_count == scene.primitives().size());
+    require(metrics.command_count == 1U);
+    require(metrics.resource_count == 1U);
+    require(metrics.stream_bytes == stream.size());
+    const auto first_generation = metrics.generation;
+
+    require(!scene.dirty());
+    require(!scene.advance(1.0F / 240.0F));
+    require(!scene.dirty());
+    require(scene.advance(1.0F / 60.0F));
+    require(scene.dirty());
+    require(scene.compile(stream, metrics));
+    require(metrics.generation > first_generation);
+    require(metrics.command_count == 1U);
+
+    require(scene.resize(640.0F, 360.0F));
+    for (const auto& primitive : scene.primitives()) {
+        require(std::isfinite(primitive.p0.x));
+        require(std::isfinite(primitive.p0.y));
+        require(primitive.stroke_thickness > 0.0F);
+    }
+    require(scene.set_element_count(2500U));
+    require(scene.element_count() == 2500U);
+    require(scene.set_color_mode(1U));
+    require(scene.regenerate(0xCAFEBABEU));
+    require(scene.compile(stream, metrics));
+    require(metrics.element_count == 2500U);
+    require(metrics.command_count == 1U);
+}
+
+} // namespace
+
+int main() {
+    managed_motion_mark_contract_is_preserved();
+    return 0;
+}

--- a/src/ProGPU.Native/tests/progpu_native_motion_mark_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_motion_mark_tests.cpp
@@ -32,8 +32,10 @@ void managed_motion_mark_contract_is_preserved() {
     require(metrics.element_count == 1000U);
     require(metrics.group_count == scene.group_count());
     require(metrics.primitive_count == scene.primitives().size());
+    require(metrics.brush_count > 0U);
+    require(metrics.brush_count <= metrics.group_count);
     require(metrics.command_count == 1U);
-    require(metrics.resource_count == 1U);
+    require(metrics.resource_count == 2U);
     require(metrics.stream_bytes == stream.size());
     const auto first_generation = metrics.generation;
 
@@ -58,6 +60,7 @@ void managed_motion_mark_contract_is_preserved() {
     require(scene.regenerate(0xCAFEBABEU));
     require(scene.compile(stream, metrics));
     require(metrics.element_count == 2500U);
+    require(metrics.brush_count > 0U);
     require(metrics.command_count == 1U);
 }
 

--- a/src/ProGPU.Samples.Browser/ProGPU.Samples.Browser.csproj
+++ b/src/ProGPU.Samples.Browser/ProGPU.Samples.Browser.csproj
@@ -33,6 +33,10 @@
     <Content Update="wwwroot/progpu-audio-worklet-smoke.js"
              CopyToOutputDirectory="Always"
              CopyToPublishDirectory="Always" />
+    <Content Include="..\ProGPU.Browser\BrowserAssets\progpu-browser-host.js"
+             Link="wwwroot/progpu-browser-host.js"
+             CopyToOutputDirectory="Always"
+             CopyToPublishDirectory="Always" />
     <UpToDateCheckInput Include="..\ProGPU.Browser\BrowserAssets\progpu-browser.js" />
     <!-- WgpuContext uses this iOS-only import to root the static wgpu-native archive.
          WebAssembly still resolves imports at link time, so provide an unreachable stub. -->

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -1265,7 +1265,7 @@ public sealed class SampleProjectSplitTests
     }
 
     [Fact]
-    public void GitHubPagesPublishesAotBrowserArtifactBelowRepositoryPath()
+    public void GitHubPagesPublishesManagedAndNativeAotBrowserArtifacts()
     {
         var workflow = Read(".github", "workflows", "browser-pages.yml");
         var html = Read("src", "ProGPU.Samples.Browser", "wwwroot", "index.html");
@@ -1273,6 +1273,9 @@ public sealed class SampleProjectSplitTests
 
         Assert.Contains("dotnet publish src/ProGPU.Samples.Browser/ProGPU.Samples.Browser.csproj", workflow, StringComparison.Ordinal);
         Assert.Contains("--configuration Release", workflow, StringComparison.Ordinal);
+        Assert.Contains("mymindstorm/setup-emsdk@v16", workflow, StringComparison.Ordinal);
+        Assert.Contains("./eng/publish-progpu-native-browser-gallery.sh", workflow, StringComparison.Ordinal);
+        Assert.Contains("artifacts/browser-aot/wwwroot/native", workflow, StringComparison.Ordinal);
         Assert.Contains("path: artifacts/browser-aot/wwwroot", workflow, StringComparison.Ordinal);
         Assert.Contains("actions/configure-pages@v5", workflow, StringComparison.Ordinal);
         Assert.Contains("actions/upload-pages-artifact@v4", workflow, StringComparison.Ordinal);

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -251,6 +251,36 @@ public sealed class SampleProjectSplitTests
     }
 
     [Fact]
+    public void ManagedAndNativeBrowserHostsShareTheWebGpuPlatformContract()
+    {
+        var managedHost = Read(
+            "src", "ProGPU.Browser", "BrowserAssets", "progpu-browser.js");
+        var sharedHost = Read(
+            "src", "ProGPU.Browser", "BrowserAssets", "progpu-browser-host.js");
+        var nativeHost = Read(
+            "src", "ProGPU.Native", "browser", "gallery_pre.js");
+        var nativeBuild = Read("src", "ProGPU.Native", "CMakeLists.txt");
+
+        Assert.Contains("from './progpu-browser-host.js'", managedHost, StringComparison.Ordinal);
+        Assert.Contains("requestProGpuWebGpuDevice({", managedHost, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "state.adapter = await navigator.gpu.requestAdapter({",
+            managedHost,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "export async function requestProGpuWebGpuDevice(options = {})",
+            sharedHost,
+            StringComparison.Ordinal);
+        Assert.Contains("import('./progpu-browser-host.js')", nativeHost, StringComparison.Ordinal);
+        Assert.Contains("host.installResponsiveCanvas(", nativeHost, StringComparison.Ordinal);
+        Assert.Contains("host.requestProGpuWebGpuDevice({", nativeHost, StringComparison.Ordinal);
+        Assert.Contains(
+            "ProGPU.Browser/BrowserAssets/progpu-browser-host.js",
+            nativeBuild,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BrowserDiagnosticsAreHiddenByDefaultAndExposedInSampleSettings()
     {
         var html = Read("src", "ProGPU.Samples.Browser", "wwwroot", "index.html");

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -271,6 +271,9 @@ public sealed class SampleProjectSplitTests
             "export async function requestProGpuWebGpuDevice(options = {})",
             sharedHost,
             StringComparison.Ordinal);
+        Assert.Contains("if (info.reason === 'destroyed')", sharedHost, StringComparison.Ordinal);
+        Assert.Contains("options.onDeviceDestroyed?.(info)", sharedHost, StringComparison.Ordinal);
+        Assert.Contains("options.onDeviceLost?.(info)", sharedHost, StringComparison.Ordinal);
         Assert.Contains("import('./progpu-browser-host.js')", nativeHost, StringComparison.Ordinal);
         Assert.Contains("host.installResponsiveCanvas(", nativeHost, StringComparison.Ordinal);
         Assert.Contains("host.requestProGpuWebGpuDevice({", nativeHost, StringComparison.Ordinal);


### PR DESCRIPTION
## Outcome

Adds a production-style pure C++20 ProGPU browser gallery, with MotionMark as the first native sample. Emscripten emits a standalone WebAssembly AOT payload with no CLR, Mono runtime, managed assembly, CPU readback, or Canvas 2D fallback.

The managed and native galleries share the canonical `progpu-browser-host.js` platform contract for physical-pixel canvas sizing, visual viewport handling, high-performance WebGPU device negotiation, feature-profile selection, uncaptured errors, and device lifecycle. Native C++ owns scene topology, animation, retained semantic-stream construction, direct swapchain rendering, and metrics.

## Milestones

- [x] Extract the managed browser WebGPU/viewport platform contract into one reusable module
- [x] Keep the existing managed browser gallery consuming that exact module
- [x] Add the C++ counterpart of `BrowserWindowHost` over Emdawnwebgpu
- [x] Port the ProGPU-owned managed MotionMark topology, grouping, animation cadence, and palettes to C++20
- [x] Preserve exact line/quadratic/cubic materials through an aligned deduplicated native brush table
- [x] Submit one retained semantic geometry resource and one GPU draw per changed native scene
- [x] Render directly into the browser canvas swapchain at physical DPI
- [x] Add responsive native gallery controls and telemetry
- [x] Add deterministic native contract tests and managed/native architecture guards
- [x] Add real Chromium WebGPU coverage at 1x and 2x DPR with screenshot evidence
- [x] Require a later presented frame after an interactive scene change
- [x] Add optimized local publish tooling and deploy the native payload beside the managed Pages gallery under `/native/`
- [x] Manual visual and interaction qualification
- [x] CI checks green

## Architecture and performance

| Concern | Managed gallery | Pure C++ gallery | Reuse/parity |
| --- | --- | --- | --- |
| Browser platform host | `ProGPU.Browser` | Native pre-host + C++ window host | Same JS WebGPU/viewport module |
| Frame loop | Managed `BrowserWindowHost` | `emscripten_request_animation_frame_loop` | Browser-vsync lifecycle |
| Scene | Managed retained compositor | Native semantic scene builder | Immutable ID/generation/update contract |
| Geometry materials | Managed brush-index compiler | Native deduplicated brush-index map | Exact curve/line colors without per-primitive draws |
| GPU | Managed backend | Native renderer | Same production WGSL resources |
| Presentation | WebGPU canvas | WebGPU canvas | Direct physical-pixel swapchain attachment |

MotionMark changed-scene preparation is O(N + G) for N segments and G groups. Stable frames reuse the serialized stream. The 1,000-segment qualification uses one geometry resource, one brush resource, one semantic command, one GPU draw, and roughly 132 KB of retained scene data.

Current optimized standalone payload is 700,374 bytes uncompressed: 628,799-byte WASM, 61,784-byte loader, 5,638-byte HTML shell, and 4,153-byte shared host module.

## Validation

- Native MotionMark Release contract test passes
- Existing native browser semantic renderer contract passes
- Pure C++ MotionMark gallery passes real Chromium WebGPU at DPR 1 and DPR 2
- DPR 2 framebuffer exactly matched 1240 x 921 physical pixels
- Complexity change from 1,000 to 250 elements presents a later GPU frame
- Managed browser/sample contract suite: 29/29 passed
- Managed Release browser project: 0 warnings, 0 errors
- JavaScript syntax and shell validation pass
- Release Emscripten publish succeeds
- `git diff --check` passes

## Research and provenance

The direct port provenance is recorded against the repository-owned `MotionMarkShowcaseVisual.cs`. Browser integration follows the WebGPU canvas presentation specification and official Emscripten Emdawnwebgpu, asynchronous main-loop, and optimized-build guidance. Full links and adopted/rejected architecture details are in `docs/NATIVE_CPP_BROWSER_GALLERY.md`.

