### PR TITLE
Cache retained picture eligibility metadata

### DIFF
--- a/src/ProGPU.Scene/Compositor.IncrementalPages.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalPages.cs
@@ -397,7 +397,8 @@ public unsafe partial class Compositor
                 ? commands[index]
                 : ownedRenderCommandCache.GetRenderCommand(index);
             if (command.UseGpuTransforms ||
-                !IsIncrementalScenePageCommandSupported(command.Type))
+                !RenderCommand.IsIncrementalScenePageCommandSupported(
+                    command.Type))
             {
                 _incrementalScenePageRejectReason ??=
                     command.UseGpuTransforms
@@ -428,35 +429,6 @@ public unsafe partial class Compositor
             _activeOpacity,
             _activeBlendMode);
         return true;
-    }
-
-    private static bool IsIncrementalScenePageCommandSupported(
-        RenderCommandType type)
-    {
-        return type is
-            RenderCommandType.DrawRect or
-            RenderCommandType.DrawPath or
-            RenderCommandType.DrawText or
-            RenderCommandType.DrawTexture or
-            RenderCommandType.DrawPicture or
-            RenderCommandType.PushClip or
-            RenderCommandType.PopClip or
-            RenderCommandType.PushOpacity or
-            RenderCommandType.PopOpacity or
-            RenderCommandType.PushBlendMode or
-            RenderCommandType.PopBlendMode or
-            RenderCommandType.DrawLine or
-            RenderCommandType.DrawEllipse or
-            RenderCommandType.DrawCircle or
-            RenderCommandType.DrawRoundedRect or
-            RenderCommandType.DrawBezier or
-            RenderCommandType.DrawCubicBezier or
-            RenderCommandType.DrawPolyline or
-            RenderCommandType.FillTriangle or
-            RenderCommandType.FillQuad or
-            RenderCommandType.DrawGlyphRun or
-            RenderCommandType.DrawVertexMesh or
-            RenderCommandType.DrawPointBatch;
     }
 
     private void CompleteIncrementalScenePage(

--- a/src/ProGPU.Scene/Compositor.RetainedPictures.cs
+++ b/src/ProGPU.Scene/Compositor.RetainedPictures.cs
@@ -83,20 +83,10 @@ public unsafe partial class Compositor
             _maskRenderPasses.Count != 0 ||
             _incrementalPagesBlockedByAnalyticMask ||
             _activeBlendMode != GpuBlendMode.SrcOver ||
-            _useGpuTransformsActive)
+            _useGpuTransformsActive ||
+            !picture.SupportsRetainedCompositionPicture)
         {
             return false;
-        }
-
-        for (int index = 0; index < picture.CommandCount; index++)
-        {
-            RenderCommand command = picture.GetCommand(index);
-            if (command.UseGpuTransforms ||
-                !IsIncrementalScenePageCommandSupported(command.Type) ||
-                command.Type == RenderCommandType.DrawVisual)
-            {
-                return false;
-            }
         }
 
         return true;
