### PR TITLE
Validate reused native glyph resources once

### DIFF
--- a/src/ProGPU.Native/README.md
+++ b/src/ProGPU.Native/README.md
@@ -1062,6 +1062,19 @@ before creating an encoder: 16,384 draw passes, 256 MiB of expanded vertices,
 64 MiB of indices, 256 MiB each of textures and aligned coverage staging, and
 512 MiB total across those domains. This bounds adversarial expansion while
 the broader stream-format limits remain available for future non-draw records.
+An immutable glyph outline resource is fully validated and charged to those
+budgets on its first command in each preflight. Later commands that reference
+the same resource validate only their independent positioned-glyph payload;
+they cannot change the already-owned outline or segment spans.
+
+The equivalent managed path already separates content layout from glyph
+residency: `GpuPictureNativeSceneCompiler` materializes each immutable glyph
+resource once, while `TtfFont`/`GlyphAtlas` retain the layout and resident glyph
+data independently. It does not repeat the native C++ per-command resource
+preflight, so this validation-loop optimization has no applicable managed
+production change. The managed layout and glyph-residency tests remain the
+parity gate.
+
 Identical repeated-family commands use a content-addressed retained revision,
 so intervening families do not force a flush or extra submission. Distinct
 repeated payloads remain the paged-buffer continuation.

