### PR TITLE
Add retained semantic damage replay

### DIFF
--- a/src/ProGPU.Backend.Native/Generated/NativeContract.g.cs
+++ b/src/ProGPU.Backend.Native/Generated/NativeContract.g.cs
@@ -646,6 +646,11 @@ internal static unsafe partial class NativeMethods
         internal NativeColor ClearColor;
         internal ulong SceneId;
         internal ulong Generation;
+        internal uint Flags;
+        internal float DamageX;
+        internal float DamageY;
+        internal float DamageWidth;
+        internal float DamageHeight;
     }
 
     // Native source: progpu_native_scene_frame_metrics.

--- a/src/ProGPU.Backend.Native/NativeCompositor.cs
+++ b/src/ProGPU.Backend.Native/NativeCompositor.cs
@@ -23,6 +23,8 @@ namespace ProGPU.Backend.Native;
 public sealed unsafe class NativeCompositor : IDisposable
 {
     private const uint ExternalImageSourceViewFlag = 1U;
+    private const uint SceneFramePreserveTargetFlag = 1U << 0;
+    private const uint SceneFrameDamageRectFlag = 1U << 1;
 
     private readonly WgpuContext _context;
     private readonly TextureFormat _targetFormat;
@@ -585,9 +587,37 @@ public sealed unsafe class NativeCompositor : IDisposable
         float dpiScale,
         ulong sceneId,
         ulong generation,
-        Vector4 clearColor)
+        Vector4 clearColor) => RenderScene(
+            target,
+            dpiScale,
+            sceneId,
+            generation,
+            clearColor,
+            damage: null);
+
+    /// <summary>
+    /// Renders the installed immutable semantic scene generation while
+    /// preserving target contents outside an optional logical damage rect.
+    /// Complex isolated-layer scenes conservatively fall back to full replay.
+    /// Damage replay does not clear the preserved target; the damaged area must
+    /// be covered opaquely before translucent or blended content is replayed.
+    /// </summary>
+    public NativeSceneFrameMetrics RenderScene(
+        GpuTexture target,
+        float dpiScale,
+        ulong sceneId,
+        ulong generation,
+        Vector4 clearColor,
+        NativeSceneDamageRect? damage)
     {
         ValidateTarget(target);
+        if (damage is { } value &&
+            (!float.IsFinite(value.X) || !float.IsFinite(value.Y) ||
+             !float.IsFinite(value.Width) || !float.IsFinite(value.Height) ||
+             value.Width <= 0f || value.Height <= 0f))
+        {
+            throw new ArgumentOutOfRangeException(nameof(damage));
+        }
         var frame = new NativeMethods.SceneFrame
         {
             StructSize = (uint)Unsafe.SizeOf<NativeMethods.SceneFrame>(),
@@ -603,7 +633,14 @@ public sealed unsafe class NativeCompositor : IDisposable
                 A = clearColor.W
             },
             SceneId = sceneId,
-            Generation = generation
+            Generation = generation,
+            Flags = damage.HasValue
+                ? SceneFramePreserveTargetFlag | SceneFrameDamageRectFlag
+                : 0U,
+            DamageX = damage?.X ?? 0f,
+            DamageY = damage?.Y ?? 0f,
+            DamageWidth = damage?.Width ?? 0f,
+            DamageHeight = damage?.Height ?? 0f
         };
         var metrics = new NativeMethods.SceneFrameMetrics
         {

--- a/src/ProGPU.Backend.Native/NativeRendererTypes.cs
+++ b/src/ProGPU.Backend.Native/NativeRendererTypes.cs
@@ -3630,6 +3630,18 @@ public readonly record struct NativeSceneUpdateMetrics(
     ulong PayloadBytes,
     bool SnapshotReused);
 
+/// <summary>
+/// Logical-coordinate rectangle whose existing target contents are preserved
+/// outside the damaged area during flat semantic scene replay. Replay does not
+/// clear the damaged area; callers must ensure it is repainted opaquely before
+/// translucent or blended content, or request a full frame.
+/// </summary>
+public readonly record struct NativeSceneDamageRect(
+    float X,
+    float Y,
+    float Width,
+    float Height);
+
 public readonly record struct NativeSceneFrameMetrics(
     uint CommandCount,
     uint DrawCallCount,

--- a/src/ProGPU.Native/include/progpu_native.h
+++ b/src/ProGPU.Native/include/progpu_native.h
@@ -1441,6 +1441,19 @@ typedef struct progpu_native_scene_color_glyph_bitmap {
     uint32_t reserved2;
 } progpu_native_scene_color_glyph_bitmap;
 
+typedef enum progpu_native_scene_frame_flags {
+    PROGPU_NATIVE_SCENE_FRAME_NONE = 0,
+    /* Load the existing target contents instead of clearing the attachment.
+     * Damage replay does not clear the damaged area; callers requesting an
+     * incremental repaint must ensure replay overwrites it opaquely before
+     * translucent/blended content, or request a full cleared frame. */
+    PROGPU_NATIVE_SCENE_FRAME_PRESERVE_TARGET = 1U << 0U,
+    /* Restrict flat semantic replay to the logical-coordinate damage rect. */
+    PROGPU_NATIVE_SCENE_FRAME_DAMAGE_RECT = 1U << 1U
+} progpu_native_scene_frame_flags;
+
+#define PROGPU_NATIVE_SCENE_FRAME_DAMAGE_RECT_AVAILABLE 1
+
 /* PROGPU_CSHARP_STRUCT: NativeMethods.SceneFrame */
 typedef struct progpu_native_scene_frame {
     uint32_t struct_size;
@@ -1451,6 +1464,11 @@ typedef struct progpu_native_scene_frame {
     progpu_native_color clear_color;
     uint64_t scene_id;
     uint64_t generation;
+    uint32_t flags;
+    float damage_x;
+    float damage_y;
+    float damage_width;
+    float damage_height;
 } progpu_native_scene_frame;
 
 /* PROGPU_CSHARP_STRUCT: NativeMethods.SceneFrameMetrics */

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
@@ -13,6 +13,9 @@ progpu_native_status render_scene(
     constexpr std::uint32_t legacy_metrics_size = offsetof(
         progpu_native_scene_frame_metrics,
         brush_upload_bytes);
+    constexpr std::uint32_t legacy_frame_size = offsetof(
+        progpu_native_scene_frame,
+        flags);
     if (metrics != nullptr &&
         metrics->struct_size >= legacy_metrics_size) {
         const std::uint32_t struct_size = metrics->struct_size;
@@ -33,7 +36,7 @@ progpu_native_status render_scene(
             "Semantic scene rendering is owner-thread affine.");
     }
     if (frame == nullptr ||
-        frame->struct_size < sizeof(progpu_native_scene_frame) ||
+        frame->struct_size < legacy_frame_size ||
         frame->width == 0U ||
         frame->height == 0U || !std::isfinite(frame->dpi_scale) ||
         frame->dpi_scale <= 0.0F || frame->target_view == 0U ||
@@ -45,6 +48,36 @@ progpu_native_status render_scene(
         return engine->fail(
             PROGPU_NATIVE_STATUS_INVALID_ARGUMENT,
             "The semantic scene frame descriptor is invalid.");
+    }
+    constexpr std::uint32_t allowed_frame_flags =
+        PROGPU_NATIVE_SCENE_FRAME_PRESERVE_TARGET |
+        PROGPU_NATIVE_SCENE_FRAME_DAMAGE_RECT;
+    const bool has_extended_frame =
+        frame->struct_size >= sizeof(progpu_native_scene_frame);
+    const auto frame_flags = has_extended_frame ? frame->flags : 0U;
+    const bool damage_requested =
+        (frame_flags & PROGPU_NATIVE_SCENE_FRAME_DAMAGE_RECT) != 0U;
+    const bool preserve_requested =
+        (frame_flags & PROGPU_NATIVE_SCENE_FRAME_PRESERVE_TARGET) != 0U;
+    const auto logical_width =
+        static_cast<float>(frame->width) / frame->dpi_scale;
+    const auto logical_height =
+        static_cast<float>(frame->height) / frame->dpi_scale;
+    if ((frame_flags & ~allowed_frame_flags) != 0U ||
+        (damage_requested &&
+            (!preserve_requested || !std::isfinite(frame->damage_x) ||
+                !std::isfinite(frame->damage_y) ||
+                !std::isfinite(frame->damage_width) ||
+                !std::isfinite(frame->damage_height) ||
+                frame->damage_width <= 0.0F ||
+                frame->damage_height <= 0.0F ||
+                frame->damage_x >= logical_width ||
+                frame->damage_y >= logical_height ||
+                frame->damage_x + frame->damage_width <= 0.0F ||
+                frame->damage_y + frame->damage_height <= 0.0F))) {
+        return engine->fail(
+            PROGPU_NATIVE_STATUS_INVALID_ARGUMENT,
+            "The semantic scene frame damage descriptor is invalid.");
     }
     if (frame->scene_id != engine->semantic_scene_id ||
         frame->generation != engine->semantic_scene_generation ||
@@ -1332,6 +1365,42 @@ progpu_native_status render_scene(
     const bool semantic_destination_sampling_active =
         semantic_advanced_layer_count != 0U ||
         semantic_backdrop_layer_count != 0U;
+    const bool semantic_partial_replay_supported =
+        !semantic_has_materialized_layers && !semantic_has_state_masks &&
+        !semantic_destination_sampling_active && semantic_3d_draw_count == 0U;
+    const bool semantic_partial_damage_active =
+        damage_requested && semantic_partial_replay_supported;
+    const bool semantic_preserve_target_active =
+        preserve_requested && semantic_partial_replay_supported &&
+        (!damage_requested || semantic_partial_damage_active);
+    semantic_scissor semantic_frame_damage{
+        0U, 0U, frame->width, frame->height, true};
+    if (semantic_partial_damage_active) {
+        const auto left = std::max(
+            0.0,
+            std::floor(
+                static_cast<double>(frame->damage_x) * frame->dpi_scale));
+        const auto top = std::max(
+            0.0,
+            std::floor(
+                static_cast<double>(frame->damage_y) * frame->dpi_scale));
+        const auto right = std::min(
+            static_cast<double>(frame->width),
+            std::ceil(
+                static_cast<double>(frame->damage_x + frame->damage_width) *
+                frame->dpi_scale));
+        const auto bottom = std::min(
+            static_cast<double>(frame->height),
+            std::ceil(
+                static_cast<double>(frame->damage_y + frame->damage_height) *
+                frame->dpi_scale));
+        semantic_frame_damage = {
+            static_cast<std::uint32_t>(left),
+            static_cast<std::uint32_t>(top),
+            static_cast<std::uint32_t>(right - left),
+            static_cast<std::uint32_t>(bottom - top),
+            right > left && bottom > top};
+    }
     std::uint64_t semantic_destination_frame_bytes = 0U;
     std::uint64_t semantic_advanced_source_bytes = 0U;
     const std::uint64_t destination_frame_texture_count =
@@ -1511,10 +1580,26 @@ progpu_native_status render_scene(
         }
     }
 
+    auto semantic_bundle_replay_hash = engine->semantic_scene_hash;
+    semantic_bundle_replay_hash = append_fnv1a64(
+        semantic_bundle_replay_hash,
+        &semantic_partial_damage_active,
+        sizeof(semantic_partial_damage_active));
+    if (semantic_partial_damage_active) {
+        const std::array damage_identity{
+            semantic_frame_damage.x,
+            semantic_frame_damage.y,
+            semantic_frame_damage.width,
+            semantic_frame_damage.height};
+        semantic_bundle_replay_hash = append_fnv1a64(
+            semantic_bundle_replay_hash,
+            damage_identity.data(),
+            sizeof(damage_identity));
+    }
     const bool semantic_render_bundle_hit =
         engine->semantic_render_bundle_valid &&
         engine->semantic_render_bundle_scene_hash ==
-            engine->semantic_scene_hash &&
+            semantic_bundle_replay_hash &&
         engine->semantic_render_bundle_dpi_scale == frame->dpi_scale &&
         engine->semantic_render_bundle_width == frame->width &&
         engine->semantic_render_bundle_height == frame->height &&
@@ -3960,12 +4045,18 @@ progpu_native_status render_scene(
                     PROGPU_NATIVE_SCENE_COMMAND_DRAW_MESH_3D_BATCH) {
                 continue;
             }
-            const auto scissor = resolve_semantic_target_scissor(
+            auto scissor = resolve_semantic_target_scissor(
                 state,
                 target_extent,
                 frame->width,
                 frame->height,
                 frame->dpi_scale);
+            if (semantic_partial_damage_active &&
+                current_target_layer == PROGPU_NATIVE_SCENE_NO_INDEX) {
+                scissor = intersect_semantic_scissors(
+                    scissor,
+                    semantic_frame_damage);
+            }
             const std::uint32_t mask_resource_index =
                 (state.flags & PROGPU_NATIVE_SCENE_STATE_MASK) != 0U
                 ? state.mask_resource_index
@@ -4327,7 +4418,7 @@ progpu_native_status render_scene(
             std::move(compiled_effect_dispatches);
         engine->semantic_render_bundle_valid = true;
         engine->semantic_render_bundle_scene_hash =
-            engine->semantic_scene_hash;
+            semantic_bundle_replay_hash;
         engine->semantic_render_bundle_dpi_scale = frame->dpi_scale;
         engine->semantic_render_bundle_width = frame->width;
         engine->semantic_render_bundle_height = frame->height;
@@ -4359,7 +4450,9 @@ progpu_native_status render_scene(
             color_attachment);
         color_attachment.view = reinterpret_cast<WGPUTextureView>(
             frame->target_view);
-        color_attachment.loadOp = WGPULoadOp_Clear;
+        color_attachment.loadOp = semantic_preserve_target_active
+            ? WGPULoadOp_Load
+            : WGPULoadOp_Clear;
         color_attachment.storeOp = WGPUStoreOp_Store;
         color_attachment.clearValue = WGPUColor{
             frame->clear_color.r,

--- a/src/ProGPU.Native/tests/progpu_native_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_tests.cpp
@@ -570,7 +570,7 @@ void api_contract_is_versioned() {
     PROGPU_REQUIRE(sizeof(progpu_native_scene_path_fill) == 96U);
     PROGPU_REQUIRE(sizeof(progpu_native_scene_stroke) == 160U);
     PROGPU_REQUIRE(sizeof(progpu_native_scene_glyph_outline) == 40U);
-    PROGPU_REQUIRE(sizeof(progpu_native_scene_frame) == 56U);
+    PROGPU_REQUIRE(sizeof(progpu_native_scene_frame) == 80U);
     PROGPU_REQUIRE(sizeof(progpu_native_scene_brush) == 256U);
     PROGPU_REQUIRE(sizeof(progpu_native_scene_gradient_stop) == 32U);
     PROGPU_REQUIRE(sizeof(progpu_native_scene_draw_brushes) == 16U);
@@ -638,6 +638,12 @@ void api_contract_is_versioned() {
     PROGPU_REQUIRE(offsetof(
         progpu_native_scene_frame,
         scene_id) == 40U);
+    PROGPU_REQUIRE(offsetof(
+        progpu_native_scene_frame,
+        flags) == 56U);
+    PROGPU_REQUIRE(offsetof(
+        progpu_native_scene_frame,
+        damage_height) == 72U);
     PROGPU_REQUIRE(sizeof(progpu_native_glyph_outline) == 40U);
     PROGPU_REQUIRE(sizeof(progpu_native_positioned_glyph) == 64U);
     PROGPU_REQUIRE(sizeof(progpu_native_clip_path) == 88U);

--- a/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
@@ -2667,6 +2667,32 @@ int main(int argc, char** argv) {
         semantic_metrics.payload_hash == semantic_payload_hash,
         "stable mixed semantic scene replay rebuilt retained resources");
 
+    auto invalid_damage_frame = semantic_frame;
+    invalid_damage_frame.flags = PROGPU_NATIVE_SCENE_FRAME_DAMAGE_RECT;
+    invalid_damage_frame.damage_width = 8.0F;
+    invalid_damage_frame.damage_height = 8.0F;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+        engine,
+        &invalid_damage_frame,
+        &semantic_metrics) == PROGPU_NATIVE_STATUS_INVALID_ARGUMENT &&
+        semantic_metrics.submission_count == 0U,
+        "semantic damage replay accepted a non-preserved target");
+
+    auto legacy_semantic_frame = semantic_frame;
+    legacy_semantic_frame.struct_size = offsetof(
+        progpu_native_scene_frame,
+        flags);
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+        engine,
+        &legacy_semantic_frame,
+        &semantic_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        semantic_metrics.submission_count == 1U,
+        "legacy semantic frame ABI no longer performs full replay");
+
     auto collapsed_stroke_scene = create_collapsed_stroke_scene_stream();
     scene_metrics = {};
     scene_metrics.struct_size = sizeof(scene_metrics);
@@ -2997,6 +3023,30 @@ int main(int argc, char** argv) {
         &semantic_submission) == PROGPU_NATIVE_STATUS_SUCCESS &&
         semantic_submission != 0U,
         "semantic restore submission token unavailable");
+
+    auto damage_frame = semantic_frame;
+    damage_frame.flags = PROGPU_NATIVE_SCENE_FRAME_PRESERVE_TARGET |
+        PROGPU_NATIVE_SCENE_FRAME_DAMAGE_RECT;
+    damage_frame.damage_x = 0.0F;
+    damage_frame.damage_y = 0.0F;
+    damage_frame.damage_width = 32.0F;
+    damage_frame.damage_height = 16.0F;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+        engine,
+        &damage_frame,
+        &semantic_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        semantic_metrics.submission_count == 1U &&
+        semantic_metrics.vertex_upload_bytes == 0U &&
+        semantic_metrics.index_upload_bytes == 0U &&
+        semantic_metrics.texture_upload_bytes == 0U,
+        "flat semantic damage replay rebuilt retained GPU resources");
+    require(progpu_native_engine_get_last_submission(
+        engine,
+        &semantic_submission) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        semantic_submission != 0U,
+        "semantic damage replay submission token unavailable");
 
     auto invalid_style_scene = create_renderable_semantic_scene_stream(4U);
     progpu_native_scene_header invalid_style_header{};

--- a/src/ProGPU.Tests/NativeRendererInteropTests.cs
+++ b/src/ProGPU.Tests/NativeRendererInteropTests.cs
@@ -361,7 +361,7 @@ public class NativeRendererInteropTests
             OffsetOf<NativeScenePathFill>(
                 nameof(NativeScenePathFill.BooleanNodeOffset)));
         Assert.Equal(40, Unsafe.SizeOf<NativeSceneGlyphOutline>());
-        Assert.Equal(56, Unsafe.SizeOf<NativeMethods.SceneFrame>());
+        Assert.Equal(80, Unsafe.SizeOf<NativeMethods.SceneFrame>());
         Assert.Equal(256, Unsafe.SizeOf<NativeSceneBrush>());
         Assert.Equal(32, Unsafe.SizeOf<NativeSceneGradientStop>());
         Assert.Equal(32, Unsafe.SizeOf<NativeSceneTextStyle>());
@@ -460,6 +460,14 @@ public class NativeRendererInteropTests
             40,
             OffsetOf<NativeMethods.SceneFrame>(
                 nameof(NativeMethods.SceneFrame.SceneId)));
+        Assert.Equal(
+            56,
+            OffsetOf<NativeMethods.SceneFrame>(
+                nameof(NativeMethods.SceneFrame.Flags)));
+        Assert.Equal(
+            72,
+            OffsetOf<NativeMethods.SceneFrame>(
+                nameof(NativeMethods.SceneFrame.DamageHeight)));
         Assert.Equal(
             24,
             OffsetOf<NativeMethods.SceneHeader>(nameof(NativeMethods.SceneHeader.SceneId)));


### PR DESCRIPTION
## Summary

- extend the semantic frame contract with explicit preserve-target and logical damage-rectangle flags
- load the existing attachment and scissor flat semantic replay to the requested damage region
- retain full replay for complex isolated-layer scenes
- expose the same optional damage contract through the managed native compositor

## Correctness contract

Damage replay does not clear the preserved target. A caller requesting incremental repaint must ensure the damaged area is overwritten opaquely before translucent or blended content is replayed; otherwise it must request a full cleared frame. This precondition is documented in both the C ABI and managed API. The real-provider regression uses a damage band covered by opaque scene content.

## Managed/native parity

- C ABI: frame flags and logical damage fields
- Native Dawn renderer: preserve/load, scale-aware scissor, and conservative complex-scene fallback
- Managed native compositor: optional `NativeSceneDamageRect`, validation, generated ABI parity, and contract tests

## Rebase audit

- exact base: `1b1d72ae3564616af84552d59234880749ffdf70`
- exact rewritten head: `cc13a5b7da1c573d13b933c438368ab957721268`
- production patch-id remains exactly `dffe2b087490f653a1e97038525fd117b5045930`
- the provider-test overlap was resolved additively: damage/preserve and legacy-ABI checks retain their original scene state, followed by the inherited collapsed-stroke zero-upload check
- generated C# contract regenerated byte-for-byte and verified against the public C header
- eight-file patch SHA-256: `8cb559877201412f8aa03d969d4311c8985f25db68c28bdde3c8d653b82083f7`

## Validation

- AppleClang Release native/Dawn/provider suite: 11/11 passed
- real WebScene Dawn Metal provider on Apple M3 Pro passed, including capture evidence
- packaged managed Dawn host passed, including forced device-loss recreation and capture evidence
- `NativeRendererInteropTests`: 56/56 passed
- invalid and empty damage inputs covered
- flat replay reports zero retained vertex/index/texture upload bytes
- real provider update/render succeeds with preserved target semantics
- generated contract verification, privacy scan, and `git diff --check`: clean

## Scope

Eight ABI, renderer, managed interop, and focused test files. The scene stream format and retained resource identities do not change.
