### PR TITLE
Native C++ browser text shaping showcase

### DIFF
--- a/docs/NATIVE_CPP_BROWSER_GALLERY.md
+++ b/docs/NATIVE_CPP_BROWSER_GALLERY.md
@@ -1,6 +1,7 @@
 # Pure C++ browser gallery
 
-Status: MotionMark first slice implemented and locally qualified on 2026-08-21.
+Status: MotionMark and native OpenType text-shaping slices implemented and
+locally qualified on 2026-08-21.
 
 ## Purpose
 
@@ -16,6 +17,14 @@ Its native implementation records the exact source provenance in
 [`progpu_native_motion_mark.hpp`](../src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp)
 and has a matched native contract test. No third-party MotionMark source was
 used.
+
+The second page ports the eight ProGPU-owned feature-wall cases from
+[`TextShapingShowcasePage.cs`](../src/ProGPU.Samples/Pages/TextShapingShowcasePage.cs)
+to [`progpu_native_text_shaping_showcase.cpp`](../src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp).
+It executes the native Unicode decoder, GSUB/GPOS shaper, TrueType outline
+decoder, semantic scene builder, compute glyph rasterizer, and shared
+production `Text.wgsl` shader. The page contains no pre-rendered text and uses
+no browser or platform text API.
 
 ## Shared managed/native browser architecture
 
@@ -67,6 +76,33 @@ quadratic and cubic GPU vertices use their inline color lanes for control-point
 metadata, while the shared brush table supplies their material. Lines, curves,
 caps, and joins therefore retain one group-end style without per-segment draws.
 
+## Text-shaping parity and quality contract
+
+| Managed feature wall | Native C++ implementation |
+| --- | --- |
+| Standard ligatures, kerning, fractions, slashed zero, stylistic set, contextual alternates, Romanian localization, and mark-to-mark positioning | The same eight feature tags, strings, language selection, and before/after comparison |
+| Unicode/OpenType shaping on the CPU | Native C++ Unicode decode plus GSUB lookups 1-8 and GPOS lookups 1-9 |
+| Retained glyph runs and cached outlines | One immutable semantic scene; unique source outlines are decoded once and reused across physical raster sizes |
+| Physical-pixel glyph coverage | Raster records are keyed by glyph and physical font size while sharing immutable source segments |
+| Canonical WebGPU text rendering | Native and managed backends consume the same `GlyphRasterizer.wgsl` and `Text.wgsl` resources |
+
+The page transfers the fetched font into native ownership once rather than
+copying it again inside the sample. A changed preset compiles once and publishes
+its scene generation; stable frames only render and submit. The Romanian case
+contains 267 positioned glyphs, 107 retained outline records, 11 draw commands,
+and a 73,992-byte semantic stream. Sharing source segments across raster sizes
+reduced that stream from 131,496 bytes by 43.7% while retaining full-resolution
+coverage.
+
+Linear filtering previously allowed a glyph quad near a packed-atlas tile edge
+to sample a neighboring tile. The canonical text shader now carries flat
+half-texel tile bounds and clamps every grayscale, ClearType, color, masked, and
+premultiplied atlas sample to its glyph tile. This preserves filtering inside
+the glyph while removing faint horizontal or vertical outlines around glyph
+quads. The corresponding source-contract and native retained-resource tests
+cover both backends; the algorithm and research record are in
+[`GPU_TEXT_COVERAGE_CACHE_ARCHITECTURE.md`](GPU_TEXT_COVERAGE_CACHE_ARCHITECTURE.md).
+
 ## WebGPU presentation and pixel quality
 
 The shared host measures the CSS canvas and assigns a backing width and height
@@ -107,28 +143,35 @@ for its compile and link phases. This matches Emscripten's [optimized build
 guidance](https://emscripten.org/docs/compiling/Building-Projects.html#building-projects-with-optimizations).
 It emits a native `.wasm` ahead of time rather than performing .NET AOT.
 
-Local optimized artifact sizes on 2026-08-21:
+Local optimized artifact sizes after the text-shaping slice on 2026-08-21:
 
-| Asset | Bytes |
-| --- | ---: |
-| `progpu_native_browser_gallery.wasm` | 628,799 |
-| `progpu_native_browser_gallery.js` | 61,784 |
-| `progpu_native_browser_gallery.html` | 5,638 |
-| shared `progpu-browser-host.js` | 4,153 |
-| Total | 700,374 |
+| Asset | Raw bytes | gzip -9 | Brotli -11 |
+| --- | ---: | ---: | ---: |
+| `progpu_native_browser_gallery.wasm` | 1,537,121 | 508,537 | 357,394 |
+| `progpu_native_browser_gallery.js` | 62,791 | 14,951 | 13,219 |
+| `progpu_native_browser_gallery.html` | 17,896 | 5,737 | 4,933 |
+| shared `progpu-browser-host.js` | 4,153 | 1,432 | 1,176 |
+| external `Inter-Regular.ttf` | 411,640 | 196,987 | 157,517 |
+| Total | 2,033,601 | 727,644 | 534,239 |
 
-Sizes are uncompressed filesystem bytes. HTTP Brotli/gzip transfer sizes are
-expected to be lower and are server-dependent.
+Compressed columns are deterministic local compression measurements; actual
+HTTP transfer sizes depend on the server. The executable Wasm is 1.47 MiB raw
+and contains the native renderer, semantic scene compiler, Unicode/OpenType
+text stack, outline decoder, and both gallery samples. Inter remains a separately
+cacheable font asset.
 
 ## Automated gates
 
 - `progpu_native_motion_mark_tests` verifies the managed sample's retained
   topology/group/update contracts with deterministic native data.
+- `progpu_native_text_shaping_showcase_tests` verifies the eight ported presets,
+  shaped glyph/outline metrics, retained scene reuse, and physical-size outline
+  records through the native C++20 text stack.
 - `eng/progpu-test-native-browser.sh` builds the Release Emscripten target and
   drives a real Chromium WebGPU context.
 - The browser gate asserts the pure-C++ renderer identity, actual canvas
-  swapchain presentation, one GPU draw, UI control round-trip, and exact
-  physical-pixel backing dimensions, then uploads a screenshot and JSON
-  contract.
+  swapchain presentation, MotionMark and text-page control round-trips, exact
+  physical-pixel backing dimensions, preset generation publication, and the
+  expected glyph/outline counts, then uploads screenshots and JSON contracts.
 - The existing Clang, GCC, and MSVC C++20 lanes compile the shared native sample
   model through the normal CMake graph.

--- a/docs/TEXT_SHAPING_SHOWCASE_RESEARCH.md
+++ b/docs/TEXT_SHAPING_SHOWCASE_RESEARCH.md
@@ -16,6 +16,12 @@ The page deliberately combines two views of the same result:
   and segment properties, following
   the role of HarfBuzz `hb-shape`.
 
+The pure C++ browser gallery now carries a deliberately smaller, performance-
+focused port of the managed feature wall. It preserves all eight before/after
+cases while using only the owned native Unicode/OpenType stack, retained
+semantic scene builder, and shared WebGPU shaders. DOM text is limited to the
+accessible gallery shell; every specimen pixel is produced by ProGPU C++.
+
 ## Primary sources
 
 - [HarfBuzz utilities](https://harfbuzz.github.io/utilities.html) documents
@@ -101,6 +107,41 @@ Rejected:
 - claiming unavailable platform font coverage as a shaper success;
 - changing raster quality, DPI snapping, cache invalidation, or GPU policy for a
   diagnostic page.
+
+## Native browser implementation
+
+The native page follows the same architecture rather than maintaining a second
+feature model:
+
+- the feature names, tags, strings, and Romanian language selection come from
+  the ProGPU-owned managed feature wall and record that in-repository
+  provenance beside the C++ table;
+- Unicode decoding and GSUB/GPOS shaping produce caller-owned glyph arrays;
+- TrueType outlines are decoded once per glyph into a shared immutable segment
+  range;
+- coverage records key physical raster size independently, allowing the title,
+  labels, and large comparison glyphs to reuse source geometry without blurring;
+- one semantic stream update publishes a generation, followed by one render
+  call and one GPU submission per displayed frame;
+- the font fetch is transferred into native ownership once, with no second
+  sample-level copy and no platform text API.
+
+The GPU atlas sampler is constrained to each glyph's half-texel inset tile
+bounds. This adapts WebGPU's whole-texture clamp semantics to a packed glyph
+atlas: a filtered lookup may combine adjacent texels, so clamping only at the
+texture edge cannot prevent neighboring glyph coverage from leaking into a
+quad. The native and managed implementations share the canonical `Text.wgsl`,
+therefore the quality correction is one implementation with matched source and
+retained-resource regressions rather than backend-specific shader forks. See
+[`GPU_TEXT_COVERAGE_CACHE_ARCHITECTURE.md`](GPU_TEXT_COVERAGE_CACHE_ARCHITECTURE.md)
+for the cross-engine comparison, exact complexity, and primary sources.
+
+Local Release qualification at DPR 2 produced exact physical backing sizes and
+no browser errors at both desktop and 390-pixel mobile viewports. The Romanian
+case contains 267 positioned glyphs, 107 outline records, 11 draws, and a
+73,992-byte stream. A 32-sample eight-preset browser benchmark on the same final
+local SwiftShader binary measured native update p50 1.90 ms, p95 2.30 ms, and
+maximum 2.60 ms. These are CPU update measurements, not discrete-GPU claims.
 
 ## Validation targets
 

--- a/eng/publish-progpu-native-browser-gallery.sh
+++ b/eng/publish-progpu-native-browser-gallery.sh
@@ -26,7 +26,8 @@ for asset in \
   progpu_native_browser_gallery.html \
   progpu_native_browser_gallery.js \
   progpu_native_browser_gallery.wasm \
-  progpu-browser-host.js; do
+  progpu-browser-host.js \
+  Inter-Regular.ttf; do
   cmake -E copy_if_different \
     "${build_dir}/${asset}" \
     "${publish_dir}/${asset}"

--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -1390,6 +1390,7 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
         "${CMAKE_CURRENT_SOURCE_DIR}/samples/Pages")
     target_compile_definitions(
         progpu_native_text_shaping_showcase_tests PRIVATE
+        PROGPU_NATIVE_BUILD=1
         "PROGPU_NATIVE_TEST_INTER_FONT=\"${CMAKE_CURRENT_SOURCE_DIR}/../ProGPU.Fonts.Inter/Fonts/Inter-Regular.ttf\"")
     target_link_libraries(
         progpu_native_text_shaping_showcase_tests PRIVATE

--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -1002,6 +1002,19 @@ target_link_libraries(progpu_native_motion_mark_sample PUBLIC
     progpu_native_scene_builder)
 progpu_native_enable_warnings(progpu_native_motion_mark_sample)
 
+add_library(progpu_native_text_shaping_showcase_sample STATIC
+    samples/Pages/progpu_native_text_shaping_showcase.cpp
+    samples/Pages/progpu_native_text_shaping_showcase.hpp)
+target_compile_features(
+    progpu_native_text_shaping_showcase_sample PUBLIC cxx_std_20)
+target_include_directories(progpu_native_text_shaping_showcase_sample PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}/samples/Pages")
+target_link_libraries(progpu_native_text_shaping_showcase_sample PUBLIC
+    progpu_native_scene_builder
+    progpu_native_text)
+progpu_native_enable_warnings(progpu_native_text_shaping_showcase_sample)
+
 if(EMSCRIPTEN)
     add_library(progpu_native_browser_renderer_objects OBJECT
         ${PROGPU_NATIVE_RENDERER_SOURCES})
@@ -1108,10 +1121,12 @@ if(EMSCRIPTEN)
         "${CMAKE_CURRENT_SOURCE_DIR}/browser"
         "${CMAKE_CURRENT_SOURCE_DIR}/browser/include"
         "${CMAKE_CURRENT_SOURCE_DIR}/samples/Views"
+        "${CMAKE_CURRENT_SOURCE_DIR}/samples/Pages"
         "${generated_directory}")
     target_link_libraries(progpu_native_browser_gallery PRIVATE
         progpu_native_image
         progpu_native_motion_mark_sample
+        progpu_native_text_shaping_showcase_sample
         progpu_native_scene_builder
         progpu_native_text)
     target_compile_options(progpu_native_browser_gallery PRIVATE
@@ -1126,6 +1141,7 @@ if(EMSCRIPTEN)
         -sEXIT_RUNTIME=0
         -sENVIRONMENT=web
         -sFILESYSTEM=0
+        "-sEXPORTED_RUNTIME_METHODS=['HEAPU8']"
         $<$<CONFIG:Release>:-O3>
         $<$<CONFIG:Release>:-flto>
         $<$<CONFIG:Release>:-sASSERTIONS=0>)
@@ -1138,6 +1154,9 @@ if(EMSCRIPTEN)
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different
             "${CMAKE_CURRENT_SOURCE_DIR}/../ProGPU.Browser/BrowserAssets/progpu-browser-host.js"
             "$<TARGET_FILE_DIR:progpu_native_browser_gallery>/progpu-browser-host.js"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/../ProGPU.Fonts.Inter/Fonts/Inter-Regular.ttf"
+            "$<TARGET_FILE_DIR:progpu_native_browser_gallery>/Inter-Regular.ttf"
         VERBATIM)
 endif()
 
@@ -1359,6 +1378,31 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
         COMMAND progpu_native_motion_mark_tests)
     set_tests_properties(
         progpu_native_motion_mark_tests PROPERTIES TIMEOUT 60)
