### PR TITLE
Apply optical-size font variations

### DIFF
--- a/src/ProGPU.Native/include/progpu_native_text.hpp
+++ b/src/ProGPU.Native/include/progpu_native_text.hpp
@@ -1654,6 +1654,9 @@ struct font_style_request final {
     std::int32_t weight = 400;
     std::int32_t width = 5;
     font_provider_slant slant = font_provider_slant::normal;
+    /* Optional OpenType opsz coordinate in signed 16.16 user units. Zero
+     * preserves the face default for callers without a point-size context. */
+    std::int32_t optical_size_fixed = 0;
 };
 
 struct font_style_variation_requirements final {
@@ -1667,7 +1670,7 @@ struct font_style_variation final {
     std::uint16_t axis_index = 0U;
 };
 
-/* Maps the managed FontStyleRequest contract onto wght/wdth/ital/slnt axes.
+/* Maps the managed FontStyleRequest contract onto wght/wdth/ital/slnt/opsz axes.
  * Requirements fully validate recognized axes before a caller-owned result is
  * written, so short buffers and malformed variation data are transactional. */
 bool try_get_font_style_variation_requirements(

--- a/src/ProGPU.Native/src/Text/Font/progpu_native_font_style.cpp
+++ b/src/ProGPU.Native/src/Text/Font/progpu_native_font_style.cpp
@@ -31,14 +31,14 @@ bool normalize_request(font_style_request& request) noexcept {
     if (request.optical_size_fixed <= 0) {
         request.optical_size_fixed = 0;
     }
-    if (request.weight == 0 && request.width == 0 &&
-        request.slant == font_provider_slant::normal &&
-        request.optical_size_fixed == 0) {
-        request = {};
-        return true;
-    }
-    request.weight = std::clamp(request.weight, 1, 1000);
-    request.width = std::clamp(request.width, 1, 9);
+    const bool unspecified_base = request.weight == 0 && request.width == 0 &&
+        request.slant == font_provider_slant::normal;
+    request.weight = unspecified_base
+        ? 400
+        : std::clamp(request.weight, 1, 1000);
+    request.width = unspecified_base
+        ? 5
+        : std::clamp(request.width, 1, 9);
     return true;
 }
 

--- a/src/ProGPU.Native/src/Text/Font/progpu_native_font_style.cpp
+++ b/src/ProGPU.Native/src/Text/Font/progpu_native_font_style.cpp
@@ -17,6 +17,7 @@ constexpr auto weight_tag = open_type_tag::from_chars('w', 'g', 'h', 't');
 constexpr auto width_tag = open_type_tag::from_chars('w', 'd', 't', 'h');
 constexpr auto italic_tag = open_type_tag::from_chars('i', 't', 'a', 'l');
 constexpr auto slant_tag = open_type_tag::from_chars('s', 'l', 'n', 't');
+constexpr auto optical_size_tag = open_type_tag::from_chars('o', 'p', 's', 'z');
 
 void set_error(font_error* destination, font_error value) noexcept {
     if (destination != nullptr) *destination = value;
@@ -27,8 +28,12 @@ bool normalize_request(font_style_request& request) noexcept {
         static_cast<std::uint8_t>(font_provider_slant::oblique)) {
         return false;
     }
+    if (request.optical_size_fixed <= 0) {
+        request.optical_size_fixed = 0;
+    }
     if (request.weight == 0 && request.width == 0 &&
-        request.slant == font_provider_slant::normal) {
+        request.slant == font_provider_slant::normal &&
+        request.optical_size_fixed == 0) {
         request = {};
         return true;
     }
@@ -85,6 +90,10 @@ bool try_select_user_fixed(
                 ? axis.minimum_fixed
                 : axis.maximum_fixed;
         }
+        return true;
+    }
+    if (axis.tag == optical_size_tag && request.optical_size_fixed > 0) {
+        result = request.optical_size_fixed;
         return true;
     }
     return false;

--- a/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
@@ -8354,6 +8354,19 @@ void font_style_variations_match_managed_font_manager_policy() {
         optical_output[0].normalized == 8192 &&
         optical_output[1].tag ==
             open_type_tag::from_chars('w', 'g', 'h', 't'));
+    const font_style_request optical_only_request{
+        0, 0, font_provider_slant::normal, 23 << 16};
+    require(try_resolve_font_style_variations(
+        font,
+        optical_only_request,
+        optical_output,
+        written,
+        &reported,
+        &error));
+    require(written == 2U &&
+        optical_output[0].user_fixed == 23 << 16 &&
+        optical_output[1].user_fixed == 400 << 16 &&
+        optical_output[1].normalized == 0);
 
     require(sfnt_font_view::try_create(data, 0U, font, &error));
     require(try_resolve_font_style_variations(

--- a/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
@@ -8330,6 +8330,32 @@ void font_style_variations_match_managed_font_manager_policy() {
     require(output[3].user_fixed == -20 * (1 << 16) &&
         output[3].normalized == -16384);
 
+    const std::array<table_data, 1U> optical_tables{
+        table_data{
+            open_type_tag::from_chars('f', 'v', 'a', 'r'),
+            make_fvar()}};
+    const auto optical_data = make_font(
+        0U, 22U, 0U, false, false, false, optical_tables);
+    require(sfnt_font_view::try_create(optical_data, 0U, font, &error));
+    const font_style_request optical_request{
+        700, 5, font_provider_slant::normal, 23 << 16};
+    std::array<font_style_variation, 2U> optical_output{};
+    require(try_resolve_font_style_variations(
+        font,
+        optical_request,
+        optical_output,
+        written,
+        &reported,
+        &error));
+    require(written == 2U &&
+        optical_output[0].tag ==
+            open_type_tag::from_chars('o', 'p', 's', 'z') &&
+        optical_output[0].user_fixed == 23 << 16 &&
+        optical_output[0].normalized == 8192 &&
+        optical_output[1].tag ==
+            open_type_tag::from_chars('w', 'g', 'h', 't'));
+
+    require(sfnt_font_view::try_create(data, 0U, font, &error));
     require(try_resolve_font_style_variations(
         font, font_style_request{0, 0, font_provider_slant::normal},
         output, written, nullptr, &error));

--- a/src/ProGPU.Tests/FontManagerTests.cs
+++ b/src/ProGPU.Tests/FontManagerTests.cs
@@ -46,6 +46,36 @@ public sealed class FontManagerTests
     }
 
     [Fact]
+    public void StaticTypefaceStyleCacheStaysBoundedAcrossOpticalSizes()
+    {
+        var manager = new FontManager();
+        TtfFont regular = InterFontFamily.Regular;
+        manager.RegisterFont(regular);
+
+        for (var index = 0; index < 1_000; index++)
+        {
+            Assert.Same(
+                regular,
+                manager.MatchTypeface(
+                    regular,
+                    new FontStyleRequest(700, 5, FontSlant.Upright)
+                    {
+                        OpticalSize = 8f + index * 0.125f
+                    }));
+        }
+
+        FieldInfo? cacheField = typeof(FontManager).GetField(
+            "_styleMatches",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(cacheField);
+        var cache = Assert.IsType<
+            System.Collections.Concurrent.ConcurrentDictionary<
+                (TtfFont Font, FontStyleRequest Style), TtfFont>>(
+                    cacheField.GetValue(manager));
+        Assert.InRange(cache.Count, 1, 256);
+    }
+
+    [Fact]
     public void RegisteringACloserFaceInvalidatesPriorStyleMatch()
     {
         var manager = new FontManager();

--- a/src/ProGPU.Tests/InterFontFamilyTests.cs
+++ b/src/ProGPU.Tests/InterFontFamilyTests.cs
@@ -321,6 +321,30 @@ public sealed class InterFontFamilyTests
         Assert.DoesNotContain(italic.VariationAxes, static axis => axis.Tag is "ital" or "slnt");
     }
 
+    [Fact]
+    public void TypefaceMatchingAppliesRequestedOpticalSizeAxis()
+    {
+        var manager = new FontManager();
+        InterFontFamily.RegisterFonts(manager);
+        var request = new FontStyleRequest(
+            637,
+            5,
+            FontSlant.Upright)
+        {
+            OpticalSize = 23f
+        };
+
+        TtfFont matched = Assert.IsType<TtfFont>(manager.MatchFamily(
+            InterFontFamily.VariableFamilyName,
+            request));
+
+        Assert.Equal(
+            23f,
+            Assert.Single(
+                matched.VariationSettings,
+                static setting => setting.Tag == "opsz").Value);
+    }
+
     [Theory]
     [InlineData(100f, 14f, 100, false)]
     [InlineData(537f, 23f, 537, false)]

--- a/src/ProGPU.Tests/InterFontFamilyTests.cs
+++ b/src/ProGPU.Tests/InterFontFamilyTests.cs
@@ -345,6 +345,46 @@ public sealed class InterFontFamilyTests
                 static setting => setting.Tag == "opsz").Value);
     }
 
+    [Fact]
+    public void OpticalSizeOnlyRequestUsesNormalWeightAndWidth()
+    {
+        var manager = new FontManager();
+        InterFontFamily.RegisterFonts(manager);
+        var request = new FontStyleRequest { OpticalSize = 23f };
+
+        TtfFont matched = Assert.IsType<TtfFont>(manager.MatchFamily(
+            InterFontFamily.VariableFamilyName,
+            request));
+
+        Assert.Equal((ushort)400, matched.WeightClass);
+        Assert.Equal((ushort)5, matched.WidthClass);
+        Assert.Equal(
+            23f,
+            Assert.Single(
+                matched.VariationSettings,
+                static setting => setting.Tag == "opsz").Value);
+    }
+
+    [Fact]
+    public void StyleRequestRecoveredFromVariableFontPreservesOpticalSize()
+    {
+        TtfFont font = InterFontFamily.GetVariableFont(537f, 23f);
+
+        FontStyleRequest style = FontStyleRequest.FromFont(font);
+
+        Assert.Equal((537, 5, FontSlant.Upright, 23f),
+            (style.Weight, style.Width, style.Slant, style.OpticalSize));
+    }
+
+    [Fact]
+    public void WinUiFontSizeConvertsDipsToOpticalPoints()
+    {
+        Assert.Equal(
+            12f,
+            Microsoft.UI.Xaml.Controls.TextLayoutEngine
+                .ConvertFontSizeToOpticalPoints(16f));
+    }
+
     [Theory]
     [InlineData(100f, 14f, 100, false)]
     [InlineData(537f, 23f, 537, false)]

--- a/src/ProGPU.Text/FontApi.cs
+++ b/src/ProGPU.Text/FontApi.cs
@@ -100,9 +100,28 @@ public static class FontApi
         out TtfFont? fallbackFont,
         out ushort glyphIndex)
     {
+        return TryResolvePlatformFallback(
+            requestedFont,
+            FontStyleRequest.FromFont(requestedFont),
+            codePoint,
+            out fallbackFont,
+            out glyphIndex);
+    }
+
+    /// <summary>
+    /// Resolves a platform fallback while preserving the caller's original
+    /// style coordinates, including values clamped by the requested face.
+    /// </summary>
+    public static bool TryResolvePlatformFallback(
+        TtfFont requestedFont,
+        FontStyleRequest requestedStyle,
+        int codePoint,
+        out TtfFont? fallbackFont,
+        out ushort glyphIndex)
+    {
         if (Manager.TryMatchCharacter(
                 requestedFont.FamilyName,
-                FontStyleRequest.FromFont(requestedFont),
+                requestedStyle,
                 languageTags: null,
                 codePoint,
                 requestedFont,
@@ -120,10 +139,14 @@ public static class FontApi
             var candidate = fonts[index];
             if (ReferenceEquals(candidate, requestedFont)) continue;
 
-            ushort candidateGlyph = candidate.GetGlyphIndex((uint)codePoint);
+            TtfFont styledCandidate = Manager.MatchTypeface(
+                candidate,
+                requestedStyle);
+            ushort candidateGlyph = styledCandidate.GetGlyphIndex(
+                (uint)codePoint);
             if (candidateGlyph != 0)
             {
-                fallbackFont = candidate;
+                fallbackFont = styledCandidate;
                 glyphIndex = candidateGlyph;
                 return true;
             }
@@ -136,10 +159,14 @@ public static class FontApi
             if (candidate is null) continue;
             if (ReferenceEquals(candidate, requestedFont)) continue;
 
-            ushort candidateGlyph = candidate.GetGlyphIndex((uint)codePoint);
+            TtfFont styledCandidate = Manager.MatchTypeface(
+                candidate,
+                requestedStyle);
+            ushort candidateGlyph = styledCandidate.GetGlyphIndex(
+                (uint)codePoint);
             if (candidateGlyph != 0)
             {
-                fallbackFont = candidate;
+                fallbackFont = styledCandidate;
                 glyphIndex = candidateGlyph;
                 return true;
             }

--- a/src/ProGPU.Text/FontManager.cs
+++ b/src/ProGPU.Text/FontManager.cs
@@ -15,6 +15,12 @@ public readonly record struct FontStyleRequest(int Weight, int Width, FontSlant 
 {
     public static FontStyleRequest Normal { get; } = new(400, 5, FontSlant.Upright);
 
+    /// <summary>
+    /// Gets an optional OpenType <c>opsz</c> coordinate in typographic points.
+    /// Zero preserves the font's default optical-size instance.
+    /// </summary>
+    public float OpticalSize { get; init; }
+
     public FontStyleRequest(int weight = 400, int width = 5)
         : this(weight, width, FontSlant.Upright)
     {
@@ -617,7 +623,16 @@ public sealed class FontManager
     private static FontStyleRequest NormalizeStyle(FontStyleRequest style) =>
         style == default
             ? FontStyleRequest.Normal
-            : new FontStyleRequest(Math.Clamp(style.Weight, 1, 1000), Math.Clamp(style.Width, 1, 9), style.Slant);
+            : new FontStyleRequest(
+                Math.Clamp(style.Weight, 1, 1000),
+                Math.Clamp(style.Width, 1, 9),
+                style.Slant)
+            {
+                OpticalSize = float.IsFinite(style.OpticalSize) &&
+                    style.OpticalSize > 0
+                        ? style.OpticalSize
+                        : 0
+            };
 
     private static string GetStyleName(string familyName, FontStyleRequest style)
     {
@@ -828,7 +843,7 @@ public sealed class FontManager
             return font;
         }
 
-        var settings = new List<FontVariationSetting>(3);
+        var settings = new List<FontVariationSetting>(4);
         IReadOnlyList<FontVariationAxis> axes = font.VariationAxes;
         for (var index = 0; index < axes.Count; index++)
         {
@@ -854,6 +869,11 @@ public sealed class FontManager
                             : MathF.Abs(axis.Minimum) >= MathF.Abs(axis.Maximum)
                                 ? axis.Minimum
                                 : axis.Maximum));
+                    break;
+                case "opsz" when style.OpticalSize > 0:
+                    settings.Add(new FontVariationSetting(
+                        axis.Tag,
+                        style.OpticalSize));
                     break;
             }
         }

--- a/src/ProGPU.Text/FontManager.cs
+++ b/src/ProGPU.Text/FontManager.cs
@@ -29,10 +29,20 @@ public readonly record struct FontStyleRequest(int Weight, int Width, FontSlant 
     public static FontStyleRequest FromFont(TtfFont font)
     {
         ArgumentNullException.ThrowIfNull(font);
-        return new FontStyleRequest(
+        var result = new FontStyleRequest(
             font.WeightClass == 0 ? 400 : font.WeightClass,
             font.WidthClass == 0 ? 5 : font.WidthClass,
             font.IsItalic ? FontSlant.Italic : FontSlant.Upright);
+        for (var index = 0; index < font.VariationSettings.Count; index++)
+        {
+            FontVariationSetting setting = font.VariationSettings[index];
+            if (setting.Tag == "opsz" && float.IsFinite(setting.Value) &&
+                setting.Value > 0)
+            {
+                return result with { OpticalSize = setting.Value };
+            }
+        }
+        return result;
     }
 }
 
@@ -620,19 +630,23 @@ public sealed class FontManager
         return result;
     }
 
-    private static FontStyleRequest NormalizeStyle(FontStyleRequest style) =>
-        style == default
-            ? FontStyleRequest.Normal
-            : new FontStyleRequest(
+    private static FontStyleRequest NormalizeStyle(FontStyleRequest style)
+    {
+        bool unspecifiedBase = style.Weight == 0 && style.Width == 0 &&
+            style.Slant == FontSlant.Upright;
+        return new FontStyleRequest(
+            unspecifiedBase ? FontStyleRequest.Normal.Weight :
                 Math.Clamp(style.Weight, 1, 1000),
+            unspecifiedBase ? FontStyleRequest.Normal.Width :
                 Math.Clamp(style.Width, 1, 9),
-                style.Slant)
-            {
-                OpticalSize = float.IsFinite(style.OpticalSize) &&
-                    style.OpticalSize > 0
-                        ? style.OpticalSize
-                        : 0
-            };
+            style.Slant)
+        {
+            OpticalSize = float.IsFinite(style.OpticalSize) &&
+                style.OpticalSize > 0
+                    ? style.OpticalSize
+                    : 0
+        };
+    }
 
     private static string GetStyleName(string familyName, FontStyleRequest style)
     {

--- a/src/ProGPU.Text/FontManager.cs
+++ b/src/ProGPU.Text/FontManager.cs
@@ -72,6 +72,7 @@ public sealed class FontFace
 public sealed class FontManager
 {
     private const int MaximumCharacterMatchCacheEntries = 4096;
+    private const int MaximumStyleMatchCacheEntries = 256;
     private const int MaximumVariationMatchCacheEntries = 256;
 
     private readonly record struct CharacterMatchKey(
@@ -122,6 +123,7 @@ public sealed class FontManager
     private readonly object _registeredLock = new();
     private RegisteredFace[] _registeredFaces = [];
     private readonly ConcurrentDictionary<(TtfFont Font, FontStyleRequest Style), TtfFont> _styleMatches = new();
+    private readonly ConcurrentQueue<(TtfFont Font, FontStyleRequest Style)> _styleMatchOrder = new();
     private readonly ConcurrentDictionary<(TtfFont Font, FontStyleRequest Style), TtfFont> _variationMatches = new();
     private readonly ConcurrentQueue<(TtfFont Font, FontStyleRequest Style)> _variationMatchOrder = new();
     // Fallback lookup is on the per-character layout path. Positive and negative
@@ -283,6 +285,7 @@ public sealed class FontManager
             };
             Volatile.Write(ref _registeredFaces, updated);
             _styleMatches.Clear();
+            _styleMatchOrder.Clear();
             _variationMatches.Clear();
             _variationMatchOrder.Clear();
             Interlocked.Increment(ref _catalogVersion);
@@ -319,7 +322,7 @@ public sealed class FontManager
             bool requestedItalic = style.Slant != FontSlant.Upright;
             if (currentItalic != requestedItalic && !SupportsSlantVariation(typeface))
             {
-                return _styleMatches.GetOrAdd(
+                return GetOrAddStyleMatch(
                     (typeface, style),
                     key => MatchFamily(key.Font.FamilyName, key.Style) is { } familyMatch &&
                            !ReferenceEquals(familyMatch, key.Font)
@@ -332,9 +335,31 @@ public sealed class FontManager
         {
             return typeface;
         }
-        return _styleMatches.GetOrAdd(
+        return GetOrAddStyleMatch(
             (typeface, style),
             key => MatchFamily(key.Font.FamilyName, key.Style) ?? key.Font);
+    }
+
+    private TtfFont GetOrAddStyleMatch(
+        (TtfFont Font, FontStyleRequest Style) key,
+        Func<(TtfFont Font, FontStyleRequest Style), TtfFont> create)
+    {
+        if (_styleMatches.TryGetValue(key, out TtfFont? cached))
+        {
+            return cached;
+        }
+        TtfFont created = create(key);
+        if (!_styleMatches.TryAdd(key, created))
+        {
+            return _styleMatches.TryGetValue(key, out cached) ? cached : created;
+        }
+        _styleMatchOrder.Enqueue(key);
+        while (_styleMatches.Count > MaximumStyleMatchCacheEntries &&
+               _styleMatchOrder.TryDequeue(out var oldest))
+        {
+            _styleMatches.TryRemove(oldest, out _);
+        }
+        return created;
     }
 
     public bool TryMatchCharacter(

--- a/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
+++ b/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
@@ -330,6 +330,7 @@ namespace Microsoft.UI.Xaml.Controls
             if (glyphIndex == 0 &&
                 FontApi.TryResolvePlatformFallback(
                     charFont,
+                    requestedStyle,
                     checked((int)scalar),
                     out TtfFont? fallbackFont,
                     out ushort fallbackGlyphIndex) &&

--- a/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
+++ b/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
@@ -320,7 +320,10 @@ namespace Microsoft.UI.Xaml.Controls
                     ? requestedFont.WidthClass == 0 ? 5 : requestedFont.WidthClass
                     : (int)richChar.FontStretch,
                 richChar.FontStyle is Windows.UI.Text.FontStyle.Italic or Windows.UI.Text.FontStyle.Oblique ||
-                richChar.IsItalic || requestedFont.IsItalic ? FontSlant.Italic : FontSlant.Upright);
+                richChar.IsItalic || requestedFont.IsItalic ? FontSlant.Italic : FontSlant.Upright)
+            {
+                OpticalSize = richChar.FontSize
+            };
             charFont = FontApi.Manager.MatchTypeface(requestedFont, requestedStyle) ?? requestedFont;
             richChar.Font = charFont;
             ushort glyphIndex = charFont.GetGlyphIndex(scalar);

--- a/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
+++ b/src/ProGPU.WinUI/Controls/TextLayoutEngine.cs
@@ -322,7 +322,7 @@ namespace Microsoft.UI.Xaml.Controls
                 richChar.FontStyle is Windows.UI.Text.FontStyle.Italic or Windows.UI.Text.FontStyle.Oblique ||
                 richChar.IsItalic || requestedFont.IsItalic ? FontSlant.Italic : FontSlant.Upright)
             {
-                OpticalSize = richChar.FontSize
+                OpticalSize = ConvertFontSizeToOpticalPoints(richChar.FontSize)
             };
             charFont = FontApi.Manager.MatchTypeface(requestedFont, requestedStyle) ?? requestedFont;
             richChar.Font = charFont;
@@ -342,6 +342,9 @@ namespace Microsoft.UI.Xaml.Controls
 
             return glyphIndex;
         }
+
+        internal static float ConvertFontSizeToOpticalPoints(float fontSize) =>
+            fontSize * (72f / 96f);
 
         private static void ResolveCharacterFonts(List<RichChar> characters, TtfFont activeFont)
         {


### PR DESCRIPTION
## Summary

- add an optional optical-size request to native C++ and managed font-style contracts
- resolve the OpenType `opsz` axis through the same normalized variation pipeline as weight, width, italic, and slant
- apply text point size automatically in the managed rich-text layout path
- preserve the face default when callers have no point-size context

## Cross-engine research

The implementation follows the OpenType registered-axis contract: `opsz` uses positive point-size user coordinates, while each font controls its supported range and normalization.

- [OpenType registered `opsz` axis](https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_opsz)
- [DirectWrite font selection](https://learn.microsoft.com/en-us/windows/win32/directwrite/font-selection)
- [HarfBuzz variable-font coordinates](https://harfbuzz.github.io/fonts-and-faces-variable.html)
- [Skia variation design positions](https://api.skia.org/structSkFontArguments.html)

Adopted: an explicit typed coordinate, font-owned clamping/normalization, and one font instance used consistently by shaping and outline extraction. Rejected: platform text APIs and implicit process-global optical-size state.

## Managed/native parity

- Native: `font_style_request`, variation resolver, and focused tests
- Managed: `FontStyleRequest`, `FontManager` variation application/tests, rich-text automatic size propagation, and bounded family/style matching
- This is a text semantic change rather than a renderer wire-format change; generated compositor declarations and shaders are not applicable
- Symbol/emoji fallback remains requested-family-first; the inherited native/managed regressions remain unchanged

## Exact rebase audit

- Base: `5bd5ee2796e2ea1facb889e8e6f40d8a028bfed3`
- Head: `bfc19611273904ec0a1c669f5c9a618259a6efb9`
- Eight-file scope; no renderer C ABI, generated declaration, shader, or package-layout change
- All five stable commit patch IDs are unchanged by the rebase: `1c6132f2`, `404d006d`, `8369a8cb`, `eb30a388`, `339afe23`
- Complete rebased patch SHA-256: `5f92db18955651bf0fd516aab800292e3c7ecb2ba306cf8573b273b25dc796ba`
- Privacy scan and `git diff --check`: clean
- Optical-size state is request/face-instance/run-local; the only shared state is bounded style caching keyed by the complete request

## Local validation

- AppleClang Release Dawn/native suite: 11/11 passed
- Focused managed FontManager, Inter, fallback, and rich-text suite: 88/88 passed
- Real WebScene Dawn provider on Apple M3 Pro: passed, including managed native packaging/capture
- Public Gallery `Native C++ Renderer`: 30 warmup + 90 measured frames passed
- Public Gallery scrolling `Inter Typeface`: 60 warmup + 180 measured frames passed
- Desktop Release build: 0 warnings, 0 errors

## Final merge gate

- Fresh exact-head GitHub matrix: 27/27 passed
- Public native package consumers: 6/6 passed
- Review threads: 6/6 resolved
- Current `main` remains the exact audited base; head, eight-file scope, five patch IDs, complete patch hash, and privacy audit are unchanged
