### PR TITLE
Fix analytic mask batch isolation

### DIFF
--- a/src/ProGPU.Backend/Shaders/Text.wgsl
+++ b/src/ProGPU.Backend/Shaders/Text.wgsl
@@ -170,29 +170,25 @@ struct MaskChainUniforms {
 
 @group(2) @binding(3) var<uniform> maskChain: MaskChainUniforms;
 
-fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUniforms) -> f32 {
-    let local = vec2<f32>(
-        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
-        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
-    let bounds = sampling.bounds;
+fn rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
     let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
     var center = vec2<f32>(0.0);
     var radius = vec2<f32>(0.0);
     var usesCorner = false;
-    if (local.x < bounds.x + sampling.cornerRadiiX.x && local.y < bounds.y + sampling.cornerRadiiY.x) {
-        radius = vec2<f32>(sampling.cornerRadiiX.x, sampling.cornerRadiiY.x);
+    if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+        radius = vec2<f32>(radiiX.x, radiiY.x);
         center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.y && local.y < bounds.y + sampling.cornerRadiiY.y) {
-        radius = vec2<f32>(sampling.cornerRadiiX.y, sampling.cornerRadiiY.y);
+    } else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+        radius = vec2<f32>(radiiX.y, radiiY.y);
         center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.z && local.y > bounds.w - sampling.cornerRadiiY.z) {
-        radius = vec2<f32>(sampling.cornerRadiiX.z, sampling.cornerRadiiY.z);
+    } else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+        radius = vec2<f32>(radiiX.z, radiiY.z);
         center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + sampling.cornerRadiiX.w && local.y > bounds.w - sampling.cornerRadiiY.w) {
-        radius = vec2<f32>(sampling.cornerRadiiX.w, sampling.cornerRadiiY.w);
+    } else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+        radius = vec2<f32>(radiiX.w, radiiY.w);
         center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
     }
@@ -202,6 +198,23 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
     let implicit = select(edge, ellipse, usesCorner);
     let antialiasWidth = max(fwidth(implicit), 0.0001);
     return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
+fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUniforms) -> f32 {
+    let local = vec2<f32>(
+        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
+        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
+    let outerAlpha = rounded_mask_alpha_local(local, sampling.bounds, sampling.cornerRadiiX, sampling.cornerRadiiY);
+    if (sampling.options.x < 2.5) {
+        return outerAlpha;
+    }
+    let inset = sampling.options.z;
+    let innerAlpha = rounded_mask_alpha_local(
+        local,
+        sampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+        max(sampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+        max(sampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+    return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Backend/Shaders/Texture.wgsl
+++ b/src/ProGPU.Backend/Shaders/Texture.wgsl
@@ -71,29 +71,25 @@ struct MaskChainUniforms {
 
 @group(2) @binding(3) var<uniform> maskChain: MaskChainUniforms;
 
-fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUniforms) -> f32 {
-    let local = vec2<f32>(
-        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
-        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
-    let bounds = sampling.bounds;
+fn rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
     let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
     var center = vec2<f32>(0.0);
     var radius = vec2<f32>(0.0);
     var usesCorner = false;
-    if (local.x < bounds.x + sampling.cornerRadiiX.x && local.y < bounds.y + sampling.cornerRadiiY.x) {
-        radius = vec2<f32>(sampling.cornerRadiiX.x, sampling.cornerRadiiY.x);
+    if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+        radius = vec2<f32>(radiiX.x, radiiY.x);
         center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.y && local.y < bounds.y + sampling.cornerRadiiY.y) {
-        radius = vec2<f32>(sampling.cornerRadiiX.y, sampling.cornerRadiiY.y);
+    } else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+        radius = vec2<f32>(radiiX.y, radiiY.y);
         center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.z && local.y > bounds.w - sampling.cornerRadiiY.z) {
-        radius = vec2<f32>(sampling.cornerRadiiX.z, sampling.cornerRadiiY.z);
+    } else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+        radius = vec2<f32>(radiiX.z, radiiY.z);
         center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + sampling.cornerRadiiX.w && local.y > bounds.w - sampling.cornerRadiiY.w) {
-        radius = vec2<f32>(sampling.cornerRadiiX.w, sampling.cornerRadiiY.w);
+    } else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+        radius = vec2<f32>(radiiX.w, radiiY.w);
         center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
     }
@@ -103,6 +99,23 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
     let implicit = select(edge, ellipse, usesCorner);
     let antialiasWidth = max(fwidth(implicit), 0.0001);
     return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
+fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUniforms) -> f32 {
+    let local = vec2<f32>(
+        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
+        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
+    let outerAlpha = rounded_mask_alpha_local(local, sampling.bounds, sampling.cornerRadiiX, sampling.cornerRadiiY);
+    if (sampling.options.x < 2.5) {
+        return outerAlpha;
+    }
+    let inset = sampling.options.z;
+    let innerAlpha = rounded_mask_alpha_local(
+        local,
+        sampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+        max(sampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+        max(sampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+    return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Backend/Shaders/Vector.wgsl
+++ b/src/ProGPU.Backend/Shaders/Vector.wgsl
@@ -265,7 +265,10 @@ fn sample_gradient_color(brush: Brush, t: f32) -> vec4<f32> {
 
         let currentColor = get_gradient_stop_color(brush, i);
         let currentOffset = get_gradient_stop_offset(brush, i);
-        if (t <= currentOffset) {
+        // An exact offset belongs to the last stop at that offset. Besides
+        // matching Skia, this preserves hard transitions and ensures Pad
+        // selects the final color when duplicate stops sit at t = 1.
+        if (t < currentOffset) {
             let factor = (t - previousOffset) / max(currentOffset - previousOffset, 0.0001);
             return interpolate_gradient_color(brush, previousColor, currentColor, clamp(factor, 0.0, 1.0));
         }

--- a/src/ProGPU.Backend/Shaders/Vector.wgsl
+++ b/src/ProGPU.Backend/Shaders/Vector.wgsl
@@ -69,11 +69,7 @@ struct MaskChainUniforms {
 
 @group(2) @binding(3) var<uniform> maskChain: MaskChainUniforms;
 
-fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUniforms) -> f32 {
-    let local = vec2<f32>(
-        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
-        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
-    let bounds = sampling.bounds;
+fn rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
     let edge = max(
         max(bounds.x - local.x, local.x - bounds.z),
         max(bounds.y - local.y, local.y - bounds.w));
@@ -81,24 +77,24 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
     var center = vec2<f32>(0.0);
     var radius = vec2<f32>(0.0);
     var usesCorner = false;
-    if (local.x < bounds.x + sampling.cornerRadiiX.x &&
-        local.y < bounds.y + sampling.cornerRadiiY.x) {
-        radius = vec2<f32>(sampling.cornerRadiiX.x, sampling.cornerRadiiY.x);
+    if (local.x < bounds.x + radiiX.x &&
+        local.y < bounds.y + radiiY.x) {
+        radius = vec2<f32>(radiiX.x, radiiY.x);
         center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.y &&
-               local.y < bounds.y + sampling.cornerRadiiY.y) {
-        radius = vec2<f32>(sampling.cornerRadiiX.y, sampling.cornerRadiiY.y);
+    } else if (local.x > bounds.z - radiiX.y &&
+               local.y < bounds.y + radiiY.y) {
+        radius = vec2<f32>(radiiX.y, radiiY.y);
         center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.z &&
-               local.y > bounds.w - sampling.cornerRadiiY.z) {
-        radius = vec2<f32>(sampling.cornerRadiiX.z, sampling.cornerRadiiY.z);
+    } else if (local.x > bounds.z - radiiX.z &&
+               local.y > bounds.w - radiiY.z) {
+        radius = vec2<f32>(radiiX.z, radiiY.z);
         center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + sampling.cornerRadiiX.w &&
-               local.y > bounds.w - sampling.cornerRadiiY.w) {
-        radius = vec2<f32>(sampling.cornerRadiiX.w, sampling.cornerRadiiY.w);
+    } else if (local.x < bounds.x + radiiX.w &&
+               local.y > bounds.w - radiiY.w) {
+        radius = vec2<f32>(radiiX.w, radiiY.w);
         center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
     }
@@ -109,6 +105,26 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
     let implicit = select(edge, ellipse, usesCorner);
     let antialiasWidth = max(fwidth(implicit), 0.0001);
     return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
+fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUniforms) -> f32 {
+    let local = vec2<f32>(
+        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
+        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
+    let outerAlpha = rounded_mask_alpha_local(
+        local, sampling.bounds, sampling.cornerRadiiX, sampling.cornerRadiiY);
+    if (sampling.options.x < 2.5) {
+        return outerAlpha;
+    }
+
+    let inset = sampling.options.z;
+    let innerBounds = sampling.bounds + vec4<f32>(inset, inset, -inset, -inset);
+    let innerAlpha = rounded_mask_alpha_local(
+        local,
+        innerBounds,
+        max(sampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+        max(sampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+    return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Backend/Shaders/Vector.wgsl
+++ b/src/ProGPU.Backend/Shaders/Vector.wgsl
@@ -198,7 +198,11 @@ fn apply_gradient_spread(t: f32, spreadMethod: u32) -> f32 {
         return fract(t);
     }
 
-    return clamp(t, 0.0, 1.0);
+    // Keep Pad coordinates outside the unit interval until stop sampling.
+    // sample_gradient_color clamps through its first/last stop while retaining
+    // the distinction between an outside coordinate and an exact duplicate
+    // endpoint, where the last stop at that offset must win.
+    return t;
 }
 
 fn get_gradient_stop_color(brush: Brush, index: u32) -> vec4<f32> {

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -30,7 +30,7 @@ public enum WgpuBackendKind
 public unsafe class WgpuContext : IDisposable
 {
     private const int QueuePollSubmissionInterval = 2;
-    private const int MaxDeferredQueueSubmissions = 8;
+    private const int DefaultMaximumDeferredQueueSubmissions = 8;
     private SharedDeviceLifetime? _sharedDeviceLifetime;
     private IWebGpuExternalDeviceLifetime? _externalDeviceLifetime;
     private WgpuDeviceResourceDomain? _deviceResourceDomain;
@@ -142,6 +142,38 @@ public unsafe class WgpuContext : IDisposable
     private long _queueSubmissionCount;
     private long _drainedQueueSubmissionCount;
     private long _polledQueueSubmissionCount;
+    private int _maximumDeferredQueueSubmissions =
+        DefaultMaximumDeferredQueueSubmissions;
+
+    /// <summary>
+    /// Gets or sets the maximum number of queue submissions that may remain
+    /// deferred before resource cleanup forces a blocking device drain.
+    /// </summary>
+    /// <remarks>
+    /// Completed work is retired by non-blocking device polling. This bound is
+    /// a safety valve for hosts that can submit work faster than the GPU can
+    /// retire it; hosts with an explicit frame-latency policy may select a
+    /// larger bounded window to avoid unnecessary CPU/GPU serialization.
+    /// </remarks>
+    public int MaximumDeferredQueueSubmissions
+    {
+        get => Volatile.Read(
+            ref _maximumDeferredQueueSubmissions);
+        set
+        {
+            if (value < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    "The deferred queue submission bound must be positive.");
+            }
+
+            Volatile.Write(
+                ref _maximumDeferredQueueSubmissions,
+                value);
+        }
+    }
 
     public void Submit(
         nuint commandCount,
@@ -366,7 +398,8 @@ public unsafe class WgpuContext : IDisposable
                 var deferredQueueSubmissions =
                     submittedQueueWork - drainedQueueWork;
                 if (externalTextureOwners is not null ||
-                    deferredQueueSubmissions >= MaxDeferredQueueSubmissions)
+                    deferredQueueSubmissions >=
+                    MaximumDeferredQueueSubmissions)
                 {
                     WaitIdle();
                     Volatile.Write(

--- a/src/ProGPU.Scene/BackdropMaterialParams.cs
+++ b/src/ProGPU.Scene/BackdropMaterialParams.cs
@@ -6,6 +6,8 @@ namespace ProGPU.Scene;
 
 public sealed class BackdropMaterialParams
 {
+    internal GpuTexture? CapturedHostBackdropTexture { get; set; }
+
     public Rect Rect { get; set; }
     public Vector4 CornerRadiiX { get; set; }
     public Vector4 CornerRadiiY { get; set; }

--- a/src/ProGPU.Scene/Compositor.IncrementalPages.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalPages.cs
@@ -143,6 +143,7 @@ public unsafe partial class Compositor
 
     private void ResetIncrementalScenePageFrameMetrics()
     {
+        ResetRetainedCompositionPictureFrameMetrics();
         _incrementalScenePageHits = 0;
         _incrementalScenePageMisses = 0;
         _incrementalScenePageCompilations = 0;

--- a/src/ProGPU.Scene/Compositor.IncrementalPages.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalPages.cs
@@ -988,24 +988,41 @@ public unsafe partial class Compositor
         int vectorVertexStart = _vectorVerticesList.Count;
         _vectorVerticesList.EnsureCapacity(
             vectorVertexStart + page.VectorVertices.Length);
-        for (int index = 0; index < page.VectorVertices.Length; index++)
+        if (page.Brushes.Length == 0)
         {
-            VectorVertex vertex = page.VectorVertices[index];
-            int localBrushIndex = (int)MathF.Round(vertex.BrushIndex);
-            if ((uint)localBrushIndex < (uint)brushMap.Length)
+            // Specialized solid primitives carry their color inline and have no
+            // brush-table indices to translate. This is the common retained UI
+            // page path, so append it as one contiguous copy instead of visiting
+            // every vertex merely to prove that the empty brush map has no entry.
+            _vectorVerticesList.AddRange(page.VectorVertices);
+        }
+        else
+        {
+            for (int index = 0; index < page.VectorVertices.Length; index++)
             {
-                vertex.BrushIndex = brushMap[localBrushIndex];
+                VectorVertex vertex = page.VectorVertices[index];
+                int localBrushIndex = (int)MathF.Round(vertex.BrushIndex);
+                if ((uint)localBrushIndex < (uint)brushMap.Length)
+                {
+                    vertex.BrushIndex = brushMap[localBrushIndex];
+                }
+                _vectorVerticesList.Add(vertex);
             }
-            _vectorVerticesList.Add(vertex);
         }
 
         int vectorIndexStart = _vectorIndicesList.Count;
         _vectorIndicesList.EnsureCapacity(
             vectorIndexStart + page.VectorIndices.Length);
+        CollectionsMarshal.SetCount(
+            _vectorIndicesList,
+            vectorIndexStart + page.VectorIndices.Length);
+        Span<uint> appendedVectorIndices =
+            CollectionsMarshal.AsSpan(_vectorIndicesList)
+                .Slice(vectorIndexStart, page.VectorIndices.Length);
         for (int index = 0; index < page.VectorIndices.Length; index++)
         {
-            _vectorIndicesList.Add(
-                page.VectorIndices[index] + (uint)vectorVertexStart);
+            appendedVectorIndices[index] =
+                page.VectorIndices[index] + (uint)vectorVertexStart;
         }
 
         int textVertexStart = _textVerticesList.Count;
@@ -1029,10 +1046,16 @@ public unsafe partial class Compositor
         int textureIndexStart = _textureIndicesList.Count;
         _textureIndicesList.EnsureCapacity(
             textureIndexStart + page.TextureIndices.Length);
+        CollectionsMarshal.SetCount(
+            _textureIndicesList,
+            textureIndexStart + page.TextureIndices.Length);
+        Span<uint> appendedTextureIndices =
+            CollectionsMarshal.AsSpan(_textureIndicesList)
+                .Slice(textureIndexStart, page.TextureIndices.Length);
         for (int index = 0; index < page.TextureIndices.Length; index++)
         {
-            _textureIndicesList.Add(
-                page.TextureIndices[index] + (uint)textureVertexStart);
+            appendedTextureIndices[index] =
+                page.TextureIndices[index] + (uint)textureVertexStart;
         }
 
         for (int index = 0; index < page.DrawCalls.Length; index++)

--- a/src/ProGPU.Scene/Compositor.RetainedPictures.cs
+++ b/src/ProGPU.Scene/Compositor.RetainedPictures.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using ProGPU.Backend;
+using ProGPU.Vector;
+
+namespace ProGPU.Scene;
+
+public unsafe partial class Compositor
+{
+    private readonly ConditionalWeakTable<GpuPicture, RetainedPictureObservation>
+        _retainedPictureObservations = new();
+    private readonly Dictionary<RetainedPicturePageLookup, IncrementalScenePage>
+        _retainedCompositionPictures = new();
+    private readonly Dictionary<GpuPicture, List<RetainedPicturePageKey>>
+        _retainedCompositionPictureKeys = new();
+    private long _retainedCompositionPictureHits;
+    private long _retainedCompositionPictureMisses;
+    private long _retainedCompositionPictureCompilations;
+
+    private readonly record struct RetainedPicturePageKey(
+        Matrix4x4 GlobalTransform,
+        float ActiveOpacity,
+        Rect? ActiveClipRect,
+        GpuBlendMode ActiveBlendMode,
+        uint LogicalWidth,
+        uint LogicalHeight,
+        uint? RenderTargetWidth,
+        uint? RenderTargetHeight,
+        RenderTargetViewport? RenderTargetViewport,
+        float DpiScale,
+        ulong GlyphAtlasGeneration,
+        ulong PathAtlasGeneration,
+        bool SolidRoundedSpecialization);
+
+    private readonly record struct RetainedPicturePageLookup(
+        GpuPicture Picture,
+        RetainedPicturePageKey Key);
+
+    private sealed class RetainedPictureObservation
+    {
+        internal int Count;
+    }
+
+    private RetainedPicturePageKey CreateRetainedPicturePageKey(
+        in Matrix4x4 globalTransform)
+    {
+        return new RetainedPicturePageKey(
+            globalTransform,
+            _activeOpacity,
+            _activeClipRect,
+            _activeBlendMode,
+            _currentWidth,
+            _currentHeight,
+            _explicitRenderTargetWidth,
+            _explicitRenderTargetHeight,
+            _explicitRenderTargetViewport,
+            _currentDpiScale,
+            _atlas.Generation,
+            _pathAtlas.Generation,
+            _previousSolidRoundedPrimitiveCount >=
+                SolidRoundedSpecializationThreshold);
+    }
+
+    private void ResetRetainedCompositionPictureFrameMetrics()
+    {
+        _retainedCompositionPictureHits = 0;
+        _retainedCompositionPictureMisses = 0;
+        _retainedCompositionPictureCompilations = 0;
+        SweepRetainedCompositionPictures();
+    }
+
+    private bool CanUseRetainedCompositionPicture(GpuPicture picture)
+    {
+        if (!Options.EnableRetainedCompositionPictures ||
+            !Options.EnableIncrementalScenePages ||
+            Options.EnableGpuHitTesting ||
+            ActiveCompilationContext != null ||
+            _maskStack.Count != 0 ||
+            _maskRenderPasses.Count != 0 ||
+            _incrementalPagesBlockedByAnalyticMask ||
+            _activeBlendMode != GpuBlendMode.SrcOver ||
+            _useGpuTransformsActive)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < picture.CommandCount; index++)
+        {
+            RenderCommand command = picture.GetCommand(index);
+            if (command.UseGpuTransforms ||
+                !IsIncrementalScenePageCommandSupported(command.Type) ||
+                command.Type == RenderCommandType.DrawVisual)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool TryReplayRetainedCompositionPicture(
+        GpuPicture picture,
+        in Matrix4x4 globalTransform)
+    {
+        if (!CanUseRetainedCompositionPicture(picture))
+        {
+            return false;
+        }
+
+        RetainedPictureObservation observation =
+            _retainedPictureObservations.GetOrCreateValue(picture);
+        if (observation.Count < 2)
+        {
+            observation.Count++;
+        }
+
+        var key = CreateRetainedPicturePageKey(globalTransform);
+        var lookup = new RetainedPicturePageLookup(picture, key);
+        if (!_retainedCompositionPictures.TryGetValue(
+                lookup,
+                out IncrementalScenePage? page) ||
+            !AreIncrementalPageTexturesValid(page))
+        {
+            if (page != null)
+            {
+                RemoveRetainedCompositionPicture(lookup);
+            }
+            _retainedCompositionPictureMisses++;
+            return false;
+        }
+
+        CommitPendingDrawCalls();
+        AppendIncrementalScenePage(page);
+        _pathAtlas.MarkRetainedPathReplay();
+        page.LastUsedFrame = _frameNumber;
+        _retainedCompositionPictureHits++;
+        return true;
+    }
+
+    private bool TryBeginRetainedCompositionPicture(
+        GpuPicture picture,
+        out IncrementalScenePageBoundary boundary)
+    {
+        boundary = default;
+        if (!CanUseRetainedCompositionPicture(picture) ||
+            !_retainedPictureObservations.TryGetValue(
+                picture,
+                out RetainedPictureObservation? observation) ||
+            observation.Count < 2)
+        {
+            return false;
+        }
+
+        CommitPendingDrawCalls();
+        boundary = new IncrementalScenePageBoundary(
+            _vectorVerticesList.Count,
+            _vectorIndicesList.Count,
+            _textVerticesList.Count,
+            _activeTextStyles.Count,
+            _textureVerticesList.Count,
+            _textureIndicesList.Count,
+            _drawCalls.Count,
+            _currentSolidRoundedPrimitiveCount,
+            _maskRenderPasses.Count,
+            _clipStack.Count,
+            _opacityStack.Count,
+            _blendModeStack.Count,
+            _activeClipRect,
+            _activeOpacity,
+            _activeBlendMode);
+        return true;
+    }
+
+    private void CompleteRetainedCompositionPicture(
+        GpuPicture picture,
+        in Matrix4x4 globalTransform,
+        in IncrementalScenePageBoundary boundary)
+    {
+        CommitPendingDrawCalls();
+        if (_maskRenderPasses.Count != boundary.MaskRenderPassStart ||
+            _clipStack.Count != boundary.ClipStackCount ||
+            _opacityStack.Count != boundary.OpacityStackCount ||
+            _blendModeStack.Count != boundary.BlendModeStackCount ||
+            _activeClipRect != boundary.ActiveClipRect ||
+            _activeOpacity != boundary.ActiveOpacity ||
+            _activeBlendMode != boundary.ActiveBlendMode)
+        {
+            MergeIncrementalDrawCallsFrom(boundary.DrawCallStart);
+            return;
+        }
+
+        IncrementalScenePage? page = CaptureIncrementalScenePage(
+            boundary,
+            reusablePage: null);
+        MergeIncrementalDrawCallsFrom(boundary.DrawCallStart);
+        if (page == null)
+        {
+            return;
+        }
+
+        var key = CreateRetainedPicturePageKey(globalTransform);
+        var lookup = new RetainedPicturePageLookup(picture, key);
+        if (_retainedCompositionPictures.ContainsKey(lookup))
+        {
+            return;
+        }
+
+        while (_retainedCompositionPictures.Count >=
+               Options.MaximumRetainedCompositionPictures)
+        {
+            EvictOldestRetainedCompositionPicture();
+        }
+        TrimRetainedCompositionPictureVariants(picture);
+
+        page.LastUsedFrame = _frameNumber;
+        _retainedCompositionPictures.Add(lookup, page);
+        if (!_retainedCompositionPictureKeys.TryGetValue(
+                picture,
+                out List<RetainedPicturePageKey>? keys))
+        {
+            keys = new List<RetainedPicturePageKey>(
+                Math.Min(
+                    Options.MaximumIncrementalScenePageVariantsPerVisual,
+                    2));
+            _retainedCompositionPictureKeys.Add(picture, keys);
+        }
+        keys.Add(key);
+        _retainedCompositionPictureCompilations++;
+    }
+
+    private void TrimRetainedCompositionPictureVariants(GpuPicture picture)
+    {
+        if (!_retainedCompositionPictureKeys.TryGetValue(
+                picture,
+                out List<RetainedPicturePageKey>? keys))
+        {
+            return;
+        }
+
+        while (keys.Count >=
+               Options.MaximumIncrementalScenePageVariantsPerVisual)
+        {
+            RetainedPicturePageKey oldestKey = keys[0];
+            ulong oldestFrame = ulong.MaxValue;
+            foreach (RetainedPicturePageKey key in keys)
+            {
+                var lookup = new RetainedPicturePageLookup(picture, key);
+                if (_retainedCompositionPictures.TryGetValue(
+                        lookup,
+                        out IncrementalScenePage? page) &&
+                    page.LastUsedFrame < oldestFrame)
+                {
+                    oldestKey = key;
+                    oldestFrame = page.LastUsedFrame;
+                }
+            }
+            RemoveRetainedCompositionPicture(
+                new RetainedPicturePageLookup(picture, oldestKey));
+        }
+    }
+
+    private void EvictOldestRetainedCompositionPicture()
+    {
+        RetainedPicturePageLookup? oldestLookup = null;
+        IncrementalScenePage? oldestPage = null;
+        foreach (var entry in _retainedCompositionPictures)
+        {
+            if (oldestPage == null ||
+                entry.Value.LastUsedFrame < oldestPage.LastUsedFrame)
+            {
+                oldestLookup = entry.Key;
+                oldestPage = entry.Value;
+            }
+        }
+
+        if (oldestLookup.HasValue)
+        {
+            RemoveRetainedCompositionPicture(oldestLookup.Value);
+        }
+    }
+
+    private void SweepRetainedCompositionPictures()
+    {
+        if (_retainedCompositionPictures.Count == 0 ||
+            _frameNumber % 60 != 0)
+        {
+            return;
+        }
+
+        List<RetainedPicturePageLookup>? expired = null;
+        foreach (var entry in _retainedCompositionPictures)
+        {
+            if (_frameNumber - entry.Value.LastUsedFrame >
+                (ulong)Options.RetainedCompositionPictureRetentionFrames)
+            {
+                (expired ??= new()).Add(entry.Key);
+            }
+        }
+
+        if (expired == null)
+        {
+            return;
+        }
+        foreach (RetainedPicturePageLookup lookup in expired)
+        {
+            RemoveRetainedCompositionPicture(lookup);
+        }
+    }
+
+    private void RemoveRetainedCompositionPicture(
+        in RetainedPicturePageLookup lookup)
+    {
+        _retainedCompositionPictures.Remove(lookup);
+        if (!_retainedCompositionPictureKeys.TryGetValue(
+                lookup.Picture,
+                out List<RetainedPicturePageKey>? keys))
+        {
+            return;
+        }
+
+        keys.Remove(lookup.Key);
+        if (keys.Count == 0)
+        {
+            _retainedCompositionPictureKeys.Remove(lookup.Picture);
+        }
+    }
+}

--- a/src/ProGPU.Scene/Compositor.RetainedPictures.cs
+++ b/src/ProGPU.Scene/Compositor.RetainedPictures.cs
@@ -75,6 +75,8 @@ public unsafe partial class Compositor
     {
         if (!Options.EnableRetainedCompositionPictures ||
             !Options.EnableIncrementalScenePages ||
+            picture.CommandCount <
+                Options.MinimumRetainedCompositionPictureCommands ||
             Options.EnableGpuHitTesting ||
             ActiveCompilationContext != null ||
             _maskStack.Count != 0 ||

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -14381,6 +14381,37 @@ SceneStateUploadComplete:
             (targetTexture.Usage & TextureUsage.TextureBinding) != 0;
     }
 
+    private static bool IsHostBackdropDrawCall(in CompositorDrawCall drawCall)
+    {
+        return drawCall.Type == DrawCallType.Extension &&
+            drawCall.ExtensionId == CompositorBuiltInExtensions.BackdropMaterial &&
+            drawCall.DataParam is BackdropMaterialParams
+            {
+                Source: BackdropMaterialSource.HostBackdrop,
+                SourceTexture: null,
+                UseFallback: false
+            };
+    }
+
+    private bool HasHostBackdropDrawCall(GpuTexture targetTexture)
+    {
+        if ((targetTexture.Usage & TextureUsage.TextureBinding) == 0)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < _drawCalls.Count; i++)
+        {
+            var drawCall = _drawCalls[i];
+            if (IsHostBackdropDrawCall(in drawCall))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private bool TryGetAdvancedBlendSourceBounds(
         in CompositorDrawCall drawCall,
         uint targetWidth,
@@ -16361,17 +16392,19 @@ SceneStateUploadComplete:
         byte? currentVectorPipelineKind = null;
         var textureEntries = stackalloc BindGroupEntry[2];
         _advancedBlendPassResourceCount = 0;
-        if (TryGetAdvancedBlendSourceCapacity(
+        bool hasHostBackdrop = HasHostBackdropDrawCall(targetTexture);
+        bool hasAdvancedBlend = TryGetAdvancedBlendSourceCapacity(
                 targetTexture,
                 out uint advancedBlendSourceWidth,
-                out uint advancedBlendSourceHeight))
+                out uint advancedBlendSourceHeight);
+        if (hasHostBackdrop || hasAdvancedBlend)
         {
             _advancedBlendLastUsedFrame = _frameNumber;
             EnsureAdvancedBlendResources(
                 targetTexture.Width,
                 targetTexture.Height,
-                advancedBlendSourceWidth,
-                advancedBlendSourceHeight,
+                Math.Max(1u, advancedBlendSourceWidth),
+                Math.Max(1u, advancedBlendSourceHeight),
                 targetTexture.Format);
         }
         else
@@ -16383,6 +16416,69 @@ SceneStateUploadComplete:
         for (var drawCallIndex = 0; drawCallIndex < drawCallCount; drawCallIndex++)
         {
             var dc = _drawCalls[drawCallIndex];
+            if (IsHostBackdropDrawCall(in dc) &&
+                dc.DataParam is BackdropMaterialParams backdropParameters &&
+                _advancedBlendScratchTexture != null)
+            {
+                _context.Api.RenderPassEncoderEnd(pass);
+                _context.Api.RenderPassEncoderRelease(pass);
+
+                var output = ReferenceEquals(currentRenderTarget, targetTexture)
+                    ? _advancedBlendScratchTexture
+                    : targetTexture;
+                var targetBounds = new MaskPixelBounds(
+                    0,
+                    0,
+                    targetTexture.Width,
+                    targetTexture.Height);
+                var copyPassResource = AcquireAdvancedBlendPassResource(
+                    targetBounds,
+                    currentRenderTarget,
+                    GpuBlendMode.Src);
+                EncodeAdvancedBlendFullscreen(
+                    encoder,
+                    currentRenderTarget,
+                    currentRenderTarget,
+                    output,
+                    copyPassResource);
+                currentRenderTarget = output;
+
+                pass = BeginOffscreenTexturePass(
+                    encoder,
+                    currentRenderTarget,
+                    LoadOp.Load,
+                    new Color());
+                currentType = null;
+                currentBlendMode = null;
+                currentMaskBindGroup = null;
+                currentPipelineHasMask = null;
+                currentVectorPipelineKind = null;
+
+                if (ApplyDrawCallScissor(pass, dc, useRenderTargetViewport: false))
+                {
+                    var pipeline = GetExtension(dc.ExtensionId);
+                    if (pipeline != null)
+                    {
+                        backdropParameters.CapturedHostBackdropTexture =
+                            ReferenceEquals(currentRenderTarget, targetTexture)
+                                ? _advancedBlendScratchTexture
+                                : targetTexture;
+                        try
+                        {
+                            var localDc = dc;
+                            pipeline.Render(this, pass, isOffscreen: true, in localDc);
+                        }
+                        finally
+                        {
+                            backdropParameters.CapturedHostBackdropTexture = null;
+                        }
+                    }
+                }
+
+                currentType = DrawCallType.Extension;
+                continue;
+            }
+
             if (CanEncodeAdvancedBlend(in dc, targetTexture) &&
                 TryGetAdvancedBlendSourceBounds(
                     in dc,

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -19686,17 +19686,27 @@ SceneStateUploadComplete:
         // parent-mask lifetime is represented explicitly.
         if (_offscreenRenderDepth > 1 ||
             _maskStack.Count != 0 ||
-            geometry.IsCombined ||
-            geometry.Figures.Count != 1 ||
-            !RoundedRectanglePathGeometry.TryReadCanonicalContour(
-                geometry.Figures[0],
-                out RoundedRectanglePathContour contour))
+            geometry.IsCombined)
+        {
+            return false;
+        }
+
+        RoundedRectanglePathContour contour;
+        float ringInset = 0f;
+        bool isRoundedRing = TryReadUniformRoundedRing(
+            geometry,
+            out contour,
+            out ringInset);
+        if (!isRoundedRing &&
+            (geometry.Figures.Count != 1 ||
+             !RoundedRectanglePathGeometry.TryReadCanonicalContour(
+                 geometry.Figures[0],
+                 out contour)))
         {
             return false;
         }
 
         CommitPendingDrawCalls();
-
         Matrix4x4 normalizedTransform =
             transform == default
                 ? Matrix4x4.Identity
@@ -19748,7 +19758,11 @@ SceneStateUploadComplete:
                 contour.Bottom),
             CornerRadiiX = contour.CornerRadiiX,
             CornerRadiiY = contour.CornerRadiiY,
-            Options = new Vector4(2f, 1f, 0f, 0f)
+            Options = new Vector4(
+                isRoundedRing ? 3f : 2f,
+                1f,
+                ringInset,
+                0f)
         };
         MaskBindGroupResource resource =
             RentAnalyticMaskResource(samplingUniforms);
@@ -19768,6 +19782,54 @@ SceneStateUploadComplete:
                 resource));
         return true;
     }
+
+    private static bool TryReadUniformRoundedRing(
+        PathGeometry geometry,
+        out RoundedRectanglePathContour outer,
+        out float inset)
+    {
+        outer = default;
+        inset = 0f;
+        if (geometry.FillRule != FillRule.EvenOdd ||
+            geometry.Figures.Count != 2 ||
+            !RoundedRectanglePathGeometry.TryReadCanonicalContour(
+                geometry.Figures[0],
+                out outer) ||
+            !RoundedRectanglePathGeometry.TryReadCanonicalContour(
+                geometry.Figures[1],
+                out RoundedRectanglePathContour inner))
+        {
+            return false;
+        }
+
+        float left = inner.Left - outer.Left;
+        float top = inner.Top - outer.Top;
+        float right = outer.Right - inner.Right;
+        float bottom = outer.Bottom - inner.Bottom;
+        float tolerance = MathF.Max(outer.Width, outer.Height) * 0.0001f + 0.0001f;
+        if (left <= tolerance ||
+            MathF.Abs(top - left) > tolerance ||
+            MathF.Abs(right - left) > tolerance ||
+            MathF.Abs(bottom - left) > tolerance ||
+            !InsetRadiiMatch(inner.CornerRadiiX, outer.CornerRadiiX, left, tolerance) ||
+            !InsetRadiiMatch(inner.CornerRadiiY, outer.CornerRadiiY, left, tolerance))
+        {
+            return false;
+        }
+
+        inset = left;
+        return true;
+    }
+
+    private static bool InsetRadiiMatch(
+        Vector4 inner,
+        Vector4 outer,
+        float inset,
+        float tolerance) =>
+        MathF.Abs(inner.X - MathF.Max(0f, outer.X - inset)) <= tolerance &&
+        MathF.Abs(inner.Y - MathF.Max(0f, outer.Y - inset)) <= tolerance &&
+        MathF.Abs(inner.Z - MathF.Max(0f, outer.Z - inset)) <= tolerance &&
+        MathF.Abs(inner.W - MathF.Max(0f, outer.W - inset)) <= tolerance;
 
     private static bool IsFinite(Matrix3x2 matrix) =>
         float.IsFinite(matrix.M11) &&

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -19695,6 +19695,8 @@ SceneStateUploadComplete:
             return false;
         }
 
+        CommitPendingDrawCalls();
+
         Matrix4x4 normalizedTransform =
             transform == default
                 ? Matrix4x4.Identity

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -19684,9 +19684,7 @@ SceneStateUploadComplete:
         // so canonical clips remain analytic there. Nested layer/effect
         // transactions retain the texture fallback until their composed
         // parent-mask lifetime is represented explicitly.
-        if (_offscreenRenderDepth > 1 ||
-            _maskStack.Count != 0 ||
-            geometry.IsCombined)
+        if (_offscreenRenderDepth > 1 || geometry.IsCombined)
         {
             return false;
         }
@@ -19705,8 +19703,11 @@ SceneStateUploadComplete:
         {
             return false;
         }
+        if (!isRoundedRing && _maskStack.Count != 0)
+        {
+            return false;
+        }
 
-        CommitPendingDrawCalls();
         Matrix4x4 normalizedTransform =
             transform == default
                 ? Matrix4x4.Identity
@@ -19764,6 +19765,14 @@ SceneStateUploadComplete:
                 ringInset,
                 0f)
         };
+        if (_maskStack.Count != 0 &&
+            (_maskStack.Count != 1 ||
+             !MatchesAnalyticOuter(_maskStack.Peek(), samplingUniforms)))
+        {
+            return false;
+        }
+
+        CommitPendingDrawCalls();
         MaskBindGroupResource resource =
             RentAnalyticMaskResource(samplingUniforms);
         var logicalBounds = new Rect(
@@ -19781,6 +19790,24 @@ SceneStateUploadComplete:
                 bounds,
                 resource));
         return true;
+    }
+
+    private static bool MatchesAnalyticOuter(
+        MaskTextureState parent,
+        MaskSamplingUniforms ring)
+    {
+        if (parent.AnalyticResource is not { } resource)
+        {
+            return false;
+        }
+
+        MaskSamplingUniforms outer = resource.SamplingUniforms;
+        return outer.Options.X == 2f &&
+            outer.Coordinate0 == ring.Coordinate0 &&
+            outer.Coordinate1 == ring.Coordinate1 &&
+            outer.Bounds == ring.Bounds &&
+            outer.CornerRadiiX == ring.CornerRadiiX &&
+            outer.CornerRadiiY == ring.CornerRadiiY;
     }
 
     private static bool TryReadUniformRoundedRing(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -5571,6 +5571,12 @@ SceneStateUploadComplete:
             context,
             activeTransform,
             ref localCommand);
+        ResolveExtensionPointBufferRange(
+            localCommand,
+            _pendingVectorStart,
+            _vectorIndicesList.Count,
+            out var pointBufferOffset,
+            out var pointBufferCount);
         _drawCalls.Add(new CompositorDrawCall
         {
             Type = DrawCallType.Extension,
@@ -5582,9 +5588,8 @@ SceneStateUploadComplete:
             TextureSamplingMode = localCommand.TextureSamplingMode,
             HasImageEffect = localCommand.HasImageEffect,
             ImageEffect = localCommand.ResolveImageEffect(context),
-            PointBufferOffset = (int)_pendingVectorStart,
-            PointBufferCount =
-                (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
+            PointBufferOffset = pointBufferOffset,
+            PointBufferCount = pointBufferCount,
             DoubleBufferOffset = localCommand.DoubleBufferOffset,
             DoubleBufferCount = localCommand.DoubleBufferCount,
             WeightBufferOffset = localCommand.WeightBufferOffset,
@@ -5912,6 +5917,12 @@ SceneStateUploadComplete:
                             CommitPendingDrawCalls();
                             var localCmd = cmd;
                             pipeline.Compile(this, picture, activeTransform, ref localCmd);
+                            ResolveExtensionPointBufferRange(
+                                localCmd,
+                                _pendingVectorStart,
+                                _vectorIndicesList.Count,
+                                out var pointBufferOffset,
+                                out var pointBufferCount);
                             _drawCalls.Add(new CompositorDrawCall
                             {
                                 Type = DrawCallType.Extension,
@@ -5923,8 +5934,8 @@ SceneStateUploadComplete:
                                 TextureSamplingMode = localCmd.TextureSamplingMode,
                                 HasImageEffect = localCmd.HasImageEffect,
                                 ImageEffect = localCmd.ResolveImageEffect(picture),
-                                PointBufferOffset = (int)_pendingVectorStart,
-                                PointBufferCount = (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
+                                PointBufferOffset = pointBufferOffset,
+                                PointBufferCount = pointBufferCount,
                                 DoubleBufferOffset = localCmd.DoubleBufferOffset,
                                 DoubleBufferCount = localCmd.DoubleBufferCount,
                                 WeightBufferOffset = localCmd.WeightBufferOffset,
@@ -15949,6 +15960,12 @@ SceneStateUploadComplete:
         };
 
         pipeline.Compile(this, null, parentTransform, ref cmd);
+        ResolveExtensionPointBufferRange(
+            cmd,
+            _pendingVectorStart,
+            _vectorIndicesList.Count,
+            out var pointBufferOffset,
+            out var pointBufferCount);
         var cmdTransform = cmd.Transform;
         if (cmdTransform == default || cmdTransform == new Matrix4x4())
         {
@@ -15962,8 +15979,8 @@ SceneStateUploadComplete:
             IntParam = cmd.IntParam,
             FloatParam = cmd.FloatParam,
             DataParam = cmd.DataParam,
-            PointBufferOffset = (int)_pendingVectorStart,
-            PointBufferCount = (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
+            PointBufferOffset = pointBufferOffset,
+            PointBufferCount = pointBufferCount,
             DoubleBufferOffset = cmd.DoubleBufferOffset,
             DoubleBufferCount = cmd.DoubleBufferCount,
             WeightBufferOffset = cmd.WeightBufferOffset,
@@ -17356,6 +17373,12 @@ SceneStateUploadComplete:
                                     activeTransform,
                                     localCmd.Transform);
                                 pipeline.Compile(this, null, compileTransform, ref localCmd);
+                                ResolveExtensionPointBufferRange(
+                                    localCmd,
+                                    pendingVectorStart,
+                                    _vectorIndicesList.Count,
+                                    out var pointBufferOffset,
+                                    out var pointBufferCount);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
                                 {
@@ -17372,8 +17395,8 @@ SceneStateUploadComplete:
                                     TextureSamplingMode = localCmd.TextureSamplingMode,
                                     HasImageEffect = localCmd.HasImageEffect,
                                     ImageEffect = localCmd.ResolveImageEffect(null),
-                                    PointBufferOffset = (int)pendingVectorStart,
-                                    PointBufferCount = (int)((uint)_vectorIndicesList.Count - pendingVectorStart),
+                                    PointBufferOffset = pointBufferOffset,
+                                    PointBufferCount = pointBufferCount,
                                     DoubleBufferOffset = localCmd.DoubleBufferOffset,
                                     DoubleBufferCount = localCmd.DoubleBufferCount,
                                     WeightBufferOffset = localCmd.WeightBufferOffset,
@@ -17822,6 +17845,12 @@ SceneStateUploadComplete:
                                     activeTransform,
                                     localCmd.Transform);
                                 pipeline.Compile(this, context, compileTransform, ref localCmd);
+                                ResolveExtensionPointBufferRange(
+                                    localCmd,
+                                    pendingVectorStart,
+                                    _vectorIndicesList.Count,
+                                    out var pointBufferOffset,
+                                    out var pointBufferCount);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
                                 {
@@ -17838,8 +17867,8 @@ SceneStateUploadComplete:
                                     TextureSamplingMode = localCmd.TextureSamplingMode,
                                     HasImageEffect = localCmd.HasImageEffect,
                                     ImageEffect = localCmd.ResolveImageEffect(context),
-                                    PointBufferOffset = (int)pendingVectorStart,
-                                    PointBufferCount = (int)((uint)_vectorIndicesList.Count - pendingVectorStart),
+                                    PointBufferOffset = pointBufferOffset,
+                                    PointBufferCount = pointBufferCount,
                                     DoubleBufferOffset = localCmd.DoubleBufferOffset,
                                     DoubleBufferCount = localCmd.DoubleBufferCount,
                                     WeightBufferOffset = localCmd.WeightBufferOffset,
@@ -18150,6 +18179,24 @@ SceneStateUploadComplete:
             // extensions retain the established identity compile contract.
             _ => Matrix4x4.Identity
         };
+    }
+
+    private static void ResolveExtensionPointBufferRange(
+        in RenderCommand command,
+        uint fallbackStart,
+        int currentIndexCount,
+        out int offset,
+        out int count)
+    {
+        if (command.PointBufferCount > 0)
+        {
+            offset = command.PointBufferOffset;
+            count = command.PointBufferCount;
+            return;
+        }
+
+        offset = (int)fallbackStart;
+        count = currentIndexCount - offset;
     }
 
     internal unsafe void DrawStaticDxfBuffer(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -5571,12 +5571,6 @@ SceneStateUploadComplete:
             context,
             activeTransform,
             ref localCommand);
-        ResolveExtensionPointBufferRange(
-            localCommand,
-            _pendingVectorStart,
-            _vectorIndicesList.Count,
-            out var pointBufferOffset,
-            out var pointBufferCount);
         _drawCalls.Add(new CompositorDrawCall
         {
             Type = DrawCallType.Extension,
@@ -5588,8 +5582,9 @@ SceneStateUploadComplete:
             TextureSamplingMode = localCommand.TextureSamplingMode,
             HasImageEffect = localCommand.HasImageEffect,
             ImageEffect = localCommand.ResolveImageEffect(context),
-            PointBufferOffset = pointBufferOffset,
-            PointBufferCount = pointBufferCount,
+            PointBufferOffset = (int)_pendingVectorStart,
+            PointBufferCount =
+                (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
             DoubleBufferOffset = localCommand.DoubleBufferOffset,
             DoubleBufferCount = localCommand.DoubleBufferCount,
             WeightBufferOffset = localCommand.WeightBufferOffset,
@@ -5917,12 +5912,6 @@ SceneStateUploadComplete:
                             CommitPendingDrawCalls();
                             var localCmd = cmd;
                             pipeline.Compile(this, picture, activeTransform, ref localCmd);
-                            ResolveExtensionPointBufferRange(
-                                localCmd,
-                                _pendingVectorStart,
-                                _vectorIndicesList.Count,
-                                out var pointBufferOffset,
-                                out var pointBufferCount);
                             _drawCalls.Add(new CompositorDrawCall
                             {
                                 Type = DrawCallType.Extension,
@@ -5934,8 +5923,8 @@ SceneStateUploadComplete:
                                 TextureSamplingMode = localCmd.TextureSamplingMode,
                                 HasImageEffect = localCmd.HasImageEffect,
                                 ImageEffect = localCmd.ResolveImageEffect(picture),
-                                PointBufferOffset = pointBufferOffset,
-                                PointBufferCount = pointBufferCount,
+                                PointBufferOffset = (int)_pendingVectorStart,
+                                PointBufferCount = (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
                                 DoubleBufferOffset = localCmd.DoubleBufferOffset,
                                 DoubleBufferCount = localCmd.DoubleBufferCount,
                                 WeightBufferOffset = localCmd.WeightBufferOffset,
@@ -15960,12 +15949,6 @@ SceneStateUploadComplete:
         };
 
         pipeline.Compile(this, null, parentTransform, ref cmd);
-        ResolveExtensionPointBufferRange(
-            cmd,
-            _pendingVectorStart,
-            _vectorIndicesList.Count,
-            out var pointBufferOffset,
-            out var pointBufferCount);
         var cmdTransform = cmd.Transform;
         if (cmdTransform == default || cmdTransform == new Matrix4x4())
         {
@@ -15979,8 +15962,8 @@ SceneStateUploadComplete:
             IntParam = cmd.IntParam,
             FloatParam = cmd.FloatParam,
             DataParam = cmd.DataParam,
-            PointBufferOffset = pointBufferOffset,
-            PointBufferCount = pointBufferCount,
+            PointBufferOffset = (int)_pendingVectorStart,
+            PointBufferCount = (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
             DoubleBufferOffset = cmd.DoubleBufferOffset,
             DoubleBufferCount = cmd.DoubleBufferCount,
             WeightBufferOffset = cmd.WeightBufferOffset,
@@ -17373,12 +17356,6 @@ SceneStateUploadComplete:
                                     activeTransform,
                                     localCmd.Transform);
                                 pipeline.Compile(this, null, compileTransform, ref localCmd);
-                                ResolveExtensionPointBufferRange(
-                                    localCmd,
-                                    pendingVectorStart,
-                                    _vectorIndicesList.Count,
-                                    out var pointBufferOffset,
-                                    out var pointBufferCount);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
                                 {
@@ -17395,8 +17372,8 @@ SceneStateUploadComplete:
                                     TextureSamplingMode = localCmd.TextureSamplingMode,
                                     HasImageEffect = localCmd.HasImageEffect,
                                     ImageEffect = localCmd.ResolveImageEffect(null),
-                                    PointBufferOffset = pointBufferOffset,
-                                    PointBufferCount = pointBufferCount,
+                                    PointBufferOffset = (int)pendingVectorStart,
+                                    PointBufferCount = (int)((uint)_vectorIndicesList.Count - pendingVectorStart),
                                     DoubleBufferOffset = localCmd.DoubleBufferOffset,
                                     DoubleBufferCount = localCmd.DoubleBufferCount,
                                     WeightBufferOffset = localCmd.WeightBufferOffset,
@@ -17845,12 +17822,6 @@ SceneStateUploadComplete:
                                     activeTransform,
                                     localCmd.Transform);
                                 pipeline.Compile(this, context, compileTransform, ref localCmd);
-                                ResolveExtensionPointBufferRange(
-                                    localCmd,
-                                    pendingVectorStart,
-                                    _vectorIndicesList.Count,
-                                    out var pointBufferOffset,
-                                    out var pointBufferCount);
                                 var cmdTransform = localCmd.Transform;
                                 if (cmdTransform == default || cmdTransform == new Matrix4x4())
                                 {
@@ -17867,8 +17838,8 @@ SceneStateUploadComplete:
                                     TextureSamplingMode = localCmd.TextureSamplingMode,
                                     HasImageEffect = localCmd.HasImageEffect,
                                     ImageEffect = localCmd.ResolveImageEffect(context),
-                                    PointBufferOffset = pointBufferOffset,
-                                    PointBufferCount = pointBufferCount,
+                                    PointBufferOffset = (int)pendingVectorStart,
+                                    PointBufferCount = (int)((uint)_vectorIndicesList.Count - pendingVectorStart),
                                     DoubleBufferOffset = localCmd.DoubleBufferOffset,
                                     DoubleBufferCount = localCmd.DoubleBufferCount,
                                     WeightBufferOffset = localCmd.WeightBufferOffset,
@@ -18179,24 +18150,6 @@ SceneStateUploadComplete:
             // extensions retain the established identity compile contract.
             _ => Matrix4x4.Identity
         };
-    }
-
-    private static void ResolveExtensionPointBufferRange(
-        in RenderCommand command,
-        uint fallbackStart,
-        int currentIndexCount,
-        out int offset,
-        out int count)
-    {
-        if (command.PointBufferCount > 0)
-        {
-            offset = command.PointBufferOffset;
-            count = command.PointBufferCount;
-            return;
-        }
-
-        offset = (int)fallbackStart;
-        count = currentIndexCount - offset;
     }
 
     internal unsafe void DrawStaticDxfBuffer(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -3878,6 +3878,14 @@ SceneStateUploadComplete:
             WavefrontTextureBytes = GetTextureBytes(_wavefrontColorTexture),
             MsaaTextureBytes = GetMsaaTextureBytes(),
             TrackedIntermediateTextureBytes = GetTrackedIntermediateTextureBytes(),
+            RetainedCompositionPictureCount =
+                _retainedCompositionPictures.Count,
+            RetainedCompositionPictureHits =
+                _retainedCompositionPictureHits,
+            RetainedCompositionPictureMisses =
+                _retainedCompositionPictureMisses,
+            RetainedCompositionPictureCompilations =
+                _retainedCompositionPictureCompilations,
             IncrementalScenePageCount = _incrementalScenePages.Count,
             IncrementalScenePageHits = _incrementalScenePageHits,
             IncrementalScenePageMisses = _incrementalScenePageMisses,
@@ -5723,6 +5731,18 @@ SceneStateUploadComplete:
         Matrix4x4? hitTestGlobalTransform = null)
     {
         if (picture == null) return;
+        if (TryReplayRetainedCompositionPicture(
+                picture,
+                globalTransform))
+        {
+            return;
+        }
+        bool captureRetainedPicture =
+            TryBeginRetainedCompositionPicture(
+                picture,
+                out IncrementalScenePageBoundary retainedPictureBoundary);
+        try
+        {
         var retainedHitTestTransform = hitTestGlobalTransform ?? globalTransform;
         var commands = picture.RetainedCommands;
         PreparePictureLayerCaches(commands);
@@ -5971,6 +5991,17 @@ SceneStateUploadComplete:
 
             _useGpuTransformsActive = savedUseGpuTransformsActive;
             _cameraViewMatrix = savedCameraViewMatrix;
+        }
+        }
+        finally
+        {
+            if (captureRetainedPicture)
+            {
+                CompleteRetainedCompositionPicture(
+                    picture,
+                    globalTransform,
+                    retainedPictureBoundary);
+            }
         }
     }
 
@@ -16790,6 +16821,14 @@ SceneStateUploadComplete:
             WavefrontTextureBytes = GetTextureBytes(_wavefrontColorTexture),
             MsaaTextureBytes = GetMsaaTextureBytes(),
             TrackedIntermediateTextureBytes = GetTrackedIntermediateTextureBytes(),
+            RetainedCompositionPictureCount =
+                _retainedCompositionPictures.Count,
+            RetainedCompositionPictureHits =
+                _retainedCompositionPictureHits,
+            RetainedCompositionPictureMisses =
+                _retainedCompositionPictureMisses,
+            RetainedCompositionPictureCompilations =
+                _retainedCompositionPictureCompilations,
             IncrementalScenePageCount = _incrementalScenePages.Count,
             IncrementalScenePageHits = _incrementalScenePageHits,
             IncrementalScenePageMisses = _incrementalScenePageMisses,

--- a/src/ProGPU.Scene/CompositorOptions.cs
+++ b/src/ProGPU.Scene/CompositorOptions.cs
@@ -66,6 +66,24 @@ public sealed record CompositorOptions
     public int IncrementalScenePageVolatilityCooldownFrames { get; init; } = 600;
 
     /// <summary>
+    /// Reuses compiled pages for immutable pictures nested inside a changing
+    /// parent recording. Admission starts on the second observation so
+    /// one-shot pictures do not occupy the bounded cache.
+    /// </summary>
+    public bool EnableRetainedCompositionPictures { get; init; } = true;
+
+    /// <summary>
+    /// Bounds CPU-resident compiled pages for retained immutable pictures.
+    /// </summary>
+    public int MaximumRetainedCompositionPictures { get; init; } = 4096;
+
+    /// <summary>
+    /// Removes retained picture pages that have not been replayed for this
+    /// many compositor frames.
+    /// </summary>
+    public int RetainedCompositionPictureRetentionFrames { get; init; } = 120;
+
+    /// <summary>
     /// Bounds inactive R8 mask textures retained for reuse. Active masks are
     /// never dropped; surplus returned textures are released after submission.
     /// </summary>
@@ -148,6 +166,16 @@ public sealed record CompositorOptions
         {
             throw new ArgumentOutOfRangeException(
                 nameof(IncrementalScenePageVolatilityCooldownFrames));
+        }
+        if (MaximumRetainedCompositionPictures <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaximumRetainedCompositionPictures));
+        }
+        if (RetainedCompositionPictureRetentionFrames <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(RetainedCompositionPictureRetentionFrames));
         }
         if (MaximumPooledMaskTextures <= 0)
         {

--- a/src/ProGPU.Scene/CompositorOptions.cs
+++ b/src/ProGPU.Scene/CompositorOptions.cs
@@ -78,6 +78,13 @@ public sealed record CompositorOptions
     public int MaximumRetainedCompositionPictures { get; init; } = 4096;
 
     /// <summary>
+    /// Minimum immutable command count required before a picture is admitted.
+    /// Tiny analytic pictures are cheaper to compile than to hash and append
+    /// from a retained page.
+    /// </summary>
+    public int MinimumRetainedCompositionPictureCommands { get; init; } = 4;
+
+    /// <summary>
     /// Removes retained picture pages that have not been replayed for this
     /// many compositor frames.
     /// </summary>
@@ -171,6 +178,11 @@ public sealed record CompositorOptions
         {
             throw new ArgumentOutOfRangeException(
                 nameof(MaximumRetainedCompositionPictures));
+        }
+        if (MinimumRetainedCompositionPictureCommands <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MinimumRetainedCompositionPictureCommands));
         }
         if (RetainedCompositionPictureRetentionFrames <= 0)
         {

--- a/src/ProGPU.Scene/Extensions/BackdropMaterialExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/BackdropMaterialExtensionPipeline.cs
@@ -239,10 +239,18 @@ public sealed unsafe class BackdropMaterialExtensionPipeline : ICompositorExtens
             SourceUvRect = sourceUvRect
         });
 
-        var pipelineKey = (isOffscreen, drawCall.BlendMode);
+        // A captured host backdrop is the destination as it existed before
+        // this draw. The shader produces the complete, coverage-mixed result,
+        // so source-over would composite the same destination twice. Replace
+        // the covered target instead; texture-backed materials keep the
+        // caller's requested blend mode.
+        var effectiveBlendMode = capturedHostBackdrop != null
+            ? GpuBlendMode.Src
+            : drawCall.BlendMode;
+        var pipelineKey = (isOffscreen, effectiveBlendMode);
         if (!_cachedPipelines.TryGetValue(pipelineKey, out var pipelinePointer))
         {
-            pipelinePointer = (nint)CreatePipeline(compositor, isOffscreen, drawCall.BlendMode);
+            pipelinePointer = (nint)CreatePipeline(compositor, isOffscreen, effectiveBlendMode);
             _cachedPipelines.Add(pipelineKey, pipelinePointer);
         }
 

--- a/src/ProGPU.Scene/Extensions/BackdropMaterialExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/BackdropMaterialExtensionPipeline.cs
@@ -185,7 +185,8 @@ public sealed unsafe class BackdropMaterialExtensionPipeline : ICompositorExtens
         }
 
         EnsureLayouts(compositor);
-        var requestedTexture = parameters.SourceTexture;
+        var capturedHostBackdrop = parameters.CapturedHostBackdropTexture;
+        var requestedTexture = parameters.SourceTexture ?? capturedHostBackdrop;
         if (requestedTexture != null &&
             !requestedTexture.Context.SharesDeviceWith(compositor.Context))
         {
@@ -203,10 +204,7 @@ public sealed unsafe class BackdropMaterialExtensionPipeline : ICompositorExtens
         var hasSource = requestedTexture != null && parameters.Source != BackdropMaterialSource.None;
         var useFallback = parameters.UseFallback ||
             (parameters.Source == BackdropMaterialSource.Texture && requestedTexture == null);
-        var effectiveMask = drawCall.MaskTexture;
         bool hasEffectiveMask = Compositor.HasMask(drawCall);
-        var maskWidth = effectiveMask?.Width ?? compositor.CurrentCanvasPixelWidth;
-        var maskHeight = effectiveMask?.Height ?? compositor.CurrentCanvasPixelHeight;
         var sourceUvRect = GetSourceUvRect(parameters, sourceTexture);
 
         var gpuResources = GetGpuResources(compositor);
@@ -229,15 +227,15 @@ public sealed unsafe class BackdropMaterialExtensionPipeline : ICompositorExtens
             Geometry0 = new Vector4(
                 MathF.Max(0.0001f, MathF.Abs(parameters.Rect.Width)),
                 MathF.Max(0.0001f, MathF.Abs(parameters.Rect.Height)),
-                MathF.Max(1f, maskWidth),
-                MathF.Max(1f, maskHeight)),
+                MathF.Max(1f, compositor.CurrentCanvasPixelWidth),
+                MathF.Max(1f, compositor.CurrentCanvasPixelHeight)),
             RadiiX = ClampRadii(parameters.CornerRadiiX),
             RadiiY = ClampRadii(parameters.CornerRadiiY),
             Flags0 = new Vector4(
                 hasSource ? 1f : 0f,
                 hasEffectiveMask ? 1f : 0f,
                 sourceTexture.AlphaMode == GpuTextureAlphaMode.Premultiplied ? 1f : 0f,
-                0f),
+                capturedHostBackdrop != null ? 1f : 0f),
             SourceUvRect = sourceUvRect
         });
 

--- a/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
+++ b/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
@@ -254,11 +254,21 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let kind = material.material1.z;
 
     var backdrop = vec4<f32>(0.0);
+    var capturedDestination = vec4<f32>(0.0);
     if (hasSource) {
         let backdropUv = select(
             input.texCoord,
             input.position.xy / max(material.geometry0.zw, vec2<f32>(1.0)),
             sourceIsCapturedHostBackdrop);
+        if (sourceIsCapturedHostBackdrop) {
+            // Captured host textures are premultiplied. Preserve the exact
+            // pre-material destination for coverage mixing below; the blurred
+            // sample is the material input, not the uncovered output.
+            capturedDestination = textureSample(
+                sourceTexture,
+                sourceSampler,
+                backdropUv);
+        }
         backdrop = sample_backdrop(backdropUv);
         if (sourceIsPremultiplied && backdrop.a > 0.00001) {
             backdrop = vec4<f32>(backdrop.rgb / backdrop.a, backdrop.a);
@@ -314,5 +324,15 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         input.color.a *
         maskAlpha *
         clamp(material.material0.z, 0.0, 1.0);
+    if (sourceIsCapturedHostBackdrop) {
+        // The render pipeline uses Src for captured host backdrops. Mix the
+        // complete material result with the captured destination here so a
+        // rounded or geometry-mask edge is preserved without source-over
+        // blending the destination into itself a second time.
+        return clamp(
+            mix(capturedDestination, result, coverage),
+            vec4<f32>(0.0),
+            vec4<f32>(1.0));
+    }
     return clamp(result * coverage, vec4<f32>(0.0), vec4<f32>(1.0));
 }

--- a/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
+++ b/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
@@ -42,38 +42,51 @@ struct MaskSamplingUniforms {
 
 @group(3) @binding(2) var<uniform> maskSampling: MaskSamplingUniforms;
 
+fn rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
+	let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
+	var center = vec2<f32>(0.0);
+	var radius = vec2<f32>(0.0);
+	var usesCorner = false;
+	if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+		radius = vec2<f32>(radiiX.x, radiiY.x);
+		center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+		radius = vec2<f32>(radiiX.y, radiiY.y);
+		center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+		radius = vec2<f32>(radiiX.z, radiiY.z);
+		center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+		radius = vec2<f32>(radiiX.w, radiiY.w);
+		center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	}
+	let safeRadius = max(radius, vec2<f32>(0.000001));
+	let ellipsePoint = (local - center) / safeRadius;
+	let ellipse = dot(ellipsePoint, ellipsePoint) - 1.0;
+	let implicit = select(edge, ellipse, usesCorner);
+	let antialiasWidth = max(fwidth(implicit), 0.0001);
+	return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
 fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {
     let local = vec2<f32>(
         dot(vec3<f32>(position, 1.0), maskSampling.coordinate0.xyz),
         dot(vec3<f32>(position, 1.0), maskSampling.coordinate1.xyz));
-    let bounds = maskSampling.bounds;
-    let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
-    var center = vec2<f32>(0.0);
-    var radius = vec2<f32>(0.0);
-    var usesCorner = false;
-    if (local.x < bounds.x + maskSampling.cornerRadiiX.x && local.y < bounds.y + maskSampling.cornerRadiiY.x) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.x, maskSampling.cornerRadiiY.x);
-        center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - maskSampling.cornerRadiiX.y && local.y < bounds.y + maskSampling.cornerRadiiY.y) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.y, maskSampling.cornerRadiiY.y);
-        center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - maskSampling.cornerRadiiX.z && local.y > bounds.w - maskSampling.cornerRadiiY.z) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.z, maskSampling.cornerRadiiY.z);
-        center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + maskSampling.cornerRadiiX.w && local.y > bounds.w - maskSampling.cornerRadiiY.w) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.w, maskSampling.cornerRadiiY.w);
-        center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    }
-    let safeRadius = max(radius, vec2<f32>(0.000001));
-    let ellipsePoint = (local - center) / safeRadius;
-    let ellipse = dot(ellipsePoint, ellipsePoint) - 1.0;
-    let implicit = select(edge, ellipse, usesCorner);
-    let antialiasWidth = max(fwidth(implicit), 0.0001);
-    return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+	let outerAlpha = rounded_mask_alpha_local(local, maskSampling.bounds, maskSampling.cornerRadiiX, maskSampling.cornerRadiiY);
+	if (maskSampling.options.x < 2.5) {
+		return outerAlpha;
+	}
+	let inset = maskSampling.options.z;
+	let innerAlpha = rounded_mask_alpha_local(
+		local,
+		maskSampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+		max(maskSampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+		max(maskSampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+	return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn sample_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
+++ b/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
@@ -197,12 +197,17 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let hasSource = material.flags0.x > 0.5;
     let hasMask = material.flags0.y > 0.5;
     let sourceIsPremultiplied = material.flags0.z > 0.5;
+    let sourceIsCapturedHostBackdrop = material.flags0.w > 0.5;
     let useFallback = material.material1.w > 0.5;
     let kind = material.material1.z;
 
     var backdrop = vec4<f32>(0.0);
     if (hasSource) {
-        backdrop = sample_backdrop(input.texCoord);
+        let backdropUv = select(
+            input.texCoord,
+            input.position.xy / max(material.geometry0.zw, vec2<f32>(1.0)),
+            sourceIsCapturedHostBackdrop);
+        backdrop = sample_backdrop(backdropUv);
         if (sourceIsPremultiplied && backdrop.a > 0.00001) {
             backdrop = vec4<f32>(backdrop.rgb / backdrop.a, backdrop.a);
         }

--- a/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
+++ b/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
@@ -132,6 +132,58 @@ fn source_over(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
     return source + destination * (1.0 - source.a);
 }
 
+fn blend_luminosity(color: vec3<f32>) -> f32 {
+    return dot(color, vec3<f32>(0.3, 0.59, 0.11));
+}
+
+fn clip_blend_color(inputColor: vec3<f32>) -> vec3<f32> {
+    var color = inputColor;
+    let lightness = blend_luminosity(color);
+    let minimum = min(min(color.r, color.g), color.b);
+    let maximum = max(max(color.r, color.g), color.b);
+    if (minimum < 0.0 && lightness > minimum) {
+        color = vec3<f32>(lightness) +
+            (color - vec3<f32>(lightness)) * lightness / (lightness - minimum);
+    }
+    if (maximum > 1.0 && maximum > lightness) {
+        color = vec3<f32>(lightness) +
+            (color - vec3<f32>(lightness)) * (1.0 - lightness) /
+                (maximum - lightness);
+    }
+    return color;
+}
+
+fn set_blend_luminosity(color: vec3<f32>, lightness: f32) -> vec3<f32> {
+    return clip_blend_color(
+        color + vec3<f32>(lightness - blend_luminosity(color)));
+}
+
+fn blend_nonseparable_source_over(
+    destination: vec4<f32>,
+    sourceColor: vec4<f32>,
+    useColorMode: bool) -> vec4<f32> {
+    let source = premultiply(sourceColor);
+    let sourceAlpha = source.a;
+    let destinationAlpha = destination.a;
+    let straightDestination = select(
+        vec3<f32>(0.0),
+        destination.rgb / destinationAlpha,
+        destinationAlpha > 0.00001);
+    var mixed = set_blend_luminosity(
+        straightDestination,
+        blend_luminosity(sourceColor.rgb));
+    if (useColorMode) {
+        mixed = set_blend_luminosity(
+            sourceColor.rgb,
+            blend_luminosity(straightDestination));
+    }
+    return vec4<f32>(
+        source.rgb * (1.0 - destinationAlpha) +
+            destination.rgb * (1.0 - sourceAlpha) +
+            mixed * sourceAlpha * destinationAlpha,
+        sourceAlpha + destinationAlpha - sourceAlpha * destinationAlpha);
+}
+
 fn sample_backdrop(uv: vec2<f32>) -> vec4<f32> {
     let blurRadius = max(material.material1.x, 0.0);
     if (blurRadius <= 0.01) {
@@ -232,8 +284,8 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let tint = vec4<f32>(
             material.tintColor.rgb,
             clamp(material.tintColor.a * material.material0.x, 0.0, 1.0));
-        result = source_over(result, premultiply(luminosity));
-        result = source_over(result, premultiply(tint));
+        result = blend_nonseparable_source_over(result, luminosity, false);
+        result = blend_nonseparable_source_over(result, tint, true);
     }
 
     let noiseOpacity = clamp(material.material0.w, 0.0, 1.0);

--- a/src/ProGPU.Scene/Shaders/Hatch.wgsl
+++ b/src/ProGPU.Scene/Shaders/Hatch.wgsl
@@ -99,7 +99,11 @@ fn apply_gradient_spread(t: f32, spreadMethod: u32) -> f32 {
         return fract(t);
     }
 
-    return clamp(t, 0.0, 1.0);
+    // Keep Pad coordinates outside the unit interval until stop sampling.
+    // sample_gradient_color clamps through its first/last stop while retaining
+    // the distinction between an outside coordinate and an exact duplicate
+    // endpoint, where the last stop at that offset must win.
+    return t;
 }
 
 fn get_gradient_stop_color(brush: Brush, index: u32) -> vec4<f32> {

--- a/src/ProGPU.Scene/Shaders/Hatch.wgsl
+++ b/src/ProGPU.Scene/Shaders/Hatch.wgsl
@@ -166,7 +166,10 @@ fn sample_gradient_color(brush: Brush, t: f32) -> vec4<f32> {
 
         let currentColor = get_gradient_stop_color(brush, i);
         let currentOffset = get_gradient_stop_offset(brush, i);
-        if (t <= currentOffset) {
+        // An exact offset belongs to the last stop at that offset. Besides
+        // matching Skia, this preserves hard transitions and ensures Pad
+        // selects the final color when duplicate stops sit at t = 1.
+        if (t < currentOffset) {
             let factor = (t - previousOffset) / max(currentOffset - previousOffset, 0.0001);
             return interpolate_gradient_color(brush, previousColor, currentColor, clamp(factor, 0.0, 1.0));
         }

--- a/src/ProGPU.Scene/Shaders/ImageEffect.wgsl
+++ b/src/ProGPU.Scene/Shaders/ImageEffect.wgsl
@@ -61,31 +61,25 @@ struct MaskChainUniforms {
 
 @group(3) @binding(3) var<uniform> maskChain: MaskChainUniforms;
 
-fn analytic_rounded_mask_alpha_for(
-    position: vec2<f32>,
-    sampling: MaskSamplingUniforms) -> f32 {
-    let local = vec2<f32>(
-        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
-        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
-    let bounds = sampling.bounds;
+fn rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
     let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
     var center = vec2<f32>(0.0);
     var radius = vec2<f32>(0.0);
     var usesCorner = false;
-    if (local.x < bounds.x + sampling.cornerRadiiX.x && local.y < bounds.y + sampling.cornerRadiiY.x) {
-        radius = vec2<f32>(sampling.cornerRadiiX.x, sampling.cornerRadiiY.x);
+    if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+        radius = vec2<f32>(radiiX.x, radiiY.x);
         center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.y && local.y < bounds.y + sampling.cornerRadiiY.y) {
-        radius = vec2<f32>(sampling.cornerRadiiX.y, sampling.cornerRadiiY.y);
+    } else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+        radius = vec2<f32>(radiiX.y, radiiY.y);
         center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - sampling.cornerRadiiX.z && local.y > bounds.w - sampling.cornerRadiiY.z) {
-        radius = vec2<f32>(sampling.cornerRadiiX.z, sampling.cornerRadiiY.z);
+    } else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+        radius = vec2<f32>(radiiX.z, radiiY.z);
         center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + sampling.cornerRadiiX.w && local.y > bounds.w - sampling.cornerRadiiY.w) {
-        radius = vec2<f32>(sampling.cornerRadiiX.w, sampling.cornerRadiiY.w);
+    } else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+        radius = vec2<f32>(radiiX.w, radiiY.w);
         center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
     }
@@ -95,6 +89,25 @@ fn analytic_rounded_mask_alpha_for(
     let implicit = select(edge, ellipse, usesCorner);
     let antialiasWidth = max(fwidth(implicit), 0.0001);
     return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
+fn analytic_rounded_mask_alpha_for(
+    position: vec2<f32>,
+    sampling: MaskSamplingUniforms) -> f32 {
+    let local = vec2<f32>(
+        dot(vec3<f32>(position, 1.0), sampling.coordinate0.xyz),
+        dot(vec3<f32>(position, 1.0), sampling.coordinate1.xyz));
+    let outerAlpha = rounded_mask_alpha_local(local, sampling.bounds, sampling.cornerRadiiX, sampling.cornerRadiiY);
+    if (sampling.options.x < 2.5) {
+        return outerAlpha;
+    }
+    let inset = sampling.options.z;
+    let innerAlpha = rounded_mask_alpha_local(
+        local,
+        sampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+        max(sampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+        max(sampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+    return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn sample_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Scene/Shaders/RetainedGlyph.wgsl
+++ b/src/ProGPU.Scene/Shaders/RetainedGlyph.wgsl
@@ -60,38 +60,51 @@ struct MaskSamplingUniforms {
 
 @group(1) @binding(2) var<uniform> maskSampling: MaskSamplingUniforms;
 
+fn rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
+	let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
+	var center = vec2<f32>(0.0);
+	var radius = vec2<f32>(0.0);
+	var usesCorner = false;
+	if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+		radius = vec2<f32>(radiiX.x, radiiY.x);
+		center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+		radius = vec2<f32>(radiiX.y, radiiY.y);
+		center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+		radius = vec2<f32>(radiiX.z, radiiY.z);
+		center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+		radius = vec2<f32>(radiiX.w, radiiY.w);
+		center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	}
+	let safeRadius = max(radius, vec2<f32>(0.000001));
+	let ellipsePoint = (local - center) / safeRadius;
+	let ellipse = dot(ellipsePoint, ellipsePoint) - 1.0;
+	let implicit = select(edge, ellipse, usesCorner);
+	let antialiasWidth = max(fwidth(implicit), 0.0001);
+	return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
 fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {
     let local = vec2<f32>(
         dot(vec3<f32>(position, 1.0), maskSampling.coordinate0.xyz),
         dot(vec3<f32>(position, 1.0), maskSampling.coordinate1.xyz));
-    let bounds = maskSampling.bounds;
-    let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
-    var center = vec2<f32>(0.0);
-    var radius = vec2<f32>(0.0);
-    var usesCorner = false;
-    if (local.x < bounds.x + maskSampling.cornerRadiiX.x && local.y < bounds.y + maskSampling.cornerRadiiY.x) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.x, maskSampling.cornerRadiiY.x);
-        center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - maskSampling.cornerRadiiX.y && local.y < bounds.y + maskSampling.cornerRadiiY.y) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.y, maskSampling.cornerRadiiY.y);
-        center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - maskSampling.cornerRadiiX.z && local.y > bounds.w - maskSampling.cornerRadiiY.z) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.z, maskSampling.cornerRadiiY.z);
-        center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + maskSampling.cornerRadiiX.w && local.y > bounds.w - maskSampling.cornerRadiiY.w) {
-        radius = vec2<f32>(maskSampling.cornerRadiiX.w, maskSampling.cornerRadiiY.w);
-        center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    }
-    let safeRadius = max(radius, vec2<f32>(0.000001));
-    let ellipsePoint = (local - center) / safeRadius;
-    let ellipse = dot(ellipsePoint, ellipsePoint) - 1.0;
-    let implicit = select(edge, ellipse, usesCorner);
-    let antialiasWidth = max(fwidth(implicit), 0.0001);
-    return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+	let outerAlpha = rounded_mask_alpha_local(local, maskSampling.bounds, maskSampling.cornerRadiiX, maskSampling.cornerRadiiY);
+	if (maskSampling.options.x < 2.5) {
+		return outerAlpha;
+	}
+	let inset = maskSampling.options.z;
+	let innerAlpha = rounded_mask_alpha_local(
+		local,
+		maskSampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+		max(maskSampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+		max(maskSampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+	return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn sample_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Scene/Shaders/WpfEffectMaskHelper.wgsl
+++ b/src/ProGPU.Scene/Shaders/WpfEffectMaskHelper.wgsl
@@ -1,38 +1,51 @@
 // Algorithm: Convert a physical framebuffer position into either bounded texture UVs or affine rounded-rectangle local coordinates and evaluate anti-aliased coverage.
 // Time complexity: O(1), with one texture sample for texture masks or fixed derivative arithmetic for analytic rounded and uniform-opacity masks.
 // Space complexity: O(1) shader-local storage.
+fn wpf_rounded_mask_alpha_local(local: vec2<f32>, bounds: vec4<f32>, radiiX: vec4<f32>, radiiY: vec4<f32>) -> f32 {
+	let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
+	var center = vec2<f32>(0.0);
+	var radius = vec2<f32>(0.0);
+	var usesCorner = false;
+	if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+		radius = vec2<f32>(radiiX.x, radiiY.x);
+		center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+		radius = vec2<f32>(radiiX.y, radiiY.y);
+		center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+		radius = vec2<f32>(radiiX.z, radiiY.z);
+		center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	} else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+		radius = vec2<f32>(radiiX.w, radiiY.w);
+		center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
+		usesCorner = all(radius > vec2<f32>(0.0));
+	}
+	let safeRadius = max(radius, vec2<f32>(0.000001));
+	let ellipsePoint = (local - center) / safeRadius;
+	let ellipse = dot(ellipsePoint, ellipsePoint) - 1.0;
+	let implicit = select(edge, ellipse, usesCorner);
+	let antialiasWidth = max(fwidth(implicit), 0.0001);
+	return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
 fn wpf_analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {
     let local = vec2<f32>(
         dot(vec3<f32>(position, 1.0), activeMaskSampling.coordinate0.xyz),
         dot(vec3<f32>(position, 1.0), activeMaskSampling.coordinate1.xyz));
-    let bounds = activeMaskSampling.bounds;
-    let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
-    var center = vec2<f32>(0.0);
-    var radius = vec2<f32>(0.0);
-    var usesCorner = false;
-    if (local.x < bounds.x + activeMaskSampling.cornerRadiiX.x && local.y < bounds.y + activeMaskSampling.cornerRadiiY.x) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.x, activeMaskSampling.cornerRadiiY.x);
-        center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - activeMaskSampling.cornerRadiiX.y && local.y < bounds.y + activeMaskSampling.cornerRadiiY.y) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.y, activeMaskSampling.cornerRadiiY.y);
-        center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - activeMaskSampling.cornerRadiiX.z && local.y > bounds.w - activeMaskSampling.cornerRadiiY.z) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.z, activeMaskSampling.cornerRadiiY.z);
-        center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + activeMaskSampling.cornerRadiiX.w && local.y > bounds.w - activeMaskSampling.cornerRadiiY.w) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.w, activeMaskSampling.cornerRadiiY.w);
-        center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
-        usesCorner = all(radius > vec2<f32>(0.0));
-    }
-    let safeRadius = max(radius, vec2<f32>(0.000001));
-    let ellipsePoint = (local - center) / safeRadius;
-    let ellipse = dot(ellipsePoint, ellipsePoint) - 1.0;
-    let implicit = select(edge, ellipse, usesCorner);
-    let antialiasWidth = max(fwidth(implicit), 0.0001);
-    return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+	let outerAlpha = wpf_rounded_mask_alpha_local(local, activeMaskSampling.bounds, activeMaskSampling.cornerRadiiX, activeMaskSampling.cornerRadiiY);
+	if (activeMaskSampling.options.x < 2.5) {
+		return outerAlpha;
+	}
+	let inset = activeMaskSampling.options.z;
+	let innerAlpha = wpf_rounded_mask_alpha_local(
+		local,
+		activeMaskSampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+		max(activeMaskSampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+		max(activeMaskSampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+	return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn wpf_active_mask_alpha(screenPosition: vec4<f32>) -> f32 {

--- a/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
+++ b/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
@@ -114,6 +114,48 @@ public sealed class BackdropMaterialRenderTests
     }
 
     [Fact]
+    public void HostBackdropReplacesCoverageWithoutCompositingDestinationTwice()
+    {
+        var window = HeadlessWindow.Shared;
+        using var target = new GpuTexture(
+            window.Context,
+            32,
+            32,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.RenderAttachment |
+                TextureUsage.TextureBinding |
+                TextureUsage.CopySrc,
+            "Host Backdrop Coverage Target",
+            alphaMode: GpuTextureAlphaMode.Premultiplied);
+
+        window.Compositor.RenderOffscreen(
+            new NestedHostBackdropVisual(),
+            32,
+            32,
+            target,
+            0f,
+            1f,
+            Vector4.Zero);
+
+        var pixels = target.ReadPixels();
+        var center = ReadPixel(pixels, target.Width, 16, 16);
+        var outsideClip = ReadPixel(pixels, target.Width, 1, 1);
+
+        // 50%-alpha black under 80%-alpha white luminosity produces a
+        // premultiplied (0.8, 0.8, 0.8, 0.9) result. Source-over blending it
+        // over the captured 50%-alpha destination again would incorrectly
+        // raise alpha to 0.95.
+        Assert.InRange(center.R, 201, 207);
+        Assert.InRange(center.G, 201, 207);
+        Assert.InRange(center.B, 201, 207);
+        Assert.InRange(center.A, 227, 232);
+        Assert.InRange(outsideClip.R, 0, 2);
+        Assert.InRange(outsideClip.G, 0, 2);
+        Assert.InRange(outsideClip.B, 0, 2);
+        Assert.InRange(outsideClip.A, 126, 129);
+    }
+
+    [Fact]
     public void AppendTranslatesBackdropMaterialWithoutChangingSourceRect()
     {
         var parameters = new BackdropMaterialParams
@@ -243,6 +285,57 @@ public sealed class BackdropMaterialRenderTests
             context.DrawRectangle(_blue, null, new Rect(16f, 0f, 16f, 32f));
             context.DrawBackdropMaterial(_material, new Rect(8f, 8f, 16f, 16f));
             context.DrawRectangle(_green, null, new Rect(14f, 14f, 4f, 4f));
+        }
+    }
+
+    private sealed class NestedHostBackdropVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _background =
+            new(new Vector4(0f, 0f, 0f, 0.5f));
+        private readonly BackdropMaterialBrush _material = new()
+        {
+            Kind = BackdropMaterialKind.Acrylic,
+            Source = BackdropMaterialSource.HostBackdrop,
+            TintColor = new Vector4(1f, 1f, 1f, 0f),
+            LuminosityColor = new Vector4(1f, 1f, 1f, 0.8f),
+            NoiseOpacity = 0f,
+            BlurRadius = 0f,
+            Saturation = 1f
+        };
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _background,
+                null,
+                new Rect(0f, 0f, 32f, 32f));
+            context.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    2f,
+                    2f,
+                    28f,
+                    28f,
+                    4f,
+                    4f));
+            context.PushGeometryClip(
+                PrimitivePathGeometry.CreateEllipse(
+                    new Vector2(16f, 16f),
+                    12f,
+                    12f));
+            context.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    6f,
+                    6f,
+                    20f,
+                    20f,
+                    3f,
+                    3f));
+            context.DrawBackdropMaterial(
+                _material,
+                new Rect(0f, 0f, 32f, 32f));
+            context.PopGeometryClip();
+            context.PopGeometryClip();
+            context.PopGeometryClip();
         }
     }
 }

--- a/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
+++ b/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
@@ -156,6 +156,45 @@ public sealed class BackdropMaterialRenderTests
     }
 
     [Fact]
+    public void ScaledNestedHostBackdropCoversItsFullHeight()
+    {
+        var window = HeadlessWindow.Shared;
+        using var target = new GpuTexture(
+            window.Context,
+            600,
+            900,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.RenderAttachment |
+                TextureUsage.TextureBinding |
+                TextureUsage.CopySrc,
+            "Scaled Host Backdrop Target",
+            alphaMode: GpuTextureAlphaMode.Premultiplied);
+
+        var visual = new ScaledNestedHostBackdropVisual();
+        for (var frame = 0; frame < 6; frame++)
+        {
+            window.Compositor.RenderOffscreen(
+                visual,
+                600,
+                900,
+                target,
+                0f,
+                1f,
+                Vector4.One);
+        }
+
+        var pixels = target.ReadPixels();
+        foreach (var y in new[] { 300, 500, 700, 850 })
+        {
+            var covered = ReadPixel(pixels, target.Width, 450, y);
+            Assert.InRange(covered.R, 209, 217);
+            Assert.InRange(covered.G, 209, 217);
+            Assert.InRange(covered.B, 209, 217);
+            Assert.Equal(255, covered.A);
+        }
+    }
+
+    [Fact]
     public void AppendTranslatesBackdropMaterialWithoutChangingSourceRect()
     {
         var parameters = new BackdropMaterialParams
@@ -335,6 +374,88 @@ public sealed class BackdropMaterialRenderTests
                 new Rect(0f, 0f, 32f, 32f));
             context.PopGeometryClip();
             context.PopGeometryClip();
+            context.PopGeometryClip();
+        }
+    }
+
+    private sealed class ScaledNestedHostBackdropVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _white =
+            new(Vector4.One);
+        private readonly SolidColorBrush _black =
+            new(new Vector4(0f, 0f, 0f, 1f));
+        private readonly BackdropMaterialBrush _material = new()
+        {
+            Kind = BackdropMaterialKind.Acrylic,
+            Source = BackdropMaterialSource.HostBackdrop,
+            TintColor = new Vector4(0.988f, 0.988f, 0.988f, 0f),
+            LuminosityColor = new Vector4(0.988f, 0.988f, 0.988f, 0.847f),
+            NoiseOpacity = 0f,
+            BlurRadius = 0f,
+            Saturation = 1f
+        };
+        private readonly Matrix4x4 _outerTransform =
+            Matrix4x4.CreateScale(2f, 2f, 1f) *
+            Matrix4x4.CreateTranslation(8f, 210f, 0f);
+        private readonly Matrix4x4 _innerTransform =
+            Matrix4x4.CreateTranslation(1f, 1f, 0f);
+        private readonly GpuPicture _popup;
+
+        public ScaledNestedHostBackdropVisual()
+        {
+            var recorder = new GpuPictureRecorder();
+            var popup = recorder.BeginRecording(
+                new Rect(0f, 0f, 600f, 900f));
+            popup.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    1f,
+                    1f,
+                    270f,
+                    324f,
+                    7.5f,
+                    7.5f),
+                Matrix4x4.Identity);
+            popup.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    0f,
+                    0f,
+                    270f,
+                    324f,
+                    7.5f,
+                    7.5f),
+                _innerTransform);
+            popup.DrawBackdropMaterial(
+                _material,
+                new Rect(1f, 1f, 269f, 323f));
+            popup.PopGeometryClip();
+            popup.PopGeometryClip();
+            _popup = recorder.EndRecording();
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _white,
+                null,
+                new Rect(0f, 0f, 600f, 900f));
+            foreach (var y in new[] { 300f, 500f, 700f, 850f })
+            {
+                context.DrawRectangle(
+                    _black,
+                    null,
+                    new Rect(400f, y - 4f, 100f, 8f));
+            }
+
+            context.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    0f,
+                    0f,
+                    272f,
+                    326f,
+                    8.5f,
+                    8.5f),
+                _outerTransform);
+            context.DrawPictureTransformed(_popup, _outerTransform);
             context.PopGeometryClip();
         }
     }