@@ -104,18 +94,13 @@ public unsafe partial class Compositor
 
     private bool TryReplayRetainedCompositionPicture(
         GpuPicture picture,
-        in Matrix4x4 globalTransform)
+        in Matrix4x4 globalTransform,
+        out RetainedPictureObservation? observation)
     {
+        observation = null;
         if (!CanUseRetainedCompositionPicture(picture))
         {
             return false;
-        }
-
-        RetainedPictureObservation observation =
-            _retainedPictureObservations.GetOrCreateValue(picture);
-        if (observation.Count < 2)
-        {
-            observation.Count++;
         }
 
         var key = CreateRetainedPicturePageKey(globalTransform);
@@ -128,6 +113,12 @@ public unsafe partial class Compositor
             if (page != null)
             {
                 RemoveRetainedCompositionPicture(lookup);
+            }
+            observation =
+                _retainedPictureObservations.GetOrCreateValue(picture);
+            if (observation.Count < 2)
+            {
+                observation.Count++;
             }
             _retainedCompositionPictureMisses++;
             return false;
@@ -142,14 +133,11 @@ public unsafe partial class Compositor
     }
 
     private bool TryBeginRetainedCompositionPicture(
-        GpuPicture picture,
+        RetainedPictureObservation? observation,
         out IncrementalScenePageBoundary boundary)
     {
         boundary = default;
-        if (!CanUseRetainedCompositionPicture(picture) ||
-            !_retainedPictureObservations.TryGetValue(
-                picture,
-                out RetainedPictureObservation? observation) ||
+        if (observation == null ||
             observation.Count < 2)
         {
             return false;

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -5733,13 +5733,14 @@ SceneStateUploadComplete:
         if (picture == null) return;
         if (TryReplayRetainedCompositionPicture(
                 picture,
-                globalTransform))
+                globalTransform,
+                out RetainedPictureObservation? retainedPictureObservation))
         {
             return;
         }
         bool captureRetainedPicture =
             TryBeginRetainedCompositionPicture(
-                picture,
+                retainedPictureObservation,
                 out IncrementalScenePageBoundary retainedPictureBoundary);
         try
         {

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -868,6 +868,38 @@ public struct RenderCommand
     public int IntParam;
     public float FloatParam;
     public object? DataParam;
+
+    internal readonly bool SupportsRetainedCompositionPicture =>
+        !UseGpuTransforms &&
+        Type != RenderCommandType.DrawVisual &&
+        IsIncrementalScenePageCommandSupported(Type);
+
+    internal static bool IsIncrementalScenePageCommandSupported(
+        RenderCommandType type) =>
+        type is
+            RenderCommandType.DrawRect or
+            RenderCommandType.DrawPath or
+            RenderCommandType.DrawText or
+            RenderCommandType.DrawTexture or
+            RenderCommandType.DrawPicture or
+            RenderCommandType.PushClip or
+            RenderCommandType.PopClip or
+            RenderCommandType.PushOpacity or
+            RenderCommandType.PopOpacity or
+            RenderCommandType.PushBlendMode or
+            RenderCommandType.PopBlendMode or
+            RenderCommandType.DrawLine or
+            RenderCommandType.DrawEllipse or
+            RenderCommandType.DrawCircle or
+            RenderCommandType.DrawRoundedRect or
+            RenderCommandType.DrawBezier or
+            RenderCommandType.DrawCubicBezier or
+            RenderCommandType.DrawPolyline or
+            RenderCommandType.FillTriangle or
+            RenderCommandType.FillQuad or
+            RenderCommandType.DrawGlyphRun or
+            RenderCommandType.DrawVertexMesh or
+            RenderCommandType.DrawPointBatch;
 }
 
 internal enum RetainedCommandDataKind : byte
@@ -1887,10 +1919,13 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
     private readonly Matrix4x4[] _transforms;
     private readonly Visual[] _embeddedVisuals;
 
+    internal bool SupportsRetainedCompositionPicture { get; }
+
     internal GpuPictureCommandCollection(ReadOnlySpan<RenderCommand> commands)
     {
         if (commands.IsEmpty)
         {
+            SupportsRetainedCompositionPicture = true;
             _order = [];
             _basic = [];
             _auxiliary = [];
@@ -1924,6 +1959,7 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
         int simpleRoundedRectangleCount = 0;
         int simpleVisualCount = 0;
         int embeddedVisualCount = 0;
+        bool supportsRetainedCompositionPicture = true;
         byte[] classifications =
             ArrayPool<byte>.Shared.Rent(commands.Length);
         int[] transformIndices =
@@ -1939,6 +1975,8 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
             int transformCount = 0;
             for (int index = 0; index < commands.Length; index++)
             {
+                supportsRetainedCompositionPicture &=
+                    commands[index].SupportsRetainedCompositionPicture;
                 RetainedCommandDataKind dataKind =
                     RetainedRenderCommand.Classify(in commands[index]);
                 classifications[index] = (byte)dataKind;
@@ -1998,6 +2036,9 @@ internal sealed class GpuPictureCommandCollection : IReadOnlyList<RenderCommand>
                     embeddedVisualCount++;
                 }
             }
+
+            SupportsRetainedCompositionPicture =
+                supportsRetainedCompositionPicture;
 
             _order = new uint[commands.Length];
             _basic = basicCount == 0
@@ -2498,6 +2539,8 @@ public class GpuPicture :
     internal int ImageEffectCount => _imageEffectBuffer.Length;
     internal GpuPictureCommandCollection RetainedCommands =>
         _retainedCommands;
+    internal bool SupportsRetainedCompositionPicture =>
+        _retainedCommands.SupportsRetainedCompositionPicture;
     internal long CommandStorageBytes =>
         _retainedCommands.ApproximateStorageBytes;
 

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -443,6 +443,89 @@ public sealed class LayerRenderTests
     }
 
     [Fact]
+    public void RetainedPictureEligibilityIsPrecomputedForSupportedStream()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableGpuHitTesting = false,
+            PrimarySampleCount = 1
+        };
+        using var window = new HeadlessWindow(64, 32, options);
+        using var visual = new RetainedPicturePlacementVisual(
+            includeEmbeddedVisual: false);
+        window.Content = visual;
+
+        try
+        {
+            Assert.True(visual.SupportsRetainedCompositionPicture);
+            window.Render();
+
+            visual.Offset = new Vector2(4f, 0f);
+            window.Render();
+
+            CompositorMetrics metrics = window.Compositor.Metrics;
+            Assert.Equal(1, metrics.RetainedCompositionPictureCompilations);
+            AssertGreen(ReadPixel(window.ReadPixels(), window.Width, 8, 8));
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
+    public void RetainedPictureEligibilityIsPrecomputedForRejectedStream()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableGpuHitTesting = false,
+            PrimarySampleCount = 1
+        };
+        using var window = new HeadlessWindow(64, 32, options);
+        using var visual = new RetainedPicturePlacementVisual(
+            includeEmbeddedVisual: true);
+        window.Content = visual;
+
+        try
+        {
+            Assert.False(visual.SupportsRetainedCompositionPicture);
+            window.Render();
+
+            visual.Offset = new Vector2(4f, 0f);
+            window.Render();
+
+            CompositorMetrics metrics = window.Compositor.Metrics;
+            Assert.Equal(0, metrics.RetainedCompositionPictureCompilations);
+            AssertGreen(ReadPixel(window.ReadPixels(), window.Width, 8, 8));
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
+    public void RetainedPictureEligibilityRejectsGpuTransformStreamAndClone()
+    {
+        using var picture = new GpuPicture(
+            [
+                new RenderCommand
+                {
+                    Type = RenderCommandType.DrawRect,
+                    UseGpuTransforms = true
+                }
+            ],
+            [],
+            [],
+            [],
+            []);
+        using GpuPicture clone = picture.Clone();
+
+        Assert.False(picture.SupportsRetainedCompositionPicture);
+        Assert.False(clone.SupportsRetainedCompositionPicture);
+    }
+
+    [Fact]
     public void EmptyOwnedCommandCacheSkipsLookupAndStillRendersChildren()
     {
         using var window = new HeadlessWindow(64, 64);
@@ -1078,6 +1161,59 @@ public sealed class LayerRenderTests
             }
             return recorder.EndRecording();
         }
