### PR TITLE
Prefer real symbol and emoji fallback fonts

### DIFF
--- a/src/ProGPU.Native/src/Text/Shaping/progpu_native_font_fallback_preferences.cpp
+++ b/src/ProGPU.Native/src/Text/Shaping/progpu_native_font_fallback_preferences.cpp
@@ -70,11 +70,28 @@ constexpr std::array latin{
     std::string_view{"Noto Sans"},
     std::string_view{"DejaVu Sans"},
     std::string_view{"Liberation Sans"}};
+constexpr std::array symbols{
+    std::string_view{"Apple Symbols"},
+    std::string_view{"Zapf Dingbats"},
+    std::string_view{"Segoe UI Symbol"},
+    std::string_view{"Noto Sans Symbols 2"},
+    std::string_view{"Noto Sans Symbols"},
+    std::string_view{"Apple Color Emoji"},
+    std::string_view{"Segoe UI Emoji"},
+    std::string_view{"Noto Color Emoji"},
+    std::string_view{"Symbola"},
+    std::string_view{"DejaVu Sans"}};
+constexpr std::array emoji{
+    std::string_view{"Apple Color Emoji"},
+    std::string_view{"Segoe UI Emoji"},
+    std::string_view{"Noto Color Emoji"},
+    std::string_view{"Noto Emoji"},
+    std::string_view{"Segoe UI Symbol"}};
 
 static_assert(
     arabic.size() + japanese.size() + korean.size() +
         chinese_traditional.size() + chinese_simplified.size() +
-        hebrew.size() + latin.size() <= 64U,
+        hebrew.size() + latin.size() + symbols.size() + emoji.size() <= 64U,
     "The fixed fallback preference buffer must contain every policy family.");
 
 constexpr char normalized(char value) noexcept {
@@ -199,6 +216,14 @@ bool is_hebrew(std::uint32_t code_point) noexcept {
         (code_point >= 0xFB1DU && code_point <= 0xFB4FU);
 }
 
+bool is_symbol(std::uint32_t code_point) noexcept {
+    return code_point >= 0x2000U && code_point <= 0x2BFFU;
+}
+
+bool is_emoji(std::uint32_t code_point) noexcept {
+    return code_point >= 0x1F000U && code_point <= 0x1FAFFU;
+}
+
 bool try_build_preferences(
     std::span<const std::string_view> language_tags,
     std::uint32_t code_point,
@@ -216,6 +241,10 @@ bool try_build_preferences(
         result.add(arabic);
     } else if (is_hebrew(code_point)) {
         result.add(hebrew);
+    } else if (is_emoji(code_point)) {
+        result.add(emoji);
+    } else if (is_symbol(code_point)) {
+        result.add(symbols);
     } else if (code_point >= 0x3040U && code_point <= 0x30FFU) {
         result.add(japanese);
     } else if ((code_point >= 0xAC00U && code_point <= 0xD7AFU) ||

--- a/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_text_tests.cpp
@@ -7070,6 +7070,33 @@ void native_font_fallback_family_preferences_match_managed_policy() {
         std::string_view{"Liberation Sans"}};
     require(latin_families == expected_latin);
 
+    std::array<std::string_view, 10U> symbol_families{};
+    require(try_get_font_fallback_family_preferences(
+        {}, 0x2630U, symbol_families, written, &error));
+    constexpr std::array expected_symbols{
+        std::string_view{"Apple Symbols"},
+        std::string_view{"Zapf Dingbats"},
+        std::string_view{"Segoe UI Symbol"},
+        std::string_view{"Noto Sans Symbols 2"},
+        std::string_view{"Noto Sans Symbols"},
+        std::string_view{"Apple Color Emoji"},
+        std::string_view{"Segoe UI Emoji"},
+        std::string_view{"Noto Color Emoji"},
+        std::string_view{"Symbola"},
+        std::string_view{"DejaVu Sans"}};
+    require(symbol_families == expected_symbols);
+
+    std::array<std::string_view, 5U> emoji_families{};
+    require(try_get_font_fallback_family_preferences(
+        {}, 0x1F600U, emoji_families, written, &error));
+    constexpr std::array expected_emoji{
+        std::string_view{"Apple Color Emoji"},
+        std::string_view{"Segoe UI Emoji"},
+        std::string_view{"Noto Color Emoji"},
+        std::string_view{"Noto Emoji"},
+        std::string_view{"Segoe UI Symbol"}};
+    require(emoji_families == expected_emoji);
+
     std::array<std::string_view, 5U> short_output{};
     short_output.fill("unchanged");
     written = 99U;

--- a/src/ProGPU.Tests/NotoFontFamilyTests.cs
+++ b/src/ProGPU.Tests/NotoFontFamilyTests.cs
@@ -121,8 +121,19 @@ public sealed class NotoFontFamilyTests
             '♠',
             out TtfFont? symbols,
             out ushort symbolGlyph));
-        Assert.Same(NotoFontFamily.Symbols, symbols);
+        Assert.NotNull(symbols);
+        Assert.Equal(symbols!.GetGlyphIndex('♠'), symbolGlyph);
         Assert.NotEqual((ushort)0, symbolGlyph);
+
+        Assert.True(manager.TryMatchCharacter(
+            NotoFontFamily.Symbols.FamilyName,
+            FontStyleRequest.Normal,
+            null,
+            '♠',
+            out TtfFont? registeredSymbols,
+            out ushort registeredSymbolGlyph));
+        Assert.Same(NotoFontFamily.Symbols, registeredSymbols);
+        Assert.NotEqual((ushort)0, registeredSymbolGlyph);
     }
 
     private static void AssertGeometryEqual(PathGeometry expected, PathGeometry actual)