--- a/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
+++ b/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
@@ -27,7 +27,7 @@ public sealed class BackdropMaterialRenderTests
             var center = ReadPixel(pixels, window.Width, 32, 32);
             var roundedCorner = ReadPixel(pixels, window.Width, 9, 9);
 
-            Assert.InRange(center.R, 120, 136);
+            Assert.InRange(center.R, 40, 54);
             Assert.InRange(center.G, 0, 8);
             Assert.InRange(center.B, 120, 136);
             Assert.Equal(255, center.A);

--- a/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
+++ b/src/ProGPU.Tests/BackdropMaterialRenderTests.cs
@@ -75,6 +75,45 @@ public sealed class BackdropMaterialRenderTests
     }
 
     [Fact]
+    public void HostBackdropCapturesPreviouslyRenderedTargetContent()
+    {
+        var window = HeadlessWindow.Shared;
+        using var target = new GpuTexture(
+            window.Context,
+            32,
+            32,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.RenderAttachment |
+                TextureUsage.TextureBinding |
+                TextureUsage.CopySrc,
+            "Host Backdrop Target",
+            alphaMode: GpuTextureAlphaMode.Premultiplied);
+        var visual = new HostBackdropVisual();
+
+        window.Compositor.RenderOffscreen(
+            visual,
+            32,
+            32,
+            target,
+            0f,
+            1f,
+            Vector4.Zero);
+
+        var pixels = target.ReadPixels();
+        var outsideLeft = ReadPixel(pixels, target.Width, 4, 16);
+        var blurredBoundary = ReadPixel(pixels, target.Width, 16, 12);
+        var foreground = ReadPixel(pixels, target.Width, 15, 15);
+
+        Assert.InRange(outsideLeft.R, 247, 255);
+        Assert.InRange(outsideLeft.B, 0, 8);
+        Assert.InRange(blurredBoundary.R, 24, 224);
+        Assert.InRange(blurredBoundary.B, 24, 224);
+        Assert.InRange(foreground.R, 0, 8);
+        Assert.InRange(foreground.G, 247, 255);
+        Assert.InRange(foreground.B, 0, 8);
+    }
+
+    [Fact]
     public void AppendTranslatesBackdropMaterialWithoutChangingSourceRect()
     {
         var parameters = new BackdropMaterialParams
@@ -181,6 +220,29 @@ public sealed class BackdropMaterialRenderTests
                 _material,
                 new Rect(0f, 0f, 32f, 32f),
                 sourceTexture: _source);
