### PR TITLE
Fix native paragraph ellipsis font ownership

### DIFF
--- a/src/ProGPU.Native/src/Text/Interop/progpu_native_text_shaping_interop.cpp
+++ b/src/ProGPU.Native/src/Text/Interop/progpu_native_text_shaping_interop.cpp
@@ -2341,10 +2341,17 @@ progpu_native_status progpu_native_text_context_layout_paragraph(
         }
         for (std::uint32_t index = 0U; index < positioned_count; ++index) {
             const auto& source = positioned[index];
+            // Layout owns the synthetic ellipsis, so it has no source-glyph
+            // index. The public paragraph contract resolves that caller-
+            // supplied glyph against the primary face.
+            const auto font_index = source.glyph_index ==
+                    std::numeric_limits<std::uint32_t>::max()
+                ? 0U
+                : glyph_font_indices[source.glyph_index];
             glyphs[index] = progpu_native_positioned_text_glyph{
                 source.glyph_index,
                 source.glyph_id,
-                glyph_font_indices[source.glyph_index],
+                font_index,
                 source.cluster,
                 source.x,
                 source.y,

--- a/src/ProGPU.Native/tests/progpu_native_text_interop_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_interop_tests.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iterator>
+#include <limits>
 #include <stdexcept>
 #include <string_view>
 #include <vector>
@@ -450,6 +451,34 @@ void bulk_shape_is_deterministic_and_caller_owned() {
             paragraph_glyphs[index].advance_x == positioned[index].advance_x &&
             paragraph_glyphs[index].advance_y == positioned[index].advance_y);
     }
+
+    auto trimmed_options = paragraph_options;
+    trimmed_options.maximum_width = 1.0F;
+    trimmed_options.maximum_lines = 1U;
+    trimmed_options.trimming = PROGPU_NATIVE_TEXT_TRIMMING_CHARACTER_ELLIPSIS;
+    trimmed_options.alignment = PROGPU_NATIVE_TEXT_ALIGNMENT_LEFT;
+    trimmed_options.ellipsis_glyph_id = first[0U].glyph_id;
+    trimmed_options.ellipsis_advance =
+        static_cast<float>(first[0U].advance_x);
+    paragraph_result.struct_size = sizeof(paragraph_result);
+    require(progpu_native_text_context_layout_paragraph(
+                context,
+                &retained_request,
+                &trimmed_options,
+                paragraph_glyphs.data(),
+                static_cast<std::uint32_t>(paragraph_glyphs.size()),
+                paragraph_lines.data(),
+                static_cast<std::uint32_t>(paragraph_lines.size()),
+                paragraph_scratch.data(),
+                paragraph_scratch.size(),
+                &paragraph_result) == PROGPU_NATIVE_STATUS_SUCCESS);
+    require(paragraph_result.glyph_count == 1U &&
+        paragraph_result.line_count == 1U &&
+        paragraph_glyphs[0U].glyph_index ==
+            std::numeric_limits<std::uint32_t>::max() &&
+        paragraph_glyphs[0U].glyph_id == trimmed_options.ellipsis_glyph_id &&
+        paragraph_glyphs[0U].font_index == 0U &&
+        paragraph_lines[0U].clipped != 0U);
 
     progpu_native_text_paragraph_result short_paragraph_result{};
     short_paragraph_result.struct_size = sizeof(short_paragraph_result);


### PR DESCRIPTION
## Summary

- assign layout-owned synthetic ellipsis glyphs to the primary font face in the native paragraph result
- avoid indexing the source-glyph font map with the synthetic `UINT32_MAX` sentinel
- cover character-ellipsis output with a focused native interop regression

## Contract and performance

The ellipsis glyph id is supplied by the caller through the paragraph options and has no source glyph record. The native paragraph contract therefore reports font index 0, the primary face, for that synthetic glyph. The wire ABI is unchanged. The projection remains allocation-free and O(glyph count), adding one predictable sentinel comparison per positioned glyph.

## Managed/native applicability

The defect is limited to the native C ABI projection from layout glyphs to integer font indices. The pure managed layout carries a direct font object on every glyph and does not index a parallel font map for synthetic layout output, so no corresponding managed source change applies. Managed native-wrapper tests exercise the corrected ABI record.

## Validation

- AppleClang Release native text static build and interop test
- AppleClang Debug ASan/UBSan native text build and interop test
- managed NativeRendererInteropTests: 56/56 passed (Release, osx-arm64)
- privacy scan clean

Base audited at `497afbb366b9ead7712eb9138f02bd829ad4cb1c`.