--- a/src/ProGPU.Tests/SkiaSharpFontManagerTests.cs
+++ b/src/ProGPU.Tests/SkiaSharpFontManagerTests.cs
@@ -202,6 +202,32 @@ public class SkiaSharpFontManagerTests
         Assert.True(IndexOf(families, "Arial") < IndexOf(families, "DejaVu Sans"));
     }
 
+    [Theory]
+    [InlineData(0x2192)]
+    [InlineData(0x25C7)]
+    [InlineData(0x2630)]
+    public void SymbolsPrioritizeRenderableSymbolFamilies(int codepoint)
+    {
+        IReadOnlyList<string> families = SKFontManager.GetFallbackFamilyPreferences(
+            Array.Empty<string>(),
+            codepoint);
+
+        Assert.Equal("Apple Symbols", families[0]);
+        Assert.True(IndexOf(families, "Zapf Dingbats") < IndexOf(families, "DejaVu Sans"));
+        Assert.True(IndexOf(families, "Segoe UI Symbol") < IndexOf(families, "DejaVu Sans"));
+    }
+
+    [Fact]
+    public void EmojiPrioritizeColorEmojiFamilies()
+    {
+        IReadOnlyList<string> families = SKFontManager.GetFallbackFamilyPreferences(
+            Array.Empty<string>(),
+            0x1F600);
+
+        Assert.Equal("Apple Color Emoji", families[0]);
+        Assert.True(IndexOf(families, "Segoe UI Emoji") < IndexOf(families, "Segoe UI Symbol"));
+    }
+
     [Fact]
     public void HebrewScriptPrioritizesNativeCompatibleHebrewFamilies()
     {

--- a/src/ProGPU.Text/FontManager.cs
+++ b/src/ProGPU.Text/FontManager.cs
@@ -583,6 +583,16 @@ public sealed class FontManager
         {
             Add("Arial Hebrew", "Lucida Grande", "Noto Sans Hebrew", "Segoe UI", "Arial", "DejaVu Sans");
         }
+        else if (codePoint is >= 0x1F000 and <= 0x1FAFF)
+        {
+            Add("Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Noto Emoji", "Segoe UI Symbol");
+        }
+        else if (codePoint is >= 0x2000 and <= 0x2BFF)
+        {
+            Add("Apple Symbols", "Zapf Dingbats", "Segoe UI Symbol", "Noto Sans Symbols 2",
+                "Noto Sans Symbols", "Apple Color Emoji", "Segoe UI Emoji",
+                "Noto Color Emoji", "Symbola", "DejaVu Sans");
+        }
         else if (codePoint is >= 0x3040 and <= 0x30FF)
         {
             AddLanguage("ja");


### PR DESCRIPTION
## Summary

- add explicit cross-platform symbol and emoji fallback-family preferences
- keep native C++ and managed text fallback policy synchronized
- cover representative arrows, geometric symbols, menu symbols, and emoji

## Why

Generic catalog enumeration can encounter a last-resort placeholder face before a real symbol font. Preferring known renderable symbol and emoji families preserves the requested scalar instead of selecting a diagnostic placeholder glyph.

## Rebase audit

- exact base: `161deb70b7f397c67a62605d21b429771d8c176b`
- exact head: `0e2e62e89067eeabc6f9ab17282fd3458a4f8479`
- synchronized production patch-id unchanged: `d9d462a324aefacd5c3d44d205cd552fe7a22c14`
- complete five-file patch SHA-256 unchanged: `159a530caab7e5eb363d875fce40bbf3d4868edec19c35ecaafba3667a45f9d3`
- inherited renderer tests preserved; exact five-file scope, privacy scan, and `git diff --check` clean

## Matching invariants

- both implementations try the explicitly requested family first and return immediately when it maps the scalar; fallback preferences are consulted only after that lookup fails
- native preferences use a fixed 64-entry allocation-free buffer, exact ordered de-duplication, a single visited catalog bitset, and a deterministic full-name/path/face-index catalog sort
- managed matching verifies outline, color-layer, or bitmap renderability before accepting an ink glyph; both managed and native character caches are bounded to 4,096 entries
- a diagnostic/last-resort face cannot preempt a matching preferred symbol or emoji family; it is reachable only in the final bounded generic catalog scan

## Validation

- AppleClang Release native Dawn build: clean, warnings-as-errors
- native text/catalog/provider suite: 11/11
- real native system catalog audit: 851 faces scanned deterministically; explicitly requested Apple Color Emoji matched Apple Color Emoji and produced a 975,184-byte glyph-resident face
- real provider verification on Apple M3 Pro: native capture and packaged managed Dawn host passed, including forced device-loss recreation
- public desktop Gallery through the Dawn provider:
  - Native C++ Renderer: 30 warmup + 90 measured frames, completed cleanly
  - scrolling Font Glyph Browser: 60 warmup + 180 measured frames; 3/3 state samples retained 36 realized/36 command glyph cells across visible glyphs 1152–2327
- focused managed symbol/emoji fallback tests: 5/5, including explicit requested-family preservation