+        }
+    }
+
+    private sealed class HostBackdropVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _red = new(new Vector4(1f, 0f, 0f, 1f));
+        private readonly SolidColorBrush _blue = new(new Vector4(0f, 0f, 1f, 1f));
+        private readonly SolidColorBrush _green = new(new Vector4(0f, 1f, 0f, 1f));
+        private readonly BackdropMaterialBrush _material = new()
+        {
+            Kind = BackdropMaterialKind.Blur,
+            Source = BackdropMaterialSource.HostBackdrop,
+            NoiseOpacity = 0f,
+            BlurRadius = 12f,
+            Saturation = 1f
+        };
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(_red, null, new Rect(0f, 0f, 16f, 32f));
+            context.DrawRectangle(_blue, null, new Rect(16f, 0f, 16f, 32f));
+            context.DrawBackdropMaterial(_material, new Rect(8f, 8f, 16f, 16f));
+            context.DrawRectangle(_green, null, new Rect(14f, 14f, 4f, 4f));
         }
     }
 }

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -6700,6 +6700,34 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void UniformRoundedRingClipUsesAnalyticMaskWithoutTexturePass()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new UniformRoundedRingClipVisual();
+
+        window.Render();
+
+        CompositorMetrics metrics = window.Compositor.Metrics;
+        Assert.Equal(0, metrics.MaskTexturePeakDemand);
+        Assert.Equal(1, metrics.AnalyticMaskBindGroupCount);
+        Assert.Equal(0, metrics.MaskRenderPassCount);
+
+        byte[] pixels = window.ReadPixels();
+        var ring = ReadPixel(pixels, window.Width, x: 6, y: 32);
+        var hole = ReadPixel(pixels, window.Width, x: 32, y: 32);
+        var outerCorner = ReadPixel(pixels, window.Width, x: 4, y: 4);
+        Assert.True(
+            ring.G >= 220 && ring.R <= 35 && ring.B <= 35,
+            $"Expected green rounded-ring coverage, found {ring}.");
+        Assert.True(
+            hole.R <= 35 && hole.G <= 35 && hole.B <= 35,
+            $"Expected the analytic rounded-ring hole to stay clear, found {hole}.");
+        Assert.True(
+            outerCorner.R <= 35 && outerCorner.G <= 35 && outerCorner.B <= 35,
+            $"Expected the rounded-ring outer corner to stay clear, found {outerCorner}.");
+    }
+
+    [Fact]
     public void AnalyticClipDoesNotMaskPendingPrecedingDraws()
     {
         using var window = new HeadlessWindow(64, 64);
@@ -9711,6 +9739,45 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
             context.DrawRectangle(
                 new SolidColorBrush(
                     new Vector4(0f, 1f, 0f, 1f)),
+                null,
+                new Rect(0f, 0f, 64f, 64f));
+            context.PopGeometryClip();
+        }
+    }
+
+    private sealed class UniformRoundedRingClipVisual : FrameworkElement
+    {
+        public UniformRoundedRingClipVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            PathGeometry ring = PrimitivePathGeometry.CreateRoundedRectangle(
+                4f,
+                4f,
+                56f,
+                56f,
+                10f,
+                10f);
+            ring.FillRule = FillRule.EvenOdd;
+            PathGeometry inner = PrimitivePathGeometry.CreateRoundedRectangle(
+                8f,
+                8f,
+                48f,
+                48f,
+                6f,
+                6f);
+            foreach (PathFigure figure in inner.Figures)
+            {
+                ring.Figures.Add(figure);
+            }
+
+            context.PushGeometryClip(ring);
+            context.DrawRectangle(
+                new SolidColorBrush(new Vector4(0f, 1f, 0f, 1f)),
                 null,
                 new Rect(0f, 0f, 64f, 64f));
             context.PopGeometryClip();

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -6700,6 +6700,25 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void AnalyticClipDoesNotMaskPendingPrecedingDraws()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new AnalyticClipBatchBoundaryVisual();
+
+        window.Render();
+
+        byte[] pixels = window.ReadPixels();
+        var preceding = ReadPixel(pixels, window.Width, x: 12, y: 28);
+        var clipped = ReadPixel(pixels, window.Width, x: 48, y: 28);
+        Assert.True(
+            preceding.R >= 220 && preceding.G <= 35 && preceding.B <= 35,
+            $"Expected the draw preceding the analytic clip to remain red, found {preceding}.");
+        Assert.True(
+            clipped.G >= 220 && clipped.R <= 35 && clipped.B <= 35,
+            $"Expected the draw inside the analytic clip to remain green, found {clipped}.");
+    }
+
+    [Fact]
     public void OpacityMaskWritesComputedAlphaIntoMaskTarget()
     {
         var window = HeadlessWindow.Shared;
@@ -9694,6 +9713,41 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                     new Vector4(0f, 1f, 0f, 1f)),
                 null,
                 new Rect(0f, 0f, 64f, 64f));
