### PR TITLE
Treat collapsed semantic strokes as empty draws

### DIFF
--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_draw_execution.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_draw_execution.cpp
@@ -106,6 +106,9 @@ progpu_native_status encode_semantic_analytic_draw(
     std::uint32_t target_layer,
     WGPUBindGroup mask_bind_group,
     WGPUBindGroup mask_chain_bind_group) {
+    if (draw.vertex_count == 0U && draw.index_count == 0U) {
+        return PROGPU_NATIVE_STATUS_SUCCESS;
+    }
     auto& page = engine.semantic_analytic_cache;
     WGPUBindGroup uniform_group =
         select_semantic_analytic_uniform_bind_group(

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_stroke.hpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_stroke.hpp
@@ -120,6 +120,17 @@ inline progpu_native_dash_style make_semantic_dash_style(
         0U};
 }
 
+inline bool semantic_stroke_is_collapsed(
+    const progpu_native_scene_stroke& stroke) noexcept {
+    float maximum_scale = 0.0F;
+    float minimum_scale = 0.0F;
+    return is_finite(stroke.transform) &&
+        !try_get_stroke_scales(
+            stroke.transform,
+            maximum_scale,
+            minimum_scale);
+}
+
 inline bool semantic_stroke_capacity(
     const progpu_native_scene_stroke& stroke,
     const progpu_native_point* points,
@@ -129,6 +140,11 @@ inline bool semantic_stroke_capacity(
     std::vector<spline_homogeneous_point>& work,
     std::size_t& vertex_count,
     std::size_t& index_count) {
+    if (semantic_stroke_is_collapsed(stroke)) {
+        vertex_count = 0U;
+        index_count = 0U;
+        return true;
+    }
     auto polyline = make_semantic_polyline(stroke);
     const auto dash = make_semantic_dash_style(stroke);
     const auto* dash_styles =
@@ -182,6 +198,9 @@ inline bool append_semantic_stroke(
     std::vector<spline_homogeneous_point>& work,
     std::vector<vector_vertex>& vertices,
     std::vector<std::uint32_t>& indices) {
+    if (semantic_stroke_is_collapsed(stroke)) {
+        return true;
+    }
     auto polyline = make_semantic_polyline(stroke);
     const auto dash = make_semantic_dash_style(stroke);
     const auto* dash_styles =

--- a/src/ProGPU.Native/tests/progpu_native_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_tests.cpp
@@ -1710,6 +1710,36 @@ void semantic_stroke_batch_preserves_retained_stroke_contracts() {
     PROGPU_REQUIRE(vertices.size() > polyline_vertex_count);
     PROGPU_REQUIRE(nearly_equal(vertices.back().brush_index, 8.0F));
 
+    auto collapsed = polyline;
+    collapsed.transform = {0.0F, 0.0F, 0.0F, 1.0F, 454.0F, 130.5F};
+    std::size_t collapsed_vertex_count = 1U;
+    std::size_t collapsed_index_count = 1U;
+    PROGPU_REQUIRE(progpu::native::semantic_stroke_capacity(
+        collapsed,
+        points.data(),
+        doubles.data(),
+        doubles.size(),
+        sampled_points,
+        work,
+        collapsed_vertex_count,
+        collapsed_index_count));
+    PROGPU_REQUIRE(collapsed_vertex_count == 0U);
+    PROGPU_REQUIRE(collapsed_index_count == 0U);
+    const auto retained_vertex_count = vertices.size();
+    const auto retained_index_count = indices.size();
+    PROGPU_REQUIRE(progpu::native::append_semantic_stroke(
+        collapsed,
+        points.data(),
+        doubles.data(),
+        doubles.size(),
+        9.0F,
+        sampled_points,
+        work,
+        vertices,
+        indices));
+    PROGPU_REQUIRE(vertices.size() == retained_vertex_count);
+    PROGPU_REQUIRE(indices.size() == retained_index_count);
+
     auto invalid_layout = strokes;
     invalid_layout[1].point_offset = 4U;
     point_count = 17U;

--- a/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
@@ -73,6 +73,41 @@ std::vector<std::byte> create_gpu_hit_test_scene_stream() {
     return scene;
 }
 
+std::vector<std::byte> create_collapsed_stroke_scene_stream() {
+    using progpu::native::semantic_scene_builder;
+    semantic_scene_builder builder(797U, 1U);
+    std::uint32_t brush = PROGPU_NATIVE_SCENE_NO_INDEX;
+    require(builder.add_solid_brush(
+        {0.9F, 0.2F, 0.4F, 1.0F}, 1.0F, brush),
+        "collapsed-stroke brush recording failed");
+    constexpr std::array points{
+        progpu_native_point{4.0F, 4.0F},
+        progpu_native_point{32.0F, 20.0F},
+        progpu_native_point{60.0F, 4.0F}};
+    progpu_native_scene_stroke stroke{};
+    stroke.struct_size = sizeof(stroke);
+    stroke.kind = PROGPU_NATIVE_SCENE_STROKE_POLYLINE;
+    stroke.point_count = points.size();
+    stroke.color = {0.9F, 0.2F, 0.4F, 1.0F};
+    stroke.transform = {0.0F, 0.0F, 0.0F, 1.0F, 32.0F, 24.0F};
+    stroke.stroke_thickness = 1.5F;
+    stroke.miter_limit = 4.0F;
+    stroke.start_cap = PROGPU_NATIVE_STROKE_CAP_ROUND;
+    stroke.end_cap = PROGPU_NATIVE_STROKE_CAP_ROUND;
+    stroke.line_join = PROGPU_NATIVE_STROKE_JOIN_ROUND;
+    stroke.dash_cap = PROGPU_NATIVE_STROKE_CAP_ROUND;
+    require(builder.draw_strokes(
+        std::span<const progpu_native_scene_stroke>(&stroke, 1U),
+        points,
+        {},
+        std::span<const std::uint32_t>(&brush, 1U),
+        {0.0F, 0.0F, 64.0F, 48.0F}),
+        "collapsed-stroke draw recording failed");
+    std::vector<std::byte> scene;
+    require(builder.build(scene), "collapsed-stroke scene build failed");
+    return scene;
+}
+
 std::vector<std::byte> create_native_3d_scene_stream() {
     using progpu::native::semantic_scene_builder;
     progpu_native_matrix_4x4 identity{};
@@ -2631,6 +2666,46 @@ int main(int argc, char** argv) {
         semantic_metrics.text_style_upload_bytes == 0U &&
         semantic_metrics.payload_hash == semantic_payload_hash,
         "stable mixed semantic scene replay rebuilt retained resources");
+
+    auto collapsed_stroke_scene = create_collapsed_stroke_scene_stream();
+    scene_metrics = {};
+    scene_metrics.struct_size = sizeof(scene_metrics);
+    require(progpu_native_engine_update_scene(
+        engine,
+        collapsed_stroke_scene.data(),
+        collapsed_stroke_scene.size(),
+        &scene_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        scene_metrics.draw_count == 1U,
+        "collapsed-stroke semantic scene update failed");
+    semantic_frame.scene_id = 797U;
+    semantic_frame.generation = 1U;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    const auto collapsed_stroke_status = progpu_native_engine_render_scene(
+        engine,
+        &semantic_frame,
+        &semantic_metrics);
+    if (collapsed_stroke_status != PROGPU_NATIVE_STATUS_SUCCESS ||
+        semantic_metrics.vertex_upload_bytes != 0U ||
+        semantic_metrics.index_upload_bytes != 0U) {
+        std::array<char, 512U> collapsed_stroke_error{};
+        progpu_native_engine_get_last_error(
+            engine,
+            collapsed_stroke_error.data(),
+            collapsed_stroke_error.size());
+        std::fprintf(stderr,
+            "collapsed stroke status=%u vertex=%llu index=%llu error=%s\n",
+            static_cast<unsigned>(collapsed_stroke_status),
+            static_cast<unsigned long long>(
+                semantic_metrics.vertex_upload_bytes),
+            static_cast<unsigned long long>(
+                semantic_metrics.index_upload_bytes),
+            collapsed_stroke_error.data());
+    }
+    require(collapsed_stroke_status == PROGPU_NATIVE_STATUS_SUCCESS &&
+        semantic_metrics.vertex_upload_bytes == 0U &&
+        semantic_metrics.index_upload_bytes == 0U,
+        "collapsed semantic stroke did not render as an empty draw");
 
     auto hit_test_scene = create_gpu_hit_test_scene_stream();
     scene_metrics = {};


### PR DESCRIPTION
## Summary

- classify finite singular semantic stroke transforms as zero-capacity draws during preflight
- keep semantic compilation successful without appending vertices or indices
- skip zero-sized analytic draw encoding while preserving invalid non-empty page checks
- cover the contract in native unit and real Dawn provider rendering tests

## Managed/native parity audit

The managed renderer already implements this behavior: `StrokeTransformRenderingTests.CollapsedStrokeTransformDoesNotEmitDirectStrokeVertices` covers a determinant-zero transform and verifies that no direct stroke vertices are emitted. The gap was native-only, so no managed source change applies. The native regression uses the same one-axis collapsed-transform contract.

## Research

- [WHATWG Canvas 2D](https://html.spec.whatwg.org/multipage/canvas.html) applies the current transform when painting paths, so a collapsed path has empty device-space coverage
- [Direct2D transforms](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview) distinguish geometry and world stroke transforms
- [Vello affine stroke discussion](https://github.com/linebender/vello/issues/303) treats stroke handling as transformed outline geometry and calls out singular-value analysis

Adopted: finite collapsed device-space strokes are empty successful draws. Rejected: failing the complete scene or emitting a point/cap artifact. The change is constant-time per stroke and allocates no additional hot-path storage.

## Validation after rebase onto `89b80057`

- exact rewritten head: `adb0cf79cbd44c229ee58afa76a1435ff9e7d1ea`
- production/test patch hash remained byte-for-byte unchanged across the rebase
- AppleClang Release native suite: 9/9 passed
- AppleClang Release Dawn/provider suite: 11/11 passed
- real provider regression: scene update and render succeed with zero vertex/index upload for the collapsed draw
- privacy scan and `git diff --check`: clean

