### PR TITLE
Fix PairPos device offset resolution

### DIFF
--- a/src/ProGPU.Native/src/Text/Shaping/progpu_native_open_type_gpos.cpp
+++ b/src/ProGPU.Native/src/Text/Shaping/progpu_native_open_type_gpos.cpp
@@ -782,6 +782,7 @@ apply_result apply_pair(
     const std::size_t value_size1 = value_record_size(value_format1);
     const std::size_t value_size2 = value_record_size(value_format2);
     std::size_t value1_offset = 0U;
+    std::size_t value_parent = subtable;
     if (format == 1U) {
         const std::uint16_t pair_set_count = read_u16(table, subtable + 8U);
         if (static_cast<std::uint32_t>(coverage_index) >= pair_set_count ||
@@ -820,6 +821,7 @@ apply_result apply_pair(
         if (value1_offset == 0U) {
             return apply_result::no_match;
         }
+        value_parent = pair_set;
     } else if (format == 2U) {
         if (!can_read(table, subtable, 16U)) {
             return apply_result::malformed;
@@ -863,14 +865,14 @@ apply_result apply_pair(
     value_adjustment value2{};
     if (!parse_value_record(
             table,
-            subtable,
+            value_parent,
             value1_offset,
             value_format1,
             options,
             value1) ||
         !parse_value_record(
             table,
-            subtable,
+            value_parent,
             value1_offset + value_size1,
             value_format2,
             options,

--- a/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
@@ -6924,6 +6924,65 @@ void open_type_gpos_device_and_variation_deltas_are_applied() {
         applied,
         &error));
     require(applied && glyphs[0U].advance_x == 520);
+
+    // PairPos format 1 Device offsets are relative to the containing PairSet,
+    // while format 2 offsets are relative to the PairPos subtable.
+    std::vector<std::byte> pair_gpos(60U);
+    write_u16(pair_gpos, 0U, 1U);
+    write_u16(pair_gpos, 4U, 10U);
+    write_u16(pair_gpos, 6U, 12U);
+    write_u16(pair_gpos, 8U, 14U);
+    write_u16(pair_gpos, 14U, 1U);
+    write_u16(pair_gpos, 16U, 4U);
+    write_u16(pair_gpos, 18U, 2U);
+    write_u16(pair_gpos, 22U, 1U);
+    write_u16(pair_gpos, 24U, 8U);
+    write_u16(pair_gpos, 26U, 1U);
+    write_u16(pair_gpos, 28U, 12U);
+    write_u16(pair_gpos, 30U, 0x0044U);
+    write_u16(pair_gpos, 34U, 1U);
+    write_u16(pair_gpos, 36U, 18U);
+    write_u16(pair_gpos, 38U, 1U);
+    write_u16(pair_gpos, 40U, 1U);
+    write_u16(pair_gpos, 42U, 3U);
+    write_u16(pair_gpos, 44U, 1U);
+    write_u16(pair_gpos, 46U, 4U);
+    write_i16(pair_gpos, 48U, -25);
+    write_u16(pair_gpos, 50U, 8U);
+    write_u16(pair_gpos, 52U, 20U);
+    write_u16(pair_gpos, 54U, 20U);
+    write_u16(pair_gpos, 56U, 3U);
+    write_u16(pair_gpos, 58U, 0xFF00U);
+    const std::array pair_tables{table_data{
+        open_type_tag::from_chars('G', 'P', 'O', 'S'), pair_gpos}};
+    const auto pair_font_bytes = make_font(
+        0U, 22U, 0U, false, false, false, pair_tables);
+    sfnt_font_view pair_font{};
+    require(sfnt_font_view::try_create(
+        pair_font_bytes, 0U, pair_font, &error));
+    require(pair_font.try_get_table(
+        open_type_tag::from_chars('G', 'P', 'O', 'S'), gpos_table));
+    require(open_type_layout_table_view::try_create(
+        gpos_table.bytes, gpos, &error));
+    std::array<shaping_glyph, 2U> pair_glyphs{
+        shaping_glyph{3U, 0U, 0, shaping_glyph_flags::none, 500},
+        shaping_glyph{4U, 0U, 1, shaping_glyph_flags::none, 500}};
+    require(try_apply_open_type_gpos_lookup(
+        gpos,
+        0U,
+        pair_glyphs,
+        open_type_gpos_apply_options{
+            nullptr,
+            progpu::native::text::shaping_direction::left_to_right,
+            {},
+            &pair_font,
+            {},
+            20U,
+            20U},
+        applied,
+        &error));
+    require(applied && pair_glyphs[0U].advance_x == 425 &&
+        pair_glyphs[1U].advance_x == 500);
 }
 
 void native_font_fallback_preserves_graphemes_and_missing_state() {

--- a/src/ProGPU.Tests/OpenTypeTextShaperTests.cs
+++ b/src/ProGPU.Tests/OpenTypeTextShaperTests.cs
@@ -157,6 +157,27 @@ public sealed class OpenTypeTextShaperTests
         Assert.Equal(new[] { 1250f, 1246f, 1241f, 1119f, 1430f, 1321f }, glyphs.Select(static glyph => glyph.AdvanceX));
     }
 
+    [Theory]
+    [InlineData("A<", 2, 1529, 1430, 1341)]
+    [InlineData("DЖ", 84, 1072, 1347, 2014)]
+    [InlineData("Ǝ_", 122, 1543, 1234, 951)]
+    [InlineData("Fȉ", 137, 706, 1335, 491)]
+    [InlineData("H_", 161, 1543, 1501, 951)]
+    [InlineData("IƗ", 197, 201, 601, 691)]
+    public void VariablePairSetDeviceOffsetsMatchHarfBuzzReference(
+        string text,
+        ushort firstGlyph,
+        ushort secondGlyph,
+        int firstAdvance,
+        int secondAdvance)
+    {
+        TtfFont font = InterFontFamily.GetVariableFont(537, 23);
+        IReadOnlyList<ShapedGlyph> glyphs = OpenTypeTextShaper.Shape(text, font, font.UnitsPerEm);
+
+        Assert.Equal(new[] { firstGlyph, secondGlyph }, glyphs.Select(static glyph => glyph.GlyphIndex));
+        Assert.Equal(new[] { (float)firstAdvance, secondAdvance }, glyphs.Select(static glyph => glyph.AdvanceX));
+    }
+
     [Fact]
     public void PrintableAsciiDataGridLabelMatchesHarfBuzzReference()
     {

--- a/src/ProGPU.Text/OpenTypeTextShaper.cs
+++ b/src/ProGPU.Text/OpenTypeTextShaper.cs
@@ -3344,7 +3344,7 @@ public static class OpenTypeTextShaper
                 }
                 ApplyRawPositionLookup(
                     plan.RawTable.Span, glyphs, enabled, options);
-                ApplyPositionVariations(font, glyphs, enabled.LookupIndex);
+                ApplyPositionVariations(font, glyphs, enabled, options);
             }
             return plan.HasKerning;
         }
@@ -4105,7 +4105,8 @@ public static class OpenTypeTextShaper
     private static void ApplyPositionVariations(
         TtfFont font,
         GlyphPositionBuffer glyphs,
-        ushort lookupIndex)
+        EnabledLookup enabled,
+        TextShapingOptions options)
     {
         if (!font.HasActiveFontVariations ||
             !font.TryGetTable("GPOS", out ReadOnlyMemory<byte> tableMemory))
@@ -4114,12 +4115,41 @@ public static class OpenTypeTextShaper
         }
 
         ReadOnlySpan<byte> data = tableMemory.Span;
-        if (!TryGetLookup(data, lookupIndex, out int lookupOffset, out ushort lookupType, out int subtableCountOffset))
+        if (!TryGetLookup(data, enabled.LookupIndex, out int lookupOffset, out ushort lookupType, out int subtableCountOffset))
         {
             return;
         }
 
         ushort subtableCount = ReadU16(data, subtableCountOffset);
+        bool hasPairPositioning = lookupType == 2;
+        if (lookupType == 9)
+        {
+            for (var subtableIndex = 0; subtableIndex < subtableCount; subtableIndex++)
+            {
+                int offsetPosition = subtableCountOffset + 2 + subtableIndex * 2;
+                if (!CanRead(data, offsetPosition, 2)) break;
+                int extension = lookupOffset + ReadU16(data, offsetPosition);
+                if (CanRead(data, extension, 8) && ReadU16(data, extension) == 1 &&
+                    ReadU16(data, extension + 2) == 2)
+                {
+                    hasPairPositioning = true;
+                    break;
+                }
+            }
+        }
+        if (hasPairPositioning)
+        {
+            ApplyPairPositionVariations(
+                data,
+                font,
+                glyphs,
+                lookupOffset,
+                lookupType,
+                subtableCountOffset,
+                enabled,
+                options);
+            return;
+        }
         for (var subtableIndex = 0; subtableIndex < subtableCount; subtableIndex++)
         {
             int offsetPosition = subtableCountOffset + 2 + subtableIndex * 2;
@@ -4139,9 +4169,6 @@ public static class OpenTypeTextShaper
             {
                 case 1:
                     ApplySinglePositionVariations(data, font, glyphs, subtableOffset);
-                    break;
-                case 2:
-                    ApplyPairPositionVariations(data, font, glyphs, subtableOffset);
                     break;
                 case 4:
                     ApplyMarkToBaseVariations(data, font, glyphs, subtableOffset);
@@ -4189,60 +4216,111 @@ public static class OpenTypeTextShaper
         ReadOnlySpan<byte> data,
         TtfFont font,
         GlyphPositionBuffer glyphs,
-        int offset)
+        int lookupOffset,
+        ushort lookupType,
+        int subtableCountOffset,
+        EnabledLookup enabled,
+        TextShapingOptions options)
     {
-        if (!CanRead(data, offset, 10)) return;
+        ushort lookupFlags = ReadU16(data, lookupOffset + 2);
+        ushort subtableCount = ReadU16(data, subtableCountOffset);
+        ushort markFilteringSet = ushort.MaxValue;
+        int markFilteringSetOffset = subtableCountOffset + 2 + subtableCount * 2;
+        if ((lookupFlags & 0x0010) != 0 && CanRead(data, markFilteringSetOffset, 2))
+            markFilteringSet = ReadU16(data, markFilteringSetOffset);
+        int previousMarkFilteringCoverage = glyphs.SetMarkFilteringSet(markFilteringSet);
+        try
+        {
+            for (var position = 0; position < glyphs.Count; position++)
+            {
+                if (enabled.HasDigest && !enabled.Digest.MayHave(glyphs.GetGlyph(position))) continue;
+                if (!enabled.Required && options.GetFeatureValue(enabled.Tag, glyphs[position].Cluster) == 0) continue;
+                if (!glyphs.IsEligibleIndex(position, lookupFlags)) continue;
+                int second = glyphs.NextEligibleIndex(position + 1, lookupFlags);
+                if (second < 0) continue;
+                for (var subtableIndex = 0; subtableIndex < subtableCount; subtableIndex++)
+                {
+                    int offsetPosition = subtableCountOffset + 2 + subtableIndex * 2;
+                    if (!CanRead(data, offsetPosition, 2)) break;
+                    int subtableOffset = lookupOffset + ReadU16(data, offsetPosition);
+                    ushort effectiveType = lookupType;
+                    if (effectiveType == 9)
+                    {
+                        if (!CanRead(data, subtableOffset, 8) || ReadU16(data, subtableOffset) != 1) continue;
+                        effectiveType = ReadU16(data, subtableOffset + 2);
+                        uint extensionOffset = ReadU32(data, subtableOffset + 4);
+                        if (extensionOffset > int.MaxValue) continue;
+                        subtableOffset += (int)extensionOffset;
+                    }
+                    if (effectiveType == 2 && TryApplyPairPositionVariationAt(
+                            data, font, glyphs, subtableOffset, position, second))
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            glyphs.RestoreMarkFilteringCoverage(previousMarkFilteringCoverage);
+        }
+    }
+
+    private static bool TryApplyPairPositionVariationAt(
+        ReadOnlySpan<byte> data,
+        TtfFont font,
+        GlyphPositionBuffer glyphs,
+        int offset,
+        int position,
+        int second)
+    {
+        if (!CanRead(data, offset, 10)) return false;
         ushort format = ReadU16(data, offset);
         int coverageOffset = offset + ReadU16(data, offset + 2);
         ushort valueFormat1 = ReadU16(data, offset + 4);
         ushort valueFormat2 = ReadU16(data, offset + 6);
         int valueSize1 = GetValueRecordSize(valueFormat1);
         int valueSize2 = GetValueRecordSize(valueFormat2);
-        for (var index = 0; index + 1 < glyphs.Count; index++)
+        int coverageIndex = FindCoverage(data, coverageOffset, glyphs.GetGlyph(position));
+        if (coverageIndex < 0) return false;
+        int value1Offset;
+        int value2Offset;
+        if (format == 1)
         {
-            int coverageIndex = FindCoverage(data, coverageOffset, glyphs.GetGlyph(index));
-            if (coverageIndex < 0) continue;
-            int value1Offset;
-            int value2Offset;
-            if (format == 1)
+            ushort setCount = ReadU16(data, offset + 8);
+            if ((uint)coverageIndex >= setCount || !CanRead(data, offset + 10 + coverageIndex * 2, 2)) return false;
+            int setOffset = offset + ReadU16(data, offset + 10 + coverageIndex * 2);
+            if (!CanRead(data, setOffset, 2)) return false;
+            int pairCount = ReadU16(data, setOffset);
+            int recordSize = 2 + valueSize1 + valueSize2;
+            int recordOffset = setOffset + 2;
+            for (var pair = 0; pair < pairCount; pair++, recordOffset += recordSize)
             {
-                ushort setCount = ReadU16(data, offset + 8);
-                if ((uint)coverageIndex >= setCount || !CanRead(data, offset + 10 + coverageIndex * 2, 2)) continue;
-                int setOffset = offset + ReadU16(data, offset + 10 + coverageIndex * 2);
-                if (!CanRead(data, setOffset, 2)) continue;
-                int pairCount = ReadU16(data, setOffset);
-                int recordSize = 2 + valueSize1 + valueSize2;
-                int recordOffset = setOffset + 2;
-                bool found = false;
-                for (var pair = 0; pair < pairCount; pair++, recordOffset += recordSize)
-                {
-                    if (!CanRead(data, recordOffset, recordSize)) break;
-                    if (ReadU16(data, recordOffset) != glyphs.GetGlyph(index + 1)) continue;
-                    value1Offset = recordOffset + 2;
-                    value2Offset = value1Offset + valueSize1;
-                    ApplyValueVariation(data, font, glyphs, index, value1Offset, valueFormat1, offset);
-                    ApplyValueVariation(data, font, glyphs, index + 1, value2Offset, valueFormat2, offset);
-                    found = true;
-                    break;
-                }
-                if (!found) continue;
-            }
-            else if (format == 2 && CanRead(data, offset, 16))
-            {
-                int class1Def = offset + ReadU16(data, offset + 8);
-                int class2Def = offset + ReadU16(data, offset + 10);
-                int class1Count = ReadU16(data, offset + 12);
-                int class2Count = ReadU16(data, offset + 14);
-                int class1 = GetGlyphClass(data, class1Def, glyphs.GetGlyph(index));
-                int class2 = GetGlyphClass(data, class2Def, glyphs.GetGlyph(index + 1));
-                if ((uint)class1 >= class1Count || (uint)class2 >= class2Count) continue;
-                int recordSize = valueSize1 + valueSize2;
-                value1Offset = offset + 16 + (class1 * class2Count + class2) * recordSize;
+                if (!CanRead(data, recordOffset, recordSize)) return false;
+                if (ReadU16(data, recordOffset) != glyphs.GetGlyph(second)) continue;
+                value1Offset = recordOffset + 2;
                 value2Offset = value1Offset + valueSize1;
-                ApplyValueVariation(data, font, glyphs, index, value1Offset, valueFormat1, offset);
-                ApplyValueVariation(data, font, glyphs, index + 1, value2Offset, valueFormat2, offset);
+                ApplyValueVariation(data, font, glyphs, position, value1Offset, valueFormat1, setOffset);
+                ApplyValueVariation(data, font, glyphs, second, value2Offset, valueFormat2, setOffset);
+                return true;
             }
+            return false;
         }
+        if (format != 2 || !CanRead(data, offset, 16)) return false;
+        int class1Def = offset + ReadU16(data, offset + 8);
+        int class2Def = offset + ReadU16(data, offset + 10);
+        int class1Count = ReadU16(data, offset + 12);
+        int class2Count = ReadU16(data, offset + 14);
+        int class1 = GetGlyphClass(data, class1Def, glyphs.GetGlyph(position));
+        int class2 = GetGlyphClass(data, class2Def, glyphs.GetGlyph(second));
+        if ((uint)class1 >= class1Count || (uint)class2 >= class2Count) return false;
+        int classRecordSize = valueSize1 + valueSize2;
+        value1Offset = offset + 16 + (class1 * class2Count + class2) * classRecordSize;
+        value2Offset = value1Offset + valueSize1;
+        if (!CanRead(data, value1Offset, classRecordSize)) return false;
+        ApplyValueVariation(data, font, glyphs, position, value1Offset, valueFormat1, offset);
+        ApplyValueVariation(data, font, glyphs, second, value2Offset, valueFormat2, offset);
+        return true;
     }
 
     private static void ApplyMarkToBaseVariations(


### PR DESCRIPTION
## Summary

- resolve PairPos format 1 Device and VariationIndex offsets from the containing PairSet in the native OpenType shaper
- synchronize the managed variation pass with OpenType lookup selection, feature ranges, lookup flags, mark filtering, and first-matching-subtable semantics
- add native synthetic and managed variable-font reference regressions

## Correctness evidence

The native regression places a valid Device table at a PairSet-relative offset that is invalid from the outer PairPos base and verifies the combined base and device advance. The managed regression covers six Inter variable-font pairs at weight 537 and optical size 23 using HarfBuzz reference glyphs and advances. Before this change five of the six reference pairs fail; changing only the offset base still leaves two selection failures. All six pass with the synchronized lookup selection.

## Managed/native parity

Both implementations now use the OpenType-defined PairSet parent for format 1 while retaining the PairPos parent for format 2. The managed pass also mirrors native raw lookup execution by applying variation deltas only from the first matching pair-position subtable.

## Performance evidence

A local Release microbenchmark alternated eight fresh-process runs of the six affected two-glyph Inter variable pairs against immutable main 0779b911. Median managed shape time was 2.030 us on main and 2.082 us on this branch, a 2.6% cost on this deliberately pair-dense microcase. Median p95 was 15.984 us and 16.410 us. Managed allocation was unchanged at approximately 252.4 bytes per shape. The change adds no collection or asymptotic complexity.

## Validation

- AppleClang Release native text, native text interop, and Dawn contract: 3/3 passed
- AppleClang Debug ASan and UBSan native text plus interop: 2/2 passed with leak detection disabled on macOS
- managed OpenTypeTextShaperTests plus NativeRendererInteropTests: 127/127 passed
- diff check and privacy scan: passed