### PR TITLE
Batch contiguous native semantic replay draws

### DIFF
--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -1326,6 +1326,7 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
         src/Scene/progpu_native_semantic_text_style.hpp
         src/Scene/progpu_native_semantic_effect_cache.cpp
         src/Scene/progpu_native_semantic_effect_cache.hpp
+        src/Scene/progpu_native_semantic_draw_merge.hpp
         src/Scene/progpu_native_semantic_replay.hpp
         src/Scene/progpu_native_semantic_state.cpp
         src/Scene/progpu_native_semantic_state.hpp

--- a/src/ProGPU.Native/browser/progpu_native_browser_smoke.cpp
+++ b/src/ProGPU.Native/browser/progpu_native_browser_smoke.cpp
@@ -717,7 +717,7 @@ bool render_browser_frame(double, void*) {
             &semantic_frame,
             &builder_frame_metrics) != PROGPU_NATIVE_STATUS_SUCCESS ||
         builder_frame_metrics.command_count != 11U ||
-        builder_frame_metrics.draw_call_count != 8U ||
+        builder_frame_metrics.draw_call_count != 5U ||
         builder_frame_metrics.submission_count != 1U ||
         builder_frame_metrics.brush_upload_bytes == 0U ||
         builder_frame_metrics.vertex_upload_bytes == 0U ||