+            context.PopGeometryClip();
+        }
+    }
+
+    private sealed class AnalyticClipBatchBoundaryVisual : FrameworkElement
+    {
+        private static readonly SolidColorBrush Red =
+            new(new Vector4(1f, 0f, 0f, 1f));
+        private static readonly SolidColorBrush Green =
+            new(new Vector4(0f, 1f, 0f, 1f));
+
+        public AnalyticClipBatchBoundaryVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                Red,
+                null,
+                new Rect(4f, 20f, 16f, 16f));
+            context.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    36f,
+                    8f,
+                    24f,
+                    48f,
+                    6f,
+                    6f));
+            context.DrawRectangle(
+                Green,
+                null,
+                new Rect(36f, 8f, 24f, 48f));
             context.PopGeometryClip();
         }
     }

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -6728,6 +6728,30 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void RoundedRingMatchingAnalyticParentAvoidsTexturePass()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new UniformRoundedRingClipVisual(nestedInMatchingOuter: true);
+
+        window.Render();
+
+        CompositorMetrics metrics = window.Compositor.Metrics;
+        Assert.Equal(0, metrics.MaskTexturePeakDemand);
+        Assert.Equal(2, metrics.AnalyticMaskBindGroupCount);
+        Assert.Equal(0, metrics.MaskRenderPassCount);
+
+        byte[] pixels = window.ReadPixels();
+        var ring = ReadPixel(pixels, window.Width, x: 6, y: 32);
+        var hole = ReadPixel(pixels, window.Width, x: 32, y: 32);
+        Assert.True(
+            ring.G >= 220 && ring.R <= 35 && ring.B <= 35,
+            $"Expected nested green rounded-ring coverage, found {ring}.");
+        Assert.True(
+            hole.R <= 35 && hole.G <= 35 && hole.B <= 35,
+            $"Expected the nested analytic rounded-ring hole to stay clear, found {hole}.");
+    }
+
+    [Fact]
     public void AnalyticClipDoesNotMaskPendingPrecedingDraws()
     {
         using var window = new HeadlessWindow(64, 64);
@@ -9747,14 +9771,29 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
 
     private sealed class UniformRoundedRingClipVisual : FrameworkElement
     {
-        public UniformRoundedRingClipVisual()
+        private readonly bool _nestedInMatchingOuter;
+
+        public UniformRoundedRingClipVisual(bool nestedInMatchingOuter = false)
         {
+            _nestedInMatchingOuter = nestedInMatchingOuter;
             Width = 64f;
             Height = 64f;
         }
 
         public override void OnRender(DrawingContext context)
         {
+            if (_nestedInMatchingOuter)
+            {
+                context.PushGeometryClip(
+                    PrimitivePathGeometry.CreateRoundedRectangle(
+                        4f,
+                        4f,
+                        56f,
+                        56f,
+                        10f,
+                        10f));
+            }
+
             PathGeometry ring = PrimitivePathGeometry.CreateRoundedRectangle(
                 4f,
                 4f,
@@ -9781,6 +9820,10 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
                 null,
                 new Rect(0f, 0f, 64f, 64f));
             context.PopGeometryClip();
+            if (_nestedInMatchingOuter)
+            {
+                context.PopGeometryClip();
+            }
         }
     }
 

--- a/src/ProGPU.Tests/GradientRenderTests.cs
+++ b/src/ProGPU.Tests/GradientRenderTests.cs
@@ -82,6 +82,35 @@ public sealed class GradientRenderTests
         }
     }
 