--- a/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
+++ b/src/ProGPU.Native/src/Scene/progpu_native_semantic_render_execution.cpp
@@ -1070,8 +1070,13 @@ progpu_native_status render_scene(
                         first_semantic_glyph_resource
                     ? resource.auxiliary_size
                     : 0U;
+                // The snapshot owns one immutable outline/segment payload per
+                // resource index. Validate and budget that payload on its
+                // first draw; later commands still validate their independent
+                // positioned-glyph payload below.
                 for (std::uint64_t segment_index = 0U;
-                     valid && segment_index < segment_count;
+                     valid && first_semantic_glyph_resource &&
+                         segment_index < segment_count;
                      ++segment_index) {
                     progpu_native_path_segment segment{};
                     std::memcpy(
@@ -1082,7 +1087,8 @@ progpu_native_status render_scene(
                     valid = is_valid_semantic_segment(segment, false);
                 }
                 for (std::uint64_t outline_index = 0U;
-                     valid && budget_valid && outline_index < outline_count;
+                     valid && budget_valid && first_semantic_glyph_resource &&
+                         outline_index < outline_count;
                      ++outline_index) {
                     if (color_glyphs) {
                         continue;
@@ -1099,11 +1105,10 @@ progpu_native_status render_scene(
                         segment_count,
                         &outline_coverage_bytes);
                     budget_valid = valid &&
-                        (!first_semantic_glyph_resource ||
-                            outline_coverage_bytes <=
-                                semantic_max_coverage_bytes -
-                                    compiled_coverage_bytes);
-                    if (budget_valid && first_semantic_glyph_resource) {
+                        outline_coverage_bytes <=
+                            semantic_max_coverage_bytes -
+                                compiled_coverage_bytes;
+                    if (budget_valid) {
                         compiled_coverage_bytes += outline_coverage_bytes;
                     }
                 }

--- a/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
@@ -16,7 +16,6 @@
 
 #include <IOSurface/IOSurface.h>
 #include <dlfcn.h>
-
 #include <chrono>
 #include <array>
 #include <condition_variable>
@@ -105,6 +104,117 @@ std::vector<std::byte> create_collapsed_stroke_scene_stream() {
         "collapsed-stroke draw recording failed");
     std::vector<std::byte> scene;
     require(builder.build(scene), "collapsed-stroke scene build failed");
+    return scene;
+}
+
+std::vector<std::byte> create_reused_glyph_resource_scene_stream(
+    std::uint64_t scene_id = 798U,
+    std::uint64_t generation = 1U) {
+    using progpu::native::semantic_scene_builder;
+    semantic_scene_builder builder(scene_id, generation);
+    constexpr std::array segments{
+        progpu_native_path_segment{{0.0F, 0.0F}, {8.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{{8.0F, 0.0F}, {8.0F, 8.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{{8.0F, 8.0F}, {0.0F, 8.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{{0.0F, 8.0F}, {0.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U}};
+    const progpu_native_scene_glyph_outline outline{
+        0U,
+        segments.size(),
+        0.0F,
+        0.0F,
+        8.0F,
+        8.0F,
+        1.0F,
+        0.0F};
+    std::uint32_t glyph_resource = PROGPU_NATIVE_SCENE_NO_INDEX;
+    require(builder.add_glyph_outlines(
+        std::span<const progpu_native_scene_glyph_outline>(&outline, 1U),
+        segments,
+        glyph_resource),
+        "reused-glyph fixture resource recording failed");
+    const progpu_native_positioned_glyph glyph{
+        0U,
+        0U,
+        {8.0F, 8.0F},
+        {1.0F, 0.0F},
+        {0.0F, 1.0F},
+        {0.2F, 0.8F, 1.0F, 1.0F},
+        1.0F,
+        0.0F,
+        0.0F,
+        0.0F};
+    for (std::uint32_t index = 0U; index < 3U; ++index) {
+        require(builder.draw_glyph_run(
+            glyph_resource,
+            std::span<const progpu_native_positioned_glyph>(&glyph, 1U),
+            {8.0F, 8.0F, 8.0F, 8.0F}),
+            "reused-glyph fixture draw recording failed");
+    }
+    std::vector<std::byte> scene;
+    require(builder.build(scene), "reused-glyph fixture build failed");
+    return scene;
+}
+
+std::vector<std::byte> create_distinct_glyph_resource_scene_stream() {
+    using progpu::native::semantic_scene_builder;
+    semantic_scene_builder builder(800U, 2U);
+    constexpr std::array segments{
+        progpu_native_path_segment{{0.0F, 0.0F}, {8.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{{8.0F, 0.0F}, {8.0F, 8.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{{8.0F, 8.0F}, {0.0F, 8.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U},
+        progpu_native_path_segment{{0.0F, 8.0F}, {0.0F, 0.0F}, {}, {},
+            PROGPU_NATIVE_PATH_SEGMENT_LINE, 0U, 0U, 0U}};
+    const progpu_native_scene_glyph_outline outline{
+        0U,
+        segments.size(),
+        0.0F,
+        0.0F,
+        8.0F,
+        8.0F,
+        1.0F,
+        0.0F};
+    std::array<std::uint32_t, 2U> glyph_resources{
+        PROGPU_NATIVE_SCENE_NO_INDEX,
+        PROGPU_NATIVE_SCENE_NO_INDEX};
+    for (std::uint32_t index = 0U; index < glyph_resources.size(); ++index) {
+        require(builder.add_glyph_outlines(
+            std::span<const progpu_native_scene_glyph_outline>(&outline, 1U),
+            segments,
+            glyph_resources[index]),
+            "distinct-glyph fixture resource recording failed");
+    }
+    require(builder.set_resource_identity(
+            glyph_resources[0], 0x800501U, 7U) &&
+        builder.set_resource_identity(
+            glyph_resources[1], 0x800502U, 8U),
+        "distinct-glyph fixture resource identity recording failed");
+    const progpu_native_positioned_glyph glyph{
+        0U,
+        0U,
+        {8.0F, 8.0F},
+        {1.0F, 0.0F},
+        {0.0F, 1.0F},
+        {0.2F, 0.8F, 1.0F, 1.0F},
+        1.0F,
+        0.0F,
+        0.0F,
+        0.0F};
+    for (const std::uint32_t glyph_resource : glyph_resources) {
+        require(builder.draw_glyph_run(
+            glyph_resource,
+            std::span<const progpu_native_positioned_glyph>(&glyph, 1U),
+            {8.0F, 8.0F, 8.0F, 8.0F}),
+            "distinct-glyph fixture draw recording failed");
+    }
+    std::vector<std::byte> scene;
+    require(builder.build(scene), "distinct-glyph fixture build failed");
     return scene;
 }
 
@@ -5550,6 +5660,174 @@ int main(int argc, char** argv) {
         semantic_metrics.command_count == 2U &&
         semantic_metrics.draw_call_count == 2U,
         "native retained 3D GPU execution failed");
+
+    const auto reused_glyph_scene = create_reused_glyph_resource_scene_stream();
+    scene_metrics = {};
+    scene_metrics.struct_size = sizeof(scene_metrics);
+    require(progpu_native_engine_update_scene(
+        engine,
+        reused_glyph_scene.data(),
+        reused_glyph_scene.size(),
+        &scene_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        scene_metrics.draw_count == 3U &&
+        scene_metrics.resource_count == 1U,
+        "reused-glyph scene update failed");
+    auto reused_glyph_frame = native_3d_frame;
+    reused_glyph_frame.scene_id = 798U;
+    reused_glyph_frame.generation = 1U;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+        engine,
+        &reused_glyph_frame,
+        &semantic_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        semantic_metrics.command_count == 3U &&
+        semantic_metrics.draw_call_count != 0U &&
+        semantic_metrics.draw_call_count <= 3U &&
+        semantic_metrics.vertex_upload_bytes != 0U &&
+        semantic_metrics.coverage_staging_bytes != 0U,
+        "reused-glyph scene initial rendering failed");
+    const std::uint64_t reused_glyph_payload_hash =
+        semantic_metrics.payload_hash;
+    const std::uint32_t reused_glyph_draw_calls =
+        semantic_metrics.draw_call_count;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+            engine,
+            &reused_glyph_frame,
+            &semantic_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+        semantic_metrics.command_count == 3U &&
+        semantic_metrics.draw_call_count == reused_glyph_draw_calls &&
+        semantic_metrics.vertex_upload_bytes == 0U &&
+        semantic_metrics.index_upload_bytes == 0U &&
+        semantic_metrics.texture_upload_bytes == 0U &&
+        semantic_metrics.coverage_staging_bytes == 0U &&
+        semantic_metrics.brush_upload_bytes == 0U &&
+        semantic_metrics.gradient_stop_upload_bytes == 0U &&
+        semantic_metrics.text_style_upload_bytes == 0U &&
+        semantic_metrics.color_glyph_upload_bytes == 0U &&
+        semantic_metrics.payload_hash == reused_glyph_payload_hash,
+        "stable reused-glyph scene replay rebuilt retained resources");
+
+    auto malformed_positioned_scene =
+        create_reused_glyph_resource_scene_stream(799U, 1U);
+    progpu_native_scene_header malformed_positioned_header{};
+    std::memcpy(
+        &malformed_positioned_header,
+        malformed_positioned_scene.data(),
+        sizeof(malformed_positioned_header));
+    require(malformed_positioned_header.command_count == 3U &&
+        malformed_positioned_header.command_stride >=
+            sizeof(progpu_native_scene_command),
+        "malformed-positioned fixture command table is invalid");
+    progpu_native_scene_command second_glyph_command{};
+    const std::size_t second_glyph_command_offset =
+        malformed_positioned_header.command_offset +
+        malformed_positioned_header.command_stride;
+    std::memcpy(
+        &second_glyph_command,
+        malformed_positioned_scene.data() + second_glyph_command_offset,
+        sizeof(second_glyph_command));
+    require(second_glyph_command.payload_size ==
+        sizeof(progpu_native_positioned_glyph),
+        "malformed-positioned fixture payload layout changed");
+    progpu_native_positioned_glyph malformed_positioned_glyph{};
+    std::memcpy(
+        &malformed_positioned_glyph,
+        malformed_positioned_scene.data() +
+            second_glyph_command.payload_offset,
+        sizeof(malformed_positioned_glyph));
+    require(malformed_positioned_glyph.outline_index == 0U,
+        "malformed-positioned fixture outline index changed");
+    malformed_positioned_glyph.outline_index = 1U;
+    std::memcpy(
+        malformed_positioned_scene.data() +
+            second_glyph_command.payload_offset,
+        &malformed_positioned_glyph,
+        sizeof(malformed_positioned_glyph));
+    scene_metrics = {};
+    scene_metrics.struct_size = sizeof(scene_metrics);
+    require(progpu_native_engine_update_scene(
+        engine,
+        malformed_positioned_scene.data(),
+        malformed_positioned_scene.size(),
+        &scene_metrics) == PROGPU_NATIVE_STATUS_SUCCESS,
+        "malformed-positioned scene update failed before render validation");
+    auto malformed_positioned_frame = native_3d_frame;
+    malformed_positioned_frame.scene_id = 799U;
+    malformed_positioned_frame.generation = 1U;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+            engine,
+            &malformed_positioned_frame,
+            &semantic_metrics) == PROGPU_NATIVE_STATUS_INVALID_ARGUMENT &&
+        semantic_metrics.submission_count == 0U,
+        "shared glyph resource skipped second positioned-payload validation");
+
+    auto distinct_glyph_scene =
+        create_distinct_glyph_resource_scene_stream();
+    progpu_native_scene_header distinct_glyph_header{};
+    std::memcpy(
+        &distinct_glyph_header,
+        distinct_glyph_scene.data(),
+        sizeof(distinct_glyph_header));
+    require(distinct_glyph_header.resource_count == 2U &&
+        distinct_glyph_header.resource_stride >=
+            sizeof(progpu_native_scene_resource),
+        "distinct-glyph fixture resource table is invalid");
+    std::array<progpu_native_scene_resource, 2U> distinct_glyph_resources{};
+    for (std::uint32_t index = 0U;
+         index < distinct_glyph_resources.size();
+         ++index) {
+        const std::size_t resource_offset =
+            distinct_glyph_header.resource_offset +
+            index * distinct_glyph_header.resource_stride;
+        std::memcpy(
+            &distinct_glyph_resources[index],
+            distinct_glyph_scene.data() + resource_offset,
+            sizeof(distinct_glyph_resources[index]));
+    }
+    require(distinct_glyph_resources[0].resource_id !=
+            distinct_glyph_resources[1].resource_id &&
+        distinct_glyph_resources[0].generation !=
+            distinct_glyph_resources[1].generation,
+        "distinct-glyph fixture identities or generations were reused");
+    progpu_native_scene_glyph_outline malformed_distinct_outline{};
+    std::memcpy(
+        &malformed_distinct_outline,
+        distinct_glyph_scene.data() +
+            distinct_glyph_resources[1].payload_offset,
+        sizeof(malformed_distinct_outline));
+    malformed_distinct_outline.segment_count =
+        distinct_glyph_resources[1].auxiliary_size /
+            sizeof(progpu_native_path_segment) +
+        1U;
+    std::memcpy(
+        distinct_glyph_scene.data() +
+            distinct_glyph_resources[1].payload_offset,
+        &malformed_distinct_outline,
+        sizeof(malformed_distinct_outline));
+    scene_metrics = {};
+    scene_metrics.struct_size = sizeof(scene_metrics);
+    require(progpu_native_engine_update_scene(
+        engine,
+        distinct_glyph_scene.data(),
+        distinct_glyph_scene.size(),
+        &scene_metrics) == PROGPU_NATIVE_STATUS_SUCCESS,
+        "distinct malformed glyph scene update failed before render validation");
+    auto distinct_glyph_frame = native_3d_frame;
+    distinct_glyph_frame.scene_id = 800U;
+    distinct_glyph_frame.generation = 2U;
+    semantic_metrics = {};
+    semantic_metrics.struct_size = sizeof(semantic_metrics);
+    require(progpu_native_engine_render_scene(
+            engine,
+            &distinct_glyph_frame,
+            &semantic_metrics) == PROGPU_NATIVE_STATUS_INVALID_ARGUMENT &&
+        semantic_metrics.submission_count == 0U,
+        "distinct glyph resource reused another resource validation result");
     require(progpu_native_engine_render(engine, &frame, &metrics) ==
         PROGPU_NATIVE_STATUS_SUCCESS,
         "post-3D capture baseline replay failed");


### PR DESCRIPTION
## Summary

- validate and budget one immutable semantic glyph outline/segment resource only on its first draw command in a scene preflight
- continue validating every independent positioned-glyph command payload
- add real Dawn provider coverage for shared retained glyph resources, malformed later command payloads, and distinct resource identities/generations
- document the managed applicability audit and existing layout/glyph-residency separation

## Correctness and ownership

The pointer-free scene snapshot owns each glyph resource by resource index for the full render call. The first command referencing an index still performs complete span, segment, outline, and coverage-budget validation before the index is marked. An invalid first use fails before that mark. Later commands cannot mutate the resource bytes and still perform complete payload-prefix and positioned-glyph validation, including outline-index bounds. The validation mark is local to the resource table index, so distinct resource identities or generations never share it.

The mark itself is a render-call-local preflight vector. It is not retained in the engine, copied across scene replacement, or cloned during device recovery. The existing device-loss/recreation provider path therefore performs fresh validation and requires fresh resource uploads on the replacement device, while the unchanged-scene regression requires zero stable resource uploads.

This changes neither the public C ABI nor the scene stream format, generated declarations, shaders, resource identity, rasterization, uploads, or output quality.

## Managed applicability

No managed production change applies. The managed path already separates content layout from glyph residency: `GpuPictureNativeSceneCompiler` materializes each immutable glyph resource once, while `TtfFont` and `GlyphAtlas` retain layout and resident glyph data independently. It does not execute the native per-command resource preflight loop.

The three relevant managed files are byte-identical to the already-qualified parent tree, and the focused ownership/residency suite passed 126/126 tests.

## Final-binary performance evidence

Apple M3 Pro Release binaries used the real WebScene Dawn Metal provider. The matched stress scene contains 512 commands sharing one immutable 8,192-segment glyph resource. Each of five independent runs alternated baseline/optimized order, used 40 warmups and 401 measured submissions, and drained each submission outside the timed interval. Every stable frame reported zero vertex, index, texture, coverage, brush, gradient, text-style, and color-glyph upload bytes.

Median of the five run-level percentiles:

| Path | p50 | p95 | p99 |
| --- | ---: | ---: | ---: |
| Parent `main` | 12,748.083 µs | 14,551.167 µs | 16,117.000 µs |
| Validation once | 56.208 µs | 166.542 µs | 221.459 µs |
| Speedup | 226.80× | 87.37× | 72.78× |

Allocator in-use deltas after the fully drained measured interval were non-positive in every run: baseline ranged from -31,856 to -26,352 bytes and optimized was -16,384 bytes in all five runs. The optimization adds no cache or retained allocation.

## Local validation

- AppleClang Release full native suite: 11/11 passed
- real WebScene Dawn provider regression on Apple M3 Pro: passed, including initial compilation, zero-upload stable replay, rejection of a malformed second positioned payload sharing a valid resource, and independent rejection of a malformed resource with a distinct identity and generation
- focused managed renderer-interop, SFNT/glyph-residency, and font-manager suite: 126/126 passed
- documentation/package verification: passed
- `git diff --check` and privacy scan: clean

Base: `106f38b852437d088c47038b8f8d7a608bd5937c`. A fresh exact-head full CI matrix and review gate are required before merge.
