### PR TITLE
Retain HVAR instance scalars during native shaping

### DIFF
--- a/docs/NATIVE_CPP_TEXT_PORT_PROVENANCE.md
+++ b/docs/NATIVE_CPP_TEXT_PORT_PROVENANCE.md
@@ -1037,6 +1037,33 @@ deltas `D`. Synthetic simple-glyph coverage resolves base advance `600` plus
 phantom delta `3`, rejects short scratch without publishing a partial result,
 and production Inter confirms that HVAR still wins without phantom scratch.
 
+The retained native shaping context now also ports the ProGPU-owned managed
+variation-instance projection from `src/ProGPU.Text/OpenTypeVariationData.cs`:
+HVAR's borrowed `ItemVariationStore` and optional `DeltaSetIndexMap` are
+validated once per shaping operation, and the normalized-coordinate scalar for
+each global variation region is computed once into caller-owned shaping
+scratch. Every glyph advance then only selects its mapped delta row and sums
+the referenced precomputed scalars. This follows the
+[OpenType 1.9.1 ItemVariationStore and HVAR contract](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats)
+without changing interpolation, rounding, HVAR precedence, or `gvar` phantom
+fallback. Work changes from repeated `O(G * A * R)` region projection to
+`O(A * R + G * D)` for glyphs `G`, axes `A`, global regions `R`, and referenced
+deltas `D`, with `O(R)` caller scratch and no retained pointer or allocation.
+The direct C++ shaping API may omit the optional scalar span and keeps its
+original allocation-free behavior.
+
+The architecture review retained the same reusable CPU shaping boundary used
+by [HarfBuzz shaping plans](https://harfbuzz.github.io/shaping-plans-and-caching.html),
+[Skia shaped text](https://skia.org/docs/dev/design/text_shaper/),
+[DirectWrite text layouts](https://learn.microsoft.com/en-us/windows/win32/directwrite/getting-started-with-directwrite),
+and [Parley shared font/layout contexts](https://docs.rs/parley/latest/parley/).
+WebRender and Vello remain renderer references only; moving HVAR interpolation
+to GPU work was rejected because it would duplicate reusable CPU metrics and
+add synchronization to a small instance-local calculation. The managed parity
+audit requires no managed source change: managed already parses `_itemStore`
+and `_advanceMap` once and stores `OpenTypeVariationInstance.RegionScalars` for
+the identical delta accumulation path.
+
 Fallback mark placement now has a direct allocation-free native port of the
 ProGPU-owned `GlyphPositionBuffer.ApplyFallbackMarkPositioning` algorithm from
 checkpoint `2b871936`. The caller-owned transient metadata span preserves

--- a/src/ProGPU.Native/include/progpu_native_text.hpp
+++ b/src/ProGPU.Native/include/progpu_native_text.hpp
@@ -1456,6 +1456,10 @@ struct open_type_shape_run_scratch final {
      * scripts whose managed contract permits reordering/composition. The
      * caller owns this maximum-Form-D scalar buffer synchronously. */
     std::span<unicode_scalar> normalization_scalars{};
+    /* Optional one-per-region HVAR scalar storage. Context-backed shaping
+     * supplies this span so repeated glyph metrics reuse one variation-
+     * instance projection; direct callers may leave it empty. */
+    std::span<float> variation_region_scalars{};
 };
 
 struct open_type_shape_run_requirements final {
@@ -2721,6 +2725,17 @@ struct sfnt_delta_set_index_map_view final {
     std::uint8_t inner_index_bits = 0U;
 };
 
+/* Borrowed HVAR state for one normalized variation instance. The variation
+ * store and optional advance map are parsed once, while the caller-owned
+ * scalar span contains one value per global ItemVariationStore region. */
+struct sfnt_horizontal_advance_variation_instance final {
+    sfnt_item_variation_store_view store{};
+    sfnt_delta_set_index_map_view advance_map{};
+    std::span<const float> region_scalars{};
+    bool uses_hvar = false;
+    bool has_advance_map = false;
+};
+
 struct sfnt_cff_index_view final {
     std::span<const std::byte> bytes{};
     std::size_t offsets_offset = 0U;
@@ -3009,6 +3024,19 @@ public:
         std::uint16_t inner_index,
         float& result,
         font_error* error = nullptr) noexcept;
+    static bool try_get_delta(
+        sfnt_item_variation_store_view store,
+        std::span<const float> region_scalars,
+        std::uint16_t outer_index,
+        std::uint16_t inner_index,
+        float& result,
+        font_error* error = nullptr) noexcept;
+    static bool try_get_region_scalar(
+        sfnt_item_variation_store_view store,
+        std::span<const std::int16_t> normalized_coordinates,
+        std::uint16_t region_index,
+        float& result,
+        font_error* error = nullptr) noexcept;
     static bool try_get_region_scalar_count(
         sfnt_item_variation_store_view store,
         std::uint16_t outer_index,
@@ -3187,6 +3215,12 @@ public:
         std::span<const std::int16_t> normalized_coordinates,
         float& result,
         font_error* error = nullptr) const noexcept;
+    bool try_get_design_advance_width(
+        std::uint16_t glyph_index,
+        std::span<const std::int16_t> normalized_coordinates,
+        const sfnt_horizontal_advance_variation_instance* variation,
+        float& result,
+        font_error* error = nullptr) const noexcept;
     bool try_get_design_advance_width_requirements(
         std::uint16_t glyph_index,
         std::span<const std::int16_t> normalized_coordinates,
@@ -3195,6 +3229,13 @@ public:
     bool try_get_design_advance_width(
         std::uint16_t glyph_index,
         std::span<const std::int16_t> normalized_coordinates,
+        float& result,
+        sfnt_glyph_phantom_variation_scratch scratch,
+        font_error* error = nullptr) const noexcept;
+    bool try_get_design_advance_width(
+        std::uint16_t glyph_index,
+        std::span<const std::int16_t> normalized_coordinates,
+        const sfnt_horizontal_advance_variation_instance* variation,
         float& result,
         sfnt_glyph_phantom_variation_scratch scratch,
         font_error* error = nullptr) const noexcept;
@@ -3415,6 +3456,16 @@ public:
         std::span<const std::int16_t> normalized_coordinates,
         float& result,
         bool& uses_hvar,
+        font_error* error = nullptr) const noexcept;
+    bool try_get_horizontal_advance_variation_region_count(
+        std::span<const std::int16_t> normalized_coordinates,
+        std::uint16_t& result,
+        bool& uses_hvar,
+        font_error* error = nullptr) const noexcept;
+    bool try_prepare_horizontal_advance_variation(
+        std::span<const std::int16_t> normalized_coordinates,
+        std::span<float> region_scalars,
+        sfnt_horizontal_advance_variation_instance& result,
         font_error* error = nullptr) const noexcept;
     bool try_get_metric_variation(
         open_type_tag metric_tag,

--- a/src/ProGPU.Native/src/Text/Font/progpu_native_font_horizontal_metrics.cpp
+++ b/src/ProGPU.Native/src/Text/Font/progpu_native_font_horizontal_metrics.cpp
@@ -48,11 +48,66 @@ bool try_get_base_advance_width(
     return true;
 }
 
+bool try_get_advance_variation_delta(
+    const sfnt_font_view& font,
+    std::uint16_t glyph_index,
+    std::span<const std::int16_t> normalized_coordinates,
+    const sfnt_horizontal_advance_variation_instance* variation,
+    float& result,
+    bool& uses_hvar,
+    font_error* error) noexcept {
+    result = 0.0F;
+    uses_hvar = false;
+    if (variation == nullptr) {
+        return font.try_get_horizontal_advance_variation(
+            glyph_index,
+            normalized_coordinates,
+            result,
+            uses_hvar,
+            error);
+    }
+    if (!variation->uses_hvar) return true;
+    std::uint16_t outer_index = 0U;
+    std::uint16_t inner_index = glyph_index;
+    if (variation->has_advance_map) {
+        sfnt_item_variation_data::get_delta_set_index(
+            variation->advance_map,
+            glyph_index,
+            outer_index,
+            inner_index);
+    }
+    if (!sfnt_item_variation_data::try_get_delta(
+            variation->store,
+            variation->region_scalars,
+            outer_index,
+            inner_index,
+            result,
+            error)) {
+        return false;
+    }
+    uses_hvar = true;
+    return true;
+}
+
 } // namespace
 
 bool sfnt_font_view::try_get_design_advance_width(
     std::uint16_t glyph_index,
     std::span<const std::int16_t> normalized_coordinates,
+    float& result,
+    font_error* error) const noexcept {
+    return try_get_design_advance_width(
+        glyph_index,
+        normalized_coordinates,
+        nullptr,
+        result,
+        error);
+}
+
+bool sfnt_font_view::try_get_design_advance_width(
+    std::uint16_t glyph_index,
+    std::span<const std::int16_t> normalized_coordinates,
+    const sfnt_horizontal_advance_variation_instance* variation,
     float& result,
     font_error* error) const noexcept {
     result = 0.0F;
@@ -65,9 +120,11 @@ bool sfnt_font_view::try_get_design_advance_width(
 
     float delta = 0.0F;
     bool uses_hvar = false;
-    if (!try_get_horizontal_advance_variation(
+    if (!try_get_advance_variation_delta(
+            *this,
             glyph_index,
             normalized_coordinates,
+            variation,
             delta,
             uses_hvar,
             error)) {
@@ -158,6 +215,22 @@ bool sfnt_font_view::try_get_design_advance_width(
     float& result,
     sfnt_glyph_phantom_variation_scratch scratch,
     font_error* error) const noexcept {
+    return try_get_design_advance_width(
+        glyph_index,
+        normalized_coordinates,
+        nullptr,
+        result,
+        scratch,
+        error);
+}
+
+bool sfnt_font_view::try_get_design_advance_width(
+    std::uint16_t glyph_index,
+    std::span<const std::int16_t> normalized_coordinates,
+    const sfnt_horizontal_advance_variation_instance* variation,
+    float& result,
+    sfnt_glyph_phantom_variation_scratch scratch,
+    font_error* error) const noexcept {
     result = 0.0F;
     set_error(error, font_error::none);
     float base = 0.0F;
@@ -170,9 +243,11 @@ bool sfnt_font_view::try_get_design_advance_width(
     }
     float delta = 0.0F;
     bool uses_hvar = false;
-    if (!try_get_horizontal_advance_variation(
+    if (!try_get_advance_variation_delta(
+            *this,
             glyph_index,
             normalized_coordinates,
+            variation,
             delta,
             uses_hvar,
             error)) {

--- a/src/ProGPU.Native/src/Text/Interop/progpu_native_text_shaping_interop.cpp
+++ b/src/ProGPU.Native/src/Text/Interop/progpu_native_text_shaping_interop.cpp
@@ -182,6 +182,7 @@ struct shape_capacities final {
     std::uint32_t explicit_features = 0U;
     std::uint32_t requested_features = 0U;
     std::uint32_t feature_settings = 0U;
+    std::uint32_t variation_region_scalars = 0U;
     std::size_t scratch_bytes = 0U;
 };
 
@@ -444,7 +445,8 @@ bool try_compute_shape_scratch_bytes(
         !size.add<std::uint32_t>(result.complex_indices) ||
         !size.add<arabic_stretch_run>(result.glyphs) ||
         !size.add<shaping_glyph>(result.verification_glyphs) ||
-        !size.add<unicode_scalar>(result.normalization_scalars)) {
+        !size.add<unicode_scalar>(result.normalization_scalars) ||
+        !size.add<float>(result.variation_region_scalars)) {
         error = font_error::invalid_argument;
         return false;
     }
@@ -544,6 +546,21 @@ bool try_build_capacities(
         return false;
     }
     result.explicit_features = request.feature_count;
+
+    if (request.normalized_coordinate_count != 0U) {
+        std::uint16_t region_count = 0U;
+        bool uses_hvar = false;
+        if (!font.try_get_horizontal_advance_variation_region_count(
+                std::span<const std::int16_t>{
+                    request.normalized_coordinates,
+                    request.normalized_coordinate_count},
+                region_count,
+                uses_hvar,
+                &error)) {
+            return false;
+        }
+        result.variation_region_scalars = uses_hvar ? region_count : 0U;
+    }
 
     if (!try_compute_shape_scratch_bytes(request, result, error)) return false;
     error = font_error::none;
@@ -813,6 +830,9 @@ bool try_build_paragraph_capacities(
             std::max(target.requested_features, source.requested_features);
         target.feature_settings =
             std::max(target.feature_settings, source.feature_settings);
+        target.variation_region_scalars = std::max(
+            target.variation_region_scalars,
+            source.variation_region_scalars);
     };
     for (std::size_t index = 0U; index < context.font_count(); ++index) {
         const auto* font = context.font_at(index);
@@ -1059,6 +1079,7 @@ progpu_native_status shape_core(
     std::span<arabic_stretch_run> arabic_stretch_runs{};
     std::span<shaping_glyph> verification_glyphs{};
     std::span<unicode_scalar> normalization_scalars{};
+    std::span<float> variation_region_scalars{};
     if (!arena.take(request.input_count, input) ||
         !arena.take(request.pre_context_count, pre_context) ||
         !arena.take(request.post_context_count, post_context) ||
@@ -1080,7 +1101,10 @@ progpu_native_status shape_core(
         !arena.take(capacities.complex_indices, script_indices) ||
         !arena.take(capacities.glyphs, arabic_stretch_runs) ||
         !arena.take(capacities.verification_glyphs, verification_glyphs) ||
-        !arena.take(capacities.normalization_scalars, normalization_scalars)) {
+        !arena.take(capacities.normalization_scalars, normalization_scalars) ||
+        !arena.take(
+            capacities.variation_region_scalars,
+            variation_region_scalars)) {
         result.error_code =
             static_cast<std::uint32_t>(font_error::insufficient_buffer);
         return PROGPU_NATIVE_STATUS_INVALID_ARGUMENT;
@@ -1149,7 +1173,8 @@ progpu_native_status shape_core(
         nullptr,
         verification_glyphs.empty() ? nullptr : &verification,
         arabic_flags,
-        normalization_scalars};
+        normalization_scalars,
+        variation_region_scalars};
     std::uint32_t written = 0U;
     if (!try_shape_open_type_run(
             font,

--- a/src/ProGPU.Native/src/Text/Shaping/progpu_native_open_type_shaper.cpp
+++ b/src/ProGPU.Native/src/Text/Shaping/progpu_native_open_type_shaper.cpp
@@ -1940,6 +1940,22 @@ bool try_shape_open_type_run(
         return false;
     }
 
+    sfnt_horizontal_advance_variation_instance advance_variation{};
+    const sfnt_horizontal_advance_variation_instance*
+        advance_variation_pointer = nullptr;
+    if (!scratch.variation_region_scalars.empty()) {
+        if (!font.try_prepare_horizontal_advance_variation(
+                options.normalized_coordinates,
+                scratch.variation_region_scalars,
+                advance_variation,
+                error)) {
+            return false;
+        }
+        if (advance_variation.uses_hvar) {
+            advance_variation_pointer = &advance_variation;
+        }
+    }
+
     std::span<const unicode_scalar> shaping_input = input;
     if (requirements.normalization_scalar_capacity != 0U) {
         std::uint32_t source_grapheme_count =
@@ -2041,11 +2057,13 @@ bool try_shape_open_type_run(
                 ? font.try_get_design_advance_width(
                     glyph,
                     options.normalized_coordinates,
+                    advance_variation_pointer,
                     advance_width,
                     error)
                 : font.try_get_design_advance_width(
                     glyph,
                     options.normalized_coordinates,
+                    advance_variation_pointer,
                     advance_width,
                     scratch.fallback_marks->advance_width,
                     error);
@@ -2861,11 +2879,13 @@ bool try_shape_open_type_run(
             ? font.try_get_design_advance_width(
                 glyph,
                 options.normalized_coordinates,
+                advance_variation_pointer,
                 advance_width,
                 error)
             : font.try_get_design_advance_width(
                 glyph,
                 options.normalized_coordinates,
+                advance_variation_pointer,
                 advance_width,
                 scratch.fallback_marks->advance_width,
                 error);

--- a/src/ProGPU.Native/src/Text/progpu_native_hvar.cpp
+++ b/src/ProGPU.Native/src/Text/progpu_native_hvar.cpp
@@ -18,6 +18,48 @@ void set_error(font_error* destination, font_error value) noexcept {
     }
 }
 
+bool try_get_hvar_instance_views(
+    const sfnt_font_view& font,
+    std::span<const std::int16_t> normalized_coordinates,
+    sfnt_item_variation_store_view& store,
+    sfnt_delta_set_index_map_view& advance_map,
+    bool& uses_hvar,
+    bool& has_advance_map,
+    font_error* error) noexcept {
+    store = {};
+    advance_map = {};
+    uses_hvar = false;
+    has_advance_map = false;
+    sfnt_table_view hvar{};
+    if (!font.try_get_table(hvar_tag, hvar)) return true;
+    if (!can_read(hvar.bytes, 0U, 12U)) {
+        set_error(error, font_error::invalid_face);
+        return false;
+    }
+    const auto store_relative = read_u32(hvar.bytes, 4U);
+    if (store_relative == 0U) return true;
+    std::uint16_t axis_count = 0U;
+    if (!font.try_get_variation_axis_count(axis_count, error)) return false;
+    if (normalized_coordinates.size() < axis_count) {
+        set_error(error, font_error::insufficient_buffer);
+        return false;
+    }
+    if (!sfnt_item_variation_data::try_get_store(
+            hvar.bytes, store_relative, axis_count, store, error)) {
+        return false;
+    }
+    const auto map_relative = read_u32(hvar.bytes, 8U);
+    if (map_relative != 0U) {
+        if (!sfnt_item_variation_data::try_get_delta_set_index_map(
+                hvar.bytes, map_relative, advance_map, error)) {
+            return false;
+        }
+        has_advance_map = true;
+    }
+    uses_hvar = true;
+    return true;
+}
+
 } // namespace
 
 bool sfnt_font_view::try_get_horizontal_advance_variation(
@@ -29,54 +71,104 @@ bool sfnt_font_view::try_get_horizontal_advance_variation(
     result = 0.0F;
     uses_hvar = false;
     set_error(error, font_error::none);
-    sfnt_table_view hvar{};
-    if (!try_get_table(hvar_tag, hvar)) {
-        return true;
-    }
-    if (!can_read(hvar.bytes, 0U, 12U)) {
-        set_error(error, font_error::invalid_face);
-        return false;
-    }
-    const auto store_relative = read_u32(hvar.bytes, 4U);
-    if (store_relative == 0U) {
-        return true;
-    }
-    std::uint16_t axis_count = 0U;
-    if (!try_get_variation_axis_count(axis_count, error)) {
-        return false;
-    }
     sfnt_item_variation_store_view store{};
-    if (!sfnt_item_variation_data::try_get_store(
-            hvar.bytes, store_relative, axis_count, store, error)) {
+    sfnt_delta_set_index_map_view map{};
+    bool has_map = false;
+    if (!try_get_hvar_instance_views(
+            *this,
+            normalized_coordinates,
+            store,
+            map,
+            uses_hvar,
+            has_map,
+            error)) {
         return false;
     }
-    if (normalized_coordinates.size() < axis_count) {
-        set_error(error, font_error::insufficient_buffer);
-        return false;
-    }
-
+    if (!uses_hvar) return true;
     std::uint16_t outer_index = 0U;
     std::uint16_t inner_index = glyph_index;
-    const auto map_relative = read_u32(hvar.bytes, 8U);
-    if (map_relative != 0U) {
-        sfnt_delta_set_index_map_view map{};
-        if (!sfnt_item_variation_data::try_get_delta_set_index_map(
-                hvar.bytes, map_relative, map, error)) {
-            return false;
-        }
+    if (has_map) {
         sfnt_item_variation_data::get_delta_set_index(
             map, glyph_index, outer_index, inner_index);
     }
     if (!sfnt_item_variation_data::try_get_delta(
             store,
-            normalized_coordinates.first(axis_count),
+            normalized_coordinates.first(store.axis_count),
             outer_index,
             inner_index,
             result,
             error)) {
         return false;
     }
-    uses_hvar = true;
+    return true;
+}
+
+bool sfnt_font_view::try_get_horizontal_advance_variation_region_count(
+    std::span<const std::int16_t> normalized_coordinates,
+    std::uint16_t& result,
+    bool& uses_hvar,
+    font_error* error) const noexcept {
+    result = 0U;
+    uses_hvar = false;
+    set_error(error, font_error::none);
+    sfnt_item_variation_store_view store{};
+    sfnt_delta_set_index_map_view map{};
+    bool has_map = false;
+    if (!try_get_hvar_instance_views(
+            *this,
+            normalized_coordinates,
+            store,
+            map,
+            uses_hvar,
+            has_map,
+            error)) {
+        return false;
+    }
+    if (uses_hvar) result = store.region_count;
+    return true;
+}
+
+bool sfnt_font_view::try_prepare_horizontal_advance_variation(
+    std::span<const std::int16_t> normalized_coordinates,
+    std::span<float> region_scalars,
+    sfnt_horizontal_advance_variation_instance& result,
+    font_error* error) const noexcept {
+    result = {};
+    set_error(error, font_error::none);
+    sfnt_item_variation_store_view store{};
+    sfnt_delta_set_index_map_view map{};
+    bool uses_hvar = false;
+    bool has_map = false;
+    if (!try_get_hvar_instance_views(
+            *this,
+            normalized_coordinates,
+            store,
+            map,
+            uses_hvar,
+            has_map,
+            error)) {
+        return false;
+    }
+    if (!uses_hvar) return true;
+    if (region_scalars.size() < store.region_count) {
+        set_error(error, font_error::insufficient_buffer);
+        return false;
+    }
+    for (std::uint16_t region = 0U; region < store.region_count; ++region) {
+        if (!sfnt_item_variation_data::try_get_region_scalar(
+                store,
+                normalized_coordinates,
+                region,
+                region_scalars[region],
+                error)) {
+            return false;
+        }
+    }
+    result.store = store;
+    result.advance_map = map;
+    result.region_scalars = region_scalars.first(store.region_count);
+    result.uses_hvar = true;
+    result.has_advance_map = has_map;
     return true;
 }
 

--- a/src/ProGPU.Native/src/Text/progpu_native_item_variation_store.cpp
+++ b/src/ProGPU.Native/src/Text/progpu_native_item_variation_store.cpp
@@ -76,6 +76,95 @@ bool try_get_subtable_offset(
     return true;
 }
 
+bool try_calculate_region_scalar(
+    sfnt_item_variation_store_view store,
+    std::span<const std::int16_t> normalized_coordinates,
+    std::uint16_t region_index,
+    float& result,
+    font_error* error) noexcept {
+    result = 0.0F;
+    if (normalized_coordinates.size() < store.axis_count) {
+        set_error(error, font_error::insufficient_buffer);
+        return false;
+    }
+    if (region_index >= store.region_count) {
+        set_error(error, font_error::invalid_argument);
+        return false;
+    }
+    const auto axes_offset = store.region_list_offset + 4U +
+        static_cast<std::size_t>(region_index) * store.axis_count * 6U;
+    constexpr float coordinate_scale = 1.0F / 16384.0F;
+    float scalar = 1.0F;
+    for (std::uint16_t axis = 0U; axis < store.axis_count; ++axis) {
+        const auto offset = axes_offset + static_cast<std::size_t>(axis) * 6U;
+        scalar *= axis_scalar(
+            normalized_coordinates[axis] * coordinate_scale,
+            read_i16(store.bytes, offset) * coordinate_scale,
+            read_i16(store.bytes, offset + 2U) * coordinate_scale,
+            read_i16(store.bytes, offset + 4U) * coordinate_scale);
+        if (scalar == 0.0F) break;
+    }
+    result = scalar;
+    return true;
+}
+
+template <typename ResolveScalar>
+bool try_get_delta_impl(
+    sfnt_item_variation_store_view store,
+    std::uint16_t outer_index,
+    std::uint16_t inner_index,
+    float& result,
+    ResolveScalar&& resolve_scalar) noexcept {
+    result = 0.0F;
+    std::size_t table_offset = 0U;
+    if (!try_get_subtable_offset(store, outer_index, table_offset)) return true;
+    const auto item_count = read_u16(store.bytes, table_offset);
+    if (inner_index >= item_count) return true;
+    const auto packed_word_count = read_u16(store.bytes, table_offset + 2U);
+    const auto region_index_count = read_u16(store.bytes, table_offset + 4U);
+    const auto word_count = packed_word_count & 0x7FFFU;
+    const bool long_words = (packed_word_count & 0x8000U) != 0U;
+    const auto index_offset = table_offset + 6U;
+    const auto word_bytes = long_words ? 4U : 2U;
+    const auto short_bytes = long_words ? 2U : 1U;
+    const auto bytes_per_row =
+        static_cast<std::size_t>(word_count) * word_bytes +
+        static_cast<std::size_t>(region_index_count - word_count) *
+            short_bytes;
+    auto delta_offset = index_offset +
+        static_cast<std::size_t>(region_index_count) * 2U +
+        static_cast<std::size_t>(inner_index) * bytes_per_row;
+    float delta_sum = 0.0F;
+    for (std::uint16_t region = 0U; region < region_index_count; ++region) {
+        std::int32_t delta = 0;
+        if (region < word_count) {
+            if (long_words) {
+                delta = static_cast<std::int32_t>(
+                    read_u32(store.bytes, delta_offset));
+                delta_offset += 4U;
+            } else {
+                delta = read_i16(store.bytes, delta_offset);
+                delta_offset += 2U;
+            }
+        } else if (long_words) {
+            delta = read_i16(store.bytes, delta_offset);
+            delta_offset += 2U;
+        } else {
+            delta = static_cast<std::int8_t>(
+                std::to_integer<std::uint8_t>(store.bytes[delta_offset++]));
+        }
+        const auto region_index = read_u16(
+            store.bytes,
+            index_offset + static_cast<std::size_t>(region) * 2U);
+        if (region_index >= store.region_count) continue;
+        float scalar = 0.0F;
+        if (!resolve_scalar(region_index, scalar)) return false;
+        delta_sum += delta * scalar;
+    }
+    result = delta_sum;
+    return true;
+}
+
 } // namespace
 
 bool sfnt_item_variation_data::try_get_store(
@@ -186,74 +275,54 @@ bool sfnt_item_variation_data::try_get_delta(
         set_error(error, font_error::insufficient_buffer);
         return false;
     }
-    std::size_t table_offset = 0U;
-    if (!try_get_subtable_offset(store, outer_index, table_offset)) {
-        return true;
+    return try_get_delta_impl(
+        store,
+        outer_index,
+        inner_index,
+        result,
+        [&](std::uint16_t region_index, float& scalar) noexcept {
+            return try_calculate_region_scalar(
+                store,
+                normalized_coordinates,
+                region_index,
+                scalar,
+                error);
+        });
+}
+
+bool sfnt_item_variation_data::try_get_delta(
+    sfnt_item_variation_store_view store,
+    std::span<const float> region_scalars,
+    std::uint16_t outer_index,
+    std::uint16_t inner_index,
+    float& result,
+    font_error* error) noexcept {
+    result = 0.0F;
+    set_error(error, font_error::none);
+    if (region_scalars.size() < store.region_count) {
+        set_error(error, font_error::insufficient_buffer);
+        return false;
     }
-    const auto item_count = read_u16(store.bytes, table_offset);
-    if (inner_index >= item_count) {
-        return true;
-    }
-    const auto packed_word_count = read_u16(store.bytes, table_offset + 2U);
-    const auto region_index_count = read_u16(store.bytes, table_offset + 4U);
-    const auto word_count = packed_word_count & 0x7FFFU;
-    const bool long_words = (packed_word_count & 0x8000U) != 0U;
-    const auto index_offset = table_offset + 6U;
-    const auto word_bytes = long_words ? 4U : 2U;
-    const auto short_bytes = long_words ? 2U : 1U;
-    const auto bytes_per_row =
-        static_cast<std::size_t>(word_count) * word_bytes +
-        static_cast<std::size_t>(region_index_count - word_count) *
-            short_bytes;
-    auto delta_offset = index_offset +
-        static_cast<std::size_t>(region_index_count) * 2U +
-        static_cast<std::size_t>(inner_index) * bytes_per_row;
-    float delta_sum = 0.0F;
-    constexpr float coordinate_scale = 1.0F / 16384.0F;
-    for (std::uint16_t region = 0U;
-        region < region_index_count;
-        ++region) {
-        std::int32_t delta = 0;
-        if (region < word_count) {
-            if (long_words) {
-                delta = static_cast<std::int32_t>(
-                    read_u32(store.bytes, delta_offset));
-                delta_offset += 4U;
-            } else {
-                delta = read_i16(store.bytes, delta_offset);
-                delta_offset += 2U;
-            }
-        } else if (long_words) {
-            delta = read_i16(store.bytes, delta_offset);
-            delta_offset += 2U;
-        } else {
-            delta = static_cast<std::int8_t>(
-                std::to_integer<std::uint8_t>(store.bytes[delta_offset++]));
-        }
-        const auto region_index = read_u16(
-            store.bytes,
-            index_offset + static_cast<std::size_t>(region) * 2U);
-        if (region_index >= store.region_count) {
-            continue;
-        }
-        const auto axes_offset = store.region_list_offset + 4U +
-            static_cast<std::size_t>(region_index) * store.axis_count * 6U;
-        float scalar = 1.0F;
-        for (std::uint16_t axis = 0U; axis < store.axis_count; ++axis) {
-            const auto offset = axes_offset + static_cast<std::size_t>(axis) * 6U;
-            scalar *= axis_scalar(
-                normalized_coordinates[axis] * coordinate_scale,
-                read_i16(store.bytes, offset) * coordinate_scale,
-                read_i16(store.bytes, offset + 2U) * coordinate_scale,
-                read_i16(store.bytes, offset + 4U) * coordinate_scale);
-            if (scalar == 0.0F) {
-                break;
-            }
-        }
-        delta_sum += delta * scalar;
-    }
-    result = delta_sum;
-    return true;
+    return try_get_delta_impl(
+        store,
+        outer_index,
+        inner_index,
+        result,
+        [&](std::uint16_t region_index, float& scalar) noexcept {
+            scalar = region_scalars[region_index];
+            return true;
+        });
+}
+
+bool sfnt_item_variation_data::try_get_region_scalar(
+    sfnt_item_variation_store_view store,
+    std::span<const std::int16_t> normalized_coordinates,
+    std::uint16_t region_index,
+    float& result,
+    font_error* error) noexcept {
+    set_error(error, font_error::none);
+    return try_calculate_region_scalar(
+        store, normalized_coordinates, region_index, result, error);
 }
 
 bool sfnt_item_variation_data::try_get_region_scalar_count(

--- a/src/ProGPU.Native/src/Text/progpu_native_text.cppm
+++ b/src/ProGPU.Native/src/Text/progpu_native_text.cppm
@@ -285,6 +285,7 @@ using ::progpu::native::text::sfnt_design_advance_width_requirements;
 using ::progpu::native::text::sfnt_item_variation_data;
 using ::progpu::native::text::sfnt_item_variation_store_view;
 using ::progpu::native::text::sfnt_delta_set_index_map_view;
+using ::progpu::native::text::sfnt_horizontal_advance_variation_instance;
 using ::progpu::native::text::sfnt_cff_data;
 using ::progpu::native::text::sfnt_cff_fd_select_view;
 using ::progpu::native::text::sfnt_cff_index_view;

--- a/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
@@ -295,6 +295,7 @@ using progpu::native::text::sfnt_glyph_bounds;
 using progpu::native::text::sfnt_item_variation_data;
 using progpu::native::text::sfnt_item_variation_store_view;
 using progpu::native::text::sfnt_delta_set_index_map_view;
+using progpu::native::text::sfnt_horizontal_advance_variation_instance;
 using progpu::native::text::sfnt_outline_point;
 using progpu::native::text::sfnt_packed_delta_requirements;
 using progpu::native::text::sfnt_packed_point_requirements;
@@ -8819,6 +8820,30 @@ void item_variation_store_and_index_map_are_bounded() {
     require(sfnt_item_variation_data::try_get_delta(
         store, normalized, 0U, 1U, delta, &error));
     require(delta == -10.0F);
+    std::array<float, 1U> region_scalars{};
+    require(sfnt_item_variation_data::try_get_region_scalar(
+        store,
+        normalized,
+        0U,
+        region_scalars[0],
+        &error));
+    require(region_scalars[0] == 1.0F);
+    require(sfnt_item_variation_data::try_get_delta(
+        store,
+        std::span<const float>{region_scalars},
+        0U,
+        0U,
+        delta,
+        &error));
+    require(delta == 20.0F);
+    require(!sfnt_item_variation_data::try_get_delta(
+        store,
+        std::span<const float>{},
+        0U,
+        0U,
+        delta,
+        &error));
+    require(error == font_error::insufficient_buffer && delta == 0.0F);
 
     sfnt_delta_set_index_map_view map{};
     require(sfnt_item_variation_data::try_get_delta_set_index_map(
@@ -12048,6 +12073,21 @@ void production_inter_variable_font_matches_fvar_axes() {
         horizontal_advance_delta,
         uses_hvar));
     require(uses_hvar && horizontal_advance_delta == -28.0F);
+    std::uint16_t hvar_region_count = 0U;
+    bool precomputed_uses_hvar = false;
+    require(font.try_get_horizontal_advance_variation_region_count(
+        optical_coordinates,
+        hvar_region_count,
+        precomputed_uses_hvar));
+    require(precomputed_uses_hvar && hvar_region_count != 0U);
+    std::vector<float> hvar_region_scalars(hvar_region_count);
+    sfnt_horizontal_advance_variation_instance hvar_instance{};
+    require(font.try_prepare_horizontal_advance_variation(
+        optical_coordinates,
+        hvar_region_scalars,
+        hvar_instance));
+    require(hvar_instance.uses_hvar &&
+        hvar_instance.region_scalars.size() == hvar_region_count);
     sfnt_horizontal_glyph_metrics horizontal_metrics{};
     require(font.try_get_horizontal_glyph_metrics(
         397U, horizontal_metrics));
@@ -12056,6 +12096,22 @@ void production_inter_variable_font_matches_fvar_axes() {
         397U, optical_coordinates, varied_advance));
     require(varied_advance ==
         static_cast<float>(horizontal_metrics.advance_width) - 28.0F);
+    float retained_varied_advance = 0.0F;
+    require(font.try_get_design_advance_width(
+        397U,
+        optical_coordinates,
+        &hvar_instance,
+        retained_varied_advance));
+    require(retained_varied_advance == varied_advance);
+    sfnt_horizontal_advance_variation_instance short_hvar_instance{};
+    font_error hvar_error = font_error::none;
+    require(!font.try_prepare_horizontal_advance_variation(
+        optical_coordinates,
+        {},
+        short_hvar_instance,
+        &hvar_error));
+    require(hvar_error == font_error::insufficient_buffer &&
+        !short_hvar_instance.uses_hvar);
     sfnt_design_advance_width_requirements advance_requirements{};
     require(font.try_get_design_advance_width_requirements(
         397U, optical_coordinates, advance_requirements));


### PR DESCRIPTION
## Summary

- parse the HVAR ItemVariationStore and optional advance map once per native shaping operation
- precompute one scalar per global variation region in caller-owned shaping scratch and reuse it for every glyph advance lookup
- keep the existing direct C++ API behavior when no prepared instance is supplied
- document the implementation provenance and algorithmic tradeoff

## Complexity and ownership

The native shaping path previously repeated the region projection while resolving advances for each glyph. The prepared instance changes the dominant projection work from `O(glyphs × referenced regions × axes)` to `O(global regions × axes + glyphs × referenced regions)` with `O(global regions)` caller-owned scratch.

- the capacity pass reads the validated HVAR global region count
- scratch reserves exactly one `float` per global region, with checked size arithmetic
- insufficient caller storage fails deterministically with `insufficient_buffer`
- borrowed store/map/scalar state is scoped to one synchronous shaping call and is never retained
- direct public API calls with no prepared instance continue through the original coordinate-based lookup

## Managed/native parity

The managed implementation already parses and retains the item store and advance map and stores `OpenTypeVariationInstance.RegionScalars`; no managed production source change applies. The focused managed parity suite confirms the retained instance, variable advances, optical-size propagation, and requested-family-first symbol/emoji policy remain intact.

## Exact rebase audit

- Base: `e9e13f07cb437fbc3fd3c13fa7f6ea8c9fef7bd8`
- Head: `37b2265e648f4a79f5acb9be4870092ee10daa15`
- Stable commit patch ID unchanged: `31dc745be6fb24c7a8cb0d633ea70749d56c7b8e`
- Complete rebased patch SHA-256: `ade5e76aa1b4a6411b353fb54b615be90cff994a062a33f82d9a549312bcab32`
- Nine native text/API/test/provenance files only; no renderer, scene ABI, package layout, generated declaration, shader, or managed production change
- Inherited optical-size header/tests and fallback-policy regressions remain present
- Privacy scan and `git diff --check`: clean

## Final-binary performance evidence

Release AppleClang benchmark linked to the exact rebased native text library, using bundled Inter 4.1 variable font (`5` HVAR regions). Each of five independent runs alternated direct/prepared order for `401` measured samples of `512` glyph advances after `40` warmups; every prepared result matched the direct result exactly.

Median of the five run-level percentiles:

| Path | p50 | p95 | p99 |
| --- | ---: | ---: | ---: |
| Direct coordinate lookup | 44.208 µs | 146.500 µs | 222.708 µs |
| Prepared instance | 10.208 µs | 25.292 µs | 52.625 µs |
| Speedup | 4.33× | 5.79× | 4.23× |

The earlier Time Profiler result remains consistent with this measurement: per-glyph HVAR `try_delta` projection frames disappeared from the shaping hotspot. The percentile benchmark is the merge-gate evidence for this rewritten final binary.

## Local validation

- AppleClang Release Dawn/native suite: 11/11 passed
- LLVM Clang C++20 module and normal suite: 12/12 passed
- Focused managed variable-font, shaping, optical-size, and fallback parity suite: 221/221 passed
- Real WebScene Dawn provider on Apple M3 Pro: passed, including packaged managed native capture/device-loss recreation
- Public Gallery `Native C++ Renderer`: 30 warmup + 90 measured frames passed
- Public Gallery scrolling `Inter Typeface`: 60 warmup + 180 measured frames passed
- Desktop Release build: 0 warnings, 0 errors

## Final merge gate

- Fresh exact-head CI: 26/26 successful, including Docs and all six public native package consumers
- Review threads: 0 total, 0 unresolved
- Current `main` and PR base remain exact `e9e13f07cb437fbc3fd3c13fa7f6ea8c9fef7bd8`
- Head, nine-file scope, stable patch ID, complete patch SHA-256, `git diff --check`, and privacy audit remain unchanged
- GitHub reports the PR mergeable with a clean merge state