+    [Fact]
+    public void DuplicateEndpointStopsUseLastColorOutsideGradientDomain()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(16, 16);
+        window.Content = new DuplicateEndpointGradientVisual();
+
+        try
+        {
+            window.Render();
+
+            var pixels = window.ReadPixels();
+            var beforeEndpoint = ReadPixel(pixels, window.Width, x: 8, y: 4);
+            var afterEndpoint = ReadPixel(pixels, window.Width, x: 8, y: 12);
+
+            Assert.InRange(beforeEndpoint.R, 0, 8);
+            Assert.InRange(beforeEndpoint.B, 247, 255);
+            Assert.Equal(255, beforeEndpoint.A);
+
+            Assert.InRange(afterEndpoint.R, 247, 255);
+            Assert.InRange(afterEndpoint.B, 0, 8);
+            Assert.Equal(255, afterEndpoint.A);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -147,6 +176,29 @@ public sealed class GradientRenderTests
             };
 
             context.DrawRectangle(brush, null, new Rect(0f, 0f, 32f, 16f));
+        }
+    }
+
+    private sealed class DuplicateEndpointGradientVisual : FrameworkElement
+    {
+        public DuplicateEndpointGradientVisual()
+        {
+            Width = 16f;
+            Height = 16f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var brush = new LinearGradientBrush(
+                Vector2.Zero,
+                new Vector2(0f, 8f),
+                new[]
+                {
+                    new GradientStop(new Vector4(0f, 0f, 1f, 1f), 1f),
+                    new GradientStop(new Vector4(1f, 0f, 0f, 1f), 1f)
+                });
+
+            context.DrawRectangle(brush, null, new Rect(0f, 0f, 16f, 16f));
         }
     }
 }

