### PR TITLE
Bound native system font residency

### DIFF
--- a/src/ProGPU.Native/include/progpu_native_text.hpp
+++ b/src/ProGPU.Native/include/progpu_native_text.hpp
@@ -3519,6 +3519,8 @@ struct font_catalog_face_info final {
     font_provider_slant slant = font_provider_slant::normal;
 };
 
+class font_file_storage;
+
 /*
  * One selected face with shared immutable file ownership. Copies are O(1),
  * and every borrowed sfnt_font_view span remains valid until the last copy is
@@ -3529,15 +3531,21 @@ public:
     loaded_font_face() noexcept = default;
 
     bool valid() const noexcept;
+    bool is_memory_mapped() const noexcept;
     std::span<const std::byte> data() const noexcept;
     const sfnt_font_view& font() const noexcept;
     std::uint32_t catalog_index() const noexcept;
     std::uint64_t identity() const noexcept;
+    bool try_create_glyph_resident_face(
+        std::uint16_t glyph_index,
+        loaded_font_face& result,
+        sfnt_glyph_resident_requirements* requirements = nullptr,
+        font_catalog_error* error = nullptr) const noexcept;
 
 private:
     friend class system_font_catalog;
 
-    std::shared_ptr<const std::vector<std::byte>> storage_{};
+    std::shared_ptr<const font_file_storage> storage_{};
     sfnt_font_view font_{};
     std::uint32_t catalog_index_ = 0U;
     std::uint64_t identity_ = 0U;

--- a/src/ProGPU.Native/src/Text/Font/progpu_native_system_font_catalog.cpp
+++ b/src/ProGPU.Native/src/Text/Font/progpu_native_system_font_catalog.cpp
@@ -19,12 +19,140 @@
 #include <utility>
 #include <vector>
 
+#if defined(_WIN32)
+#define NOMINMAX
+#include <windows.h>
+#elif (defined(__unix__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
 // Direct native port provenance: ProGPU-owned FontApi.ScanSystemFonts,
 // SfntFontMetadataReader, and FontManager matching policy at checkpoint
 // 497afbb3. The native catalog keeps the same metadata-only discovery and
 // lazy-cmap/full-face ownership boundaries without using a platform text API.
+// Native residency port provenance: ProGPU-owned MappedFontData,
+// TtfFont.CreateFileStorage, and TtfFont.LoadGlyphResidentFile at checkpoint
+// 0779b911. Selected SFNT files use the same read-only mapped-file policy, and
+// large bitmap fallbacks can derive a bounded owned face for one glyph.
 
 namespace progpu::native::text {
+
+class font_file_storage final {
+  public:
+    static std::shared_ptr<const font_file_storage> try_map(
+        const std::filesystem::path& path) noexcept {
+#if defined(_WIN32)
+        const auto file = CreateFileW(
+            path.c_str(), GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS,
+            nullptr);
+        if (file == INVALID_HANDLE_VALUE) return {};
+        LARGE_INTEGER length{};
+        if (!GetFileSizeEx(file, &length) || length.QuadPart <= 0 ||
+            static_cast<std::uint64_t>(length.QuadPart) >
+                std::numeric_limits<std::size_t>::max()) {
+            CloseHandle(file);
+            return {};
+        }
+        const auto mapping = CreateFileMappingW(
+            file, nullptr, PAGE_READONLY, 0U, 0U, nullptr);
+        CloseHandle(file);
+        if (mapping == nullptr) return {};
+        const auto view = MapViewOfFile(mapping, FILE_MAP_READ, 0U, 0U, 0U);
+        if (view == nullptr) {
+            CloseHandle(mapping);
+            return {};
+        }
+        try {
+            return std::shared_ptr<const font_file_storage>(
+                new font_file_storage(view,
+                    static_cast<std::size_t>(length.QuadPart), mapping));
+        } catch (...) {
+            UnmapViewOfFile(view);
+            CloseHandle(mapping);
+            return {};
+        }
+#elif (defined(__unix__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__)
+        auto flags = O_RDONLY;
+#if defined(O_CLOEXEC)
+        flags |= O_CLOEXEC;
+#endif
+        const auto file = ::open(path.c_str(), flags);
+        if (file < 0) return {};
+        struct stat status {};
+        if (::fstat(file, &status) != 0 || status.st_size <= 0 ||
+            static_cast<std::uint64_t>(status.st_size) >
+                std::numeric_limits<std::size_t>::max()) {
+            ::close(file);
+            return {};
+        }
+        const auto length = static_cast<std::size_t>(status.st_size);
+        const auto view = ::mmap(
+            nullptr, length, PROT_READ, MAP_PRIVATE, file, 0);
+        ::close(file);
+        if (view == MAP_FAILED) return {};
+#if defined(MADV_RANDOM)
+        (void)::madvise(view, length, MADV_RANDOM);
+#endif
+        try {
+            return std::shared_ptr<const font_file_storage>(
+                new font_file_storage(view, length));
+        } catch (...) {
+            ::munmap(view, length);
+            return {};
+        }
+#else
+        (void)path;
+        return {};
+#endif
+    }
+
+    static std::shared_ptr<const font_file_storage> from_owned(
+        std::vector<std::byte> bytes) {
+        return std::shared_ptr<const font_file_storage>(
+            new font_file_storage(std::move(bytes)));
+    }
+
+    ~font_file_storage() {
+#if defined(_WIN32)
+        if (mapped_data_ != nullptr) UnmapViewOfFile(mapped_data_);
+        if (mapping_ != nullptr) CloseHandle(mapping_);
+#elif (defined(__unix__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__)
+        if (mapped_data_ != nullptr) ::munmap(mapped_data_, size_);
+#endif
+    }
+
+    std::span<const std::byte> data() const noexcept {
+        return {static_cast<const std::byte*>(data_), size_};
+    }
+
+    bool is_memory_mapped() const noexcept { return mapped_data_ != nullptr; }
+
+  private:
+    explicit font_file_storage(std::vector<std::byte> bytes)
+        : owned_(std::move(bytes)), data_(owned_.data()), size_(owned_.size()) {}
+
+#if defined(_WIN32)
+    font_file_storage(void* data, std::size_t size, HANDLE mapping) noexcept
+        : data_(data), size_(size), mapped_data_(data), mapping_(mapping) {}
+#elif (defined(__unix__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__)
+    font_file_storage(void* data, std::size_t size) noexcept
+        : data_(data), size_(size), mapped_data_(data) {}
+#endif
+
+    std::vector<std::byte> owned_{};
+    const void* data_{};
+    std::size_t size_{};
+    void* mapped_data_{};
+#if defined(_WIN32)
+    HANDLE mapping_{};
+#endif
+};
+
 namespace {
 
 using detail::read_u16;
@@ -444,7 +572,7 @@ class system_font_catalog::implementation final {
 
     std::vector<entry> entries{};
     mutable std::mutex cache_mutex{};
-    mutable std::unordered_map<std::string, std::weak_ptr<const std::vector<std::byte>>>
+    mutable std::unordered_map<std::string, std::weak_ptr<const font_file_storage>>
         loaded_files{};
     mutable std::unordered_map<character_key, character_result, character_key_hash>
         character_cache{};
@@ -570,11 +698,15 @@ bool system_font_catalog::implementation::read_font_entries(const std::filesyste
 }
 
 bool loaded_font_face::valid() const noexcept {
-    return storage_ != nullptr && !storage_->empty() && !font_.data().empty();
+    return storage_ != nullptr && !storage_->data().empty() && !font_.data().empty();
+}
+
+bool loaded_font_face::is_memory_mapped() const noexcept {
+    return storage_ != nullptr && storage_->is_memory_mapped();
 }
 
 std::span<const std::byte> loaded_font_face::data() const noexcept {
-    return storage_ == nullptr ? std::span<const std::byte>{} : *storage_;
+    return storage_ == nullptr ? std::span<const std::byte>{} : storage_->data();
 }
 
 const sfnt_font_view& loaded_font_face::font() const noexcept { return font_; }
@@ -582,6 +714,55 @@ const sfnt_font_view& loaded_font_face::font() const noexcept { return font_; }
 std::uint32_t loaded_font_face::catalog_index() const noexcept { return catalog_index_; }
 
 std::uint64_t loaded_font_face::identity() const noexcept { return identity_; }
+
+bool loaded_font_face::try_create_glyph_resident_face(
+    std::uint16_t glyph_index, loaded_font_face& result,
+    sfnt_glyph_resident_requirements* requirements,
+    font_catalog_error* error) const noexcept {
+    result = {};
+    set_error(error, font_catalog_error::none);
+    if (requirements != nullptr) *requirements = {};
+    if (!valid()) {
+        set_error(error, font_catalog_error::invalid_argument);
+        return false;
+    }
+    sfnt_glyph_resident_requirements resolved{};
+    font_error font_result = font_error::none;
+    if (!font_.try_get_glyph_resident_requirements(
+            glyph_index, resolved, &font_result)) {
+        set_error(error, font_catalog_error::invalid_font);
+        return false;
+    }
+    if (requirements != nullptr) *requirements = resolved;
+    try {
+        std::vector<std::byte> bytes(resolved.font_bytes);
+        std::size_t written = 0U;
+        if (!font_.try_create_glyph_resident_font(
+                glyph_index, bytes, written, &resolved, &font_result)) {
+            set_error(error, font_catalog_error::invalid_font);
+            return false;
+        }
+        bytes.resize(written);
+        auto storage = font_file_storage::from_owned(std::move(bytes));
+        sfnt_font_view resident{};
+        if (!sfnt_font_view::try_create(
+                storage->data(), 0U, resident, &font_result)) {
+            set_error(error, font_catalog_error::invalid_font);
+            return false;
+        }
+        result.storage_ = std::move(storage);
+        result.font_ = resident;
+        result.catalog_index_ = catalog_index_;
+        result.identity_ = identity_;
+        return true;
+    } catch (const std::bad_alloc&) {
+        set_error(error, font_catalog_error::out_of_memory);
+        return false;
+    } catch (...) {
+        set_error(error, font_catalog_error::invalid_font);
+        return false;
+    }
+}
 
 system_font_catalog::system_font_catalog() : implementation_(std::make_unique<implementation>()) {}
 
@@ -918,7 +1099,7 @@ bool system_font_catalog::try_load_face(std::uint32_t catalog_index, loaded_font
         return false;
     }
     const auto& entry = implementation_->entries[catalog_index];
-    std::shared_ptr<const std::vector<std::byte>> storage;
+    std::shared_ptr<const font_file_storage> storage;
     {
         std::lock_guard lock(implementation_->cache_mutex);
         const auto cached = implementation_->loaded_files.find(entry.file_path);
@@ -928,18 +1109,21 @@ bool system_font_catalog::try_load_face(std::uint32_t catalog_index, loaded_font
     }
     if (!storage) {
         try {
-            file_reader reader(entry.file_path);
-            if (!reader.valid() || reader.size() > std::numeric_limits<std::size_t>::max()) {
-                set_error(error, font_catalog_error::filesystem_error);
-                return false;
+            storage = font_file_storage::try_map(entry.file_path);
+            if (!storage) {
+                file_reader reader(entry.file_path);
+                if (!reader.valid() ||
+                    reader.size() > std::numeric_limits<std::size_t>::max()) {
+                    set_error(error, font_catalog_error::filesystem_error);
+                    return false;
+                }
+                std::vector<std::byte> loaded(static_cast<std::size_t>(reader.size()));
+                if (!reader.read(0U, loaded)) {
+                    set_error(error, font_catalog_error::filesystem_error);
+                    return false;
+                }
+                storage = font_file_storage::from_owned(std::move(loaded));
             }
-            auto loaded =
-                std::make_shared<std::vector<std::byte>>(static_cast<std::size_t>(reader.size()));
-            if (!reader.read(0U, *loaded)) {
-                set_error(error, font_catalog_error::filesystem_error);
-                return false;
-            }
-            storage = std::move(loaded);
             std::lock_guard lock(implementation_->cache_mutex);
             auto& slot = implementation_->loaded_files[entry.file_path];
             if (auto concurrent = slot.lock())
@@ -955,7 +1139,7 @@ bool system_font_catalog::try_load_face(std::uint32_t catalog_index, loaded_font
         }
     }
     sfnt_font_view font{};
-    if (!sfnt_font_view::try_create(*storage, entry.face_index, font)) {
+    if (!sfnt_font_view::try_create(storage->data(), entry.face_index, font)) {
         set_error(error, font_catalog_error::invalid_font);
         return false;
     }

--- a/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
@@ -10104,6 +10104,7 @@ void system_font_catalog_streams_metadata_and_owns_selected_faces() {
     const auto inter = directory / "Inter-Medium.ttf";
     const auto noto = directory / "NotoSansCJKjp-Regular.otf";
     const auto collection_path = directory / "CatalogFace.ttc";
+    const auto color_path = directory / "ColorFixture.ttf";
     std::filesystem::copy_file(
         PROGPU_NATIVE_TEST_INTER_FONT, inter,
         std::filesystem::copy_options::overwrite_existing);
@@ -10121,6 +10122,15 @@ void system_font_catalog_streams_metadata_and_owns_selected_faces() {
             static_cast<std::streamsize>(collection.size()));
         require(output.good());
     }
+    const std::array<table_data, 1U> color_tables{
+        table_data{open_type_tag::from_chars('s', 'b', 'i', 'x'), make_sbix()}};
+    const auto color_font = make_font(0U, 22U, 0U, false, false, false, color_tables);
+    {
+        std::ofstream output(color_path, std::ios::binary);
+        output.write(reinterpret_cast<const char*>(color_font.data()),
+            static_cast<std::streamsize>(color_font.size()));
+        require(output.good());
+    }
 
     system_font_catalog catalog;
     const auto directory_string = directory.string();
@@ -10130,13 +10140,14 @@ void system_font_catalog_streams_metadata_and_owns_selected_faces() {
     require(catalog.try_discover_fonts(directories, &metrics, &error));
     require(error == font_catalog_error::none);
     require(metrics.directory_count == 1U);
-    require(metrics.file_count == 3U);
-    require(metrics.face_count == 3U);
+    require(metrics.file_count == 4U);
+    require(metrics.face_count == 4U);
     require(metrics.skipped_file_count == 0U);
-    require(catalog.face_count() == 3U);
+    require(catalog.face_count() == 4U);
     const auto complete_bytes = std::filesystem::file_size(inter) +
         std::filesystem::file_size(noto) +
-        std::filesystem::file_size(collection_path);
+        std::filesystem::file_size(collection_path) +
+        std::filesystem::file_size(color_path);
     require(metrics.bytes_read < complete_bytes / 2U);
 
     std::uint32_t inter_index = 0U;
@@ -10157,6 +10168,9 @@ void system_font_catalog_streams_metadata_and_owns_selected_faces() {
     require(catalog.try_load_face(inter_index, second, &error));
     require(first.valid() && second.valid());
     require(first.data().data() == second.data().data());
+#if !defined(__EMSCRIPTEN__)
+    require(first.is_memory_mapped() && second.is_memory_mapped());
+#endif
     require(first.identity() == inter_info.identity);
     std::uint16_t glyph = 0U;
     require(first.font().try_get_glyph_index('A', glyph) && glyph != 0U);
@@ -10183,7 +10197,38 @@ void system_font_catalog_streams_metadata_and_owns_selected_faces() {
     require(catalog.try_load_face(collection_index, collection_face, &error));
     require(collection_face.font().face_offset() == 16U);
 
+    std::uint32_t color_index = catalog.face_count();
+    for (std::uint32_t index = 0U; index < catalog.face_count(); ++index) {
+        font_catalog_face_info info{};
+        require(catalog.try_get_face_info(index, info));
+        if (std::filesystem::path(info.file_path) == color_path) {
+            color_index = index;
+            break;
+        }
+    }
+    require(color_index < catalog.face_count());
+    loaded_font_face color_face{};
+    require(catalog.try_load_face(color_index, color_face, &error));
+    loaded_font_face resident_face{};
+    sfnt_glyph_resident_requirements resident_requirements{};
+    font_catalog_error resident_result = font_catalog_error::invalid_font;
+    require(color_face.try_create_glyph_resident_face(
+        2U, resident_face, &resident_requirements, &resident_result));
+    require(resident_result == font_catalog_error::none && resident_face.valid());
+    require(!resident_face.is_memory_mapped());
+    require(resident_face.identity() == color_face.identity());
+    require(resident_face.catalog_index() == color_face.catalog_index());
+    require(resident_face.data().size() == resident_requirements.font_bytes);
+    require(resident_face.data().size() < color_face.data().size());
+    sfnt_bitmap_glyph_data_view bitmap{};
+    font_error font_result = font_error::invalid_face;
+    require(resident_face.font().try_get_sbix_glyph(2U, 19.0F, bitmap, &font_result));
+    require(bitmap.bytes.size() == 3U && bitmap.bytes[0U] == std::byte{20U});
+
     std::filesystem::remove_all(directory);
+    glyph = 0U;
+    require(first.font().try_get_glyph_index('A', glyph) && glyph != 0U);
+    require(resident_face.font().try_get_sbix_glyph(2U, 19.0F, bitmap, &font_result));
 }
 
 void benchmark_system_font_catalog_if_requested() {
@@ -10222,6 +10267,26 @@ void benchmark_system_font_catalog_if_requested() {
                 static_cast<int>(info.full_name.size()), info.full_name.data(),
                 info.face_index);
         }
+    }
+    std::uint32_t emoji_index = 0U;
+    loaded_font_face emoji_face{};
+    std::uint16_t emoji_glyph = 0U;
+    loaded_font_face resident_face{};
+    sfnt_glyph_resident_requirements resident_requirements{};
+    if (catalog.try_match_character(
+            "Apple Color Emoji", font_style_request{}, {}, 0x1F469U, 0U,
+            emoji_index, emoji_glyph) &&
+        catalog.try_load_face(emoji_index, emoji_face) &&
+        emoji_face.try_create_glyph_resident_face(
+            emoji_glyph, resident_face, &resident_requirements)) {
+        std::fprintf(stderr,
+            "progpu-native-system-font-residency "
+            "{\"mapped\":%s,\"source_bytes\":%llu,"
+            "\"resident_bytes\":%llu,\"glyph\":%u}\n",
+            emoji_face.is_memory_mapped() ? "true" : "false",
+            static_cast<unsigned long long>(emoji_face.data().size()),
+            static_cast<unsigned long long>(resident_face.data().size()),
+            emoji_glyph);
     }
 }
 


### PR DESCRIPTION
## Summary

- memory-map selected native SFNT/TTC files on Windows and POSIX hosts, with the existing owned-buffer path retained as a portable fallback
- keep mapped bytes shared across loaded faces and valid for the complete `loaded_font_face` lifetime
- add an owned glyph-resident face derivative for large bitmap fonts while preserving catalog and face identity
- cover shared mapping, file-removal lifetime, and resident sbix filtering with native regressions

## Managed/native parity audit

This is the native port of the existing ProGPU-owned managed `MappedFontData`, `TtfFont.CreateFileStorage`, and `TtfFont.LoadGlyphResidentFile` residency policy. The managed implementation already memory-maps ordinary font files and uses glyph-resident large fallback faces, so no managed source gap remains and no managed change is required.

## Performance evidence

Apple M3 Pro, macOS, AppleClang 21 Release. Eight balanced alternating fresh-process runs compare exact main `7fc03a5d429d3d30358d82e375ef83878828d0a1` with this head after cataloging 434 files / 851 faces and selecting U+1F469 from the system color emoji collection.

- exact-main median maximum RSS: 246,972,416 bytes (range 246,349,824–247,365,632)
- fixed median maximum RSS: 55,713,792 bytes (range 55,083,008–56,606,720)
- reduction: 191,258,624 bytes / 77.4%
- mapped source collection: 192,123,488 bytes
- derived glyph-resident face: 975,184 bytes
- median wall time: 0.200 s exact main, 0.155 s fixed

The workload at the fixed head also creates the bounded resident derivative, so the memory comparison includes the new owned resource rather than measuring mapping alone.

## Local gates

- AppleClang Release native text and C text-interop: 2/2 pass
- LLVM Clang 22 Release C++ module consumer: pass
- AppleClang Debug ASan+UBSan native text: pass (`ASAN_OPTIONS=detect_leaks=0`)
- privacy and diff checks: clean