+    }
+
+    private sealed class RetainedPicturePlacementVisual : FrameworkElement,
+        IDisposable
+    {
+        private readonly GpuPicture _picture;
+        private readonly EmbeddedColorVisual? _embedded;
+
+        public RetainedPicturePlacementVisual(bool includeEmbeddedVisual)
+        {
+            Width = 64f;
+            Height = 32f;
+            var recorder = new GpuPictureRecorder();
+            DrawingContext context = recorder.BeginRecording(
+                new Rect(0f, 0f, 64f, 32f));
+            var green = new SolidColorBrush(
+                new Vector4(0f, 1f, 0f, 1f));
+            context.DrawRectangle(
+                green,
+                null,
+                new Rect(0f, 0f, 8f, 8f));
+            context.DrawRectangle(
+                green,
+                null,
+                new Rect(8f, 0f, 8f, 8f));
+            context.DrawRectangle(
+                green,
+                null,
+                new Rect(0f, 8f, 8f, 8f));
+            if (includeEmbeddedVisual)
+            {
+                _embedded = new EmbeddedColorVisual();
+                context.DrawVisual(
+                    _embedded,
+                    Matrix4x4.CreateTranslation(24f, 0f, 0f));
+            }
+            else
+            {
+                context.DrawRectangle(
+                    green,
+                    null,
+                    new Rect(8f, 8f, 8f, 8f));
+            }
+            _picture = recorder.EndRecording();
+        }
+
+        public override void OnRender(DrawingContext context) =>
+            context.DrawPicture(_picture);
+
+        public bool SupportsRetainedCompositionPicture =>
+            _picture.SupportsRetainedCompositionPicture;
+
+        public void Dispose() => _picture.Dispose();
     }
 
     private sealed class OwnedPageVisual : FrameworkElement,


### PR DESCRIPTION
## Summary

- classify immutable picture command streams during the existing packed-command construction pass
- skip weak observation-table work on retained page cache hits
- share command capability classification with incremental page admission
- cover supported, embedded-visual, and GPU-transform eligibility paths

## Validation

- 3,695 core tests passed
- 240 headless tests passed
- eight fresh-process sparse retained-scene runs reduced process-median CPU/frame from 0.2357 ms to 0.1635 ms and scene compile from 0.1655 ms to 0.0912 ms
- all before/after output hashes matched and unsupported-operation count remained zero