--- a/src/ProGPU.Tests/GradientRenderTests.cs
+++ b/src/ProGPU.Tests/GradientRenderTests.cs
@@ -111,6 +111,37 @@ public sealed class GradientRenderTests
         }
     }
 
+    [Fact]
+    public void DuplicateStartStopsPreserveFirstColorBeforeGradientDomain()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(16, 16);
+        window.Content = new DuplicateStartGradientVisual();
+
+        try
+        {
+            window.Render();
+
+            var pixels = window.ReadPixels();
+            var beforeStart = ReadPixel(pixels, window.Width, x: 8, y: 2);
+            var afterStart = ReadPixel(pixels, window.Width, x: 8, y: 12);
+
+            Assert.InRange(beforeStart.R, 0, 8);
+            Assert.InRange(beforeStart.G, 0, 8);
+            Assert.InRange(beforeStart.B, 247, 255);
+            Assert.Equal(255, beforeStart.A);
+
+            Assert.InRange(afterStart.R, 247, 255);
+            Assert.InRange(afterStart.G, 0, 8);
+            Assert.InRange(afterStart.B, 0, 8);
+            Assert.Equal(255, afterStart.A);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -195,6 +226,30 @@ public sealed class GradientRenderTests
                 new[]
                 {
                     new GradientStop(new Vector4(0f, 0f, 1f, 1f), 1f),
+                    new GradientStop(new Vector4(1f, 0f, 0f, 1f), 1f)
+                });
+
+            context.DrawRectangle(brush, null, new Rect(0f, 0f, 16f, 16f));
+        }
+    }
+
+    private sealed class DuplicateStartGradientVisual : FrameworkElement
+    {
+        public DuplicateStartGradientVisual()
+        {
+            Width = 16f;
+            Height = 16f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            var brush = new LinearGradientBrush(
+                new Vector2(0f, 8f),
+                new Vector2(0f, 16f),
+                new[]
+                {
+                    new GradientStop(new Vector4(0f, 0f, 1f, 1f), 0f),
+                    new GradientStop(new Vector4(1f, 0f, 0f, 1f), 0f),
                     new GradientStop(new Vector4(1f, 0f, 0f, 1f), 1f)
                 });
 

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -1048,7 +1048,19 @@ public sealed class LayerRenderTests
             context.DrawRectangle(
                 new SolidColorBrush(color),
                 null,
-                new Rect(index % 8 * 8f, index / 8 * 8f, 8f, 8f));
+                new Rect(index % 8 * 8f, index / 8 * 8f, 4f, 4f));
+            context.DrawRectangle(
+                new SolidColorBrush(color),
+                null,
+                new Rect(index % 8 * 8f + 4f, index / 8 * 8f, 4f, 4f));
+            context.DrawRectangle(
+                new SolidColorBrush(color),
+                null,
+                new Rect(index % 8 * 8f, index / 8 * 8f + 4f, 4f, 4f));
+            context.DrawRectangle(
+                new SolidColorBrush(color),
+                null,
+                new Rect(index % 8 * 8f + 4f, index / 8 * 8f + 4f, 4f, 4f));
             return recorder.EndRecording();
         }
 

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -384,6 +384,65 @@ public sealed class LayerRenderTests
     }
 
     [Fact]
