### PR TITLE
Retain native semantic GPU pages by draw family

### DIFF
--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -55,21 +55,59 @@ bool is_3d_resource(std::uint32_t kind) noexcept {
         kind == PROGPU_NATIVE_SCENE_RESOURCE_MESH_3D_BATCH;
 }
 
-std::uint64_t append_command(
+std::uint64_t append_resource_reference(
     std::uint64_t hash,
     const std::byte* bytes,
+    const progpu_native_scene_header& header,
+    std::uint32_t resource_index) noexcept {
+    const std::uint32_t marker = resource_index ==
+            PROGPU_NATIVE_SCENE_NO_INDEX
+        ? 0U
+        : resource_index < header.resource_count ? 1U : 2U;
+    hash = append_fnv1a64(hash, &marker, sizeof(marker));
+    if (marker != 1U) {
+        return hash;
+    }
+    const auto resource = read_record<progpu_native_scene_resource>(
+        bytes,
+        header.resource_offset +
+            static_cast<std::size_t>(resource_index) *
+                header.resource_stride);
+    return append_identity(hash, resource);
+}
+
+std::uint64_t append_command_record(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_header& header,
     const progpu_native_scene_command& command) noexcept {
     // command_id and payload_offset are stream serialization identities. They
-    // move when an unrelated family inserts a command or changes the arena
-    // layout, but compiled family pages consume neither value. The full scene
-    // hash independently retains both for render-bundle ordering and effect
-    // cache identity.
+    // move when an unrelated family inserts a command or changes arena layout.
+    // Resource table ordinals likewise move when a lower stable resource id is
+    // inserted. Compiled pages consume the referenced stable identities, not
+    // those serialization positions. The full scene hash independently keeps
+    // the exact byte-stream identity for bundle ordering and effect caches.
     auto semantic_command = command;
     semantic_command.command_id = 0U;
+    semantic_command.state_index = 0U;
+    semantic_command.resource_index = 0U;
     semantic_command.payload_offset = 0U;
     hash = append_fnv1a64(
         hash, &semantic_command, sizeof(semantic_command));
-    if (command.payload_size != 0U) {
+    hash = append_resource_reference(
+        hash, bytes, header, command.state_index);
+    return append_resource_reference(
+        hash, bytes, header, command.resource_index);
+}
+
+std::uint64_t append_command(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_header& header,
+    const progpu_native_scene_command& command,
+    bool include_payload) noexcept {
+    hash = append_command_record(hash, bytes, header, command);
+    if (include_payload && command.payload_size != 0U) {
         hash = append_fnv1a64(
             hash,
             bytes + command.payload_offset,
@@ -78,31 +116,69 @@ std::uint64_t append_command(
     return hash;
 }
 
-std::uint64_t append_family_command(
+std::uint64_t append_scope_command(
     std::uint64_t hash,
     const std::byte* bytes,
+    const progpu_native_scene_header& header,
+    const progpu_native_scene_command& command) noexcept {
+    hash = append_command_record(hash, bytes, header, command);
+    if (command.kind != PROGPU_NATIVE_SCENE_COMMAND_PUSH_LAYER ||
+        command.payload_size < sizeof(progpu_native_scene_layer)) {
+        if (command.payload_size != 0U) {
+            hash = append_fnv1a64(
+                hash,
+                bytes + command.payload_offset,
+                command.payload_size);
+        }
+        return hash;
+    }
+    auto layer = read_record<progpu_native_scene_layer>(
+        bytes, command.payload_offset);
+    const std::uint32_t mask_resource_index = layer.mask_resource_index;
+    const std::uint32_t effect_resource_index = layer.effect_resource_index;
+    layer.mask_resource_index = 0U;
+    layer.effect_resource_index = 0U;
+    hash = append_fnv1a64(hash, &layer, sizeof(layer));
+    hash = append_resource_reference(
+        hash, bytes, header, mask_resource_index);
+    return append_resource_reference(
+        hash, bytes, header, effect_resource_index);
+}
+
+std::uint64_t append_state_scope(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_header& header,
     std::uint32_t command_index,
     const progpu_native_scene_command& command) noexcept {
     hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
-    return append_command(hash, bytes, command);
+    hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
+    return append_resource_reference(
+        hash, bytes, header, command.state_index);
 }
 
 std::uint64_t append_brush_mapping(
     std::uint64_t hash,
     const std::byte* bytes,
+    const progpu_native_scene_header& header,
     std::uint32_t command_index,
     const progpu_native_scene_command& command) noexcept {
     hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
     hash = append_fnv1a64(hash, &command.flags, sizeof(command.flags));
-    hash = append_fnv1a64(
-        hash, &command.state_index, sizeof(command.state_index));
+    hash = append_resource_reference(
+        hash, bytes, header, command.state_index);
     if (command.payload_size < sizeof(progpu_native_scene_draw_brushes)) {
         return hash;
     }
-    const auto draw = read_record<progpu_native_scene_draw_brushes>(
+    auto draw = read_record<progpu_native_scene_draw_brushes>(
         bytes, command.payload_offset);
+    const std::uint32_t brush_resource_index =
+        draw.brush_resource_index;
+    draw.brush_resource_index = 0U;
     hash = append_fnv1a64(hash, &draw, sizeof(draw));
+    hash = append_resource_reference(
+        hash, bytes, header, brush_resource_index);
     const auto remaining = command.payload_size - sizeof(draw);
     if (draw.brush_count <= remaining / sizeof(std::uint32_t)) {
         const auto index_bytes = static_cast<std::size_t>(draw.brush_count) *
@@ -113,6 +189,56 @@ std::uint64_t append_brush_mapping(
             index_bytes);
     }
     return hash;
+}
+
+std::uint64_t append_style_mapping(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_header& header,
+    std::uint32_t command_index,
+    const progpu_native_scene_command& command) noexcept {
+    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
+    hash = append_resource_reference(
+        hash, bytes, header, command.state_index);
+    if (command.payload_size < sizeof(progpu_native_scene_glyph_draw)) {
+        return hash;
+    }
+    const auto draw = read_record<progpu_native_scene_glyph_draw>(
+        bytes, command.payload_offset);
+    hash = append_fnv1a64(
+        hash, &draw.style_index, sizeof(draw.style_index));
+    return append_resource_reference(
+        hash, bytes, header, draw.style_resource_index);
+}
+
+std::uint64_t append_glyph_command(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_header& header,
+    const progpu_native_scene_command& command) noexcept {
+    hash = append_command_record(hash, bytes, header, command);
+    if (command.payload_size == 0U) {
+        return hash;
+    }
+    if ((command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) == 0U ||
+        command.payload_size < sizeof(progpu_native_scene_glyph_draw)) {
+        return append_fnv1a64(
+            hash,
+            bytes + command.payload_offset,
+            command.payload_size);
+    }
+    auto draw = read_record<progpu_native_scene_glyph_draw>(
+        bytes, command.payload_offset);
+    const std::uint32_t style_resource_index =
+        draw.style_resource_index;
+    draw.style_resource_index = 0U;
+    hash = append_fnv1a64(hash, &draw, sizeof(draw));
+    hash = append_resource_reference(
+        hash, bytes, header, style_resource_index);
+    return append_fnv1a64(
+        hash,
+        bytes + command.payload_offset + sizeof(draw),
+        command.payload_size - sizeof(draw));
 }
 
 bool is_scope_command(std::uint32_t kind) noexcept {
@@ -163,40 +289,46 @@ semantic_content_hashes compute_content_hashes(
         const auto command =
             read_record<progpu_native_scene_command>(bytes, offset);
         if (is_scope_command(command.kind)) {
-            brush_commands = append_family_command(
-                brush_commands, bytes, index, command);
-            style_commands = append_family_command(
-                style_commands, bytes, index, command);
-            analytic_commands = append_command(
-                analytic_commands, bytes, command);
-            path_commands = append_command(path_commands, bytes, command);
-            glyph_commands = append_command(glyph_commands, bytes, command);
-            image_commands = append_command(image_commands, bytes, command);
-            three_d_commands = append_command(
-                three_d_commands, bytes, command);
+            brush_commands = append_state_scope(
+                brush_commands, bytes, header, index, command);
+            style_commands = append_state_scope(
+                style_commands, bytes, header, index, command);
+            analytic_commands = append_scope_command(
+                analytic_commands, bytes, header, command);
+            path_commands = append_scope_command(
+                path_commands, bytes, header, command);
+            glyph_commands = append_scope_command(
+                glyph_commands, bytes, header, command);
+            image_commands = append_scope_command(
+                image_commands, bytes, header, command);
+            three_d_commands = append_scope_command(
+                three_d_commands, bytes, header, command);
             continue;
         }
         if (is_analytic_command(command.kind)) {
             analytic_commands = append_command(
-                analytic_commands, bytes, command);
+                analytic_commands, bytes, header, command, false);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, index, command);
+                brush_commands, bytes, header, index, command);
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_PATH) {
-            path_commands = append_command(path_commands, bytes, command);
+            path_commands = append_command(
+                path_commands, bytes, header, command, false);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, index, command);
+                brush_commands, bytes, header, index, command);
         } else if (command.kind ==
             PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN) {
-            glyph_commands = append_command(glyph_commands, bytes, command);
+            glyph_commands = append_glyph_command(
+                glyph_commands, bytes, header, command);
             if ((command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U) {
-                style_commands = append_family_command(
-                    style_commands, bytes, index, command);
+                style_commands = append_style_mapping(
+                    style_commands, bytes, header, index, command);
             }
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE) {
-            image_commands = append_command(image_commands, bytes, command);
+            image_commands = append_command(
+                image_commands, bytes, header, command, true);
         } else if (is_3d_command(command.kind)) {
             three_d_commands = append_command(
-                three_d_commands, bytes, command);
+                three_d_commands, bytes, header, command, true);
         }
         glyph_uses_text_styles = glyph_uses_text_styles ||
             (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN &&

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -77,14 +77,18 @@ std::uint64_t append_command(
 std::uint64_t append_family_command(
     std::uint64_t hash,
     const std::byte* bytes,
+    std::uint32_t command_index,
     const progpu_native_scene_command& command) noexcept {
+    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     return append_command(hash, bytes, command);
 }
 
 std::uint64_t append_brush_mapping(
     std::uint64_t hash,
     const std::byte* bytes,
+    std::uint32_t command_index,
     const progpu_native_scene_command& command) noexcept {
+    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
     hash = append_fnv1a64(hash, &command.flags, sizeof(command.flags));
     hash = append_fnv1a64(
@@ -156,36 +160,36 @@ semantic_content_hashes compute_content_hashes(
             read_record<progpu_native_scene_command>(bytes, offset);
         if (is_scope_command(command.kind)) {
             brush_commands = append_family_command(
-                brush_commands, bytes, command);
+                brush_commands, bytes, index, command);
             style_commands = append_family_command(
-                style_commands, bytes, command);
+                style_commands, bytes, index, command);
             analytic_commands = append_family_command(
-                analytic_commands, bytes, command);
+                analytic_commands, bytes, index, command);
             path_commands = append_family_command(
-                path_commands, bytes, command);
+                path_commands, bytes, index, command);
             glyph_commands = append_family_command(
-                glyph_commands, bytes, command);
+                glyph_commands, bytes, index, command);
             image_commands = append_family_command(
-                image_commands, bytes, command);
+                image_commands, bytes, index, command);
             three_d_commands = append_family_command(
-                three_d_commands, bytes, command);
+                three_d_commands, bytes, index, command);
             continue;
         }
         if (is_analytic_command(command.kind)) {
             analytic_commands = append_command(
                 analytic_commands, bytes, command);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, command);
+                brush_commands, bytes, index, command);
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_PATH) {
             path_commands = append_command(path_commands, bytes, command);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, command);