@@ -884,7 +884,7 @@ bool render_browser_frame(double, void*) {
             &geometry_metrics);
     if (geometry_status != PROGPU_NATIVE_STATUS_SUCCESS ||
         geometry_metrics.command_count != 4U ||
-        geometry_metrics.draw_call_count != 4U ||
+        geometry_metrics.draw_call_count != 1U ||
         geometry_metrics.submission_count != 1U ||
         geometry_metrics.brush_upload_bytes !=
             3U * sizeof(progpu_native_scene_brush) ||

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_draw_merge.hpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_draw_merge.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "progpu_native_gpu_records.hpp"
+
+#include <cstdint>
+#include <limits>
+
+struct semantic_analytic_draw {
+    std::uint64_t vertex_offset_bytes = 0U;
+    std::uint64_t index_offset_bytes = 0U;
+    std::uint32_t vertex_count = 0U;
+    std::uint32_t index_count = 0U;
+
+    bool operator==(const semantic_analytic_draw&) const = default;
+};
+
+inline bool try_merge_semantic_analytic_draw(
+    semantic_analytic_draw& retained,
+    const semantic_analytic_draw& next) noexcept {
+    constexpr std::uint64_t vertex_stride =
+        sizeof(progpu::native::vector_vertex);
+    constexpr std::uint64_t index_stride = sizeof(std::uint32_t);
+    if (retained.vertex_count == 0U || retained.index_count == 0U ||
+        next.vertex_count == 0U || next.index_count == 0U ||
+        retained.vertex_count >
+            std::numeric_limits<std::uint32_t>::max() - next.vertex_count ||
+        retained.index_count >
+            std::numeric_limits<std::uint32_t>::max() - next.index_count ||
+        retained.vertex_offset_bytes +
+                static_cast<std::uint64_t>(retained.vertex_count) *
+                    vertex_stride !=
+            next.vertex_offset_bytes ||
+        retained.index_offset_bytes +
+                static_cast<std::uint64_t>(retained.index_count) *
+                    index_stride !=
+            next.index_offset_bytes) {
+        return false;
+    }
+    retained.vertex_count += next.vertex_count;
+    retained.index_count += next.index_count;
+    return true;
+}
+
+struct semantic_path_draw {
+    std::uint32_t first_index = 0U;
+    std::uint32_t index_count = 0U;
+};
+
+inline bool try_merge_semantic_path_draw(
+    semantic_path_draw& retained,
+    const semantic_path_draw& next) noexcept {
+    if (retained.index_count == 0U || next.index_count == 0U ||
+        retained.index_count >
+            std::numeric_limits<std::uint32_t>::max() - next.index_count ||
+        retained.first_index + retained.index_count != next.first_index) {
+        return false;
+    }
+    retained.index_count += next.index_count;
+    return true;
+}
+
+struct semantic_glyph_draw {
+    std::uint32_t first_instance = 0U;
+    std::uint32_t instance_count = 0U;
+
+    bool operator==(const semantic_glyph_draw&) const = default;
+};
+
+inline bool try_merge_semantic_glyph_draw(
+    semantic_glyph_draw& retained,
+    const semantic_glyph_draw& next) noexcept {
+    if (retained.instance_count == 0U || next.instance_count == 0U ||
+        retained.instance_count >
+            std::numeric_limits<std::uint32_t>::max() - next.instance_count ||
+        retained.first_instance + retained.instance_count !=
+            next.first_instance) {
+        return false;
+    }
+    retained.instance_count += next.instance_count;
+    return true;
+}

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -69,6 +69,7 @@ semantic_content_hashes compute_content_hashes(
     // are shared inputs to compiled pages. Hash them once without the header's
     // scene generation, then combine them with typed resource identities.
     std::uint64_t commands = fnv_offset;
+    bool glyph_uses_text_styles = false;
     for (std::uint32_t index = 0U; index < header.command_count; ++index) {
         const std::size_t offset = header.command_offset +
             static_cast<std::size_t>(index) * header.command_stride;
@@ -81,6 +82,9 @@ semantic_content_hashes compute_content_hashes(
                 bytes + command.payload_offset,
                 command.payload_size);
         }
+        glyph_uses_text_styles = glyph_uses_text_styles ||
+            (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN &&
+                (command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U);
     }
 
     std::uint64_t common = fnv_offset;
@@ -137,9 +141,15 @@ semantic_content_hashes compute_content_hashes(
     result.text_style = combine(fnv_offset ^ 0x02U, styles);
     result.analytic = combine(fnv_offset ^ 0x03U, analytics, brushes);
     result.path = combine(fnv_offset ^ 0x04U, paths, brushes);
-    result.glyph = combine(fnv_offset ^ 0x05U, glyphs, brushes);
-    result.glyph = finish(append_fnv1a64(
-        result.glyph, &styles, sizeof(styles)));
+    // Positioned glyphs carry their color directly. Only the optional styled
+    // command form reads the text-style page; neither glyph form reads the
+    // analytic brush table. Keep unrelated material updates out of the glyph
+    // page identity so its retained coverage survives analytic-only changes.
+    result.glyph = combine(fnv_offset ^ 0x05U, glyphs);
+    if (glyph_uses_text_styles) {
+        result.glyph = finish(append_fnv1a64(
+            result.glyph, &styles, sizeof(styles)));
+    }
     result.image = combine(fnv_offset ^ 0x06U, images);
     result.three_d = combine(fnv_offset ^ 0x07U, three_d);
     result.hit_test = combine(fnv_offset ^ 0x08U, hit_tests);

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
@@ -3388,6 +3388,16 @@ progpu_native_status render_scene(
         std::uint32_t active_mask_resource_index =
             PROGPU_NATIVE_SCENE_NO_INDEX;
         semantic_render_bundle_span active_mask{};
+        enum class pending_draw_kind : std::uint8_t {
+            none,
+            analytic,
+            path,
+            glyph,
+        };
+        pending_draw_kind pending_kind = pending_draw_kind::none;
+        semantic_analytic_draw pending_analytic_draw{};
+        semantic_path_draw pending_path_draw{};
+        semantic_glyph_draw pending_glyph_draw{};
         const auto release_mask_resources = [](
             semantic_render_bundle_span& span) noexcept {
             if (span.mask_bind_group != nullptr) {
@@ -3442,9 +3452,53 @@ progpu_native_status render_scene(
             discard_encoder();
             return status;
         };
+        const auto flush_pending_draw = [&]() {
+            progpu_native_status status = PROGPU_NATIVE_STATUS_SUCCESS;
+            switch (pending_kind) {
+                case pending_draw_kind::analytic:
+                    status = encode_semantic_analytic_bundle_draw(
+                        *engine,
+                        bundle_encoder,
+                        pending_analytic_draw,
+                        active_target_layer,
+                        active_mask.mask_bind_group,
+                        active_mask.mask_chain_bind_group);
+                    break;
+                case pending_draw_kind::path:
+                    status = encode_semantic_path_bundle_draw(
+                        *engine,
+                        bundle_encoder,
+                        pending_path_draw,
+                        active_target_layer,
+                        active_mask.mask_bind_group,
+                        active_mask.mask_chain_bind_group);
+                    break;
+                case pending_draw_kind::glyph:
+                    status = encode_semantic_glyph_bundle_draw(
+                        *engine,
+                        bundle_encoder,
+                        pending_glyph_draw,
+                        active_target_layer,
+                        active_mask.mask_bind_group,
+                        active_mask.mask_chain_bind_group);
+                    break;
+                case pending_draw_kind::none:
+                    return PROGPU_NATIVE_STATUS_SUCCESS;
+            }
+            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                ++draw_calls;
+                ++active_bundle_draw_count;
+                pending_kind = pending_draw_kind::none;
+            }
+            return status;
+        };
         const auto finish_active_bundle = [&]() {
             if (bundle_encoder == nullptr) {
                 return PROGPU_NATIVE_STATUS_SUCCESS;
+            }
+            const auto flush_status = flush_pending_draw();
+            if (flush_status != PROGPU_NATIVE_STATUS_SUCCESS) {
+                return flush_status;
             }
             WGPURenderBundleDescriptor finish_descriptor{};
             finish_descriptor.label = progpu::native::webgpu::string_view(
@@ -3955,13 +4009,18 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_analytic_draw_index;
                     ++semantic_analytic_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_analytic_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_analytic_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw =
+                            semantic_analytic_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::analytic ||
+                            !try_merge_semantic_analytic_draw(
+                                pending_analytic_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_analytic_draw = draw;
+                                pending_kind = pending_draw_kind::analytic;
+                            }
+                        }
                     }
                     break;
                 }
@@ -3975,13 +4034,18 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_analytic_draw_index;
                     ++semantic_analytic_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_analytic_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_analytic_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw =
+                            semantic_analytic_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::analytic ||
+                            !try_merge_semantic_analytic_draw(
+                                pending_analytic_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_analytic_draw = draw;
+                                pending_kind = pending_draw_kind::analytic;
+                            }
+                        }
                     }
                     break;
                 }
@@ -3995,13 +4059,18 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_analytic_draw_index;
                     ++semantic_analytic_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_analytic_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_analytic_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw =
+                            semantic_analytic_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::analytic ||
+                            !try_merge_semantic_analytic_draw(
+                                pending_analytic_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_analytic_draw = draw;
+                                pending_kind = pending_draw_kind::analytic;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4015,13 +4084,18 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_analytic_draw_index;
                     ++semantic_analytic_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_analytic_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_analytic_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw =
+                            semantic_analytic_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::analytic ||
+                            !try_merge_semantic_analytic_draw(
+                                pending_analytic_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_analytic_draw = draw;
+                                pending_kind = pending_draw_kind::analytic;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4035,13 +4109,18 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_analytic_draw_index;
                     ++semantic_analytic_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_analytic_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_analytic_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw =
+                            semantic_analytic_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::analytic ||
+                            !try_merge_semantic_analytic_draw(
+                                pending_analytic_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_analytic_draw = draw;
+                                pending_kind = pending_draw_kind::analytic;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4055,13 +4134,17 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_path_draw_index;
                     ++semantic_path_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_path_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_path_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw = semantic_path_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::path ||
+                            !try_merge_semantic_path_draw(
+                                pending_path_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_path_draw = draw;
+                                pending_kind = pending_draw_kind::path;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4075,13 +4158,18 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_glyph_draw_index;
                     ++semantic_glyph_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_glyph_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_glyph_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        const auto& draw =
+                            semantic_glyph_page.draws[draw_index];
+                        if (pending_kind != pending_draw_kind::glyph ||
+                            !try_merge_semantic_glyph_draw(
+                                pending_glyph_draw,
+                                draw)) {
+                            status = flush_pending_draw();
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                pending_glyph_draw = draw;
+                                pending_kind = pending_draw_kind::glyph;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4095,13 +4183,20 @@ progpu_native_status render_scene(
                     const auto draw_index = semantic_image_draw_index;
                     ++semantic_image_draw_index;
                     if (scissor.drawable) {
-                        status = encode_semantic_image_bundle_draw(
-                                *engine,
-                                bundle_encoder,
-                                semantic_image_page.draws[draw_index],
-                                current_target_layer,
-                                active_mask.mask_bind_group,
-                                active_mask.mask_chain_bind_group);
+                        status = flush_pending_draw();
+                        if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                            status = encode_semantic_image_bundle_draw(
+                                    *engine,
+                                    bundle_encoder,
+                                    semantic_image_page.draws[draw_index],
+                                    current_target_layer,
+                                    active_mask.mask_bind_group,
+                                    active_mask.mask_chain_bind_group);
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                ++draw_calls;
+                                ++active_bundle_draw_count;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4115,10 +4210,17 @@ progpu_native_status render_scene(
                     }
                     const auto draw_index = semantic_3d_draw_index++;
                     if (scissor.drawable) {
-                        status = encode_semantic_3d_bundle_draw(
-                            *engine,
-                            bundle_encoder,
-                            engine->semantic_3d_cache.draws[draw_index]);
+                        status = flush_pending_draw();
+                        if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                            status = encode_semantic_3d_bundle_draw(
+                                *engine,
+                                bundle_encoder,
+                                engine->semantic_3d_cache.draws[draw_index]);
+                            if (status == PROGPU_NATIVE_STATUS_SUCCESS) {
+                                ++draw_calls;
+                                ++active_bundle_draw_count;
+                            }
+                        }
                     }
                     break;
                 }
@@ -4128,8 +4230,6 @@ progpu_native_status render_scene(
             if (status != PROGPU_NATIVE_STATUS_SUCCESS) {
                 return fail_bundle(status);
             }
-            draw_calls += scissor.drawable ? 1U : 0U;
-            active_bundle_draw_count += scissor.drawable ? 1U : 0U;
         }
 
         if (semantic_destination_sampling_active) {

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_replay.hpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_replay.hpp
@@ -5,18 +5,12 @@
 #include "progpu_native.h"
 #include "progpu_native_gpu_records.hpp"
 #include "progpu_native_semantic_brush.hpp"
+#include "progpu_native_semantic_draw_merge.hpp"
 #include "progpu_native_semantic_effect_cache.hpp"
 
 #include <array>
 #include <cstdint>
 #include <vector>
-
-struct semantic_analytic_draw {
-    std::uint64_t vertex_offset_bytes = 0U;
-    std::uint64_t index_offset_bytes = 0U;
-    std::uint32_t vertex_count = 0U;
-    std::uint32_t index_count = 0U;
-};
 
 struct semantic_analytic_page {
     WGPUBuffer vertex_buffer = nullptr;
@@ -33,11 +27,6 @@ struct semantic_analytic_page {
     std::vector<semantic_analytic_draw> draws;
 };
 
-struct semantic_path_draw {
-    std::uint32_t first_index = 0U;
-    std::uint32_t index_count = 0U;
-};
-
 struct semantic_path_page {
     std::uint64_t scene_hash = 0U;
     float dpi_scale = 0.0F;
@@ -49,11 +38,6 @@ struct semantic_path_page {
     std::vector<progpu_native_scene_path_boolean_node> boolean_nodes;
     std::vector<std::uint32_t> brush_indices;
     std::vector<semantic_path_draw> draws;
-};
-
-struct semantic_glyph_draw {
-    std::uint32_t first_instance = 0U;
-    std::uint32_t instance_count = 0U;
 };
 
 struct semantic_color_glyph_raster {

--- a/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
@@ -12,6 +12,7 @@
 #include "progpu_native_semantic_effect_cache.hpp"
 #include "progpu_native_semantic_image_tests.hpp"
 #include "progpu_native_semantic_layer_mask_tests.hpp"
+#include "progpu_native_semantic_draw_merge.hpp"
 #include "progpu_native_scene_builder_tests.hpp"
 #include "progpu_native_semantic_state.hpp"
 #include "progpu_native_semantic_text_style.hpp"
@@ -22,6 +23,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <limits>
 
 namespace {
 
@@ -29,6 +31,50 @@ void require(bool condition) {
     if (!condition) {
         std::abort();
     }
+}
+
+void semantic_contiguous_draws_merge_without_reordering() {
+    const auto vertex_stride =
+        sizeof(progpu::native::vector_vertex);
+    const auto index_stride = sizeof(std::uint32_t);
+    semantic_analytic_draw analytic{
+        0U,
+        0U,
+        4U,
+        6U};
+    require(try_merge_semantic_analytic_draw(
+        analytic,
+        semantic_analytic_draw{
+            4U * vertex_stride,
+            6U * index_stride,
+            8U,
+            12U}));
+    require(analytic.vertex_count == 12U && analytic.index_count == 18U);
+    const auto retained_analytic = analytic;
+    require(!try_merge_semantic_analytic_draw(
+        analytic,
+        semantic_analytic_draw{
+            13U * vertex_stride,
+            18U * index_stride,
+            4U,
+            6U}));
+    require(analytic.vertex_count == retained_analytic.vertex_count &&
+        analytic.index_count == retained_analytic.index_count);
+
+    semantic_path_draw path{4U, 6U};
+    require(try_merge_semantic_path_draw(path, {10U, 9U}));
+    require(path.first_index == 4U && path.index_count == 15U);
+    require(!try_merge_semantic_path_draw(path, {20U, 3U}));
+
+    semantic_glyph_draw glyph{7U, 3U};
+    require(try_merge_semantic_glyph_draw(glyph, {10U, 5U}));
+    require(glyph.first_instance == 7U && glyph.instance_count == 8U);
+    require(!try_merge_semantic_glyph_draw(glyph, {16U, 1U}));
+
+    semantic_glyph_draw overflow{
+        0U,
+        std::numeric_limits<std::uint32_t>::max()};
+    require(!try_merge_semantic_glyph_draw(overflow, {0U, 1U}));
 }
 
 progpu_native_group_effect effect(std::uint32_t kind) noexcept {
@@ -763,6 +809,7 @@ void draw_state_resolution_is_cpu_only_and_bounded() {
 } // namespace
 
 int main() {
+    semantic_contiguous_draws_merge_without_reordering();
     effect_plan_uses_three_bounded_intermediates();
     semantic_budget_counts_effected_depth_once();
     semantic_compilation_budget_is_checked();

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -1535,8 +1535,9 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
     for (std::uint32_t index = 0U;
          index < brush_header.resource_count;
          ++index) {
-        const auto offset = brush_header.resource_offset +
-            static_cast<std::size_t>(index) * brush_header.resource_stride;
+        const auto offset = static_cast<std::uint32_t>(
+            brush_header.resource_offset +
+            index * brush_header.resource_stride);
         auto resource = read<progpu_native_scene_resource>(
             brush_changed, offset);
         if (resource.kind != PROGPU_NATIVE_SCENE_RESOURCE_BRUSH_TABLE) {

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -901,7 +901,7 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
     const auto command = read<progpu_native_scene_command>(
         stream,
         validated.header.command_offset);
-    return glyph_record.kind == PROGPU_NATIVE_SCENE_RESOURCE_GLYPH_RUN &&
+    if (!(glyph_record.kind == PROGPU_NATIVE_SCENE_RESOURCE_GLYPH_RUN &&
         glyph_record.payload_size == sizeof(outline) &&
         glyph_record.auxiliary_size == sizeof(segments) &&
         style_record.kind ==
@@ -909,7 +909,24 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
         style_record.payload_size == sizeof(style) &&
         (command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U &&
         command.payload_size == sizeof(progpu_native_scene_glyph_draw) +
-            sizeof(glyphs);
+            sizeof(glyphs))) {
+        return false;
+    }
+
+    const auto original_hashes = semantic::compute_content_hashes(
+        stream.data(), validated.header);
+    auto style_changed = stream;
+    auto changed_style = style_record;
+    ++changed_style.generation;
+    std::memcpy(
+        style_changed.data() + validated.header.resource_offset +
+            validated.header.resource_stride,
+        &changed_style,
+        sizeof(changed_style));
+    const auto changed_hashes = semantic::compute_content_hashes(
+        style_changed.data(), validated.header);
+    return changed_hashes.text_style != original_hashes.text_style &&
+        changed_hashes.glyph != original_hashes.glyph;
 }
 
 bool semantic_scene_builder_records_native_shaped_runs() {
@@ -1503,12 +1520,39 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         first.data(), first_header);
     const auto second_hashes = semantic::compute_content_hashes(
         second.data(), second_header);
-    return first_hashes.brush == second_hashes.brush &&
+    if (!(first_hashes.brush == second_hashes.brush &&
         first_hashes.text_style == second_hashes.text_style &&
         first_hashes.analytic == second_hashes.analytic &&
         first_hashes.path == second_hashes.path &&
         first_hashes.glyph == second_hashes.glyph &&
-        first_hashes.image != second_hashes.image;
+        first_hashes.image != second_hashes.image)) {
+        return false;
+    }
+
+    auto brush_changed = first;
+    const auto brush_header = read<progpu_native_scene_header>(
+        brush_changed, 0U);
+    for (std::uint32_t index = 0U;
+         index < brush_header.resource_count;
+         ++index) {
+        const auto offset = brush_header.resource_offset +
+            static_cast<std::size_t>(index) * brush_header.resource_stride;
+        auto resource = read<progpu_native_scene_resource>(
+            brush_changed, offset);
+        if (resource.kind != PROGPU_NATIVE_SCENE_RESOURCE_BRUSH_TABLE) {
+            continue;
+        }
+        ++resource.generation;
+        std::memcpy(
+            brush_changed.data() + offset,
+            &resource,
+            sizeof(resource));
+    }
+    const auto brush_hashes = semantic::compute_content_hashes(
+        brush_changed.data(), brush_header);
+    return brush_hashes.brush != first_hashes.brush &&
+        brush_hashes.analytic != first_hashes.analytic &&
+        brush_hashes.glyph == first_hashes.glyph;
 }
 
 bool semantic_scene_builder_records_retained_hit_test_index() {


### PR DESCRIPTION
## Summary

- merge adjacent analytic, path, and glyph ranges when replay state remains compatible
- keep unrelated analytic brush updates out of positioned-glyph cache identity
- retain text-style dependency for styled glyph commands
- cover merge adjacency, overflow, and typed hash isolation with internal regressions

## Architecture basis

This adopts the same bounded command-reduction principle used by retained GPU renderers: preserve semantic order and state boundaries while reducing redundant low-level draw commands. The implementation is deliberately local to native semantic replay and does not introduce a new scene model.

Primary references:
- Skia Graphite DrawPass sorting/batching: https://skia.googlesource.com/skia/+/2135d686708b/src/gpu/graphite/DrawPass.cpp
- WebRender retained display-list architecture: https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst
- Vello retained scene fragments: https://github.com/linebender/vello/blob/main/doc/vision.md

## Validation

- AppleClang Release build
- 10/10 native CTest suite, including the real provider integration suite
- representative 899-command mixed analytic/text scene: 899 physical draws reduced to 2
- exact rendered pixel hash unchanged before/after
- sparse material-update frame time reduced approximately 16.0 ms to 4.0 ms in the integration workload; further damage-region work is intentionally separate

## Managed parity audit

No managed renderer change applies to this patch. The managed compositor already compiles retained per-family incremental scene pages and uploads family buffers in batches; it does not use this native semantic replay command loop or its serialized typed-content hashes. The native interop consumer benefits automatically when using the native engine.

## Privacy

Changed files and PR text contain only generic native-renderer terminology.