+    public void RetainedPicturesReuseNestedImmutablePagesDuringRootMutation()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableGpuHitTesting = false,
+            PrimarySampleCount = 1,
+            MaximumRetainedCompositionPictures = 128
+        };
+        using var window = new HeadlessWindow(64, 32, options);
+        using var visual = new RetainedPictureMutationVisual();
+        window.Content = visual;
+
+        try
+        {
+            window.Render();
+
+            visual.Advance();
+            window.Render();
+            Assert.InRange(
+                window.Compositor.Metrics
+                    .RetainedCompositionPictureCompilations,
+                29,
+                30);
+
+            visual.Advance();
+            window.Render();
+            Assert.InRange(
+                window.Compositor.Metrics.RetainedCompositionPictureHits,
+                29,
+                30);
+            Assert.Equal(
+                2,
+                window.Compositor.Metrics
+                    .RetainedCompositionPictureCompilations);
+
+            visual.Advance();
+            window.Render();
+            CompositorMetrics metrics = window.Compositor.Metrics;
+            Assert.InRange(
+                metrics.RetainedCompositionPictureHits,
+                30,
+                31);
+            Assert.Equal(0, metrics.RetainedCompositionPictureCompilations);
+            Assert.InRange(
+                metrics.RetainedCompositionPictureCount,
+                31,
+                32);
+
+            byte[] pixels = window.ReadPixels();
+            AssertGreen(ReadPixel(pixels, window.Width, 4, 4));
+            AssertRed(ReadPixel(pixels, window.Width, 28, 4));
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
     public void EmptyOwnedCommandCacheSkipsLookupAndStillRendersChildren()
     {
         using var window = new HeadlessWindow(64, 64);
@@ -927,6 +986,85 @@ public sealed class LayerRenderTests
             {
                 AddChild(child);
             }
+        }
+    }
+
+    private sealed class RetainedPictureMutationVisual : FrameworkElement,
+        IDisposable
+    {
+        private readonly GpuPicture[] _normal = new GpuPicture[32];
+        private readonly GpuPicture[] _changed = new GpuPicture[32];
+        private GpuPicture _root;
+        private int _changedIndex;
+
+        public RetainedPictureMutationVisual()
+        {
+            Width = 64f;
+            Height = 32f;
+            for (int index = 0; index < _normal.Length; index++)
+            {
+                _normal[index] = CreateCellPicture(
+                    index,
+                    new Vector4(0f, 1f, 0f, 1f));
+                _changed[index] = CreateCellPicture(
+                    index,
+                    new Vector4(1f, 0f, 0f, 1f));
+            }
+            _root = CreateRootPicture();
+        }
+
+        public void Advance()
+        {
+            _changedIndex = (_changedIndex + 1) % _normal.Length;
+            GpuPicture previous = _root;
+            _root = CreateRootPicture();
+            Invalidate();
+            previous.Dispose();
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPicture(_root);
+
+        public void Dispose()
+        {
+            _root.Dispose();
+            foreach (GpuPicture picture in _normal)
+            {
+                picture.Dispose();
+            }
+            foreach (GpuPicture picture in _changed)
+            {
+                picture.Dispose();
+            }
+        }
+
+        private static GpuPicture CreateCellPicture(
+            int index,
+            Vector4 color)
+        {
+            var recorder = new GpuPictureRecorder();
+            DrawingContext context = recorder.BeginRecording(
+                new Rect(0f, 0f, 64f, 32f));
+            context.DrawRectangle(
+                new SolidColorBrush(color),
+                null,
+                new Rect(index % 8 * 8f, index / 8 * 8f, 8f, 8f));
+            return recorder.EndRecording();
+        }
+
+        private GpuPicture CreateRootPicture()
+        {
+            var recorder = new GpuPictureRecorder();
+            DrawingContext context = recorder.BeginRecording(
+                new Rect(0f, 0f, 64f, 32f));
+            for (int index = 0; index < _normal.Length; index++)
+            {
+                context.DrawPicture(
+                    index == _changedIndex
+                        ? _changed[index]
+                        : _normal[index]);
+            }
+            return recorder.EndRecording();
         }
     }
 

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -170,6 +170,36 @@ public sealed class WgpuContextTests
     }
 
     [Fact]
+    public unsafe void DeferredQueueSubmissionBoundCanBeConfiguredByHost()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext
+        {
+            MaximumDeferredQueueSubmissions = 2
+        };
+        context.InitializeExternalNativeDevice(
+            api,
+            lifetime,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm);
+
+        var commandBuffer = (CommandBuffer*)1;
+        context.Submit(1, &commandBuffer);
+        context.CleanupPendingResources();
+
+        Assert.Equal(0, lifetime.WaitingPollCount);
+
+        context.Submit(1, &commandBuffer);
+        context.CleanupPendingResources();
+
+        Assert.Equal(1, lifetime.WaitingPollCount);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => context.MaximumDeferredQueueSubmissions = 0);
+    }
+
+    [Fact]
     public void Tier1TextureFormatsFailBeforeBackendAllocationWhenUnsupported()
     {
         using var context = new WgpuContext();


### PR DESCRIPTION
## Summary
- commit pending draw calls before activating an analytic geometry mask
- preserve draws recorded immediately before the clip
- recognize exact uniform-inset rounded rings as analytic masks
- preserve the fast path when a ring is nested in its matching analytic outer clip
- evaluate rounded-ring coverage in vector, text, texture, retained-glyph, image-effect, backdrop, and WPF-effect shaders
- keep non-uniform and arbitrary geometry on the existing texture-mask fallback
- cache compiled pages for immutable pictures nested in changing parent recordings
- admit retained pictures only after reuse, with bounded variants, capacity, and age-based eviction
- bypass retained-page lookup for tiny analytic pictures that are cheaper to compile directly
- bulk-append retained solid-primitive pages and rebase indices through contiguous spans
- expose retained-picture hit, miss, compilation, and resident-count metrics
- preserve hard gradient transitions by selecting the last duplicate stop at an exact offset
- let hosts configure the bounded deferred queue-submission window while retaining the conservative default
- capture host-backdrop pixels on the GPU at ordered material boundaries
- resume rendering through ping-pong targets without CPU readback or fallback substitution
- match non-separable Color and Luminosity backdrop blend semantics
- replace captured host-backdrop coverage without blending the destination twice

## Validation
- batch-boundary regression fails without the isolation fix and passes with it
- analytic rounded-ring pixel regressions verify standalone and matching-parent nesting
- both rounded-ring paths use zero texture-mask render passes
- retained-picture regression verifies that unchanged nested pictures reuse compiled pages while the changed picture updates correctly
- duplicate endpoint gradient regression fails on the previous sampler and passes with the corrected exact-offset rule
- configurable queue-bound tests preserve the default drain behavior, verify host overrides, and reject invalid bounds
- host-backdrop regressions verify capture, blur sampling, subsequent foreground ordering, destination replacement, nested transformed coverage, and non-separable blend output
- all focused queue-context, backdrop-material, layer-render, gradient, and text-rendering-mode regression tests pass
- targeted vector, text, and texture compositor regressions pass