### PR TITLE
Make WinRT geometry contracts optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,13 @@ The ProGPU solution is partitioned into modular, highly specialized C# projects.
 | **`ProGPU.Virtualization`** | `ProGPU.Virtualization.dll` | Dynamic scrolling viewport orchestration and UI virtualization controllers. | `VirtualizingPanel`, `ViewportInfo` |
 | **`ProGPU.Samples`** | `ProGPU.Samples.dll` | Showcase bootstrap, bounded UI scheduling, animation drivers, diagnostics, and repeatable stress/performance workloads. | `MainWindowController`, `SamplePerformanceBenchmark`, `LolsPage`, `UIThread` |
 
+`ProGPU.Vector` includes its WinRT-shaped `IGeometrySource2D` compatibility
+contract by default. A host that already supplies an incompatible
+`Windows.Graphics` projection can build the core vector/scene stack with
+`-p:ProGPUUseWinRTContracts=false`. In that mode `PathGeometry` retains the same
+vector and renderer behavior but does not implement the optional projection
+marker, and `ProGPU.Vector` does not reference `ProGPU.WinRT`.
+
 ---
 
 ## WebGPU WGSL Shader Specifications & Implementations

--- a/src/ProGPU.Vector/PathGeometry.cs
+++ b/src/ProGPU.Vector/PathGeometry.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
+#if PROGPU_USE_WINRT_CONTRACTS
 using Windows.Graphics;
+#endif
 
 #nullable enable
 #pragma warning disable IDE0057, IDE0059, IDE0078, IDE0300, IDE0301, IDE0305
@@ -237,7 +239,10 @@ internal
 #else
 public
 #endif
-class PathGeometry : IGeometrySource2D
+class PathGeometry
+#if PROGPU_USE_WINRT_CONTRACTS
+    : IGeometrySource2D
+#endif
 {
     private const byte CombinedBit = 1 << 0;
     private const byte SharedSnapshotBit = 1 << 1;

--- a/src/ProGPU.Vector/ProGPU.Vector.csproj
+++ b/src/ProGPU.Vector/ProGPU.Vector.csproj
@@ -4,9 +4,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProGPUUseWinRTContracts Condition="'$(ProGPUUseWinRTContracts)' == ''">true</ProGPUUseWinRTContracts>
+    <DefineConstants Condition="'$(ProGPUUseWinRTContracts)' == 'true'">$(DefineConstants);PROGPU_USE_WINRT_CONTRACTS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProGPU.Backend\ProGPU.Backend.csproj" />
-    <ProjectReference Include="..\ProGPU.WinRT\ProGPU.WinRT.csproj" />
+    <ProjectReference Include="..\ProGPU.WinRT\ProGPU.WinRT.csproj" Condition="'$(ProGPUUseWinRTContracts)' == 'true'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- keep the WinRT-shaped `IGeometrySource2D` contract enabled by default
- add `ProGPUUseWinRTContracts=false` for hosts that provide a different `Windows.Graphics` projection
- remove the `ProGPU.WinRT` dependency from the core vector/scene closure in that mode
- document the opt-out property

The renderer, path representation, and GPU behavior are unchanged; only the optional compatibility marker and project dependency are gated. The native renderer is not applicable because this is a managed MSBuild/reference-closure concern.

## Validation

- `dotnet build src/ProGPU.Vector/ProGPU.Vector.csproj -c Release`
- `dotnet build src/ProGPU.Vector/ProGPU.Vector.csproj -c Release -p:ProGPUUseWinRTContracts=false`
- `dotnet build src/ProGPU.Scene/ProGPU.Scene.csproj -c Release -p:ProGPUUseWinRTContracts=false`

All three builds pass with zero warnings and zero errors. The full managed test project is currently blocked in the fresh worktree because its Microsoft UI XAML test-data submodule is not initialized.