+                brush_commands, bytes, index, command);
         } else if (command.kind ==
             PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN) {
             glyph_commands = append_command(glyph_commands, bytes, command);
             if ((command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U) {
                 style_commands = append_family_command(
-                    style_commands, bytes, command);
+                    style_commands, bytes, index, command);
             }
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE) {
             image_commands = append_command(image_commands, bytes, command);

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -55,6 +55,75 @@ bool is_3d_resource(std::uint32_t kind) noexcept {
         kind == PROGPU_NATIVE_SCENE_RESOURCE_MESH_3D_BATCH;
 }
 
+std::uint64_t append_command(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_command& command) noexcept {
+    hash = append_fnv1a64(hash, &command, sizeof(command));
+    if (command.payload_size != 0U) {
+        hash = append_fnv1a64(
+            hash,
+            bytes + command.payload_offset,
+            command.payload_size);
+    }
+    return hash;
+}
+
+std::uint64_t append_indexed_command(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    std::uint32_t command_index,
+    const progpu_native_scene_command& command) noexcept {
+    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
+    return append_command(hash, bytes, command);
+}
+
+std::uint64_t append_brush_mapping(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    std::uint32_t command_index,
+    const progpu_native_scene_command& command) noexcept {
+    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
+    hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
+    hash = append_fnv1a64(hash, &command.flags, sizeof(command.flags));
+    if (command.payload_size < sizeof(progpu_native_scene_draw_brushes)) {
+        return hash;
+    }
+    const auto draw = read_record<progpu_native_scene_draw_brushes>(
+        bytes, command.payload_offset);
+    hash = append_fnv1a64(hash, &draw, sizeof(draw));
+    const auto remaining = command.payload_size - sizeof(draw);
+    if (draw.brush_count <= remaining / sizeof(std::uint32_t)) {
+        const auto index_bytes = static_cast<std::size_t>(draw.brush_count) *
+            sizeof(std::uint32_t);
+        hash = append_fnv1a64(
+            hash,
+            bytes + command.payload_offset + sizeof(draw),
+            index_bytes);
+    }
+    return hash;
+}
+
+bool is_scope_command(std::uint32_t kind) noexcept {
+    return kind == PROGPU_NATIVE_SCENE_COMMAND_SAVE ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_RESTORE ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_PUSH_LAYER ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_POP_LAYER;
+}
+
+bool is_analytic_command(std::uint32_t kind) noexcept {
+    return kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_ANALYTIC ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_GEOMETRY ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_POINT_BATCH ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_VERTEX_MESH ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_STROKE_BATCH;
+}
+
+bool is_3d_command(std::uint32_t kind) noexcept {
+    return kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_LINE_3D_BATCH ||
+        kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_MESH_3D_BATCH;
+}
+
 } // namespace
 
 semantic_content_hashes compute_content_hashes(
@@ -65,22 +134,61 @@ semantic_content_hashes compute_content_hashes(
         return result;
     }
 
-    // Command placement, state selection, brush/style maps, and layer scopes
-    // are shared inputs to compiled pages. Hash them once without the header's
-    // scene generation, then combine them with typed resource identities.
-    std::uint64_t commands = fnv_offset;
+    // One draw family cannot affect another family's compiled GPU page, but
+    // every family consumes the shared save/restore and layer cursors. Preserve
+    // complete draw identity within each family and shared scope identity
+    // across them; the full scene hash independently owns bundle ordering.
+    std::uint64_t brush_commands = fnv_offset;
+    std::uint64_t style_commands = fnv_offset;
+    std::uint64_t analytic_commands = fnv_offset;
+    std::uint64_t path_commands = fnv_offset;
+    std::uint64_t glyph_commands = fnv_offset;
+    std::uint64_t image_commands = fnv_offset;
+    std::uint64_t three_d_commands = fnv_offset;
     bool glyph_uses_text_styles = false;
     for (std::uint32_t index = 0U; index < header.command_count; ++index) {
         const std::size_t offset = header.command_offset +
             static_cast<std::size_t>(index) * header.command_stride;
         const auto command =
             read_record<progpu_native_scene_command>(bytes, offset);
-        commands = append_fnv1a64(commands, &command, sizeof(command));
-        if (command.payload_size != 0U) {
-            commands = append_fnv1a64(
-                commands,
-                bytes + command.payload_offset,
-                command.payload_size);
+        if (is_scope_command(command.kind)) {
+            brush_commands = append_indexed_command(
+                brush_commands, bytes, index, command);
+            style_commands = append_indexed_command(
+                style_commands, bytes, index, command);
+            analytic_commands = append_indexed_command(
+                analytic_commands, bytes, index, command);
+            path_commands = append_indexed_command(
+                path_commands, bytes, index, command);
+            glyph_commands = append_indexed_command(
+                glyph_commands, bytes, index, command);
+            image_commands = append_indexed_command(
+                image_commands, bytes, index, command);
+            three_d_commands = append_indexed_command(
+                three_d_commands, bytes, index, command);
+            continue;
+        }
+        if (is_analytic_command(command.kind)) {
+            analytic_commands = append_command(
+                analytic_commands, bytes, command);
+            brush_commands = append_brush_mapping(
+                brush_commands, bytes, index, command);
+        } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_PATH) {
+            path_commands = append_command(path_commands, bytes, command);
+            brush_commands = append_brush_mapping(
+                brush_commands, bytes, index, command);
+        } else if (command.kind ==
+            PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN) {
+            glyph_commands = append_command(glyph_commands, bytes, command);
+            if ((command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U) {
+                style_commands = append_indexed_command(
+                    style_commands, bytes, index, command);
+            }
+        } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE) {
+            image_commands = append_command(image_commands, bytes, command);
+        } else if (is_3d_command(command.kind)) {
+            three_d_commands = append_command(
+                three_d_commands, bytes, command);
         }
         glyph_uses_text_styles = glyph_uses_text_styles ||
             (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN &&
@@ -125,8 +233,9 @@ semantic_content_hashes compute_content_hashes(
         }
     }
 
-    const auto combine = [commands, common](
+    const auto combine = [common](
         std::uint64_t seed,
+        std::uint64_t commands,
         std::uint64_t primary,
         std::uint64_t secondary = 0U) noexcept {
         auto hash = append_fnv1a64(seed, &commands, sizeof(commands));
@@ -137,22 +246,37 @@ semantic_content_hashes compute_content_hashes(
         }
         return finish(hash);
     };
-    result.brush = combine(fnv_offset ^ 0x01U, brushes);
-    result.text_style = combine(fnv_offset ^ 0x02U, styles);
-    result.analytic = combine(fnv_offset ^ 0x03U, analytics, brushes);
-    result.path = combine(fnv_offset ^ 0x04U, paths, brushes);
+    const auto resource_only = [](std::uint64_t seed,
+                                  std::uint64_t commands,
+                                  std::uint64_t resources) noexcept {
+        auto hash = append_fnv1a64(seed, &commands, sizeof(commands));
+        return finish(append_fnv1a64(
+            hash, &resources, sizeof(resources)));
+    };
+    result.brush = resource_only(
+        fnv_offset ^ 0x01U, brush_commands, brushes);
+    result.text_style = resource_only(
+        fnv_offset ^ 0x02U, style_commands, styles);
+    result.analytic = combine(
+        fnv_offset ^ 0x03U, analytic_commands, analytics, brushes);
+    result.path = combine(
+        fnv_offset ^ 0x04U, path_commands, paths, brushes);
     // Positioned glyphs carry their color directly. Only the optional styled
     // command form reads the text-style page; neither glyph form reads the
     // analytic brush table. Keep unrelated material updates out of the glyph
     // page identity so its retained coverage survives analytic-only changes.
-    result.glyph = combine(fnv_offset ^ 0x05U, glyphs);
+    result.glyph = combine(
+        fnv_offset ^ 0x05U, glyph_commands, glyphs);
     if (glyph_uses_text_styles) {
         result.glyph = finish(append_fnv1a64(
             result.glyph, &styles, sizeof(styles)));
     }
-    result.image = combine(fnv_offset ^ 0x06U, images);
-    result.three_d = combine(fnv_offset ^ 0x07U, three_d);
-    result.hit_test = combine(fnv_offset ^ 0x08U, hit_tests);
+    result.image = combine(
+        fnv_offset ^ 0x06U, image_commands, images);
+    result.three_d = combine(
+        fnv_offset ^ 0x07U, three_d_commands, three_d);
+    result.hit_test = resource_only(
+        fnv_offset ^ 0x08U, fnv_offset, hit_tests);
     return result;
 }
 

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -74,21 +74,17 @@ std::uint64_t append_command(
     return hash;
 }
 
-std::uint64_t append_indexed_command(
+std::uint64_t append_family_command(
     std::uint64_t hash,
     const std::byte* bytes,
-    std::uint32_t command_index,
     const progpu_native_scene_command& command) noexcept {
-    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     return append_command(hash, bytes, command);
 }
 
 std::uint64_t append_brush_mapping(
     std::uint64_t hash,
     const std::byte* bytes,
-    std::uint32_t command_index,
     const progpu_native_scene_command& command) noexcept {
-    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
     hash = append_fnv1a64(hash, &command.flags, sizeof(command.flags));
     hash = append_fnv1a64(
@@ -159,37 +155,37 @@ semantic_content_hashes compute_content_hashes(
         const auto command =
             read_record<progpu_native_scene_command>(bytes, offset);
         if (is_scope_command(command.kind)) {
-            brush_commands = append_indexed_command(
-                brush_commands, bytes, index, command);
-            style_commands = append_indexed_command(
-                style_commands, bytes, index, command);
-            analytic_commands = append_indexed_command(
-                analytic_commands, bytes, index, command);
-            path_commands = append_indexed_command(
-                path_commands, bytes, index, command);
-            glyph_commands = append_indexed_command(
-                glyph_commands, bytes, index, command);
-            image_commands = append_indexed_command(
-                image_commands, bytes, index, command);
-            three_d_commands = append_indexed_command(
-                three_d_commands, bytes, index, command);
+            brush_commands = append_family_command(
+                brush_commands, bytes, command);
+            style_commands = append_family_command(
+                style_commands, bytes, command);
+            analytic_commands = append_family_command(
+                analytic_commands, bytes, command);
+            path_commands = append_family_command(
+                path_commands, bytes, command);
+            glyph_commands = append_family_command(
+                glyph_commands, bytes, command);
+            image_commands = append_family_command(
+                image_commands, bytes, command);
+            three_d_commands = append_family_command(
+                three_d_commands, bytes, command);
             continue;
         }
         if (is_analytic_command(command.kind)) {
             analytic_commands = append_command(
                 analytic_commands, bytes, command);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, index, command);
+                brush_commands, bytes, command);
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_PATH) {
             path_commands = append_command(path_commands, bytes, command);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, index, command);
+                brush_commands, bytes, command);
         } else if (command.kind ==
             PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN) {
             glyph_commands = append_command(glyph_commands, bytes, command);
             if ((command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U) {
-                style_commands = append_indexed_command(
-                    style_commands, bytes, index, command);
+                style_commands = append_family_command(
+                    style_commands, bytes, command);
             }
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE) {
             image_commands = append_command(image_commands, bytes, command);

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -2,6 +2,7 @@
 
 #include "progpu_native_draw_state.hpp"
 
+#include <array>
 #include <cstring>
 
 namespace progpu::native::semantic {
@@ -33,12 +34,6 @@ std::uint64_t append_identity(
         hash, &resource.payload_size, sizeof(resource.payload_size));
     return append_fnv1a64(
         hash, &resource.auxiliary_size, sizeof(resource.auxiliary_size));
-}
-
-bool is_common_resource(std::uint32_t kind) noexcept {
-    return kind == PROGPU_NATIVE_SCENE_RESOURCE_STATE ||
-        kind == PROGPU_NATIVE_SCENE_RESOURCE_LAYER_MASK ||
-        kind == PROGPU_NATIVE_SCENE_RESOURCE_EFFECT_CHAIN;
 }
 
 bool is_analytic_resource(std::uint32_t kind) noexcept {
@@ -94,8 +89,6 @@ std::uint64_t append_command_record(
     semantic_command.payload_offset = 0U;
     hash = append_fnv1a64(
         hash, &semantic_command, sizeof(semantic_command));
-    hash = append_resource_reference(
-        hash, bytes, header, command.state_index);
     return append_resource_reference(
         hash, bytes, header, command.resource_index);
 }
@@ -145,16 +138,29 @@ std::uint64_t append_scope_command(
         hash, bytes, header, effect_resource_index);
 }
 
-std::uint64_t append_state_scope(
+std::uint64_t append_effective_state(
     std::uint64_t hash,
     const std::byte* bytes,
     const progpu_native_scene_header& header,
-    std::uint32_t command_index,
-    const progpu_native_scene_command& command) noexcept {
-    hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
-    hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
+    std::uint32_t state_index) noexcept {
     return append_resource_reference(
-        hash, bytes, header, command.state_index);
+        hash, bytes, header, state_index);
+}
+
+std::uint64_t append_active_layers(
+    std::uint64_t hash,
+    const std::byte* bytes,
+    const progpu_native_scene_header& header,
+    const std::array<progpu_native_scene_command,
+        PROGPU_NATIVE_SCENE_MAX_STACK_DEPTH>& scopes,
+    std::uint32_t depth) noexcept {
+    for (std::uint32_t index = 0U; index < depth; ++index) {
+        if (scopes[index].kind == PROGPU_NATIVE_SCENE_COMMAND_PUSH_LAYER) {
+            hash = append_scope_command(
+                hash, bytes, header, scopes[index]);
+        }
+    }
+    return hash;
 }
 
 std::uint64_t append_brush_mapping(
@@ -162,12 +168,13 @@ std::uint64_t append_brush_mapping(
     const std::byte* bytes,
     const progpu_native_scene_header& header,
     std::uint32_t command_index,
-    const progpu_native_scene_command& command) noexcept {
+    const progpu_native_scene_command& command,
+    std::uint32_t effective_state_index) noexcept {
     hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
     hash = append_fnv1a64(hash, &command.flags, sizeof(command.flags));
-    hash = append_resource_reference(
-        hash, bytes, header, command.state_index);
+    hash = append_effective_state(
+        hash, bytes, header, effective_state_index);
     if (command.payload_size < sizeof(progpu_native_scene_draw_brushes)) {
         return hash;
     }
@@ -196,10 +203,11 @@ std::uint64_t append_style_mapping(
     const std::byte* bytes,
     const progpu_native_scene_header& header,
     std::uint32_t command_index,
-    const progpu_native_scene_command& command) noexcept {
+    const progpu_native_scene_command& command,
+    std::uint32_t effective_state_index) noexcept {
     hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
-    hash = append_resource_reference(
-        hash, bytes, header, command.state_index);
+    hash = append_effective_state(
+        hash, bytes, header, effective_state_index);
     if (command.payload_size < sizeof(progpu_native_scene_glyph_draw)) {
         return hash;
     }
@@ -271,10 +279,10 @@ semantic_content_hashes compute_content_hashes(
         return result;
     }
 
-    // One draw family cannot affect another family's compiled GPU page, but
-    // every family consumes the shared save/restore and layer cursors. Preserve
-    // complete draw identity within each family and shared scope identity
-    // across them; the full scene hash independently owns bundle ordering.
+    // One draw family cannot affect another family's compiled GPU page. Hash
+    // the effective state and active layer stack only when a family consumes
+    // them; closed or trailing scopes cannot affect that family's compiler.
+    // The full scene hash independently owns bundle ordering.
     std::uint64_t brush_commands = fnv_offset;
     std::uint64_t style_commands = fnv_offset;
     std::uint64_t analytic_commands = fnv_offset;
@@ -283,59 +291,111 @@ semantic_content_hashes compute_content_hashes(
     std::uint64_t image_commands = fnv_offset;
     std::uint64_t three_d_commands = fnv_offset;
     bool glyph_uses_text_styles = false;
+    std::array<progpu_native_scene_command,
+        PROGPU_NATIVE_SCENE_MAX_STACK_DEPTH> active_scopes{};
+    std::array<std::uint32_t,
+        PROGPU_NATIVE_SCENE_MAX_STACK_DEPTH> state_stack{};
+    std::uint32_t scope_depth = 0U;
+    std::uint32_t current_state_index = PROGPU_NATIVE_SCENE_NO_INDEX;
     for (std::uint32_t index = 0U; index < header.command_count; ++index) {
         const std::size_t offset = header.command_offset +
             static_cast<std::size_t>(index) * header.command_stride;
         const auto command =
             read_record<progpu_native_scene_command>(bytes, offset);
         if (is_scope_command(command.kind)) {
-            brush_commands = append_state_scope(
-                brush_commands, bytes, header, index, command);
-            style_commands = append_state_scope(
-                style_commands, bytes, header, index, command);
-            analytic_commands = append_scope_command(
-                analytic_commands, bytes, header, command);
-            path_commands = append_scope_command(
-                path_commands, bytes, header, command);
-            glyph_commands = append_scope_command(
-                glyph_commands, bytes, header, command);
-            image_commands = append_scope_command(
-                image_commands, bytes, header, command);
-            three_d_commands = append_scope_command(
-                three_d_commands, bytes, header, command);
+            if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_SAVE ||
+                command.kind == PROGPU_NATIVE_SCENE_COMMAND_PUSH_LAYER) {
+                if (scope_depth == PROGPU_NATIVE_SCENE_MAX_STACK_DEPTH) {
+                    return {};
+                }
+                active_scopes[scope_depth] = command;
+                state_stack[scope_depth] = current_state_index;
+                ++scope_depth;
+                if (command.state_index != PROGPU_NATIVE_SCENE_NO_INDEX) {
+                    current_state_index = command.state_index;
+                }
+            } else {
+                if (scope_depth == 0U) {
+                    return {};
+                }
+                --scope_depth;
+                current_state_index = state_stack[scope_depth];
+            }
             continue;
         }
+        const auto effective_state_index = command.state_index ==
+                PROGPU_NATIVE_SCENE_NO_INDEX
+            ? current_state_index
+            : command.state_index;
         if (is_analytic_command(command.kind)) {
+            analytic_commands = append_active_layers(
+                analytic_commands,
+                bytes,
+                header,
+                active_scopes,
+                scope_depth);
             analytic_commands = append_command(
                 analytic_commands, bytes, header, command, false);
+            analytic_commands = append_effective_state(
+                analytic_commands, bytes, header, effective_state_index);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, header, index, command);
+                brush_commands,
+                bytes,
+                header,
+                index,
+                command,
+                effective_state_index);
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_PATH) {
+            path_commands = append_active_layers(
+                path_commands, bytes, header, active_scopes, scope_depth);
             path_commands = append_command(
                 path_commands, bytes, header, command, false);
+            path_commands = append_effective_state(
+                path_commands, bytes, header, effective_state_index);
             brush_commands = append_brush_mapping(
-                brush_commands, bytes, header, index, command);
+                brush_commands,
+                bytes,
+                header,
+                index,
+                command,
+                effective_state_index);
         } else if (command.kind ==
             PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN) {
+            glyph_commands = append_active_layers(
+                glyph_commands, bytes, header, active_scopes, scope_depth);
             glyph_commands = append_glyph_command(
                 glyph_commands, bytes, header, command);
+            glyph_commands = append_effective_state(
+                glyph_commands, bytes, header, effective_state_index);
             if ((command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U) {
                 style_commands = append_style_mapping(
-                    style_commands, bytes, header, index, command);
+                    style_commands,
+                    bytes,
+                    header,
+                    index,
+                    command,
+                    effective_state_index);
             }
         } else if (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE) {
+            image_commands = append_active_layers(
+                image_commands, bytes, header, active_scopes, scope_depth);
             image_commands = append_command(
                 image_commands, bytes, header, command, true);
+            image_commands = append_effective_state(
+                image_commands, bytes, header, effective_state_index);
         } else if (is_3d_command(command.kind)) {
+            three_d_commands = append_active_layers(
+                three_d_commands, bytes, header, active_scopes, scope_depth);
             three_d_commands = append_command(
                 three_d_commands, bytes, header, command, true);
+            three_d_commands = append_effective_state(
+                three_d_commands, bytes, header, effective_state_index);
         }
         glyph_uses_text_styles = glyph_uses_text_styles ||
             (command.kind == PROGPU_NATIVE_SCENE_COMMAND_DRAW_GLYPH_RUN &&
                 (command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U);
     }
 
-    std::uint64_t common = fnv_offset;
     std::uint64_t brushes = fnv_offset;
     std::uint64_t styles = fnv_offset;
     std::uint64_t analytics = fnv_offset;
@@ -349,9 +409,6 @@ semantic_content_hashes compute_content_hashes(
             static_cast<std::size_t>(index) * header.resource_stride;
         const auto resource =
             read_record<progpu_native_scene_resource>(bytes, offset);
-        if (is_common_resource(resource.kind)) {
-            common = append_identity(common, resource);
-        }
         if (resource.kind == PROGPU_NATIVE_SCENE_RESOURCE_BRUSH_TABLE) {
             brushes = append_identity(brushes, resource);
         } else if (resource.kind ==
@@ -373,13 +430,12 @@ semantic_content_hashes compute_content_hashes(
         }
     }
 
-    const auto combine = [common](
+    const auto combine = [](
         std::uint64_t seed,
         std::uint64_t commands,
         std::uint64_t primary,
         std::uint64_t secondary = 0U) noexcept {
         auto hash = append_fnv1a64(seed, &commands, sizeof(commands));
-        hash = append_fnv1a64(hash, &common, sizeof(common));
         hash = append_fnv1a64(hash, &primary, sizeof(primary));
         if (secondary != 0U) {
             hash = append_fnv1a64(hash, &secondary, sizeof(secondary));

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -59,9 +59,13 @@ std::uint64_t append_command(
     std::uint64_t hash,
     const std::byte* bytes,
     const progpu_native_scene_command& command) noexcept {
-    // payload_offset is an arena serialization detail. It moves whenever the
-    // resource/command tables change size and is not part of draw semantics.
+    // command_id and payload_offset are stream serialization identities. They
+    // move when an unrelated family inserts a command or changes the arena
+    // layout, but compiled family pages consume neither value. The full scene
+    // hash independently retains both for render-bundle ordering and effect
+    // cache identity.
     auto semantic_command = command;
+    semantic_command.command_id = 0U;
     semantic_command.payload_offset = 0U;
     hash = append_fnv1a64(
         hash, &semantic_command, sizeof(semantic_command));

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -163,16 +163,13 @@ semantic_content_hashes compute_content_hashes(
                 brush_commands, bytes, index, command);
             style_commands = append_family_command(
                 style_commands, bytes, index, command);
-            analytic_commands = append_family_command(
-                analytic_commands, bytes, index, command);
-            path_commands = append_family_command(
-                path_commands, bytes, index, command);
-            glyph_commands = append_family_command(
-                glyph_commands, bytes, index, command);
-            image_commands = append_family_command(
-                image_commands, bytes, index, command);
-            three_d_commands = append_family_command(
-                three_d_commands, bytes, index, command);
+            analytic_commands = append_command(
+                analytic_commands, bytes, command);
+            path_commands = append_command(path_commands, bytes, command);
+            glyph_commands = append_command(glyph_commands, bytes, command);
+            image_commands = append_command(image_commands, bytes, command);
+            three_d_commands = append_command(
+                three_d_commands, bytes, command);
             continue;
         }
         if (is_analytic_command(command.kind)) {

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -59,7 +59,12 @@ std::uint64_t append_command(
     std::uint64_t hash,
     const std::byte* bytes,
     const progpu_native_scene_command& command) noexcept {
-    hash = append_fnv1a64(hash, &command, sizeof(command));
+    // payload_offset is an arena serialization detail. It moves whenever the
+    // resource/command tables change size and is not part of draw semantics.
+    auto semantic_command = command;
+    semantic_command.payload_offset = 0U;
+    hash = append_fnv1a64(
+        hash, &semantic_command, sizeof(semantic_command));
     if (command.payload_size != 0U) {
         hash = append_fnv1a64(
             hash,

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.cpp
@@ -86,6 +86,8 @@ std::uint64_t append_brush_mapping(
     hash = append_fnv1a64(hash, &command_index, sizeof(command_index));
     hash = append_fnv1a64(hash, &command.kind, sizeof(command.kind));
     hash = append_fnv1a64(hash, &command.flags, sizeof(command.flags));
+    hash = append_fnv1a64(
+        hash, &command.state_index, sizeof(command.state_index));
     if (command.payload_size < sizeof(progpu_native_scene_draw_brushes)) {
         return hash;
     }
@@ -253,14 +255,14 @@ semantic_content_hashes compute_content_hashes(
         return finish(append_fnv1a64(
             hash, &resources, sizeof(resources)));
     };
-    result.brush = resource_only(
+    result.brush = combine(
         fnv_offset ^ 0x01U, brush_commands, brushes);
-    result.text_style = resource_only(
+    result.text_style = combine(
         fnv_offset ^ 0x02U, style_commands, styles);
     result.analytic = combine(
-        fnv_offset ^ 0x03U, analytic_commands, analytics, brushes);
+        fnv_offset ^ 0x03U, analytic_commands, analytics, result.brush);
     result.path = combine(
-        fnv_offset ^ 0x04U, path_commands, paths, brushes);
+        fnv_offset ^ 0x04U, path_commands, paths, result.brush);
     // Positioned glyphs carry their color directly. Only the optional styled
     // command form reads the text-style page; neither glyph form reads the
     // analytic brush table. Keep unrelated material updates out of the glyph
@@ -269,7 +271,7 @@ semantic_content_hashes compute_content_hashes(
         fnv_offset ^ 0x05U, glyph_commands, glyphs);
     if (glyph_uses_text_styles) {
         result.glyph = finish(append_fnv1a64(
-            result.glyph, &styles, sizeof(styles)));
+            result.glyph, &result.text_style, sizeof(result.text_style)));
     }
     result.image = combine(
         fnv_offset ^ 0x06U, image_commands, images);

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.hpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.hpp
@@ -9,7 +9,10 @@ namespace progpu::native::semantic {
 
 // Content identities deliberately exclude scene generation and resource
 // payload offsets. Stable resource id/generation pairs are the retained
-// ownership boundary; command records and their payloads describe placement.
+// ownership boundary. Each compiled draw-family identity includes only that
+// family's draw records/payloads plus the shared scope commands that affect
+// its compiled state. Full-scene replay ordering remains owned by the
+// independent immutable stream hash.
 struct semantic_content_hashes final {
     std::uint64_t brush = 0U;
     std::uint64_t text_style = 0U;

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.hpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_identity.hpp
@@ -10,9 +10,10 @@ namespace progpu::native::semantic {
 // Content identities deliberately exclude scene generation and resource
 // payload offsets. Stable resource id/generation pairs are the retained
 // ownership boundary. Each compiled draw-family identity includes only that
-// family's draw records/payloads plus the shared scope commands that affect
-// its compiled state. Full-scene replay ordering remains owned by the
-// independent immutable stream hash.
+// family's draw records/payloads plus the effective state and active layers at
+// its draws. Closed and trailing scopes do not affect unrelated retained
+// pages. Full-scene replay ordering remains owned by the independent immutable
+// stream hash.
 struct semantic_content_hashes final {
     std::uint64_t brush = 0U;
     std::uint64_t text_style = 0U;

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
@@ -2204,12 +2204,16 @@ progpu_native_status render_scene(
                 const std::size_t glyph_count = glyph_count32;
                 std::uint32_t text_style_index =
                     PROGPU_NATIVE_SCENE_NO_INDEX;
-                if (!try_get_command_text_style_index(
-                        semantic_text_style_page,
-                        index,
-                        text_style_index) ||
-                    ((command.flags &
-                            PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U &&
+                // Unstyled glyphs consume their inline color and do not depend
+                // on the command-indexed retained text-style page. Its family-
+                // local identity may therefore remain valid across unrelated
+                // command insertions that change this command's global index.
+                if ((command.flags &
+                        PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U &&
+                    (!try_get_command_text_style_index(
+                            semantic_text_style_page,
+                            index,
+                            text_style_index) ||
                         text_style_index ==
                             PROGPU_NATIVE_SCENE_NO_INDEX)) {
                     return engine->fail(

--- a/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
@@ -842,6 +842,8 @@ int main() {
     require(progpu::native::tests::
         semantic_scene_builder_records_styled_glyph_runs());
     require(progpu::native::tests::
+        semantic_scene_content_hashes_normalize_resource_ordinals());
+    require(progpu::native::tests::
         semantic_scene_builder_shares_glyph_segments_across_raster_sizes());
     require(progpu::native::tests::
         semantic_scene_builder_records_native_shaped_runs());

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -939,6 +939,23 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
         return false;
     }
 
+    auto glyph_position_changed = stream;
+    auto positioned_glyph = read<progpu_native_positioned_glyph>(
+        glyph_position_changed,
+        command.payload_offset + sizeof(progpu_native_scene_glyph_draw));
+    positioned_glyph.position.x += 3.0F;
+    std::memcpy(
+        glyph_position_changed.data() + command.payload_offset +
+            sizeof(progpu_native_scene_glyph_draw),
+        &positioned_glyph,
+        sizeof(positioned_glyph));
+    const auto positioned_hashes = semantic::compute_content_hashes(
+        glyph_position_changed.data(), validated.header);
+    if (!(positioned_hashes.text_style == original_hashes.text_style &&
+        positioned_hashes.glyph != original_hashes.glyph)) {
+        return false;
+    }
+
     auto style_mapping_changed = stream;
     auto glyph_draw = read<progpu_native_scene_glyph_draw>(
         style_mapping_changed, command.payload_offset);
@@ -951,6 +968,181 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
         style_mapping_changed.data(), validated.header);
     return mapping_hashes.text_style != original_hashes.text_style &&
         mapping_hashes.glyph != original_hashes.glyph;
+}
+
+bool semantic_scene_content_hashes_normalize_resource_ordinals() {
+    const std::array segments{
+        progpu_native_path_segment{
+            {0.0F, 0.0F}, {12.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{
+            {12.0F, 0.0F}, {12.0F, 16.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{
+            {12.0F, 16.0F}, {0.0F, 16.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{
+            {0.0F, 16.0F}, {0.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U}};
+    const progpu_native_scene_glyph_outline outline{
+        0U,
+        segments.size(),
+        0.0F,
+        0.0F,
+        12.0F,
+        16.0F,
+        1.0F,
+        0.0F};
+    const progpu_native_scene_text_style style{
+        {0.4F, 0.7F, 0.9F, 1.0F},
+        PROGPU_NATIVE_SCENE_TEXT_GRAYSCALE,
+        0U,
+        0U,
+        0U};
+    const progpu_native_positioned_glyph glyph{
+        0U,
+        0U,
+        {20.0F, 24.0F},
+        {1.0F, 0.0F},
+        {0.0F, 1.0F},
+        {1.0F, 1.0F, 1.0F, 1.0F},
+        1.0F,
+        0.0F,
+        0.0F,
+        0.0F};
+    constexpr std::array<std::byte, 4U> pixel{
+        std::byte{0x20},
+        std::byte{0x40},
+        std::byte{0x80},
+        std::byte{0xff}};
+    const auto build = [&](bool insert_unrelated_image,
+                           std::vector<std::byte>& stream) {
+        semantic_scene_builder builder(706U, 1U);
+        if (insert_unrelated_image) {
+            std::uint32_t image_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
+            if (!builder.add_rgba8_image(
+                    1U, 1U, 4U, pixel, image_resource) ||
+                !builder.set_resource_identity(
+                    image_resource, 5U, 1U)) {
+                return false;
+            }
+        }
+        std::uint32_t glyph_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
+        std::uint32_t style_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+        if (!builder.add_glyph_outlines(
+                std::span<const progpu_native_scene_glyph_outline>(
+                    &outline, 1U),
+                segments,
+                glyph_resource) ||
+            !builder.set_resource_identity(glyph_resource, 10U, 1U) ||
+            !builder.add_text_style(style, style_index)) {
+            return false;
+        }
+        const std::uint32_t style_resource = glyph_resource + 1U;
+        return builder.set_resource_identity(style_resource, 20U, 1U) &&
+            builder.draw_glyph_run(
+                glyph_resource,
+                std::span<const progpu_native_positioned_glyph>(&glyph, 1U),
+                {20.0F, 24.0F, 12.0F, 16.0F},
+                PROGPU_NATIVE_SCENE_NO_INDEX,
+                style_index) &&
+            builder.build(stream);
+    };
+
+    std::vector<std::byte> original;
+    std::vector<std::byte> shifted;
+    if (!build(false, original) || !build(true, shifted)) {
+        return false;
+    }
+    const auto original_validation = scene::validate(
+        original.data(), original.size());
+    const auto shifted_validation = scene::validate(
+        shifted.data(), shifted.size());
+    if (original_validation.status != PROGPU_NATIVE_STATUS_SUCCESS ||
+        shifted_validation.status != PROGPU_NATIVE_STATUS_SUCCESS) {
+        return false;
+    }
+    const auto original_hashes = semantic::compute_content_hashes(
+        original.data(), original_validation.header);
+    const auto shifted_hashes = semantic::compute_content_hashes(
+        shifted.data(), shifted_validation.header);
+    if (!(original_hashes.text_style == shifted_hashes.text_style &&
+        original_hashes.glyph == shifted_hashes.glyph &&
+        original_hashes.image != shifted_hashes.image)) {
+        return false;
+    }
+
+    const progpu_native_analytic_primitive primitive{
+        PROGPU_NATIVE_PRIMITIVE_RECTANGLE,
+        0U,
+        4.0F,
+        6.0F,
+        18.0F,
+        14.0F,
+        0.0F,
+        0.0F,
+        {1.0F, 1.0F, 1.0F, 1.0F},
+        semantic_scene_builder::identity_transform()};
+    const auto build_analytic = [&](bool insert_unrelated_image,
+                                    std::vector<std::byte>& stream) {
+        semantic_scene_builder builder(707U, 1U);
+        const std::uint32_t shift = insert_unrelated_image ? 1U : 0U;
+        if (insert_unrelated_image) {
+            std::uint32_t image_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
+            if (!builder.add_rgba8_image(
+                    1U, 1U, 4U, pixel, image_resource) ||
+                !builder.set_resource_identity(
+                    image_resource, 5U, 1U)) {
+                return false;
+            }
+        }
+        std::uint32_t brush_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+        if (!builder.add_solid_brush(
+                {0.3F, 0.6F, 0.8F, 1.0F},
+                1.0F,
+                brush_index) ||
+            !builder.draw_analytic(
+                std::span<const progpu_native_analytic_primitive>(
+                    &primitive, 1U),
+                std::span<const std::uint32_t>(&brush_index, 1U),
+                {4.0F, 6.0F, 18.0F, 14.0F}) ||
+            !builder.set_resource_identity(shift, 10U, 1U) ||
+            !builder.set_resource_identity(shift + 1U, 20U, 1U)) {
+            return false;
+        }
+        return builder.build(stream);
+    };
+
+    std::vector<std::byte> original_analytic;
+    std::vector<std::byte> shifted_analytic;
+    if (!build_analytic(false, original_analytic) ||
+        !build_analytic(true, shifted_analytic)) {
+        return false;
+    }
+    const auto original_analytic_validation = scene::validate(
+        original_analytic.data(), original_analytic.size());
+    const auto shifted_analytic_validation = scene::validate(
+        shifted_analytic.data(), shifted_analytic.size());
+    if (original_analytic_validation.status !=
+            PROGPU_NATIVE_STATUS_SUCCESS ||
+        shifted_analytic_validation.status !=
+            PROGPU_NATIVE_STATUS_SUCCESS) {
+        return false;
+    }
+    const auto original_analytic_hashes =
+        semantic::compute_content_hashes(
+            original_analytic.data(),
+            original_analytic_validation.header);
+    const auto shifted_analytic_hashes =
+        semantic::compute_content_hashes(
+            shifted_analytic.data(),
+            shifted_analytic_validation.header);
+    return original_analytic_hashes.brush ==
+            shifted_analytic_hashes.brush &&
+        original_analytic_hashes.analytic ==
+            shifted_analytic_hashes.analytic &&
+        original_analytic_hashes.image !=
+            shifted_analytic_hashes.image;
 }
 
 bool semantic_scene_builder_shares_glyph_segments_across_raster_sizes() {

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -1631,6 +1631,30 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         return false;
     }
 
+    auto image_before_analytic = first;
+    auto first_analytic_command = read<progpu_native_scene_command>(
+        image_before_analytic, first_header.command_offset);
+    auto first_image_command = read<progpu_native_scene_command>(
+        image_before_analytic,
+        first_header.command_offset + first_header.command_stride);
+    std::memcpy(
+        image_before_analytic.data() + first_header.command_offset,
+        &first_image_command,
+        sizeof(first_image_command));
+    std::memcpy(
+        image_before_analytic.data() + first_header.command_offset +
+            first_header.command_stride,
+        &first_analytic_command,
+        sizeof(first_analytic_command));
+    const auto image_before_analytic_hashes =
+        semantic::compute_content_hashes(
+            image_before_analytic.data(), first_header);
+    if (!(image_before_analytic_hashes.brush == first_hashes.brush &&
+        image_before_analytic_hashes.analytic == first_hashes.analytic &&
+        image_before_analytic_hashes.image == first_hashes.image)) {
+        return false;
+    }
+
     auto brush_changed = first;
     const auto brush_header = read<progpu_native_scene_header>(
         brush_changed, 0U);

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -1631,30 +1631,6 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         return false;
     }
 
-    auto image_before_analytic = first;
-    auto first_analytic_command = read<progpu_native_scene_command>(
-        image_before_analytic, first_header.command_offset);
-    auto first_image_command = read<progpu_native_scene_command>(
-        image_before_analytic,
-        first_header.command_offset + first_header.command_stride);
-    std::memcpy(
-        image_before_analytic.data() + first_header.command_offset,
-        &first_image_command,
-        sizeof(first_image_command));
-    std::memcpy(
-        image_before_analytic.data() + first_header.command_offset +
-            first_header.command_stride,
-        &first_analytic_command,
-        sizeof(first_analytic_command));
-    const auto image_before_analytic_hashes =
-        semantic::compute_content_hashes(
-            image_before_analytic.data(), first_header);
-    if (!(image_before_analytic_hashes.brush == first_hashes.brush &&
-        image_before_analytic_hashes.analytic == first_hashes.analytic &&
-        image_before_analytic_hashes.image == first_hashes.image)) {
-        return false;
-    }
-
     auto brush_changed = first;
     const auto brush_header = read<progpu_native_scene_header>(
         brush_changed, 0U);

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -842,11 +842,20 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
         0U,
         0U,
         0U};
+    const progpu_native_scene_text_style alternate_style{
+        {0.2F, 0.6F, 0.9F, 1.0F},
+        PROGPU_NATIVE_SCENE_TEXT_GRAYSCALE,
+        0U,
+        0U,
+        0U};
     std::uint32_t style_index = PROGPU_NATIVE_SCENE_NO_INDEX;
     std::uint32_t duplicate_style = PROGPU_NATIVE_SCENE_NO_INDEX;
+    std::uint32_t alternate_style_index = PROGPU_NATIVE_SCENE_NO_INDEX;
     if (!builder.add_text_style(style, style_index) ||
         !builder.add_text_style(style, duplicate_style) ||
-        style_index != duplicate_style) {
+        !builder.add_text_style(alternate_style, alternate_style_index) ||
+        style_index != duplicate_style ||
+        style_index == alternate_style_index) {
         return false;
     }
     const std::array glyphs{
@@ -883,7 +892,7 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
     std::vector<std::byte> stream;
     scene_build_metrics metrics{};
     if (!builder.build(stream, &metrics) || metrics.command_count != 1U ||
-        metrics.resource_count != 2U || metrics.text_style_count != 1U) {
+        metrics.resource_count != 2U || metrics.text_style_count != 2U) {
         return false;
     }
     const auto validated = scene::validate(stream.data(), stream.size());
@@ -906,7 +915,7 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
         glyph_record.auxiliary_size == sizeof(segments) &&
         style_record.kind ==
             PROGPU_NATIVE_SCENE_RESOURCE_TEXT_STYLE_TABLE &&
-        style_record.payload_size == sizeof(style) &&
+        style_record.payload_size == sizeof(style) * 2U &&
         (command.flags & PROGPU_NATIVE_SCENE_GLYPH_STYLED) != 0U &&
         command.payload_size == sizeof(progpu_native_scene_glyph_draw) +
             sizeof(glyphs))) {
@@ -925,8 +934,23 @@ bool semantic_scene_builder_records_styled_glyph_runs() {
         sizeof(changed_style));
     const auto changed_hashes = semantic::compute_content_hashes(
         style_changed.data(), validated.header);
-    return changed_hashes.text_style != original_hashes.text_style &&
-        changed_hashes.glyph != original_hashes.glyph;
+    if (!(changed_hashes.text_style != original_hashes.text_style &&
+        changed_hashes.glyph != original_hashes.glyph)) {
+        return false;
+    }
+
+    auto style_mapping_changed = stream;
+    auto glyph_draw = read<progpu_native_scene_glyph_draw>(
+        style_mapping_changed, command.payload_offset);
+    glyph_draw.style_index = alternate_style_index;
+    std::memcpy(
+        style_mapping_changed.data() + command.payload_offset,
+        &glyph_draw,
+        sizeof(glyph_draw));
+    const auto mapping_hashes = semantic::compute_content_hashes(
+        style_mapping_changed.data(), validated.header);
+    return mapping_hashes.text_style != original_hashes.text_style &&
+        mapping_hashes.glyph != original_hashes.glyph;
 }
 
 bool semantic_scene_builder_shares_glyph_segments_across_raster_sizes() {
@@ -1501,8 +1525,12 @@ bool semantic_scene_builder_records_retained_3d_families() {
 bool semantic_scene_content_hashes_isolate_image_updates() {
     semantic_scene_builder builder(710U, 1U);
     std::uint32_t brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    std::uint32_t alternate_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
     if (!builder.add_solid_brush(
-            {0.2F, 0.5F, 0.9F, 1.0F}, 1.0F, brush)) {
+            {0.2F, 0.5F, 0.9F, 1.0F}, 1.0F, brush) ||
+        !builder.add_solid_brush(
+            {0.9F, 0.4F, 0.1F, 1.0F}, 1.0F, alternate_brush) ||
+        brush == alternate_brush) {
         return false;
     }
     const progpu_native_analytic_primitive primitive{
@@ -1593,9 +1621,119 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
     }
     const auto brush_hashes = semantic::compute_content_hashes(
         brush_changed.data(), brush_header);
-    return brush_hashes.brush != first_hashes.brush &&
+    if (!(brush_hashes.brush != first_hashes.brush &&
         brush_hashes.analytic != first_hashes.analytic &&
-        brush_hashes.glyph == first_hashes.glyph;
+        brush_hashes.glyph == first_hashes.glyph)) {
+        return false;
+    }
+
+    auto image_placement_changed = first;
+    const auto image_command_offset = first_header.command_offset +
+        first_header.command_stride;
+    auto image_command = read<progpu_native_scene_command>(
+        image_placement_changed, image_command_offset);
+    if (image_command.kind != PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE) {
+        return false;
+    }
+    image_command.bounds_x += 1.0F;
+    std::memcpy(
+        image_placement_changed.data() + image_command_offset,
+        &image_command,
+        sizeof(image_command));
+    const auto image_placement_hashes = semantic::compute_content_hashes(
+        image_placement_changed.data(), first_header);
+    if (!(image_placement_hashes.image != first_hashes.image &&
+        image_placement_hashes.analytic == first_hashes.analytic &&
+        image_placement_hashes.brush == first_hashes.brush)) {
+        return false;
+    }
+
+    auto analytic_placement_changed = first;
+    auto analytic_command = read<progpu_native_scene_command>(
+        analytic_placement_changed, first_header.command_offset);
+    if (analytic_command.kind !=
+        PROGPU_NATIVE_SCENE_COMMAND_DRAW_ANALYTIC) {
+        return false;
+    }
+    analytic_command.bounds_y += 1.0F;
+    std::memcpy(
+        analytic_placement_changed.data() + first_header.command_offset,
+        &analytic_command,
+        sizeof(analytic_command));
+    const auto analytic_placement_hashes = semantic::compute_content_hashes(
+        analytic_placement_changed.data(), first_header);
+    if (!(analytic_placement_hashes.analytic != first_hashes.analytic &&
+        analytic_placement_hashes.image == first_hashes.image &&
+        analytic_placement_hashes.brush == first_hashes.brush)) {
+        return false;
+    }
+
+    auto brush_mapping_changed = first;
+    const auto analytic_draw = read<progpu_native_scene_draw_brushes>(
+        brush_mapping_changed, analytic_command.payload_offset);
+    if (analytic_draw.brush_count != 1U) {
+        return false;
+    }
+    std::memcpy(
+        brush_mapping_changed.data() + analytic_command.payload_offset +
+            sizeof(analytic_draw),
+        &alternate_brush,
+        sizeof(alternate_brush));
+    const auto brush_mapping_hashes = semantic::compute_content_hashes(
+        brush_mapping_changed.data(), first_header);
+    if (!(brush_mapping_hashes.brush != first_hashes.brush &&
+        brush_mapping_hashes.analytic != first_hashes.analytic &&
+        brush_mapping_hashes.image == first_hashes.image)) {
+        return false;
+    }
+
+    semantic_scene_builder scoped_builder(711U, 1U);
+    std::uint32_t scoped_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    auto first_state = semantic_scene_builder::identity_state();
+    auto second_state = first_state;
+    second_state.opacity = 0.5F;
+    std::uint32_t first_state_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+    std::uint32_t second_state_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+    if (!scoped_builder.add_solid_brush(
+            {0.2F, 0.5F, 0.9F, 1.0F}, 1.0F, scoped_brush) ||
+        !scoped_builder.add_state(first_state, first_state_index) ||
+        !scoped_builder.add_state(second_state, second_state_index) ||
+        !scoped_builder.save(first_state_index) ||
+        !scoped_builder.draw_analytic(
+            std::span<const progpu_native_analytic_primitive>(
+                &primitive, 1U),
+            std::span<const std::uint32_t>(&scoped_brush, 1U),
+            {0.0F, 0.0F, 20.0F, 20.0F}) ||
+        !scoped_builder.restore()) {
+        return false;
+    }
+    std::vector<std::byte> scoped;
+    if (!scoped_builder.build(scoped)) {
+        return false;
+    }
+    const auto scoped_header = read<progpu_native_scene_header>(scoped, 0U);
+    const auto scoped_hashes = semantic::compute_content_hashes(
+        scoped.data(), scoped_header);
+    auto scope_changed = scoped;
+    auto save_command = read<progpu_native_scene_command>(
+        scope_changed, scoped_header.command_offset);
+    if (save_command.kind != PROGPU_NATIVE_SCENE_COMMAND_SAVE) {
+        return false;
+    }
+    save_command.state_index = second_state_index;
+    std::memcpy(
+        scope_changed.data() + scoped_header.command_offset,
+        &save_command,
+        sizeof(save_command));
+    const auto scope_hashes = semantic::compute_content_hashes(
+        scope_changed.data(), scoped_header);
+    return scope_hashes.brush != scoped_hashes.brush &&
+        scope_hashes.text_style != scoped_hashes.text_style &&
+        scope_hashes.analytic != scoped_hashes.analytic &&
+        scope_hashes.path != scoped_hashes.path &&
+        scope_hashes.glyph != scoped_hashes.glyph &&
+        scope_hashes.image != scoped_hashes.image &&
+        scope_hashes.three_d != scoped_hashes.three_d;
 }
 
 bool semantic_scene_builder_records_retained_hit_test_index() {

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -1700,6 +1700,22 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         return false;
     }
 
+    auto analytic_command_id_changed = first;
+    auto renumbered_analytic_command = read<progpu_native_scene_command>(
+        analytic_command_id_changed, first_header.command_offset);
+    renumbered_analytic_command.command_id += 100U;
+    std::memcpy(
+        analytic_command_id_changed.data() + first_header.command_offset,
+        &renumbered_analytic_command,
+        sizeof(renumbered_analytic_command));
+    const auto analytic_command_id_hashes = semantic::compute_content_hashes(
+        analytic_command_id_changed.data(), first_header);
+    if (!(analytic_command_id_hashes.analytic == first_hashes.analytic &&
+        analytic_command_id_hashes.brush == first_hashes.brush &&
+        analytic_command_id_hashes.image == first_hashes.image)) {
+        return false;
+    }
+
     auto brush_mapping_changed = first;
     const auto analytic_draw = read<progpu_native_scene_draw_brushes>(
         brush_mapping_changed, analytic_command.payload_offset);

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -2030,30 +2030,35 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
     const auto scoped_header = read<progpu_native_scene_header>(scoped, 0U);
     const auto scoped_hashes = semantic::compute_content_hashes(
         scoped.data(), scoped_header);
-    auto state_resource_changed = scoped;
-    for (std::uint32_t index = 0U;
-         index < scoped_header.resource_count;
-         ++index) {
-        const auto offset = static_cast<std::uint32_t>(
-            scoped_header.resource_offset +
-            index * scoped_header.resource_stride);
-        auto resource = read<progpu_native_scene_resource>(
-            state_resource_changed, offset);
-        if (resource.kind != PROGPU_NATIVE_SCENE_RESOURCE_STATE) {
-            continue;
-        }
-        ++resource.generation;
-        std::memcpy(
-            state_resource_changed.data() + offset,
-            &resource,
-            sizeof(resource));
-        break;
+    const auto active_save_command = read<progpu_native_scene_command>(
+        scoped, scoped_header.command_offset);
+    if (active_save_command.kind != PROGPU_NATIVE_SCENE_COMMAND_SAVE ||
+        active_save_command.state_index == PROGPU_NATIVE_SCENE_NO_INDEX) {
+        return false;
     }
+    auto state_resource_changed = scoped;
+    const auto active_state_offset = static_cast<std::uint32_t>(
+        scoped_header.resource_offset +
+        active_save_command.state_index * scoped_header.resource_stride);
+    auto active_state_resource = read<progpu_native_scene_resource>(
+        state_resource_changed, active_state_offset);
+    if (active_state_resource.kind != PROGPU_NATIVE_SCENE_RESOURCE_STATE) {
+        return false;
+    }
+    ++active_state_resource.generation;
+    std::memcpy(
+        state_resource_changed.data() + active_state_offset,
+        &active_state_resource,
+        sizeof(active_state_resource));
     const auto state_resource_hashes = semantic::compute_content_hashes(
         state_resource_changed.data(), scoped_header);
     if (!(state_resource_hashes.brush != scoped_hashes.brush &&
-        state_resource_hashes.text_style != scoped_hashes.text_style &&
-        state_resource_hashes.analytic != scoped_hashes.analytic)) {
+        state_resource_hashes.text_style == scoped_hashes.text_style &&
+        state_resource_hashes.analytic != scoped_hashes.analytic &&
+        state_resource_hashes.path != scoped_hashes.path &&
+        state_resource_hashes.glyph == scoped_hashes.glyph &&
+        state_resource_hashes.image == scoped_hashes.image &&
+        state_resource_hashes.three_d == scoped_hashes.three_d)) {
         return false;
     }
 
@@ -2079,11 +2084,7 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
     }
 
     auto scope_changed = scoped;
-    auto save_command = read<progpu_native_scene_command>(
-        scope_changed, scoped_header.command_offset);
-    if (save_command.kind != PROGPU_NATIVE_SCENE_COMMAND_SAVE) {
-        return false;
-    }
+    auto save_command = active_save_command;
     save_command.state_index = second_state_index;
     std::memcpy(
         scope_changed.data() + scoped_header.command_offset,
@@ -2091,13 +2092,95 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         sizeof(save_command));
     const auto scope_hashes = semantic::compute_content_hashes(
         scope_changed.data(), scoped_header);
-    return scope_hashes.brush != scoped_hashes.brush &&
-        scope_hashes.text_style != scoped_hashes.text_style &&
+    if (!(scope_hashes.brush != scoped_hashes.brush &&
+        scope_hashes.text_style == scoped_hashes.text_style &&
         scope_hashes.analytic != scoped_hashes.analytic &&
         scope_hashes.path != scoped_hashes.path &&
-        scope_hashes.glyph != scoped_hashes.glyph &&
-        scope_hashes.image != scoped_hashes.image &&
-        scope_hashes.three_d != scoped_hashes.three_d;
+        scope_hashes.glyph == scoped_hashes.glyph &&
+        scope_hashes.image == scoped_hashes.image &&
+        scope_hashes.three_d == scoped_hashes.three_d)) {
+        return false;
+    }
+
+    semantic_scene_builder image_layer_builder(713U, 1U);
+    std::uint32_t image_layer_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    std::uint32_t image_layer_image = PROGPU_NATIVE_SCENE_NO_INDEX;
+    constexpr std::array<std::byte, 16U> image_layer_pixels{
+        std::byte{0xff}, std::byte{0x00}, std::byte{0x00}, std::byte{0xff},
+        std::byte{0x00}, std::byte{0xff}, std::byte{0x00}, std::byte{0xff},
+        std::byte{0x00}, std::byte{0x00}, std::byte{0xff}, std::byte{0xff},
+        std::byte{0xff}, std::byte{0xff}, std::byte{0xff}, std::byte{0xff}};
+    progpu_native_scene_layer image_layer{};
+    image_layer.flags = PROGPU_NATIVE_SCENE_LAYER_BOUNDS |
+        PROGPU_NATIVE_SCENE_LAYER_FORCE_ISOLATION;
+    image_layer.bounds = {20.0F, 0.0F, 20.0F, 20.0F};
+    image_layer.opacity = 1.0F;
+    image_layer.mask_resource_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+    image_layer.effect_resource_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+    image_layer.content_revision = 1U;
+    progpu_native_scene_image_draw image_draw{};
+    image_draw.image_width = 2U;
+    image_draw.image_height = 2U;
+    image_draw.row_bytes = 8U;
+    image_draw.sampling = PROGPU_NATIVE_IMAGE_SAMPLING_NEAREST;
+    image_draw.source_rect = {0.0F, 0.0F, 2.0F, 2.0F};
+    image_draw.destination_rect = {20.0F, 0.0F, 20.0F, 20.0F};
+    image_draw.transform = semantic_scene_builder::identity_transform();
+    image_draw.opacity = 1.0F;
+    if (!image_layer_builder.add_solid_brush(
+            {0.2F, 0.5F, 0.9F, 1.0F}, 1.0F, image_layer_brush) ||
+        !image_layer_builder.draw_analytic(
+            std::span<const progpu_native_analytic_primitive>(
+                &primitive, 1U),
+            std::span<const std::uint32_t>(&image_layer_brush, 1U),
+            {0.0F, 0.0F, 20.0F, 20.0F}) ||
+        !image_layer_builder.add_rgba8_image(
+            2U,
+            2U,
+            8U,
+            image_layer_pixels,
+            image_layer_image) ||
+        !image_layer_builder.push_layer(image_layer) ||
+        !image_layer_builder.draw_image(
+            image_layer_image,
+            image_draw,
+            {20.0F, 0.0F, 20.0F, 20.0F}) ||
+        !image_layer_builder.pop_layer()) {
+        return false;
+    }
+    std::vector<std::byte> image_layer_stream;
+    if (!image_layer_builder.build(image_layer_stream)) {
+        return false;
+    }
+    const auto image_layer_header = read<progpu_native_scene_header>(
+        image_layer_stream, 0U);
+    const auto image_layer_hashes = semantic::compute_content_hashes(
+        image_layer_stream.data(), image_layer_header);
+    auto changed_image_layer_stream = image_layer_stream;
+    auto image_layer_command = read<progpu_native_scene_command>(
+        changed_image_layer_stream,
+        image_layer_header.command_offset + image_layer_header.command_stride);
+    if (image_layer_command.kind != PROGPU_NATIVE_SCENE_COMMAND_PUSH_LAYER) {
+        return false;
+    }
+    auto changed_image_layer = read<progpu_native_scene_layer>(
+        changed_image_layer_stream, image_layer_command.payload_offset);
+    ++changed_image_layer.content_revision;
+    std::memcpy(
+        changed_image_layer_stream.data() + image_layer_command.payload_offset,
+        &changed_image_layer,
+        sizeof(changed_image_layer));
+    const auto changed_image_layer_hashes =
+        semantic::compute_content_hashes(
+            changed_image_layer_stream.data(), image_layer_header);
+    return changed_image_layer_hashes.image != image_layer_hashes.image &&
+        changed_image_layer_hashes.brush == image_layer_hashes.brush &&
+        changed_image_layer_hashes.text_style ==
+            image_layer_hashes.text_style &&
+        changed_image_layer_hashes.analytic == image_layer_hashes.analytic &&
+        changed_image_layer_hashes.path == image_layer_hashes.path &&
+        changed_image_layer_hashes.glyph == image_layer_hashes.glyph &&
+        changed_image_layer_hashes.three_d == image_layer_hashes.three_d;
 }
 
 bool semantic_scene_builder_records_retained_hit_test_index() {

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -1599,6 +1599,38 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         return false;
     }
 
+    semantic_scene_builder analytic_only_builder(710U, 1U);
+    std::uint32_t analytic_only_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    std::uint32_t analytic_only_alternate = PROGPU_NATIVE_SCENE_NO_INDEX;
+    if (!analytic_only_builder.add_solid_brush(
+            {0.2F, 0.5F, 0.9F, 1.0F},
+            1.0F,
+            analytic_only_brush) ||
+        !analytic_only_builder.add_solid_brush(
+            {0.9F, 0.4F, 0.1F, 1.0F},
+            1.0F,
+            analytic_only_alternate) ||
+        !analytic_only_builder.draw_analytic(
+            std::span<const progpu_native_analytic_primitive>(
+                &primitive, 1U),
+            std::span<const std::uint32_t>(&analytic_only_brush, 1U),
+            {0.0F, 0.0F, 20.0F, 20.0F})) {
+        return false;
+    }
+    std::vector<std::byte> analytic_only;
+    if (!analytic_only_builder.build(analytic_only)) {
+        return false;
+    }
+    const auto analytic_only_header = read<progpu_native_scene_header>(
+        analytic_only, 0U);
+    const auto analytic_only_hashes = semantic::compute_content_hashes(
+        analytic_only.data(), analytic_only_header);
+    if (!(analytic_only_hashes.brush == first_hashes.brush &&
+        analytic_only_hashes.analytic == first_hashes.analytic &&
+        analytic_only_hashes.image != first_hashes.image)) {
+        return false;
+    }
+
     auto brush_changed = first;
     const auto brush_header = read<progpu_native_scene_header>(
         brush_changed, 0U);

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -1687,6 +1687,82 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
         return false;
     }
 
+    semantic_scene_builder interleaved_builder(712U, 1U);
+    std::uint32_t interleaved_analytic_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    std::uint32_t interleaved_path_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    const std::array path_segments{
+        progpu_native_path_segment{
+            {0.0F, 0.0F}, {12.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{
+            {12.0F, 0.0F}, {12.0F, 12.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{
+            {12.0F, 12.0F}, {0.0F, 12.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{
+            {0.0F, 12.0F}, {0.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U}};
+    auto path = progpu_native_scene_path_fill{};
+    path.segment_count = path_segments.size();
+    path.max_x = 12.0F;
+    path.max_y = 12.0F;
+    path.color = {1.0F, 1.0F, 1.0F, 1.0F};
+    path.transform = semantic_scene_builder::identity_transform();
+    path.fill_rule = PROGPU_NATIVE_FILL_RULE_NON_ZERO;
+    path.sample_grid = 4U;
+    if (!interleaved_builder.add_solid_brush(
+            {0.2F, 0.5F, 0.9F, 1.0F},
+            1.0F,
+            interleaved_analytic_brush) ||
+        !interleaved_builder.add_solid_brush(
+            {0.9F, 0.4F, 0.1F, 1.0F},
+            1.0F,
+            interleaved_path_brush) ||
+        !interleaved_builder.draw_analytic(
+            std::span<const progpu_native_analytic_primitive>(
+                &primitive, 1U),
+            std::span<const std::uint32_t>(
+                &interleaved_analytic_brush, 1U),
+            {0.0F, 0.0F, 20.0F, 20.0F}) ||
+        !interleaved_builder.draw_paths(
+            std::span<const progpu_native_scene_path_fill>(&path, 1U),
+            path_segments,
+            std::span<const std::uint32_t>(&interleaved_path_brush, 1U),
+            {24.0F, 0.0F, 12.0F, 12.0F})) {
+        return false;
+    }
+    std::vector<std::byte> interleaved;
+    if (!interleaved_builder.build(interleaved)) {
+        return false;
+    }
+    const auto interleaved_header = read<progpu_native_scene_header>(
+        interleaved, 0U);
+    const auto interleaved_hashes = semantic::compute_content_hashes(
+        interleaved.data(), interleaved_header);
+    auto reordered = interleaved;
+    auto analytic_record = read<progpu_native_scene_command>(
+        reordered, interleaved_header.command_offset);
+    auto path_record = read<progpu_native_scene_command>(
+        reordered,
+        interleaved_header.command_offset + interleaved_header.command_stride);
+    std::memcpy(
+        reordered.data() + interleaved_header.command_offset,
+        &path_record,
+        sizeof(path_record));
+    std::memcpy(
+        reordered.data() + interleaved_header.command_offset +
+            interleaved_header.command_stride,
+        &analytic_record,
+        sizeof(analytic_record));
+    const auto reordered_hashes = semantic::compute_content_hashes(
+        reordered.data(), interleaved_header);
+    if (!(reordered_hashes.brush != interleaved_hashes.brush &&
+        reordered_hashes.analytic != interleaved_hashes.analytic &&
+        reordered_hashes.path != interleaved_hashes.path)) {
+        return false;
+    }
+
     semantic_scene_builder scoped_builder(711U, 1U);
     std::uint32_t scoped_brush = PROGPU_NATIVE_SCENE_NO_INDEX;
     auto first_state = semantic_scene_builder::identity_state();
@@ -1714,6 +1790,54 @@ bool semantic_scene_content_hashes_isolate_image_updates() {
     const auto scoped_header = read<progpu_native_scene_header>(scoped, 0U);
     const auto scoped_hashes = semantic::compute_content_hashes(
         scoped.data(), scoped_header);
+    auto state_resource_changed = scoped;
+    for (std::uint32_t index = 0U;
+         index < scoped_header.resource_count;
+         ++index) {
+        const auto offset = static_cast<std::uint32_t>(
+            scoped_header.resource_offset +
+            index * scoped_header.resource_stride);
+        auto resource = read<progpu_native_scene_resource>(
+            state_resource_changed, offset);
+        if (resource.kind != PROGPU_NATIVE_SCENE_RESOURCE_STATE) {
+            continue;
+        }
+        ++resource.generation;
+        std::memcpy(
+            state_resource_changed.data() + offset,
+            &resource,
+            sizeof(resource));
+        break;
+    }
+    const auto state_resource_hashes = semantic::compute_content_hashes(
+        state_resource_changed.data(), scoped_header);
+    if (!(state_resource_hashes.brush != scoped_hashes.brush &&
+        state_resource_hashes.text_style != scoped_hashes.text_style &&
+        state_resource_hashes.analytic != scoped_hashes.analytic)) {
+        return false;
+    }
+
+    auto draw_state_changed = scoped;
+    auto analytic_draw_command = read<progpu_native_scene_command>(
+        draw_state_changed,
+        scoped_header.command_offset + scoped_header.command_stride);
+    if (analytic_draw_command.kind !=
+        PROGPU_NATIVE_SCENE_COMMAND_DRAW_ANALYTIC) {
+        return false;
+    }
+    analytic_draw_command.state_index = second_state_index;
+    std::memcpy(
+        draw_state_changed.data() + scoped_header.command_offset +
+            scoped_header.command_stride,
+        &analytic_draw_command,
+        sizeof(analytic_draw_command));
+    const auto draw_state_hashes = semantic::compute_content_hashes(
+        draw_state_changed.data(), scoped_header);
+    if (!(draw_state_hashes.brush != scoped_hashes.brush &&
+        draw_state_hashes.analytic != scoped_hashes.analytic)) {
+        return false;
+    }
+
     auto scope_changed = scoped;
     auto save_command = read<progpu_native_scene_command>(
         scope_changed, scoped_header.command_offset);

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.hpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.hpp
@@ -13,6 +13,7 @@ bool semantic_scene_builder_records_image_patch_batches();
 bool semantic_scene_builder_serializes_external_images_pointer_free();
 bool semantic_scene_builder_updates_retained_images_transactionally();
 bool semantic_scene_builder_records_styled_glyph_runs();
+bool semantic_scene_content_hashes_normalize_resource_ordinals();
 bool semantic_scene_builder_shares_glyph_segments_across_raster_sizes();
 bool semantic_scene_builder_records_native_shaped_runs();
 bool semantic_scene_builder_records_color_bitmap_glyphs();


### PR DESCRIPTION
## Summary

- hash analytic, path, glyph, image, and 3D command streams independently so an update in one family does not rebuild unrelated retained GPU pages
- normalize command, state, brush, and style references to stable resource identities so canonical table-ordinal shifts do not invalidate unchanged family pages
- hash only compiler-consumed text-style mapping fields; positioned glyph bytes remain in the glyph-family identity
- keep brush, text-style, and hit-test resource identities independent of unrelated draw placement while preserving the full immutable stream hash as the render-bundle ordering/layer boundary
- skip command-indexed text-style lookup for unstyled retained glyphs, which consume inline color and intentionally remain independent of the text-style page
- add focused resource-ordinal, styled-glyph placement, image/analytic placement, brush/glyph, scope, and resource-generation isolation regressions

## Correctness finding after the CI prerequisite

After rebasing onto main 72c4e1f97dbb34860bac691ba198bd324274ca00, the extended browser readiness gate exposed a real scene-transition failure rather than a timeout: the MotionMark-to-text-showcase transition returned INTERNAL_ERROR with the detail that the semantic glyph text style changed after validation. The retained text-style page was correctly reused because the incoming glyph run was unstyled, but the render path still indexed that command-local style map.

The targeted correction consults the text-style page only for commands carrying PROGPU_NATIVE_SCENE_GLYPH_STYLED. Styled commands retain the original strict lookup and validation. The real Chromium browser gallery now completes the same transition successfully.

## Review-driven retention corrections

The family digest originally removed command ids and arena offsets but still copied resource-table ordinals from command records and brush/style payload prefixes. A valid canonical update that inserts a lower stable resource id could therefore rebuild an unchanged family. Exact head 1c6323b98ffa6a64806637ef4ccc41a30e0ee43b replaces those ordinals with the referenced stable resource identities. Two independently constructed, validated streams now prove glyph/style and analytic/brush hashes remain stable when an unrelated image shifts their table positions.

The original styled-glyph mapping digest also included positioned glyph records even though the text-style compiler consumes only command position, state opacity, style resource, and style index. The mapping digest now contains only those inputs. A focused regression moves a styled glyph and proves the glyph identity changes while the text-style identity is retained.

A further review correction restricts scope identity to the effective state and active layer stack at each affected family draw. Closed scopes, trailing scopes, and unreferenced common resources no longer evict unrelated pages. A focused image-only layer regression changes the layer content revision after the final analytic draw and proves that only the image identity changes; the existing shared brush-page dependency for analytic/path state changes remains explicit.

## Managed/native parity audit

The family hash defect and the unstyled command-index lookup are specific to the native pointer-free semantic stream. The managed compositor does not use this identity loop or a global command-indexed text-style page. It already retains per-visual IncrementalScenePage objects keyed by content/presentation/target state and diffs independent 4 KiB vector, text, texture, brush, style, gradient, and uniform upload shadows. No managed code change applies; its page and upload invalidation are already family-local, and unstyled glyphs do not perform this native command-index lookup.

## Performance and correctness evidence

- rebased production family-hash patch matched the previously reviewed byte-for-byte patch identity before the targeted correctness and review follow-ups
- AppleClang C++20 Release build: pass
- native CTest matrix: 11/11 pass
- real Chromium WebGPU: core native contract pass; MotionMark one GPU draw; text showcase 281 shaped glyph records and 106 retained outlines at 648x433 physical pixels
- real-provider alternating 4+4 quick-process sample before the correctness-only and digest-precision follow-ups: sparse-update median process p50 4.118 ms -> 4.000 ms (-2.9%); text-update 19.764 ms -> 19.649 ms (-0.6%); cached full frame 1.512 ms -> 1.486 ms (-1.7%, within observed run noise)
- output hashes and the exact persistent-target replay invariant remained stable within each compared SDK
- review threads: 14 total, 0 unresolved at exact head publication
- privacy scan: clean

The measurements are deliberately treated as a small retention improvement, not a complete sparse-update solution; full immutable stream serialization remains in the update boundary. The complete paired comparison will be refreshed only after the dependency chain is merged onto immutable main commits.

## Research / clean room

The design follows the architectural contracts, not implementation text, of:

- Skia Graphite DrawPass sorting/batching: https://skia.googlesource.com/skia/+/2135d686708b/src/gpu/graphite/DrawPass.cpp
- WebRender retained display lists: https://searchfox.org/mozilla-central/source/gfx/docs/RenderingOverview.rst
- Vello retained scene fragments: https://github.com/linebender/vello/blob/main/doc/vision.md
- Direct2D command lists: https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1_1commandlist

The implementation is original ProGPU code and preserves the typed resource-generation and full-scene replay contracts.