+
+    add_executable(progpu_native_text_shaping_showcase_tests
+        tests/progpu_native_text_shaping_showcase_tests.cpp
+        src/Text/Interop/progpu_native_text_shaping_interop.cpp)
+    target_compile_features(
+        progpu_native_text_shaping_showcase_tests PRIVATE cxx_std_20)
+    target_include_directories(
+        progpu_native_text_shaping_showcase_tests PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/samples/Pages")
+    target_compile_definitions(
+        progpu_native_text_shaping_showcase_tests PRIVATE
+        "PROGPU_NATIVE_TEST_INTER_FONT=\"${CMAKE_CURRENT_SOURCE_DIR}/../ProGPU.Fonts.Inter/Fonts/Inter-Regular.ttf\"")
+    target_link_libraries(
+        progpu_native_text_shaping_showcase_tests PRIVATE
+        progpu_native_text_shaping_showcase_sample)
+    progpu_native_enable_warnings(
+        progpu_native_text_shaping_showcase_tests)
+    progpu_native_enable_sanitizers(
+        progpu_native_text_shaping_showcase_tests)
+    add_test(
+        NAME progpu_native_text_shaping_showcase_tests
+        COMMAND progpu_native_text_shaping_showcase_tests)
+    set_tests_properties(
+        progpu_native_text_shaping_showcase_tests PROPERTIES TIMEOUT 60)
 
     if(PROGPU_NATIVE_BUILD_WGPU_TARGET)
     add_executable(progpu_native_text_interop_tests

--- a/src/ProGPU.Native/README.md
+++ b/src/ProGPU.Native/README.md
@@ -809,8 +809,13 @@ PROGPU_NATIVE_BROWSER_INSTALL_CHROMIUM=1 \
 ```
 
 The same browser lane also builds and exercises the production-style pure C++
-gallery with MotionMark as its first sample. Publish its optimized C++20/LTO
-WebAssembly files without a .NET runtime using:
+gallery. Its MotionMark page covers retained vector animation; its text-shaping
+laboratory ports the managed eight-case feature wall through the native
+Unicode/OpenType shaper, TrueType outline decoder, retained physical-size glyph
+coverage, and shared production WebGPU text shaders. Neither page uses a DOM,
+Canvas2D, platform-text, or pre-rendered-pixel fallback inside the render
+surface. Publish the optimized C++20/LTO WebAssembly files without a .NET
+runtime using:
 
 ```sh
 ./eng/publish-progpu-native-browser-gallery.sh

--- a/src/ProGPU.Native/browser/gallery_shell.html
+++ b/src/ProGPU.Native/browser/gallery_shell.html
@@ -22,13 +22,16 @@
     .workspace { min-height: 0; display: grid; grid-template-columns: 224px minmax(0, 1fr); }
     nav { padding: 24px 14px; border-right: 1px solid #ffffff12; background: #0d0f18d9; }
     .nav-label { padding: 0 12px 10px; color: #666f87; font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
-    .nav-item { width: 100%; display: flex; gap: 10px; align-items: center; padding: 11px 12px; border: 1px solid #4c7fd33d; border-radius: 10px; color: #eef4ff; background: #24487948; text-align: left; }
+    .nav-item { width: 100%; display: flex; gap: 10px; align-items: center; padding: 11px 12px; border: 1px solid transparent; border-radius: 10px; color: #929bb2; background: transparent; text-align: left; cursor: pointer; }
+    .nav-item + .nav-item { margin-top: 6px; }
+    .nav-item.active { border-color: #4c7fd33d; color: #eef4ff; background: #24487948; }
     .nav-item span { color: #7bbcff; }
     main { min-width: 0; padding: clamp(18px, 3vw, 38px); overflow: auto; }
     .intro { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 18px; }
     h2 { margin: 0; font-size: clamp(25px, 4vw, 40px); letter-spacing: -.045em; }
     .intro p { max-width: 720px; margin: 7px 0 0; color: #8f98b0; line-height: 1.5; }
     .controls { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; }
+    .controls[hidden] { display: none; }
     .control { min-height: 40px; padding: 0 14px; border: 1px solid #ffffff19; border-radius: 9px; color: #edf1ff; background: #202431; }
     button.control { cursor: pointer; }
     button.control:hover { border-color: #4d98ff; background: #293044; }
@@ -56,13 +59,17 @@
       <div class="badge">C++20 · WASM AOT · WEBGPU</div>
     </header>
     <div class="workspace">
-      <nav><div class="nav-label">Native samples</div><button class="nav-item"><span>◉</span> MotionMark</button></nav>
+      <nav>
+        <div class="nav-label">Native samples</div>
+        <button id="sample-motion" class="nav-item active"><span>◉</span> MotionMark</button>
+        <button id="sample-text" class="nav-item"><span>Aa</span> Text shaping</button>
+      </nav>
       <main>
         <section class="intro">
-          <div><h2>MotionMark</h2><p>Mixed line, quadratic, and cubic paths animated through one immutable native semantic stream and the production ProGPU GPU pipeline.</p></div>
+          <div><h2 id="sample-title">MotionMark</h2><p id="sample-description">Mixed line, quadratic, and cubic paths animated through one immutable native semantic stream and the production ProGPU GPU pipeline.</p></div>
           <div id="status-message">Initializing native WebGPU…</div>
         </section>
-        <div class="controls">
+        <div id="motion-controls" class="controls">
           <select id="complexity" class="control" aria-label="Shape count">
             <option value="250">250 segments</option><option value="1000" selected>1,000 segments</option><option value="2500">2,500 segments</option><option value="5000">5,000 segments</option>
           </select>
@@ -72,12 +79,25 @@
           <button id="pause" class="control">Pause</button>
           <button id="regenerate" class="control">Regenerate</button>
         </div>
+        <div id="text-controls" class="controls" hidden>
+          <select id="text-preset" class="control" aria-label="OpenType feature specimen">
+            <option value="0">liga · Standard ligatures</option>
+            <option value="1">kern · Pair positioning</option>
+            <option value="2">frac · Automatic fractions</option>
+            <option value="3">zero · Slashed zero</option>
+            <option value="4">ss01 · Stylistic set 01</option>
+            <option value="5">calt · Contextual alternates</option>
+            <option value="6">locl · Localized Romanian</option>
+            <option value="7">mkmk · Mark-to-mark</option>
+          </select>
+          <span class="control" aria-label="Font asset">Inter Regular · separate 404 KiB asset</span>
+        </div>
         <div class="stage">
-          <canvas id="progpu-canvas" aria-label="Pure C++ ProGPU MotionMark rendering surface"></canvas>
+          <canvas id="progpu-canvas" aria-label="Pure C++ ProGPU rendering surface"></canvas>
           <div class="metrics">
             <div class="metric">FPS <strong id="metric-fps">0</strong></div>
-            <div class="metric">segments <strong id="metric-elements">0</strong></div>
-            <div class="metric">groups <strong id="metric-groups">0</strong></div>
+            <div class="metric"><span id="metric-elements-label">segments</span> <strong id="metric-elements">0</strong></div>
+            <div class="metric"><span id="metric-groups-label">groups</span> <strong id="metric-groups">0</strong></div>
             <div class="metric">GPU draws <strong id="metric-draws">0</strong></div>
             <div class="metric">scene <strong id="metric-bytes">0 B</strong></div>
             <div class="metric">DPR <strong id="metric-dpr">1</strong></div>
@@ -92,6 +112,43 @@
       const palette = document.querySelector('#palette');
       const pause = document.querySelector('#pause');
       const regenerate = document.querySelector('#regenerate');
+      const motionButton = document.querySelector('#sample-motion');
+      const textButton = document.querySelector('#sample-text');
+      const motionControls = document.querySelector('#motion-controls');
+      const textControls = document.querySelector('#text-controls');
+      const textPreset = document.querySelector('#text-preset');
+      const title = document.querySelector('#sample-title');
+      const description = document.querySelector('#sample-description');
+      const status = document.querySelector('#status-message');
+      let fontPromise;
+
+      const showSampleUi = sample => {
+        const text = sample === 1;
+        motionButton.classList.toggle('active', !text);
+        textButton.classList.toggle('active', text);
+        motionControls.hidden = text;
+        textControls.hidden = !text;
+        title.textContent = text ? 'Text shaping' : 'MotionMark';
+        description.textContent = text
+          ? 'The managed Text Shaping Showcase feature wall ported to pure C++: one native OpenType result feeds retained glyph outlines and the production WebGPU text pipeline.'
+          : 'Mixed line, quadratic, and cubic paths animated through one immutable native semantic stream and the production ProGPU GPU pipeline.';
+        document.querySelector('#metric-elements-label').textContent = text ? 'glyphs' : 'segments';
+        document.querySelector('#metric-groups-label').textContent = text ? 'outlines' : 'groups';
+      };
+
+      const ensureFont = () => fontPromise ??= (async () => {
+        status.textContent = 'Loading the separate Inter font asset…';
+        const response = await fetch('Inter-Regular.ttf');
+        if (!response.ok) throw new Error(`Font request failed: ${response.status}`);
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const pointer = Module._progpu_native_gallery_prepare_font(bytes.byteLength);
+        if (!pointer) throw new Error('Native font staging allocation failed.');
+        Module.HEAPU8.set(bytes, pointer);
+        if (Module._progpu_native_gallery_commit_font(bytes.byteLength) === 0) {
+          throw new Error('The native OpenType stack rejected the font asset.');
+        }
+        document.body.dataset.progpuNativeFontBytes = String(bytes.byteLength);
+      })();
 
       complexity.addEventListener('change', event => Module._progpu_native_gallery_set_element_count(Number(event.target.value)));
       palette.addEventListener('change', event => Module._progpu_native_gallery_set_color_mode(Number(event.target.value)));
@@ -100,6 +157,28 @@
         pause.textContent = paused ? 'Resume' : 'Pause';
       });
       regenerate.addEventListener('click', () => Module._progpu_native_gallery_regenerate());
+      motionButton.addEventListener('click', () => {
+        Module._progpu_native_gallery_set_sample(0);
+        showSampleUi(0);
+      });
+      textButton.addEventListener('click', async () => {
+        textButton.disabled = true;
+        try {
+          await ensureFont();
+          if (Module._progpu_native_gallery_set_sample(1) !== 1) {
+            throw new Error('The native text sample did not activate.');
+          }
+          showSampleUi(1);
+        } catch (error) {
+          document.body.dataset.progpuNativeError = String(error);
+          status.textContent = String(error);
+          console.error(error);
+        } finally {
+          textButton.disabled = false;
+        }
+      });
+      textPreset.addEventListener('change', event =>
+        Module._progpu_native_gallery_set_text_preset(Number(event.target.value)));
     });
   </script>
   {{{ SCRIPT }}}

--- a/src/ProGPU.Native/browser/gallery_shell.html
+++ b/src/ProGPU.Native/browser/gallery_shell.html
@@ -90,6 +90,7 @@
             <option value="6">locl · Localized Romanian</option>
             <option value="7">mkmk · Mark-to-mark</option>
           </select>
+          <button id="benchmark-text" class="control">Benchmark all presets</button>
           <span class="control" aria-label="Font asset">Inter Regular · separate 404 KiB asset</span>
         </div>
         <div class="stage">
@@ -100,6 +101,9 @@
             <div class="metric"><span id="metric-groups-label">groups</span> <strong id="metric-groups">0</strong></div>
             <div class="metric">GPU draws <strong id="metric-draws">0</strong></div>
             <div class="metric">scene <strong id="metric-bytes">0 B</strong></div>
+            <div class="metric">update <strong id="metric-update">0 ms</strong></div>
+            <div class="metric">preset p95 <strong id="metric-benchmark">—</strong></div>
+            <div class="metric">Wasm <strong id="metric-wasm">—</strong></div>
             <div class="metric">DPR <strong id="metric-dpr">1</strong></div>
           </div>
         </div>
@@ -117,6 +121,7 @@
       const motionControls = document.querySelector('#motion-controls');
       const textControls = document.querySelector('#text-controls');
       const textPreset = document.querySelector('#text-preset');
+      const benchmarkText = document.querySelector('#benchmark-text');
       const title = document.querySelector('#sample-title');
       const description = document.querySelector('#sample-description');
       const status = document.querySelector('#status-message');
@@ -150,6 +155,15 @@
         document.body.dataset.progpuNativeFontBytes = String(bytes.byteLength);
       })();
 
+      fetch('progpu_native_browser_gallery.wasm', { method: 'HEAD' })
+        .then(response => Number(response.headers.get('content-length')))
+        .then(bytes => {
+          if (!Number.isFinite(bytes) || bytes <= 0) return;
+          document.body.dataset.progpuNativeWasmBytes = String(bytes);
+          document.querySelector('#metric-wasm').textContent =
+            (bytes / (1024 * 1024)).toFixed(2) + ' MiB';
+        });
+
       complexity.addEventListener('change', event => Module._progpu_native_gallery_set_element_count(Number(event.target.value)));
       palette.addEventListener('change', event => Module._progpu_native_gallery_set_color_mode(Number(event.target.value)));
       pause.addEventListener('click', () => {
@@ -179,6 +193,51 @@
       });
       textPreset.addEventListener('change', event =>
         Module._progpu_native_gallery_set_text_preset(Number(event.target.value)));
+      benchmarkText.addEventListener('click', async () => {
+        benchmarkText.disabled = true;
+        const samples = [];
+        try {
+          for (let round = 0; round < 4; round++) {
+            for (let step = 0; step < textPreset.options.length; step++) {
+              const preset = (step + 1) % textPreset.options.length;
+              textPreset.value = String(preset);
+              Module._progpu_native_gallery_set_text_preset(preset);
+              await new Promise((resolve, reject) => {
+                const started = performance.now();
+                const poll = () => {
+                  if (document.body.dataset.progpuNativeTextPreset === String(preset)) {
+                    resolve();
+                  } else if (performance.now() - started > 5000) {
+                    reject(new Error('Preset benchmark timed out.'));
+                  } else {
+                    requestAnimationFrame(poll);
+                  }
+                };
+                requestAnimationFrame(poll);
+              });
+              samples.push(Number(
+                document.body.dataset.progpuNativeUpdateMilliseconds));
+            }
+          }
+          samples.sort((left, right) => left - right);
+          const percentile = value => samples[
+            Math.min(samples.length - 1, Math.ceil(samples.length * value) - 1)];
+          const p50 = percentile(0.50);
+          const p95 = percentile(0.95);
+          const maximum = samples[samples.length - 1];
+          document.querySelector('#metric-benchmark').textContent =
+            p95.toFixed(2) + ' ms';
+          document.body.dataset.progpuNativeBenchmarkSamples = String(samples.length);
+          document.body.dataset.progpuNativeBenchmarkP50 = String(p50);
+          document.body.dataset.progpuNativeBenchmarkP95 = String(p95);
+          document.body.dataset.progpuNativeBenchmarkMax = String(maximum);
+        } catch (error) {
+          status.textContent = String(error);
+          console.error(error);
+        } finally {
+          benchmarkText.disabled = false;
+        }
+      });
     });
   </script>
   {{{ SCRIPT }}}

--- a/src/ProGPU.Native/browser/gallery_shell.html
+++ b/src/ProGPU.Native/browser/gallery_shell.html
@@ -7,47 +7,191 @@
   <link rel="icon" href="data:,">
   <title>ProGPU Native C++ Gallery</title>
   <style>
-    :root { font: 15px Inter, ui-sans-serif, system-ui, sans-serif; color: #f4f6ff; background: #070911; }
+    :root {
+      font: 15px Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+      color: #f5f7ff;
+      background: #080910;
+      --surface: #0d0f18;
+      --surface-raised: #131620;
+      --line: #ffffff14;
+      --muted: #8d96ab;
+      --quiet: #626b7e;
+      --accent: #5aa9ff;
+      --accent-strong: #168fff;
+    }
     * { box-sizing: border-box; }
     html, body { width: 100%; min-height: 100%; margin: 0; }
-    body { min-height: 100dvh; background: radial-gradient(circle at 70% 0%, #182244 0, #090b15 36%, #05060b 100%); }
+    body { min-height: 100dvh; background: #080910; }
     button, select { font: inherit; }
-    .app { min-height: 100dvh; display: grid; grid-template-rows: auto 1fr; }
-    header { min-height: 68px; display: flex; align-items: center; gap: 18px; padding: 14px clamp(18px, 3vw, 44px); border-bottom: 1px solid #ffffff14; background: #090a11d9; backdrop-filter: blur(18px); }
-    .mark { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 10px; background: linear-gradient(145deg, #168fff, #6559ff); font-weight: 900; }
-    .title { min-width: 0; }
-    h1 { margin: 0; font-size: clamp(18px, 2vw, 24px); letter-spacing: -.03em; }
-    .subtitle { margin-top: 3px; color: #9098ae; font-size: 12px; }
-    .badge { margin-left: auto; padding: 7px 10px; border: 1px solid #65a9ff4a; border-radius: 999px; color: #9bc8ff; background: #1164bd20; font: 700 11px ui-monospace, monospace; white-space: nowrap; }
-    .workspace { min-height: 0; display: grid; grid-template-columns: 224px minmax(0, 1fr); }
-    nav { padding: 24px 14px; border-right: 1px solid #ffffff12; background: #0d0f18d9; }
-    .nav-label { padding: 0 12px 10px; color: #666f87; font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
-    .nav-item { width: 100%; display: flex; gap: 10px; align-items: center; padding: 11px 12px; border: 1px solid transparent; border-radius: 10px; color: #929bb2; background: transparent; text-align: left; cursor: pointer; }
-    .nav-item + .nav-item { margin-top: 6px; }
-    .nav-item.active { border-color: #4c7fd33d; color: #eef4ff; background: #24487948; }
-    .nav-item span { color: #7bbcff; }
-    main { min-width: 0; padding: clamp(18px, 3vw, 38px); overflow: auto; }
+    button:focus-visible, select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .app { min-height: 100dvh; display: grid; grid-template-rows: 64px minmax(0, 1fr); }
+    header {
+      z-index: 3;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 0 clamp(18px, 3vw, 42px);
+      border-bottom: 1px solid var(--line);
+      background: #090a11eb;
+      backdrop-filter: blur(18px);
+    }
+    .mark {
+      width: 32px;
+      height: 32px;
+      display: grid;
+      place-items: center;
+      border-radius: 9px;
+      background: var(--accent-strong);
+      color: white;
+      font-weight: 900;
+      letter-spacing: -.06em;
+      box-shadow: 0 0 32px #168fff40;
+    }
+    .brand { min-width: 0; display: flex; align-items: baseline; gap: 9px; }
+    h1 { margin: 0; font-size: 18px; letter-spacing: -.035em; white-space: nowrap; }
+    .brand-subtitle { color: var(--quiet); font-size: 12px; white-space: nowrap; }
+    .badge {
+      margin-left: auto;
+      color: #a9cff8;
+      font: 700 10px ui-monospace, SFMono-Regular, monospace;
+      letter-spacing: .08em;
+      white-space: nowrap;
+    }
+    .workspace { min-height: 0; display: grid; grid-template-columns: 196px minmax(0, 1fr); }
+    nav { padding: 28px 16px; border-right: 1px solid var(--line); background: #0a0c13; }
+    .nav-label { padding: 0 10px 12px; color: var(--quiet); font-size: 10px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+    .nav-item {
+      width: 100%;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      gap: 11px;
+      padding: 0 10px;
+      border: 0;
+      border-radius: 8px;
+      color: var(--muted);
+      background: transparent;
+      text-align: left;
+      cursor: pointer;
+      transition: color 140ms ease, background 140ms ease, transform 140ms ease;
+    }
+    .nav-item + .nav-item { margin-top: 4px; }
+    .nav-item:hover { color: #e8edfb; background: #ffffff08; transform: translateX(2px); }
+    .nav-item.active { color: white; background: #1d3556; }
+    .nav-icon { width: 24px; color: var(--accent); font: 700 12px ui-monospace, monospace; }
+    main { min-width: 0; padding: clamp(22px, 3vw, 40px); overflow: auto; animation: reveal 360ms ease-out both; }
     .intro { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 18px; }
-    h2 { margin: 0; font-size: clamp(25px, 4vw, 40px); letter-spacing: -.045em; }
-    .intro p { max-width: 720px; margin: 7px 0 0; color: #8f98b0; line-height: 1.5; }
-    .controls { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; }
+    .eyebrow { margin-bottom: 7px; color: var(--accent); font: 700 10px ui-monospace, monospace; letter-spacing: .14em; text-transform: uppercase; }
+    h2 { margin: 0; font-size: clamp(26px, 3.4vw, 42px); letter-spacing: -.05em; line-height: .98; }
+    .intro p { max-width: 760px; margin: 10px 0 0; color: var(--muted); line-height: 1.45; }
+    #status-message { flex: 0 0 auto; color: #788297; font: 11px ui-monospace, monospace; white-space: nowrap; }
+    .controls { display: flex; flex-wrap: wrap; gap: 9px; margin-bottom: 15px; }
     .controls[hidden] { display: none; }
-    .control { min-height: 40px; padding: 0 14px; border: 1px solid #ffffff19; border-radius: 9px; color: #edf1ff; background: #202431; }
-    button.control { cursor: pointer; }
-    button.control:hover { border-color: #4d98ff; background: #293044; }
-    .stage { position: relative; overflow: hidden; min-height: 340px; height: min(68vh, 720px); border: 1px solid #ffffff1b; border-radius: 16px; background: #202026; box-shadow: 0 28px 90px #0008; }
+    .control {
+      min-height: 39px;
+      padding: 0 13px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      color: #eef2ff;
+      background: #171a24;
+    }
+    button.control { cursor: pointer; transition: border-color 140ms ease, background 140ms ease, transform 140ms ease; }
+    button.control:hover { border-color: #5aa9ff80; background: #1d2432; transform: translateY(-1px); }
+    button.control:disabled { cursor: wait; opacity: .62; transform: none; }
+    .text-workbench {
+      display: grid;
+      grid-template-columns: minmax(0, 1.4fr) minmax(0, .6fr);
+      gap: clamp(20px, 3vw, 40px);
+      padding: 16px 0 18px;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }
+    .text-workbench > * { min-width: 0; }
+    .workbench-label { margin-bottom: 10px; color: var(--quiet); font: 700 10px ui-monospace, monospace; letter-spacing: .12em; text-transform: uppercase; }
+    .preset-grid { min-width: 0; max-width: 100%; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 6px; }
+    .preset-option {
+      min-width: 0;
+      height: 45px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 10px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      color: #929bb0;
+      background: #11131c;
+      cursor: pointer;
+      text-align: left;
+      transition: color 140ms ease, background 140ms ease, border-color 140ms ease;
+    }
+    .preset-option code { color: #6bb4ff; font: 700 11px ui-monospace, monospace; }
+    .preset-option span { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+    .preset-option:hover { color: #e8edfa; background: #171b26; }
+    .preset-option.active { border-color: #5aa9ff52; color: white; background: #18314f; }
+    .feature-context { min-width: 0; display: flex; flex-direction: column; justify-content: space-between; }
+    .feature-heading { display: flex; align-items: baseline; gap: 10px; }
+    #feature-tag { color: var(--accent); font: 800 18px ui-monospace, monospace; }
+    #feature-name { color: #e9edf9; font-weight: 700; }
+    #feature-detail { min-height: 38px; margin: 7px 0 13px; color: var(--muted); font-size: 12px; line-height: 1.5; }
+    .lab-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 9px; }
+    .asset-note { color: #7f899e; font: 10px ui-monospace, monospace; }
+    #benchmark-output { color: #8dbff4; font: 10px ui-monospace, monospace; }
+    #benchmark-text.running { animation: pulse 900ms ease-in-out infinite alternate; }
+    #text-preset { display: none; }
+    .stage {
+      position: relative;
+      overflow: hidden;
+      min-height: 420px;
+      height: min(64vh, 720px);
+      margin-top: 15px;
+      border: 1px solid #ffffff1a;
+      border-radius: 14px;
+      background: #11131b;
+      box-shadow: 0 24px 70px #0007;
+    }
     #progpu-canvas { display: block; width: 100%; height: 100%; touch-action: none; }
-    .metrics { position: absolute; left: 14px; right: 14px; bottom: 14px; display: flex; flex-wrap: wrap; gap: 8px; pointer-events: none; }
-    .metric { padding: 7px 10px; border: 1px solid #ffffff1c; border-radius: 8px; background: #080b14d9; color: #9fa8be; font: 11px ui-monospace, monospace; backdrop-filter: blur(10px); }
-    .metric strong { color: #62adff; }
-    #status-message { color: #7f899f; font: 12px ui-monospace, monospace; }
+    .telemetry {
+      display: grid;
+      grid-template-columns: repeat(9, minmax(74px, 1fr));
+      margin-top: 10px;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }
+    .metric { min-width: 0; padding: 10px 9px; color: #717a8d; font: 9px ui-monospace, monospace; text-transform: uppercase; }
+    .metric + .metric { border-left: 1px solid var(--line); }
+    .metric strong { display: block; margin-top: 4px; overflow: hidden; color: #dce7f8; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; text-transform: none; }
+    .metric:first-child strong, .metric:nth-child(6) strong, .metric:nth-child(7) strong { color: var(--accent); }
+    @keyframes reveal { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: none; } }
+    @keyframes pulse { from { border-color: #5aa9ff45; } to { border-color: #5aa9ff; } }
+    @media (max-width: 1040px) {
+      .brand-subtitle { display: none; }
+      .text-workbench { grid-template-columns: minmax(0, 1fr); }
+      .preset-grid { grid-template-columns: repeat(4, minmax(100px, 1fr)); }
+      .telemetry { grid-template-columns: repeat(5, 1fr); }
+      .metric:nth-child(6) { border-left: 0; }
+    }
     @media (max-width: 760px) {
+      .app { grid-template-rows: 58px auto auto; }
+      header { padding: 0 16px; }
       .badge { display: none; }
-      .workspace { grid-template-columns: 1fr; }
-      nav { display: none; }
-      main { padding: 16px; }
-      .intro { align-items: start; flex-direction: column; }
-      .stage { height: 58vh; min-height: 360px; }
+      .workspace { display: contents; }
+      nav { z-index: 2; display: flex; gap: 4px; padding: 8px 12px; overflow-x: auto; border: 0; border-bottom: 1px solid var(--line); }
+      .nav-label { display: none; }
+      .nav-item { width: auto; flex: 0 0 auto; padding: 0 13px; }
+      .nav-item + .nav-item { margin: 0; }
+      main { padding: 18px 14px 26px; overflow: visible; }
+      .intro { align-items: start; flex-direction: column; gap: 10px; }
+      #status-message { white-space: normal; }
+      .text-workbench { gap: 14px; padding-top: 12px; }
+      .preset-grid { display: flex; overflow-x: auto; scroll-snap-type: x mandatory; }
+      .preset-option { flex: 0 0 132px; scroll-snap-align: start; }
+      .stage { height: 58vh; min-height: 420px; margin-top: 12px; }
+      .telemetry { grid-template-columns: repeat(3, 1fr); }
+      .metric:nth-child(4), .metric:nth-child(7) { border-left: 0; }
+      .metric:nth-child(6) { border-left: 1px solid var(--line); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
     }
   </style>
 </head>
@@ -55,20 +199,25 @@
   <div class="app">
     <header>
       <div class="mark">P</div>
-      <div class="title"><h1>ProGPU Native C++ Gallery</h1><div class="subtitle">The shared ProGPU architecture compiled directly to WebAssembly</div></div>
-      <div class="badge">C++20 · WASM AOT · WEBGPU</div>
+      <div class="brand"><h1>ProGPU Native</h1><div class="brand-subtitle">C++ rendering laboratory</div></div>
+      <div class="badge">C++20 / WASM AOT / WEBGPU</div>
     </header>
     <div class="workspace">
-      <nav>
+      <nav aria-label="Native samples">
         <div class="nav-label">Native samples</div>
-        <button id="sample-motion" class="nav-item active"><span>◉</span> MotionMark</button>
-        <button id="sample-text" class="nav-item"><span>Aa</span> Text shaping</button>
+        <button id="sample-motion" class="nav-item active"><span class="nav-icon">◉</span> MotionMark</button>
+        <button id="sample-text" class="nav-item"><span class="nav-icon">Aa</span> Text shaping</button>
       </nav>
-      <main>
+      <main data-sample="motion">
         <section class="intro">
-          <div><h2 id="sample-title">MotionMark</h2><p id="sample-description">Mixed line, quadratic, and cubic paths animated through one immutable native semantic stream and the production ProGPU GPU pipeline.</p></div>
-          <div id="status-message">Initializing native WebGPU…</div>
+          <div>
+            <div class="eyebrow" id="sample-eyebrow">Native vector workload</div>
+            <h2 id="sample-title">MotionMark</h2>
+            <p id="sample-description">Mixed analytic paths animated through one immutable semantic stream and the production ProGPU WebGPU pipeline.</p>
+          </div>
+          <div id="status-message" role="status">Initializing native WebGPU…</div>
         </section>
+
         <div id="motion-controls" class="controls">
           <select id="complexity" class="control" aria-label="Shape count">
             <option value="250">250 segments</option><option value="1000" selected>1,000 segments</option><option value="2500">2,500 segments</option><option value="5000">5,000 segments</option>
@@ -79,33 +228,51 @@
           <button id="pause" class="control">Pause</button>
           <button id="regenerate" class="control">Regenerate</button>
         </div>
-        <div id="text-controls" class="controls" hidden>
-          <select id="text-preset" class="control" aria-label="OpenType feature specimen">
-            <option value="0">liga · Standard ligatures</option>
-            <option value="1">kern · Pair positioning</option>
-            <option value="2">frac · Automatic fractions</option>
-            <option value="3">zero · Slashed zero</option>
-            <option value="4">ss01 · Stylistic set 01</option>
-            <option value="5">calt · Contextual alternates</option>
-            <option value="6">locl · Localized Romanian</option>
-            <option value="7">mkmk · Mark-to-mark</option>
-          </select>
-          <button id="benchmark-text" class="control">Benchmark all presets</button>
-          <span class="control" aria-label="Font asset">Inter Regular · separate 404 KiB asset</span>
-        </div>
+
+        <section id="text-controls" class="text-workbench" hidden aria-label="OpenType feature laboratory">
+          <div>
+            <div class="workbench-label">Feature wall · choose a comparison</div>
+            <select id="text-preset" aria-label="OpenType feature specimen">
+              <option value="0">liga · Standard ligatures</option><option value="1">kern · Pair positioning</option><option value="2">frac · Automatic fractions</option><option value="3">zero · Slashed zero</option><option value="4">ss01 · Stylistic set 01</option><option value="5">calt · Contextual alternates</option><option value="6">locl · Localized Romanian</option><option value="7">mkmk · Mark-to-mark</option>
+            </select>
+            <div class="preset-grid" role="group" aria-label="OpenType feature specimens">
+              <button class="preset-option active" data-preset="0" aria-pressed="true"><code>liga</code><span>Ligatures</span></button>
+              <button class="preset-option" data-preset="1" aria-pressed="false"><code>kern</code><span>Kerning</span></button>
+              <button class="preset-option" data-preset="2" aria-pressed="false"><code>frac</code><span>Fractions</span></button>
+              <button class="preset-option" data-preset="3" aria-pressed="false"><code>zero</code><span>Slashed zero</span></button>
+              <button class="preset-option" data-preset="4" aria-pressed="false"><code>ss01</code><span>Stylistic set</span></button>
+              <button class="preset-option" data-preset="5" aria-pressed="false"><code>calt</code><span>Contextual</span></button>
+              <button class="preset-option" data-preset="6" aria-pressed="false"><code>locl</code><span>Romanian</span></button>
+              <button class="preset-option" data-preset="7" aria-pressed="false"><code>mkmk</code><span>Mark stacking</span></button>
+            </div>
+          </div>
+          <div class="feature-context">
+            <div>
+              <div class="workbench-label">Selected capability</div>
+              <div class="feature-heading"><span id="feature-tag">liga</span><span id="feature-name">Standard ligatures</span></div>
+              <p id="feature-detail">Compare independent glyphs with the GSUB ligature substitution produced by the native shaper.</p>
+            </div>
+            <div class="lab-actions">
+              <button id="benchmark-text" class="control">Benchmark 8 presets</button>
+              <span class="asset-note">Inter Regular · 404 KiB external asset</span>
+              <span id="benchmark-output" aria-live="polite"></span>
+            </div>
+          </div>
+        </section>
+
         <div class="stage">
           <canvas id="progpu-canvas" aria-label="Pure C++ ProGPU rendering surface"></canvas>
-          <div class="metrics">
-            <div class="metric">FPS <strong id="metric-fps">0</strong></div>
-            <div class="metric"><span id="metric-elements-label">segments</span> <strong id="metric-elements">0</strong></div>
-            <div class="metric"><span id="metric-groups-label">groups</span> <strong id="metric-groups">0</strong></div>
-            <div class="metric">GPU draws <strong id="metric-draws">0</strong></div>
-            <div class="metric">scene <strong id="metric-bytes">0 B</strong></div>
-            <div class="metric">update <strong id="metric-update">0 ms</strong></div>
-            <div class="metric">preset p95 <strong id="metric-benchmark">—</strong></div>
-            <div class="metric">Wasm <strong id="metric-wasm">—</strong></div>
-            <div class="metric">DPR <strong id="metric-dpr">1</strong></div>
-          </div>
+        </div>
+        <div class="telemetry" aria-label="Native renderer metrics">
+          <div class="metric">FPS<strong id="metric-fps">0</strong></div>
+          <div class="metric"><span id="metric-elements-label">segments</span><strong id="metric-elements">0</strong></div>
+          <div class="metric"><span id="metric-groups-label">groups</span><strong id="metric-groups">0</strong></div>
+          <div class="metric">GPU draws<strong id="metric-draws">0</strong></div>
+          <div class="metric">scene stream<strong id="metric-bytes">0 B</strong></div>
+          <div class="metric">native update<strong id="metric-update">0 ms</strong></div>
+          <div class="metric">preset p95<strong id="metric-benchmark">—</strong></div>
+          <div class="metric">Wasm HEAD<strong id="metric-wasm">—</strong></div>
+          <div class="metric">device scale<strong id="metric-dpr">1</strong></div>
         </div>
       </main>
     </div>
@@ -121,28 +288,58 @@
       const motionControls = document.querySelector('#motion-controls');
       const textControls = document.querySelector('#text-controls');
       const textPreset = document.querySelector('#text-preset');
+      const presetButtons = [...document.querySelectorAll('.preset-option')];
       const benchmarkText = document.querySelector('#benchmark-text');
+      const benchmarkOutput = document.querySelector('#benchmark-output');
       const title = document.querySelector('#sample-title');
+      const eyebrow = document.querySelector('#sample-eyebrow');
       const description = document.querySelector('#sample-description');
       const status = document.querySelector('#status-message');
+      const main = document.querySelector('main');
       let fontPromise;
+
+      const features = [
+        ['liga', 'Standard ligatures', 'Compare independent glyphs with the GSUB ligature substitution produced by the native shaper.'],
+        ['kern', 'Pair positioning', 'Inspect GPOS pair adjustments and the exact retained advances used by the GPU glyph run.'],
+        ['frac', 'Automatic fractions', 'Follow numerator, denominator, and fraction substitutions through one feature-selected shaping plan.'],
+        ['zero', 'Slashed zero', 'Toggle a stylistic alternate without changing the source Unicode scalar or cluster ownership.'],
+        ['ss01', 'Stylistic set 01', 'Exercise an author-selected OpenType stylistic set while preserving glyph positions and cache identity.'],
+        ['calt', 'Contextual alternates', 'Compare context-sensitive substitutions resolved by the native GSUB lookup pipeline.'],
+        ['locl', 'Localized Romanian', 'Verify language-specific substitutions and composite diacritic coverage at the physical display size.'],
+        ['mkmk', 'Mark-to-mark positioning', 'Inspect chained combining-mark attachment and GPOS offsets without platform text APIs.']
+      ];
+
+      const syncPresetUi = value => {
+        const preset = Math.max(0, Math.min(features.length - 1, Number(value)));
+        textPreset.value = String(preset);
+        presetButtons.forEach((button, index) => {
+          const selected = index === preset;
+          button.classList.toggle('active', selected);
+          button.setAttribute('aria-pressed', String(selected));
+        });
+        document.querySelector('#feature-tag').textContent = features[preset][0];
+        document.querySelector('#feature-name').textContent = features[preset][1];
+        document.querySelector('#feature-detail').textContent = features[preset][2];
+      };
 
       const showSampleUi = sample => {
         const text = sample === 1;
+        main.dataset.sample = text ? 'text' : 'motion';
         motionButton.classList.toggle('active', !text);
         textButton.classList.toggle('active', text);
         motionControls.hidden = text;
         textControls.hidden = !text;
-        title.textContent = text ? 'Text shaping' : 'MotionMark';
+        eyebrow.textContent = text ? 'Native OpenType feature wall' : 'Native vector workload';
+        title.textContent = text ? 'Text shaping laboratory' : 'MotionMark';
         description.textContent = text
-          ? 'The managed Text Shaping Showcase feature wall ported to pure C++: one native OpenType result feeds retained glyph outlines and the production WebGPU text pipeline.'
-          : 'Mixed line, quadratic, and cubic paths animated through one immutable native semantic stream and the production ProGPU GPU pipeline.';
+          ? 'Eight managed showcase cases ported to pure C++ shaping, retained physical-size glyph coverage, and the shared production WebGPU text shader.'
+          : 'Mixed analytic paths animated through one immutable semantic stream and the production ProGPU WebGPU pipeline.';
         document.querySelector('#metric-elements-label').textContent = text ? 'glyphs' : 'segments';
         document.querySelector('#metric-groups-label').textContent = text ? 'outlines' : 'groups';
       };
 
       const ensureFont = () => fontPromise ??= (async () => {
-        status.textContent = 'Loading the separate Inter font asset…';
+        status.textContent = 'Loading Inter into native font memory…';
         const response = await fetch('Inter-Regular.ttf');
         if (!response.ok) throw new Error(`Font request failed: ${response.status}`);
         const bytes = new Uint8Array(await response.arrayBuffer());
@@ -183,6 +380,7 @@
             throw new Error('The native text sample did not activate.');
           }
           showSampleUi(1);
+          syncPresetUi(Number(textPreset.value));
         } catch (error) {
           document.body.dataset.progpuNativeError = String(error);
           status.textContent = String(error);
@@ -191,21 +389,34 @@
           textButton.disabled = false;
         }
       });
-      textPreset.addEventListener('change', event =>
-        Module._progpu_native_gallery_set_text_preset(Number(event.target.value)));
+
+      const selectPreset = value => {
+        const preset = Number(value);
+        syncPresetUi(preset);
+        Module._progpu_native_gallery_set_text_preset(preset);
+      };
+      textPreset.addEventListener('change', event => selectPreset(event.target.value));
+      presetButtons.forEach(button => button.addEventListener('click', () =>
+        selectPreset(button.dataset.preset)));
+
       benchmarkText.addEventListener('click', async () => {
         benchmarkText.disabled = true;
+        benchmarkText.classList.add('running');
+        benchmarkOutput.textContent = 'warming…';
         const samples = [];
         try {
           for (let round = 0; round < 4; round++) {
             for (let step = 0; step < textPreset.options.length; step++) {
               const preset = (step + 1) % textPreset.options.length;
-              textPreset.value = String(preset);
-              Module._progpu_native_gallery_set_text_preset(preset);
+              syncPresetUi(preset);
+              const generation =
+                Module._progpu_native_gallery_set_text_preset(preset);
+              benchmarkOutput.textContent = `${samples.length + 1} / 32`;
               await new Promise((resolve, reject) => {
                 const started = performance.now();
                 const poll = () => {
-                  if (document.body.dataset.progpuNativeTextPreset === String(preset)) {
+                  if (document.body.dataset.progpuNativeTextGeneration ===
+                      String(generation)) {
                     resolve();
                   } else if (performance.now() - started > 5000) {
                     reject(new Error('Preset benchmark timed out.'));
@@ -215,27 +426,26 @@
                 };
                 requestAnimationFrame(poll);
               });
-              samples.push(Number(
-                document.body.dataset.progpuNativeUpdateMilliseconds));
+              samples.push(Number(document.body.dataset.progpuNativeUpdateMilliseconds));
             }
           }
           samples.sort((left, right) => left - right);
-          const percentile = value => samples[
-            Math.min(samples.length - 1, Math.ceil(samples.length * value) - 1)];
+          const percentile = value => samples[Math.min(samples.length - 1, Math.ceil(samples.length * value) - 1)];
           const p50 = percentile(0.50);
           const p95 = percentile(0.95);
           const maximum = samples[samples.length - 1];
-          document.querySelector('#metric-benchmark').textContent =
-            p95.toFixed(2) + ' ms';
+          document.querySelector('#metric-benchmark').textContent = p95.toFixed(2) + ' ms';
+          benchmarkOutput.textContent = `p50 ${p50.toFixed(2)} · p95 ${p95.toFixed(2)} ms`;
           document.body.dataset.progpuNativeBenchmarkSamples = String(samples.length);
           document.body.dataset.progpuNativeBenchmarkP50 = String(p50);
           document.body.dataset.progpuNativeBenchmarkP95 = String(p95);
           document.body.dataset.progpuNativeBenchmarkMax = String(maximum);
         } catch (error) {
-          status.textContent = String(error);
+          benchmarkOutput.textContent = String(error);
           console.error(error);
         } finally {
           benchmarkText.disabled = false;
+          benchmarkText.classList.remove('running');
         }
       });
     });

--- a/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
+++ b/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <new>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -133,6 +134,7 @@ void publish_metrics(
         document.body.dataset.progpuNativeOutlines = String($13);
         document.body.dataset.progpuNativeUpdateMilliseconds = String($6);
         document.body.dataset.progpuNativeTextPreset = String($14);
+        document.body.dataset.progpuNativeTextGeneration = String($15);
     },
         static_cast<double>(app.fps),
         app.active_sample == gallery_sample::motion_mark
@@ -154,7 +156,8 @@ void publish_metrics(
         static_cast<std::uint32_t>(app.active_sample),
         app.text_metrics.shaped_glyph_count,
         app.text_metrics.unique_outline_count,
-        app.text_metrics.preset_index);
+        app.text_metrics.preset_index,
+        static_cast<double>(app.text_metrics.generation));
 }
 #pragma clang diagnostic pop
 
@@ -292,10 +295,10 @@ EMSCRIPTEN_KEEPALIVE std::int32_t
 progpu_native_gallery_commit_font(std::uint32_t size) noexcept {
     if (application == nullptr ||
         size == 0U || size != application->font_staging.size() ||
-        !application->text_sample.load_font(application->font_staging)) {
+        !application->text_sample.load_font(
+            std::move(application->font_staging))) {
         return 0;
     }
-    application->font_staging.clear();
     return 1;
 }
 
@@ -322,11 +325,14 @@ progpu_native_gallery_set_sample(std::uint32_t sample) noexcept {
     return static_cast<std::uint32_t>(application->active_sample);
 }
 
-EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_set_text_preset(
+EMSCRIPTEN_KEEPALIVE std::uint32_t progpu_native_gallery_set_text_preset(
     std::uint32_t preset) noexcept {
     if (application != nullptr) {
         application->text_sample.set_preset(preset);
+        return static_cast<std::uint32_t>(
+            application->text_sample.generation());
     }
+    return 0U;
 }
 
 } // extern "C"

--- a/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
+++ b/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
@@ -109,6 +109,7 @@ void publish_metrics(
         set('#metric-draws', Number($3).toLocaleString());
         set('#metric-bytes', Number($4).toLocaleString() + ' B');
         set('#metric-dpr', Number($5).toFixed(2));
+        set('#metric-update', Number($6).toFixed(3) + ' ms');
         const status = document.querySelector('#status-message');
         if (status) status.textContent =
           'native update ' + Number($6).toFixed(3) + ' ms / ' +

--- a/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
+++ b/src/ProGPU.Native/browser/progpu_native_browser_gallery.cpp
@@ -1,6 +1,7 @@
 #include "Host/progpu_native_browser_window_host.hpp"
 #include "progpu_native_browser.h"
 #include "progpu_native_motion_mark.hpp"
+#include "progpu_native_text_shaping_showcase.hpp"
 
 #include <emscripten.h>
 #include <emscripten/html5.h>
@@ -19,11 +20,21 @@ using progpu::native::browser::browser_frame;
 using progpu::native::browser::browser_window_host;
 using progpu::native::samples::motion_mark_scene;
 using progpu::native::samples::motion_mark_scene_metrics;
+using progpu::native::samples::text_shaping_showcase_metrics;
+using progpu::native::samples::text_shaping_showcase_scene;
+
+enum class gallery_sample : std::uint32_t {
+    motion_mark = 0U,
+    text_shaping = 1U
+};
 
 struct gallery_application final {
     browser_window_host host{};
-    motion_mark_scene sample{};
-    motion_mark_scene_metrics sample_metrics{};
+    motion_mark_scene motion_sample{};
+    motion_mark_scene_metrics motion_metrics{};
+    text_shaping_showcase_scene text_sample{};
+    text_shaping_showcase_metrics text_metrics{};
+    std::vector<std::byte> font_staging{};
     std::vector<std::byte> scene_stream{};
     progpu_native_engine* engine = nullptr;
     WGPUDevice device = nullptr;
@@ -36,6 +47,7 @@ struct gallery_application final {
     double scene_update_milliseconds = 0.0;
     std::uint64_t fps_frame = 0U;
     float fps = 0.0F;
+    gallery_sample active_sample = gallery_sample::motion_mark;
     bool paused = false;
 };
 
@@ -55,11 +67,17 @@ void fail(const char* message) noexcept {
 #pragma clang diagnostic pop
 
 bool update_scene(gallery_application& app) noexcept {
-    if (!app.sample.dirty()) {
+    const bool dirty = app.active_sample == gallery_sample::motion_mark
+        ? app.motion_sample.dirty()
+        : app.text_sample.dirty();
+    if (!dirty) {
         return true;
     }
     const double start = emscripten_get_now();
-    if (!app.sample.compile(app.scene_stream, app.sample_metrics)) {
+    const bool compiled = app.active_sample == gallery_sample::motion_mark
+        ? app.motion_sample.compile(app.scene_stream, app.motion_metrics)
+        : app.text_sample.compile(app.scene_stream, app.text_metrics);
+    if (!compiled) {
         return false;
     }
     progpu_native_scene_metrics metrics{};
@@ -107,18 +125,35 @@ void publish_metrics(
         document.body.dataset.progpuNativeBackingHeight = String($9);
         document.body.dataset.progpuNativeDpiScale = String($5);
         document.body.dataset.progpuNativeFrames = String($10);
+        document.body.dataset.progpuNativeSample = Number($11) === 0
+          ? 'motion-mark'
+          : 'text-shaping';
+        document.body.dataset.progpuNativeGlyphs = String($12);
+        document.body.dataset.progpuNativeOutlines = String($13);
+        document.body.dataset.progpuNativeUpdateMilliseconds = String($6);
+        document.body.dataset.progpuNativeTextPreset = String($14);
     },
         static_cast<double>(app.fps),
-        app.sample_metrics.element_count,
-        app.sample_metrics.group_count,
+        app.active_sample == gallery_sample::motion_mark
+            ? app.motion_metrics.element_count
+            : app.text_metrics.shaped_glyph_count,
+        app.active_sample == gallery_sample::motion_mark
+            ? app.motion_metrics.group_count
+            : app.text_metrics.unique_outline_count,
         render.draw_call_count,
-        static_cast<double>(app.sample_metrics.stream_bytes),
+        static_cast<double>(app.active_sample == gallery_sample::motion_mark
+            ? app.motion_metrics.stream_bytes
+            : app.text_metrics.stream_bytes),
         static_cast<double>(frame.dpi_scale),
         app.scene_update_milliseconds,
         static_cast<double>(render.submission_count),
         frame.width,
         frame.height,
-        static_cast<double>(app.frame_count));
+        static_cast<double>(app.frame_count),
+        static_cast<std::uint32_t>(app.active_sample),
+        app.text_metrics.shaped_glyph_count,
+        app.text_metrics.unique_outline_count,
+        app.text_metrics.preset_index);
 }
 #pragma clang diagnostic pop
 
@@ -136,13 +171,20 @@ EM_BOOL render_frame(double timestamp, void*) noexcept {
     if (!app.host.begin_frame(frame)) {
         return EM_TRUE;
     }
-    app.sample.resize(frame.logical_width, frame.logical_height);
-    if (!app.paused) {
-        app.sample.advance(delta);
+    if (app.active_sample == gallery_sample::motion_mark) {
+        app.motion_sample.resize(frame.logical_width, frame.logical_height);
+        if (!app.paused) {
+            app.motion_sample.advance(delta);
+        }
+    } else {
+        app.text_sample.resize(
+            frame.logical_width,
+            frame.logical_height,
+            frame.dpi_scale);
     }
     if (!update_scene(app)) {
         app.host.end_frame(frame);
-        fail("The pure C++ MotionMark scene update failed.");
+        fail("The pure C++ gallery scene update failed.");
         return EM_FALSE;
     }
 
@@ -158,8 +200,12 @@ EM_BOOL render_frame(double timestamp, void*) noexcept {
     // against the shell chrome's almost-black background and make connected
     // curves look like isolated blocks.
     native_frame.clear_color = {0.125F, 0.125F, 0.15F, 1.0F};
-    native_frame.scene_id = 0x4D4F54494F4E4D4BULL;
-    native_frame.generation = app.sample.generation();
+    native_frame.scene_id = app.active_sample == gallery_sample::motion_mark
+        ? 0x4D4F54494F4E4D4BULL
+        : 0x5445585453484150ULL;
+    native_frame.generation = app.active_sample == gallery_sample::motion_mark
+        ? app.motion_sample.generation()
+        : app.text_sample.generation();
 
     progpu_native_scene_frame_metrics render_metrics{};
     render_metrics.struct_size = sizeof(render_metrics);
@@ -199,14 +245,14 @@ extern "C" {
 EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_set_element_count(
     std::uint32_t count) noexcept {
     if (application != nullptr) {
-        application->sample.set_element_count(count);
+        application->motion_sample.set_element_count(count);
     }
 }
 
 EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_set_color_mode(
     std::uint32_t mode) noexcept {
     if (application != nullptr) {
-        application->sample.set_color_mode(mode);
+        application->motion_sample.set_color_mode(mode);
     }
 }
 
@@ -221,8 +267,64 @@ progpu_native_gallery_toggle_paused() noexcept {
 
 EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_regenerate() noexcept {
     if (application != nullptr) {
-        application->sample.regenerate(
+        application->motion_sample.regenerate(
             0x50A7C0DEU + application->regeneration++ * 0x9E3779B9U);
+    }
+}
+
+EMSCRIPTEN_KEEPALIVE std::uintptr_t
+progpu_native_gallery_prepare_font(std::uint32_t size) noexcept {
+    if (application == nullptr || size == 0U || size > 8U * 1024U * 1024U) {
+        return 0U;
+    }
+    try {
+        application->font_staging.resize(size);
+        return reinterpret_cast<std::uintptr_t>(
+            application->font_staging.data());
+    } catch (...) {
+        application->font_staging.clear();
+        return 0U;
+    }
+}
+
+EMSCRIPTEN_KEEPALIVE std::int32_t
+progpu_native_gallery_commit_font(std::uint32_t size) noexcept {
+    if (application == nullptr ||
+        size == 0U || size != application->font_staging.size() ||
+        !application->text_sample.load_font(application->font_staging)) {
+        return 0;
+    }
+    application->font_staging.clear();
+    return 1;
+}
+
+EMSCRIPTEN_KEEPALIVE std::uint32_t
+progpu_native_gallery_set_sample(std::uint32_t sample) noexcept {
+    if (application == nullptr) {
+        return 0U;
+    }
+    const auto requested = sample == 1U
+        ? gallery_sample::text_shaping
+        : gallery_sample::motion_mark;
+    if (requested == gallery_sample::text_shaping &&
+        !application->text_sample.ready()) {
+        return static_cast<std::uint32_t>(application->active_sample);
+    }
+    if (application->active_sample != requested) {
+        application->active_sample = requested;
+        if (requested == gallery_sample::motion_mark) {
+            application->motion_sample.invalidate();
+        } else {
+            application->text_sample.invalidate();
+        }
+    }
+    return static_cast<std::uint32_t>(application->active_sample);
+}
+
+EMSCRIPTEN_KEEPALIVE void progpu_native_gallery_set_text_preset(
+    std::uint32_t preset) noexcept {
+    if (application != nullptr) {
+        application->text_sample.set_preset(preset);
     }
 }
 

--- a/src/ProGPU.Native/browser/test.mjs
+++ b/src/ProGPU.Native/browser/test.mjs
@@ -325,7 +325,7 @@ try {
   assert.equal(textContract.dpiScale, galleryContract.dpiScale);
   assert.equal(textContract.error, "");
 
-  await page.locator("#text-preset").selectOption("1");
+  await page.locator('[data-preset="1"]').click();
   await page.waitForFunction(
     () => document.body.dataset.progpuNativeTextPreset === "1",
     undefined,

--- a/src/ProGPU.Native/browser/test.mjs
+++ b/src/ProGPU.Native/browser/test.mjs
@@ -284,13 +284,70 @@ try {
   });
   assert.ok(galleryScreenshot.length > 1000,
     "The native gallery WebGPU screenshot is empty.");
+
+  await page.getByRole("button", { name: "Aa Text shaping" }).click();
+  await page.waitForFunction(
+    () => document.body.dataset.progpuNativeSample === "text-shaping" &&
+      Number(document.body.dataset.progpuNativeFontBytes) > 0 &&
+      Number(document.body.dataset.progpuNativeGlyphs) > 0 &&
+      Number(document.body.dataset.progpuNativeOutlines) > 0,
+    undefined,
+    { timeout: 30_000 });
+  const textContract = await page.evaluate(() => ({
+    sample: document.body.dataset.progpuNativeSample,
+    fontBytes: Number(document.body.dataset.progpuNativeFontBytes),
+    glyphs: Number(document.body.dataset.progpuNativeGlyphs),
+    outlines: Number(document.body.dataset.progpuNativeOutlines),
+    draws: Number(document.body.dataset.progpuNativeDraws),
+    streamBytes: Number(document.body.dataset.progpuNativeStreamBytes),
+    preset: Number(document.body.dataset.progpuNativeTextPreset),
+    updateMilliseconds:
+      Number(document.body.dataset.progpuNativeUpdateMilliseconds),
+    width: Number(document.body.dataset.progpuNativeBackingWidth),
+    height: Number(document.body.dataset.progpuNativeBackingHeight),
+    dpiScale: Number(document.body.dataset.progpuNativeDpiScale),
+    error: document.body.dataset.progpuNativeError ?? ""
+  }));
+  assert.equal(textContract.sample, "text-shaping");
+  assert.ok(textContract.fontBytes > 300_000);
+  assert.ok(textContract.glyphs > 100);
+  assert.ok(textContract.outlines > 16);
+  assert.ok(textContract.draws > 1);
+  assert.ok(textContract.streamBytes > 0);
+  assert.equal(textContract.preset, 0);
+  assert.ok(Number.isFinite(textContract.updateMilliseconds) &&
+    textContract.updateMilliseconds >= 0);
+  assert.equal(textContract.width, galleryContract.width);
+  assert.equal(textContract.height, galleryContract.height);
+  assert.equal(textContract.dpiScale, galleryContract.dpiScale);
+  assert.equal(textContract.error, "");
+
+  await page.locator("#text-preset").selectOption("1");
+  await page.waitForFunction(
+    () => document.body.dataset.progpuNativeTextPreset === "1",
+    undefined,
+    { timeout: 30_000 });
+  textContract.changedPreset = Number(
+    await page.locator("body").getAttribute(
+      "data-progpu-native-text-preset"));
+  assert.equal(textContract.changedPreset, 1);
+  const textScreenshot = await page.locator(".stage").screenshot({
+    path: path.join(
+      evidenceDirectory,
+      "progpu-native-browser-text-shaping.png")
+  });
+  assert.ok(textScreenshot.length > 1000,
+    "The native text-shaping WebGPU screenshot is empty.");
+  galleryContract.textShaping = textContract;
   await fs.writeFile(
     path.join(evidenceDirectory, "progpu-native-browser-gallery.json"),
     `${JSON.stringify(galleryContract, null, 2)}\n`);
   assert.deepEqual(errors, []);
   process.stdout.write(
     `ProGPU pure C++ browser gallery presented MotionMark as one GPU draw ` +
-    `at ${galleryContract.width}x${galleryContract.height} physical pixels.\n`);
+    `and ${textContract.glyphs} shaped glyph records with ` +
+    `${textContract.outlines} retained outlines at ` +
+    `${galleryContract.width}x${galleryContract.height} physical pixels.\n`);
 } finally {
   await browser.close();
 }

--- a/src/ProGPU.Native/browser/test.mjs
+++ b/src/ProGPU.Native/browser/test.mjs
@@ -289,6 +289,7 @@ try {
   await page.waitForFunction(
     () => document.body.dataset.progpuNativeSample === "text-shaping" &&
       Number(document.body.dataset.progpuNativeFontBytes) > 0 &&
+      Number(document.body.dataset.progpuNativeWasmBytes) > 0 &&
       Number(document.body.dataset.progpuNativeGlyphs) > 0 &&
       Number(document.body.dataset.progpuNativeOutlines) > 0,
     undefined,
@@ -296,6 +297,7 @@ try {
   const textContract = await page.evaluate(() => ({
     sample: document.body.dataset.progpuNativeSample,
     fontBytes: Number(document.body.dataset.progpuNativeFontBytes),
+    wasmBytes: Number(document.body.dataset.progpuNativeWasmBytes),
     glyphs: Number(document.body.dataset.progpuNativeGlyphs),
     outlines: Number(document.body.dataset.progpuNativeOutlines),
     draws: Number(document.body.dataset.progpuNativeDraws),
@@ -310,6 +312,7 @@ try {
   }));
   assert.equal(textContract.sample, "text-shaping");
   assert.ok(textContract.fontBytes > 300_000);
+  assert.ok(textContract.wasmBytes > 1_000_000);
   assert.ok(textContract.glyphs > 100);
   assert.ok(textContract.outlines > 16);
   assert.ok(textContract.draws > 1);
@@ -331,6 +334,23 @@ try {
     await page.locator("body").getAttribute(
       "data-progpu-native-text-preset"));
   assert.equal(textContract.changedPreset, 1);
+  await page.locator("#benchmark-text").click();
+  await page.waitForFunction(
+    () => Number(document.body.dataset.progpuNativeBenchmarkSamples) === 32,
+    undefined,
+    { timeout: 30_000 });
+  Object.assign(textContract, await page.evaluate(() => ({
+    benchmarkSamples:
+      Number(document.body.dataset.progpuNativeBenchmarkSamples),
+    benchmarkP50: Number(document.body.dataset.progpuNativeBenchmarkP50),
+    benchmarkP95: Number(document.body.dataset.progpuNativeBenchmarkP95),
+    benchmarkMax: Number(document.body.dataset.progpuNativeBenchmarkMax)
+  })));
+  assert.equal(textContract.benchmarkSamples, 32);
+  assert.ok(Number.isFinite(textContract.benchmarkP50) &&
+    textContract.benchmarkP50 >= 0);
+  assert.ok(textContract.benchmarkP95 >= textContract.benchmarkP50);
+  assert.ok(textContract.benchmarkMax >= textContract.benchmarkP95);
   const textScreenshot = await page.locator(".stage").screenshot({
     path: path.join(
       evidenceDirectory,

--- a/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp
+++ b/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cmath>
 #include <limits>
 #include <new>
@@ -49,6 +50,23 @@ struct shaped_run final {
     progpu_native_color color{1.0F, 1.0F, 1.0F, 1.0F};
     float advance_x = 0.0F;
 };
+
+struct retained_glyph_geometry final {
+    std::uint64_t segment_offset = 0U;
+    std::uint32_t segment_count = 0U;
+    float min_x = 0.0F;
+    float min_y = 0.0F;
+    float max_x = 0.0F;
+    float max_y = 0.0F;
+};
+
+std::uint64_t outline_key(
+    std::uint32_t glyph_id,
+    float raster_font_size) noexcept {
+    return static_cast<std::uint64_t>(
+        std::bit_cast<std::uint32_t>(raster_font_size)) << 32U |
+        glyph_id;
+}
 
 bool shape(
     std::span<const std::byte> font_bytes,
@@ -307,14 +325,9 @@ bool text_shaping_showcase_scene::compile(
         if (!font_.try_get_header_metrics(header) || header.units_per_em == 0U) {
             return false;
         }
-        const float raster_font_size = std::max(56.0F, preview_size);
-        const float raster_scale = raster_font_size * dpi_scale_ /
-            static_cast<float>(header.units_per_em);
-        std::vector<progpu_native_scene_glyph_outline> outlines;
         std::vector<progpu_native_path_segment> segments;
-        std::unordered_map<std::uint32_t, std::uint32_t> outline_indices;
-        outlines.reserve(glyph_ids.size());
-        outline_indices.reserve(glyph_ids.size());
+        std::unordered_map<std::uint32_t, retained_glyph_geometry> geometries;
+        geometries.reserve(glyph_ids.size());
         for (const std::uint32_t glyph_id : glyph_ids) {
             const auto glyph_index = static_cast<std::uint16_t>(glyph_id);
             text::sfnt_glyph_data_view data{};
@@ -349,20 +362,62 @@ bool text_shaping_showcase_scene::compile(
                 segments.resize(segment_offset);
                 return false;
             }
-            const std::uint32_t outline_index = static_cast<std::uint32_t>(
-                outlines.size());
-            outline_indices.emplace(glyph_id, outline_index);
-            outlines.push_back({
+            geometries.emplace(glyph_id, retained_glyph_geometry{
                 segment_offset,
                 segments_written,
                 static_cast<float>(data.x_min),
                 static_cast<float>(data.y_min),
                 static_cast<float>(data.x_max),
-                static_cast<float>(data.y_max),
-                raster_scale,
-                0.0F});
+                static_cast<float>(data.y_max)});
         }
-        if (outlines.empty() || segments.empty()) {
+        if (geometries.empty() || segments.empty()) {
+            return false;
+        }
+
+        std::vector<progpu_native_scene_glyph_outline> outlines;
+        std::vector<progpu_native_path_segment> raster_segments;
+        std::unordered_map<std::uint64_t, std::uint32_t> outline_indices;
+        outlines.reserve(glyph_ids.size() * 3U);
+        raster_segments.reserve(segments.size() * 3U);
+        outline_indices.reserve(glyph_ids.size() * 3U);
+        for (const auto& run : runs) {
+            const float raster_font_size = std::clamp(
+                run.font_size, 4.0F, 128.0F);
+            const float raster_scale = raster_font_size * dpi_scale_ /
+                static_cast<float>(header.units_per_em);
+            for (const auto& glyph : run.glyphs) {
+                const auto geometry = geometries.find(glyph.glyph_id);
+                if (geometry == geometries.end()) {
+                    continue;
+                }
+                const std::uint64_t key = outline_key(
+                    glyph.glyph_id, raster_font_size);
+                if (outline_indices.contains(key)) {
+                    continue;
+                }
+                const std::uint32_t outline_index =
+                    static_cast<std::uint32_t>(outlines.size());
+                outline_indices.emplace(key, outline_index);
+                const auto& retained = geometry->second;
+                const std::uint64_t segment_offset = raster_segments.size();
+                raster_segments.insert(
+                    raster_segments.end(),
+                    segments.begin() + static_cast<std::ptrdiff_t>(
+                        retained.segment_offset),
+                    segments.begin() + static_cast<std::ptrdiff_t>(
+                        retained.segment_offset + retained.segment_count));
+                outlines.push_back({
+                    segment_offset,
+                    retained.segment_count,
+                    retained.min_x,
+                    retained.min_y,
+                    retained.max_x,
+                    retained.max_y,
+                    raster_scale,
+                    0.0F});
+            }
+        }
+        if (outlines.empty() || raster_segments.empty()) {
             return false;
         }
 
@@ -372,11 +427,14 @@ bool text_shaping_showcase_scene::compile(
             total_glyphs += static_cast<std::uint32_t>(run.glyphs.size());
             float cursor_x = run.x;
             float cursor_y = run.baseline;
+            const float raster_font_size = std::clamp(
+                run.font_size, 4.0F, 128.0F);
             const float design_scale = run.font_size /
                 static_cast<float>(header.units_per_em);
             run.positioned.reserve(run.glyphs.size());
             for (const auto& glyph : run.glyphs) {
-                const auto found = outline_indices.find(glyph.glyph_id);
+                const auto found = outline_indices.find(outline_key(
+                    glyph.glyph_id, raster_font_size));
                 if (found != outline_indices.end()) {
                     run.positioned.push_back({
                         found->second,
@@ -402,7 +460,7 @@ bool text_shaping_showcase_scene::compile(
             !builder_.reserve(
                 static_cast<std::uint32_t>(runs.size() + 1U),
                 6U,
-                static_cast<std::uint64_t>(segments.size()) *
+                static_cast<std::uint64_t>(raster_segments.size()) *
                     sizeof(progpu_native_path_segment) +
                     visible_glyphs * sizeof(progpu_native_positioned_glyph))) {
             return false;
@@ -440,7 +498,7 @@ bool text_shaping_showcase_scene::compile(
         }
         std::uint32_t glyph_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
         if (!builder_.add_glyph_outlines(
-                outlines, segments, glyph_resource)) {
+                outlines, raster_segments, glyph_resource)) {
             return false;
         }
         for (const auto& run : runs) {

--- a/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp
+++ b/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp
@@ -194,6 +194,25 @@ bool text_shaping_showcase_scene::load_font(
     return true;
 }
 
+bool text_shaping_showcase_scene::load_font(
+    std::vector<std::byte>&& font_bytes) noexcept {
+    if (font_bytes.empty()) {
+        return false;
+    }
+    font_bytes_ = std::move(font_bytes);
+    text::font_error error = text::font_error::none;
+    text::sfnt_font_view parsed;
+    if (!text::sfnt_font_view::try_create(
+            font_bytes_, 0U, parsed, &error)) {
+        font_bytes_.clear();
+        return false;
+    }
+    font_ = parsed;
+    ready_ = true;
+    mark_dirty();
+    return true;
+}
+
 bool text_shaping_showcase_scene::resize(
     float width,
     float height,
@@ -253,11 +272,13 @@ bool text_shaping_showcase_scene::compile(
 
         const float compact = std::clamp(width_ / 900.0F, 0.72F, 1.0F);
         const float margin = std::clamp(width_ * 0.045F, 16.0F, 42.0F);
-        const float preview_size = std::clamp(width_ / 20.0F, 25.0F, 46.0F);
-        const float title_size = 34.0F * compact;
+        const float preview_size = std::clamp(width_ / 16.0F, 30.0F, 62.0F);
+        const float title_size = std::min(
+            34.0F * compact,
+            std::max(18.0F, width_ / 18.5F));
         const float body_size = 14.0F * compact;
         const float card_top = 126.0F * compact;
-        const float row_gap = std::clamp(height_ * 0.14F, 62.0F, 92.0F);
+        const float row_gap = std::clamp(height_ * 0.18F, 75.0F, 112.0F);
 
         std::vector<shaped_run> runs(10U);
         runs[0U] = {{}, {}, margin, 48.0F * compact, title_size,
@@ -375,49 +396,65 @@ bool text_shaping_showcase_scene::compile(
         }
 
         std::vector<progpu_native_scene_glyph_outline> outlines;
-        std::vector<progpu_native_path_segment> raster_segments;
         std::unordered_map<std::uint64_t, std::uint32_t> outline_indices;
+        std::unordered_map<std::uint32_t, float> first_raster_sizes;
         outlines.reserve(glyph_ids.size() * 3U);
-        raster_segments.reserve(segments.size() * 3U);
         outline_indices.reserve(glyph_ids.size() * 3U);
+        first_raster_sizes.reserve(glyph_ids.size());
         for (const auto& run : runs) {
             const float raster_font_size = std::clamp(
                 run.font_size, 4.0F, 128.0F);
-            const float raster_scale = raster_font_size * dpi_scale_ /
-                static_cast<float>(header.units_per_em);
             for (const auto& glyph : run.glyphs) {
-                const auto geometry = geometries.find(glyph.glyph_id);
-                if (geometry == geometries.end()) {
-                    continue;
+                if (geometries.contains(glyph.glyph_id)) {
+                    first_raster_sizes.try_emplace(
+                        glyph.glyph_id, raster_font_size);
                 }
-                const std::uint64_t key = outline_key(
-                    glyph.glyph_id, raster_font_size);
-                if (outline_indices.contains(key)) {
-                    continue;
-                }
-                const std::uint32_t outline_index =
-                    static_cast<std::uint32_t>(outlines.size());
-                outline_indices.emplace(key, outline_index);
-                const auto& retained = geometry->second;
-                const std::uint64_t segment_offset = raster_segments.size();
-                raster_segments.insert(
-                    raster_segments.end(),
-                    segments.begin() + static_cast<std::ptrdiff_t>(
-                        retained.segment_offset),
-                    segments.begin() + static_cast<std::ptrdiff_t>(
-                        retained.segment_offset + retained.segment_count));
-                outlines.push_back({
-                    segment_offset,
-                    retained.segment_count,
-                    retained.min_x,
-                    retained.min_y,
-                    retained.max_x,
-                    retained.max_y,
-                    raster_scale,
-                    0.0F});
             }
         }
-        if (outlines.empty() || raster_segments.empty()) {
+
+        const auto append_outline = [&](std::uint32_t glyph_id,
+                                        float raster_font_size) {
+            const std::uint64_t key = outline_key(
+                glyph_id, raster_font_size);
+            if (outline_indices.contains(key)) {
+                return;
+            }
+            const auto geometry = geometries.find(glyph_id);
+            if (geometry == geometries.end()) {
+                return;
+            }
+            const std::uint32_t outline_index =
+                static_cast<std::uint32_t>(outlines.size());
+            outline_indices.emplace(key, outline_index);
+            const auto& retained = geometry->second;
+            outlines.push_back({
+                retained.segment_offset,
+                retained.segment_count,
+                retained.min_x,
+                retained.min_y,
+                retained.max_x,
+                retained.max_y,
+                raster_font_size * dpi_scale_ /
+                    static_cast<float>(header.units_per_em),
+                0.0F});
+        };
+        // The first record for each glyph follows the packed source-segment
+        // order, keeping the shared auxiliary stream gap-free. Additional
+        // physical sizes then reference those same immutable ranges.
+        for (const std::uint32_t glyph_id : glyph_ids) {
+            const auto size = first_raster_sizes.find(glyph_id);
+            if (size != first_raster_sizes.end()) {
+                append_outline(glyph_id, size->second);
+            }
+        }
+        for (const auto& run : runs) {
+            const float raster_font_size = std::clamp(
+                run.font_size, 4.0F, 128.0F);
+            for (const auto& glyph : run.glyphs) {
+                append_outline(glyph.glyph_id, raster_font_size);
+            }
+        }
+        if (outlines.empty()) {
             return false;
         }
 
@@ -460,7 +497,7 @@ bool text_shaping_showcase_scene::compile(
             !builder_.reserve(
                 static_cast<std::uint32_t>(runs.size() + 1U),
                 6U,
-                static_cast<std::uint64_t>(raster_segments.size()) *
+                static_cast<std::uint64_t>(segments.size()) *
                     sizeof(progpu_native_path_segment) +
                     visible_glyphs * sizeof(progpu_native_positioned_glyph))) {
             return false;
@@ -469,8 +506,10 @@ bool text_shaping_showcase_scene::compile(
         constexpr progpu_native_color card{0.105F, 0.112F, 0.148F, 1.0F};
         constexpr progpu_native_color off_row{0.125F, 0.132F, 0.17F, 1.0F};
         constexpr progpu_native_color on_row{0.075F, 0.20F, 0.35F, 1.0F};
-        const float card_height = std::max(
-            230.0F, std::min(height_ - card_top - 48.0F, row_gap * 2.55F));
+        const float available_card_height = std::max(
+            180.0F, height_ - card_top - 42.0F);
+        const float card_height = std::min(
+            available_card_height, 94.0F + row_gap * 2.0F);
         const std::array backgrounds{
             rectangle(0.0F, 0.0F, width_, height_, 0.0F, page),
             rectangle(margin, card_top, width_ - margin * 2.0F,
@@ -498,7 +537,7 @@ bool text_shaping_showcase_scene::compile(
         }
         std::uint32_t glyph_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
         if (!builder_.add_glyph_outlines(
-                outlines, raster_segments, glyph_resource)) {
+                outlines, segments, glyph_resource)) {
             return false;
         }
         for (const auto& run : runs) {

--- a/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp
+++ b/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.cpp
@@ -1,0 +1,521 @@
+#include "progpu_native_text_shaping_showcase.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <new>
+#include <string_view>
+#include <unordered_map>
+
+namespace progpu::native::samples {
+namespace {
+
+constexpr std::uint32_t tag(char a, char b, char c, char d) noexcept {
+    return (static_cast<std::uint32_t>(static_cast<unsigned char>(a)) << 24U) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(b)) << 16U) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(c)) << 8U) |
+        static_cast<std::uint32_t>(static_cast<unsigned char>(d));
+}
+
+struct feature_preset final {
+    std::string_view feature;
+    std::string_view name;
+    std::string_view text;
+    std::uint32_t language = 0U;
+    bool disable_composition = false;
+};
+
+// Exact feature-wall specimens from TextShapingShowcasePage.CreateFeatureWall.
+constexpr std::array<feature_preset, 8U> presets{{
+    {"liga", "Standard ligatures", "office affinity"},
+    {"kern", "Pair positioning", "AVATAR \xC2\xB7 To Wa Yo"},
+    {"frac", "Automatic fractions", "1/2  12/25"},
+    {"zero", "Slashed zero", "O0  1002003"},
+    {"ss01", "Stylistic set 01", "1234567890"},
+    {"calt", "Contextual alternates", "->  -->  <->  =>"},
+    {"locl", "Localized Romanian", "\xC5\x9E \xC5\x9F  \xC5\xA2 \xC5\xA3",
+        tag('R', 'O', 'M', ' ')},
+    {"mkmk", "Mark-to-mark", "a\xCC\x88\xCC\x81  o\xCC\x82\xCC\x81",
+        0U, true}
+}};
+
+struct shaped_run final {
+    std::vector<progpu_native_text_shaping_glyph> glyphs{};
+    std::vector<progpu_native_positioned_glyph> positioned{};
+    float x = 0.0F;
+    float baseline = 0.0F;
+    float font_size = 16.0F;
+    progpu_native_color color{1.0F, 1.0F, 1.0F, 1.0F};
+    float advance_x = 0.0F;
+};
+
+bool shape(
+    std::span<const std::byte> font_bytes,
+    std::string_view utf8,
+    std::span<const progpu_native_text_feature> features,
+    std::uint32_t language,
+    shaped_run& run) {
+    const auto input_bytes = std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(utf8.data()), utf8.size());
+    text::unicode_decode_requirements decode_requirements{};
+    if (!text::try_get_utf8_decode_requirements(
+            input_bytes, decode_requirements)) {
+        return false;
+    }
+    std::vector<text::unicode_scalar> decoded(
+        decode_requirements.scalar_count);
+    std::uint32_t decoded_count = 0U;
+    if (!text::try_decode_utf8(
+            input_bytes, decoded, decoded_count) ||
+        decoded_count != decoded.size()) {
+        return false;
+    }
+    std::vector<progpu_native_text_scalar> input;
+    input.reserve(decoded.size());
+    for (const auto& scalar : decoded) {
+        input.push_back({
+            scalar.code_point,
+            scalar.input_index,
+            scalar.input_length,
+            scalar.canonical_combining_class,
+            0U,
+            scalar.script.value});
+    }
+
+    progpu_native_text_shape_request request{};
+    request.struct_size = sizeof(request);
+    request.abi_version = PROGPU_NATIVE_ABI_VERSION;
+    request.font_data = reinterpret_cast<const std::uint8_t*>(
+        font_bytes.data());
+    request.font_size = font_bytes.size();
+    request.flags = PROGPU_NATIVE_TEXT_SHAPE_ZERO_MARK_ADVANCES;
+    request.input = input.data();
+    request.input_count = static_cast<std::uint32_t>(input.size());
+    request.features = features.data();
+    request.feature_count = static_cast<std::uint32_t>(features.size());
+    request.unicode_script = tag('l', 'a', 't', 'n');
+    request.language = language;
+    request.direction = PROGPU_NATIVE_TEXT_DIRECTION_LEFT_TO_RIGHT;
+    request.cluster_level = PROGPU_NATIVE_TEXT_CLUSTER_MONOTONE_GRAPHEMES;
+    request.alternate_value = 1U;
+
+    progpu_native_text_shape_requirements requirements{};
+    requirements.struct_size = sizeof(requirements);
+    if (progpu_native_text_get_shape_requirements(
+            &request, &requirements) != PROGPU_NATIVE_STATUS_SUCCESS ||
+        requirements.glyph_capacity == 0U) {
+        return false;
+    }
+    run.glyphs.resize(requirements.glyph_capacity);
+    std::vector<std::uint8_t> scratch(
+        static_cast<std::size_t>(requirements.scratch_bytes));
+    progpu_native_text_shape_result result{};
+    result.struct_size = sizeof(result);
+    if (progpu_native_text_shape(
+            &request,
+            run.glyphs.data(),
+            static_cast<std::uint32_t>(run.glyphs.size()),
+            scratch.data(),
+            scratch.size(),
+            &result) != PROGPU_NATIVE_STATUS_SUCCESS ||
+        result.glyph_count == 0U ||
+        result.glyph_count > run.glyphs.size()) {
+        return false;
+    }
+    run.glyphs.resize(result.glyph_count);
+    return true;
+}
+
+progpu_native_analytic_primitive rectangle(
+    float x,
+    float y,
+    float width,
+    float height,
+    float radius,
+    progpu_native_color color) noexcept {
+    return {
+        PROGPU_NATIVE_PRIMITIVE_ROUNDED_RECTANGLE,
+        0U,
+        x,
+        y,
+        width,
+        height,
+        radius,
+        0.0F,
+        color,
+        semantic_scene_builder::identity_transform()};
+}
+
+} // namespace
+
+text_shaping_showcase_scene::text_shaping_showcase_scene() {
+    font_bytes_.reserve(512U * 1024U);
+}
+
+bool text_shaping_showcase_scene::load_font(
+    std::span<const std::byte> font_bytes) noexcept {
+    if (font_bytes.empty()) {
+        return false;
+    }
+    try {
+        font_bytes_.assign(font_bytes.begin(), font_bytes.end());
+    } catch (...) {
+        return false;
+    }
+    text::font_error error = text::font_error::none;
+    text::sfnt_font_view parsed;
+    if (!text::sfnt_font_view::try_create(
+            font_bytes_, 0U, parsed, &error)) {
+        font_bytes_.clear();
+        return false;
+    }
+    font_ = parsed;
+    ready_ = true;
+    mark_dirty();
+    return true;
+}
+
+bool text_shaping_showcase_scene::resize(
+    float width,
+    float height,
+    float dpi_scale) noexcept {
+    if (!std::isfinite(width) || !std::isfinite(height) ||
+        !std::isfinite(dpi_scale) || width <= 0.0F || height <= 0.0F ||
+        dpi_scale < 1.0F || dpi_scale > 4.0F) {
+        return false;
+    }
+    if (width_ == width && height_ == height && dpi_scale_ == dpi_scale) {
+        return false;
+    }
+    width_ = width;
+    height_ = height;
+    dpi_scale_ = dpi_scale;
+    mark_dirty();
+    return true;
+}
+
+bool text_shaping_showcase_scene::set_preset(
+    std::uint32_t preset_index) noexcept {
+    preset_index = std::min(
+        preset_index,
+        static_cast<std::uint32_t>(presets.size() - 1U));
+    if (preset_index_ == preset_index) {
+        return false;
+    }
+    preset_index_ = preset_index;
+    mark_dirty();
+    return true;
+}
+
+void text_shaping_showcase_scene::invalidate() noexcept {
+    mark_dirty();
+}
+
+bool text_shaping_showcase_scene::compile(
+    std::vector<std::byte>& stream,
+    text_shaping_showcase_metrics& metrics) noexcept {
+    if (!ready_ || !dirty_) {
+        return false;
+    }
+    try {
+        const feature_preset& preset = presets[preset_index_];
+        const std::uint32_t feature_tag = tag(
+            preset.feature[0], preset.feature[1],
+            preset.feature[2], preset.feature[3]);
+        std::array<progpu_native_text_feature, 2U> enabled_features{{
+            {feature_tag, 1U, 0U, std::numeric_limits<std::uint32_t>::max()},
+            {tag('c', 'c', 'm', 'p'), 0U, 0U,
+                std::numeric_limits<std::uint32_t>::max()}}};
+        std::array<progpu_native_text_feature, 2U> disabled_features{{
+            {feature_tag, 0U, 0U, std::numeric_limits<std::uint32_t>::max()},
+            {tag('c', 'c', 'm', 'p'), 0U, 0U,
+                std::numeric_limits<std::uint32_t>::max()}}};
+        const std::size_t feature_count = preset.disable_composition ? 2U : 1U;
+
+        const float compact = std::clamp(width_ / 900.0F, 0.72F, 1.0F);
+        const float margin = std::clamp(width_ * 0.045F, 16.0F, 42.0F);
+        const float preview_size = std::clamp(width_ / 20.0F, 25.0F, 46.0F);
+        const float title_size = 34.0F * compact;
+        const float body_size = 14.0F * compact;
+        const float card_top = 126.0F * compact;
+        const float row_gap = std::clamp(height_ * 0.14F, 62.0F, 92.0F);
+
+        std::vector<shaped_run> runs(10U);
+        runs[0U] = {{}, {}, margin, 48.0F * compact, title_size,
+            {0.94F, 0.96F, 1.0F, 1.0F}};
+        runs[1U] = {{}, {}, margin, 78.0F * compact, body_size,
+            {0.57F, 0.62F, 0.73F, 1.0F}};
+        runs[2U] = {{}, {}, margin, 105.0F * compact, body_size * 0.86F,
+            {0.35F, 0.68F, 1.0F, 1.0F}};
+        runs[3U] = {{}, {}, margin + 18.0F, card_top + 35.0F, body_size,
+            {0.43F, 0.72F, 1.0F, 1.0F}};
+        runs[4U] = {{}, {}, margin + 18.0F, card_top + 68.0F, body_size * 0.8F,
+            {0.52F, 0.56F, 0.67F, 1.0F}};
+        runs[5U] = {{}, {}, margin + 30.0F, card_top + 106.0F,
+            body_size * 0.78F, {0.52F, 0.56F, 0.67F, 1.0F}};
+        runs[6U] = {{}, {}, margin + 62.0F, card_top + 68.0F + row_gap,
+            preview_size, {0.65F, 0.69F, 0.78F, 1.0F}};
+        runs[7U] = {{}, {}, margin + 30.0F, card_top + 106.0F + row_gap,
+            body_size * 0.78F, {0.43F, 0.72F, 1.0F, 1.0F}};
+        runs[8U] = {{}, {}, margin + 62.0F, card_top + 68.0F + row_gap * 2.0F,
+            preview_size, {0.95F, 0.97F, 1.0F, 1.0F}};
+        runs[9U] = {{}, {}, margin, height_ - 24.0F, body_size * 0.8F,
+            {0.47F, 0.52F, 0.63F, 1.0F}};
+
+        const std::string_view labels[10U]{
+            "From Unicode to positioned glyphs.",
+            "Native C++ OpenType shaping and retained WebGPU glyph runs",
+            "GSUB 1-8  /  GPOS 1-9  /  pooled buffers  /  one retained scene",
+            preset.name,
+            preset.feature,
+            "OFF",
+            preset.text,
+            "ON",
+            preset.text,
+            "Glyph IDs, clusters, advances and offsets feed the same rendered run."
+        };
+        for (std::size_t index = 0U; index < runs.size(); ++index) {
+            std::span<const progpu_native_text_feature> features{};
+            std::uint32_t language = 0U;
+            if (index == 6U) {
+                features = std::span(disabled_features).first(feature_count);
+                language = preset.language;
+            } else if (index == 8U) {
+                features = std::span(enabled_features).first(feature_count);
+                language = preset.language;
+            }
+            if (!shape(font_bytes_, labels[index], features, language, runs[index])) {
+                return false;
+            }
+        }
+
+        std::vector<std::uint32_t> glyph_ids;
+        for (const auto& run : runs) {
+            for (const auto& glyph : run.glyphs) {
+                if (glyph.glyph_id != 0U &&
+                    glyph.glyph_id <= std::numeric_limits<std::uint16_t>::max()) {
+                    glyph_ids.push_back(glyph.glyph_id);
+                }
+            }
+        }
+        std::sort(glyph_ids.begin(), glyph_ids.end());
+        glyph_ids.erase(
+            std::unique(glyph_ids.begin(), glyph_ids.end()), glyph_ids.end());
+
+        text::sfnt_header_metrics header{};
+        if (!font_.try_get_header_metrics(header) || header.units_per_em == 0U) {
+            return false;
+        }
+        const float raster_font_size = std::max(56.0F, preview_size);
+        const float raster_scale = raster_font_size * dpi_scale_ /
+            static_cast<float>(header.units_per_em);
+        std::vector<progpu_native_scene_glyph_outline> outlines;
+        std::vector<progpu_native_path_segment> segments;
+        std::unordered_map<std::uint32_t, std::uint32_t> outline_indices;
+        outlines.reserve(glyph_ids.size());
+        outline_indices.reserve(glyph_ids.size());
+        for (const std::uint32_t glyph_id : glyph_ids) {
+            const auto glyph_index = static_cast<std::uint16_t>(glyph_id);
+            text::sfnt_glyph_data_view data{};
+            text::sfnt_expanded_glyph_requirements requirements{};
+            text::font_error error = text::font_error::none;
+            if (!font_.try_get_glyph_data(glyph_index, data) || data.empty() ||
+                !font_.try_get_expanded_glyph_requirements(
+                    glyph_index, requirements, &error) ||
+                requirements.path_segment_count == 0U) {
+                continue;
+            }
+            std::vector<std::uint16_t> contour_scratch(
+                requirements.simple_contour_scratch_count);
+            std::vector<text::sfnt_outline_point> point_scratch(
+                requirements.simple_point_scratch_count);
+            std::vector<progpu_native_point> points(requirements.point_count);
+            const std::size_t segment_offset = segments.size();
+            segments.resize(segment_offset + requirements.path_segment_count);
+            std::uint32_t points_written = 0U;
+            std::uint32_t segments_written = 0U;
+            if (!font_.try_decode_glyph_outline(
+                    glyph_index,
+                    contour_scratch,
+                    point_scratch,
+                    points,
+                    std::span(segments).subspan(
+                        segment_offset, requirements.path_segment_count),
+                    points_written,
+                    segments_written,
+                    &error) ||
+                segments_written != requirements.path_segment_count) {
+                segments.resize(segment_offset);
+                return false;
+            }
+            const std::uint32_t outline_index = static_cast<std::uint32_t>(
+                outlines.size());
+            outline_indices.emplace(glyph_id, outline_index);
+            outlines.push_back({
+                segment_offset,
+                segments_written,
+                static_cast<float>(data.x_min),
+                static_cast<float>(data.y_min),
+                static_cast<float>(data.x_max),
+                static_cast<float>(data.y_max),
+                raster_scale,
+                0.0F});
+        }
+        if (outlines.empty() || segments.empty()) {
+            return false;
+        }
+
+        std::uint32_t total_glyphs = 0U;
+        std::uint32_t visible_glyphs = 0U;
+        for (auto& run : runs) {
+            total_glyphs += static_cast<std::uint32_t>(run.glyphs.size());
+            float cursor_x = run.x;
+            float cursor_y = run.baseline;
+            const float design_scale = run.font_size /
+                static_cast<float>(header.units_per_em);
+            run.positioned.reserve(run.glyphs.size());
+            for (const auto& glyph : run.glyphs) {
+                const auto found = outline_indices.find(glyph.glyph_id);
+                if (found != outline_indices.end()) {
+                    run.positioned.push_back({
+                        found->second,
+                        0U,
+                        {cursor_x + glyph.offset_x * design_scale,
+                            cursor_y + glyph.offset_y * design_scale},
+                        {1.0F, 0.0F},
+                        {0.0F, 1.0F},
+                        run.color,
+                        run.font_size / raster_font_size,
+                        0.0F,
+                        0.0F,
+                        0.0F});
+                    ++visible_glyphs;
+                }
+                cursor_x += glyph.advance_x * design_scale;
+                cursor_y += glyph.advance_y * design_scale;
+            }
+            run.advance_x = cursor_x - run.x;
+        }
+
+        if (!builder_.reset(scene_id_, generation_) ||
+            !builder_.reserve(
+                static_cast<std::uint32_t>(runs.size() + 1U),
+                6U,
+                static_cast<std::uint64_t>(segments.size()) *
+                    sizeof(progpu_native_path_segment) +
+                    visible_glyphs * sizeof(progpu_native_positioned_glyph))) {
+            return false;
+        }
+        constexpr progpu_native_color page{0.075F, 0.078F, 0.105F, 1.0F};
+        constexpr progpu_native_color card{0.105F, 0.112F, 0.148F, 1.0F};
+        constexpr progpu_native_color off_row{0.125F, 0.132F, 0.17F, 1.0F};
+        constexpr progpu_native_color on_row{0.075F, 0.20F, 0.35F, 1.0F};
+        const float card_height = std::max(
+            230.0F, std::min(height_ - card_top - 48.0F, row_gap * 2.55F));
+        const std::array backgrounds{
+            rectangle(0.0F, 0.0F, width_, height_, 0.0F, page),
+            rectangle(margin, card_top, width_ - margin * 2.0F,
+                card_height, 14.0F, card),
+            rectangle(margin + 14.0F, card_top + 82.0F,
+                width_ - margin * 2.0F - 28.0F, row_gap - 12.0F,
+                9.0F, off_row),
+            rectangle(margin + 14.0F, card_top + 82.0F + row_gap,
+                width_ - margin * 2.0F - 28.0F, row_gap - 12.0F,
+                9.0F, on_row)};
+        std::array<std::uint32_t, backgrounds.size()> background_brushes{};
+        for (std::size_t index = 0U; index < backgrounds.size(); ++index) {
+            if (!builder_.add_solid_brush(
+                    backgrounds[index].color,
+                    1.0F,
+                    background_brushes[index])) {
+                return false;
+            }
+        }
+        if (!builder_.draw_analytic(
+                backgrounds,
+                background_brushes,
+                {0.0F, 0.0F, width_, height_})) {
+            return false;
+        }
+        std::uint32_t glyph_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
+        if (!builder_.add_glyph_outlines(
+                outlines, segments, glyph_resource)) {
+            return false;
+        }
+        for (const auto& run : runs) {
+            if (!run.positioned.empty() &&
+                !builder_.draw_glyph_run(
+                    glyph_resource,
+                    run.positioned,
+                    {0.0F, 0.0F, width_, height_})) {
+                return false;
+            }
+        }
+
+        const std::size_t required = builder_.required_stream_size();
+        if (required == 0U) {
+            return false;
+        }
+        if (stream.capacity() < required) {
+            stream.reserve(required);
+        }
+        stream.resize(required);
+        std::size_t written = 0U;
+        scene_build_metrics build_metrics{};
+        if (!builder_.build_into(stream, written, &build_metrics) ||
+            written != required) {
+            return false;
+        }
+        metrics.preset_index = preset_index_;
+        metrics.shaped_glyph_count = total_glyphs;
+        metrics.visible_glyph_count = visible_glyphs;
+        metrics.unique_outline_count = static_cast<std::uint32_t>(outlines.size());
+        metrics.feature_off_glyph_count = static_cast<std::uint32_t>(
+            runs[6U].glyphs.size());
+        metrics.feature_on_glyph_count = static_cast<std::uint32_t>(
+            runs[8U].glyphs.size());
+        metrics.feature_off_advance = runs[6U].advance_x;
+        metrics.feature_on_advance = runs[8U].advance_x;
+        metrics.command_count = build_metrics.command_count;
+        metrics.resource_count = build_metrics.resource_count;
+        metrics.stream_bytes = build_metrics.stream_bytes;
+        metrics.generation = generation_;
+        dirty_ = false;
+        return true;
+    } catch (const std::bad_alloc&) {
+        return false;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool text_shaping_showcase_scene::ready() const noexcept {
+    return ready_;
+}
+
+bool text_shaping_showcase_scene::dirty() const noexcept {
+    return dirty_;
+}
+
+std::uint64_t text_shaping_showcase_scene::generation() const noexcept {
+    return generation_;
+}
+
+std::uint32_t text_shaping_showcase_scene::preset_index() const noexcept {
+    return preset_index_;
+}
+
+std::uint32_t text_shaping_showcase_scene::preset_count() noexcept {
+    return static_cast<std::uint32_t>(presets.size());
+}
+
+void text_shaping_showcase_scene::mark_dirty() noexcept {
+    ++generation_;
+    if (generation_ == 0U) {
+        generation_ = 1U;
+    }
+    dirty_ = true;
+}
+
+} // namespace progpu::native::samples

--- a/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.hpp
+++ b/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.hpp
@@ -47,6 +47,7 @@ public:
     text_shaping_showcase_scene();
 
     bool load_font(std::span<const std::byte> font_bytes) noexcept;
+    bool load_font(std::vector<std::byte>&& font_bytes) noexcept;
     bool resize(float width, float height, float dpi_scale) noexcept;
     bool set_preset(std::uint32_t preset_index) noexcept;
     void invalidate() noexcept;

--- a/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.hpp
+++ b/src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "progpu_native.h"
+#include "progpu_native_scene_builder.hpp"
+#include "progpu_native_text.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace progpu::native::samples {
+
+struct text_shaping_showcase_metrics final {
+    std::uint32_t preset_index = 0U;
+    std::uint32_t shaped_glyph_count = 0U;
+    std::uint32_t visible_glyph_count = 0U;
+    std::uint32_t unique_outline_count = 0U;
+    std::uint32_t feature_off_glyph_count = 0U;
+    std::uint32_t feature_on_glyph_count = 0U;
+    float feature_off_advance = 0.0F;
+    float feature_on_advance = 0.0F;
+    std::uint32_t command_count = 0U;
+    std::uint32_t resource_count = 0U;
+    std::uint64_t stream_bytes = 0U;
+    std::uint64_t generation = 0U;
+};
+
+/*
+ * Pure C++20 port of the live specimen and feature-comparison portions of the
+ * ProGPU-owned managed sample:
+ * src/ProGPU.Samples/Pages/TextShapingShowcasePage.cs.
+ *
+ * The port preserves the managed sample's exact preset text, OpenType feature
+ * ranges, script/language/direction metadata, one value-only shaping result,
+ * and retained DrawGlyphRun boundary. Browser UI chrome remains DOM-owned;
+ * every specimen pixel is shaped, outlined, rasterized, and composited by the
+ * native ProGPU text and WebGPU stacks.
+ *
+ * A changed preset or physical DPI performs O(S + G + P) CPU work for S input
+ * scalars, G shaped glyphs, and P decoded outline segments, then serializes one
+ * immutable scene. Stable replay performs no shaping, outline decode, scene
+ * serialization, or sample-side allocation.
+ */
+class text_shaping_showcase_scene final {
+public:
+    text_shaping_showcase_scene();
+
+    bool load_font(std::span<const std::byte> font_bytes) noexcept;
+    bool resize(float width, float height, float dpi_scale) noexcept;
+    bool set_preset(std::uint32_t preset_index) noexcept;
+    void invalidate() noexcept;
+
+    bool compile(
+        std::vector<std::byte>& stream,
+        text_shaping_showcase_metrics& metrics) noexcept;
+
+    bool ready() const noexcept;
+    bool dirty() const noexcept;
+    std::uint64_t generation() const noexcept;
+    std::uint32_t preset_index() const noexcept;
+    static std::uint32_t preset_count() noexcept;
+
+private:
+    void mark_dirty() noexcept;
+
+    static constexpr std::uint64_t scene_id_ = 0x5445585453484150ULL;
+    semantic_scene_builder builder_{scene_id_, 1U};
+    std::vector<std::byte> font_bytes_{};
+    text::sfnt_font_view font_{};
+    std::uint64_t generation_ = 1U;
+    std::uint32_t preset_index_ = 0U;
+    float width_ = 960.0F;
+    float height_ = 540.0F;
+    float dpi_scale_ = 1.0F;
+    bool ready_ = false;
+    bool dirty_ = true;
+};
+
+} // namespace progpu::native::samples

--- a/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.cpp
+++ b/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.cpp
@@ -200,6 +200,10 @@ bool motion_mark_scene::advance(float delta_seconds) noexcept {
     return true;
 }
 
+void motion_mark_scene::invalidate() noexcept {
+    mark_dirty();
+}
+
 bool motion_mark_scene::compile(
     std::vector<std::byte>& stream,
     motion_mark_scene_metrics& metrics) noexcept {

--- a/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp
+++ b/src/ProGPU.Native/samples/Views/progpu_native_motion_mark.hpp
@@ -48,6 +48,7 @@ public:
     bool set_color_mode(std::uint32_t mode) noexcept;
     bool regenerate(std::uint32_t seed) noexcept;
     bool advance(float delta_seconds) noexcept;
+    void invalidate() noexcept;
 
     bool compile(
         std::vector<std::byte>& stream,

--- a/src/ProGPU.Native/tests/progpu_native_text_shaping_showcase_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_shaping_showcase_tests.cpp
@@ -1,0 +1,95 @@
+#include "progpu_native_text_shaping_showcase.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using progpu::native::samples::text_shaping_showcase_metrics;
+using progpu::native::samples::text_shaping_showcase_scene;
+
+void require_impl(bool condition, int line) {
+    if (!condition) {
+        throw std::runtime_error(
+            "native text shaping showcase assertion failed at line " +
+            std::to_string(line));
+    }
+}
+
+#define require(condition) require_impl((condition), __LINE__)
+
+std::vector<std::byte> read_font() {
+    std::ifstream input(PROGPU_NATIVE_TEST_INTER_FONT, std::ios::binary);
+    require(input.good());
+    const std::vector<char> chars{
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>()};
+    std::vector<std::byte> bytes(chars.size());
+    for (std::size_t index = 0U; index < chars.size(); ++index) {
+        bytes[index] = static_cast<std::byte>(
+            static_cast<unsigned char>(chars[index]));
+    }
+    return bytes;
+}
+
+void managed_feature_wall_port_is_retained_and_dpi_sensitive() {
+    const auto font = read_font();
+    text_shaping_showcase_scene scene;
+    require(scene.load_font(font));
+    require(scene.ready());
+    require(scene.resize(960.0F, 640.0F, 1.0F));
+
+    std::vector<std::byte> stream;
+    text_shaping_showcase_metrics metrics{};
+    require(scene.compile(stream, metrics));
+    require(metrics.preset_index == 0U);
+    require(metrics.shaped_glyph_count > metrics.visible_glyph_count);
+    require(metrics.visible_glyph_count > 0U);
+    require(metrics.unique_outline_count > 16U);
+    require(metrics.feature_off_glyph_count > 0U);
+    require(metrics.feature_on_glyph_count > 0U);
+    require(metrics.command_count == 11U);
+    require(metrics.resource_count >= 2U);
+    require(metrics.stream_bytes == stream.size());
+    const auto first_stream = stream;
+    const auto first_generation = metrics.generation;
+
+    require(!scene.compile(stream, metrics));
+    require(scene.generation() == first_generation);
+
+    require(scene.set_preset(1U));
+    require(scene.compile(stream, metrics));
+    require(metrics.preset_index == 1U);
+    require(metrics.feature_on_glyph_count == metrics.feature_off_glyph_count);
+    require(metrics.feature_on_advance != metrics.feature_off_advance);
+    require(stream != first_stream);
+
+    for (std::uint32_t preset = 2U;
+         preset < text_shaping_showcase_scene::preset_count();
+         ++preset) {
+        require(scene.set_preset(preset));
+        require(scene.compile(stream, metrics));
+        require(metrics.preset_index == preset);
+        require(metrics.visible_glyph_count > 0U);
+        require(metrics.unique_outline_count > 0U);
+    }
+
+    const std::uint32_t glyph_count = metrics.shaped_glyph_count;
+    const std::uint32_t outline_count = metrics.unique_outline_count;
+    require(scene.resize(960.0F, 640.0F, 2.0F));
+    require(scene.compile(stream, metrics));
+    require(metrics.shaped_glyph_count == glyph_count);
+    require(metrics.unique_outline_count == outline_count);
+}
+
+} // namespace
+
+int main() {
+    managed_feature_wall_port_is_retained_and_dpi_sensitive();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Ports the eight feature-comparison cases from ProGPU's managed
`TextShapingShowcasePage` into the pure C++20 browser gallery. The page uses the
owned native Unicode/OpenType shaper, TrueType outline decoder, retained
semantic scene builder, compute glyph rasterizer, and the shared production
WebGPU text shader. There is no CLR, Canvas2D, browser/platform text API, or
pre-rendered specimen inside the render surface.

The gallery shell is redesigned as a responsive rendering laboratory with a
canvas-first desktop layout, horizontal mobile sample/preset navigation,
accessible pressed-state feature buttons, benchmark feedback, and a telemetry
rail that does not cover the canvas. The mobile document now fits a 390-pixel
viewport without horizontal or nested-scroll overflow, and the native scene
scales its typography/specimen layout to the available canvas.

Generic renderer PR #110 is now merged at exact main commit
`755952d6e70106533962dc2ebc9f3a8c5940dd31`. This branch has been merged
additively onto that immutable result and retargeted to `main`; the remaining
delta is exactly the 13 browser-gallery, sample, documentation, and test files.

## Milestones

- [x] Phase 1 — exact managed-sample provenance and C++ feature-wall model
- [x] Phase 2 — retained native shaping/outline/scene pipeline with physical-DPI raster sizing
- [x] Phase 3 — zero-copy native font ownership transfer, gallery controls, generation publication, and live counters
- [x] Phase 4 — responsive desktop/mobile laboratory UI and adaptive native scene typography
- [x] Phase 5 — focused native lifecycle tests, real Chromium WebGPU integration, repeated timing, and final size report
- [x] Phase 6 — rewritten-head Clang/GCC/MSVC, RID/package, managed, and browser CI closure (26/26 green)
- [x] Phase 7 — user manual visual acceptance and ready-for-review handoff

## Rendering-quality and retained-resource result

- Each coverage record is keyed by glyph and physical raster size, so large
  specimens do not magnify label-sized atlas coverage.
- Different physical sizes reuse one immutable source outline range. The
  Romanian scene fell from 131,496 to 73,992 stream bytes (-43.7%) while
  retaining full-resolution glyph coverage.
- Generic PR #110 constrains filtered atlas coordinates to each glyph's
  half-texel tile bounds. This removes faint horizontal/vertical glyph-quad
  lines without changing winding rules or relaxing the native/managed image
  threshold.
- Stable replay remains one render call and one GPU submission with no scene
  rebuild. Preset updates publish one immutable scene generation.

## Local validation

- [x] AppleClang C++20 Release `progpu_native_internal_tests`: 1/1
- [x] AppleClang C++20 Release `progpu_native_text_shaping_showcase_tests`: 1/1
- [x] managed `ShaderResourceTests`: 19/19
- [x] documentation/package gate
- [x] Release Emscripten `-O3 -flto` publish
- [x] complete real-Chromium WebGPU smoke and gallery contract
- [x] DPR 1 and DPR 2 physical-backing checks
- [x] 390×844 responsive capture: document width exactly 390, no console errors
- [x] explicit Windows test-target export definition for the C-ABI implementation
- [x] exact `main` merge and 13-file scope audit at rewritten head `046d28a979064760800b606fb55410ca7a4b0225`

The local 32-sample/eight-preset run on the final SwiftShader browser binary
measured native scene-update p50 1.90 ms, p95 2.30 ms, maximum 2.60 ms. These are
CPU update measurements, not discrete-GPU claims.

The representative Romanian preset records 267 positioned glyphs, 107 retained
outline records, 11 draws, and a 73,992-byte semantic stream.

## Optimized AOT payload

| Asset | Raw bytes | gzip -9 | Brotli -11 |
| --- | ---: | ---: | ---: |
| Gallery Wasm | 1,538,403 | 508,994 | 359,860 |
| Gallery JavaScript | 62,791 | 14,951 | 13,219 |
| Gallery HTML | 17,896 | 5,737 | 4,933 |
| Shared browser host | 4,153 | 1,432 | 1,176 |
| External Inter Regular | 411,640 | 196,987 | 157,517 |
| Total | 2,034,883 | 728,101 | 536,705 |

The 1.47 MiB raw Wasm contains the native renderer, semantic scene compiler,
Unicode/OpenType stack, outline decoder, and both gallery samples. Inter remains
a separately cacheable 404 KiB asset. The original MotionMark-only baseline was
628,799 raw Wasm bytes; the increase makes the previously dead-stripped native
text/font/outline code reachable rather than adding another shaping dependency.

## Provenance and research

Authoritative managed source:
`src/ProGPU.Samples/Pages/TextShapingShowcasePage.cs`. Native port:
`src/ProGPU.Native/samples/Pages/progpu_native_text_shaping_showcase.*`.
Architecture and measured evidence are recorded in
`docs/NATIVE_CPP_BROWSER_GALLERY.md`,
`docs/TEXT_SHAPING_SHOWCASE_RESEARCH.md`, and
`docs/GPU_TEXT_COVERAGE_CACHE_ARCHITECTURE.md`.

The records link primary WebGPU, Skia/SkParagraph, DirectWrite/Direct2D and
Win2D, WebRender, Vello, Parley, and HarfBuzz sources. No third-party
implementation source was copied.
