### PR TITLE
Optimize analytic clip holes and effect lifetimes

### DIFF
--- a/src/ProGPU.Backend/Shaders/Text.wgsl
+++ b/src/ProGPU.Backend/Shaders/Text.wgsl
@@ -208,6 +208,14 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
     if (sampling.options.x < 2.5) {
         return outerAlpha;
     }
+    if (sampling.options.x > 3.5) {
+        let innerAlpha = rounded_mask_alpha_local(
+            local,
+            vec4<f32>(sampling.coordinate0.w, sampling.coordinate1.w, sampling.options.z, sampling.options.w),
+            vec4<f32>(0.0),
+            vec4<f32>(0.0));
+        return outerAlpha * (1.0 - innerAlpha);
+    }
     let inset = sampling.options.z;
     let innerAlpha = rounded_mask_alpha_local(
         local,

--- a/src/ProGPU.Backend/Shaders/Texture.wgsl
+++ b/src/ProGPU.Backend/Shaders/Texture.wgsl
@@ -109,6 +109,14 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
     if (sampling.options.x < 2.5) {
         return outerAlpha;
     }
+    if (sampling.options.x > 3.5) {
+        let innerAlpha = rounded_mask_alpha_local(
+            local,
+            vec4<f32>(sampling.coordinate0.w, sampling.coordinate1.w, sampling.options.z, sampling.options.w),
+            vec4<f32>(0.0),
+            vec4<f32>(0.0));
+        return outerAlpha * (1.0 - innerAlpha);
+    }
     let inset = sampling.options.z;
     let innerAlpha = rounded_mask_alpha_local(
         local,

--- a/src/ProGPU.Backend/Shaders/Vector.wgsl
+++ b/src/ProGPU.Backend/Shaders/Vector.wgsl
@@ -117,6 +117,15 @@ fn analytic_rounded_mask_alpha_for(position: vec2<f32>, sampling: MaskSamplingUn
         return outerAlpha;
     }
 
+    if (sampling.options.x > 3.5) {
+        let innerAlpha = rounded_mask_alpha_local(
+            local,
+            vec4<f32>(sampling.coordinate0.w, sampling.coordinate1.w, sampling.options.z, sampling.options.w),
+            vec4<f32>(0.0),
+            vec4<f32>(0.0));
+        return outerAlpha * (1.0 - innerAlpha);
+    }
+
     let inset = sampling.options.z;
     let innerBounds = sampling.bounds + vec4<f32>(inset, inset, -inset, -inset);
     let innerAlpha = rounded_mask_alpha_local(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -15411,7 +15411,7 @@ SceneStateUploadComplete:
             {
                 // Draw blurred shadow first (at offset, shifted back by padding)
                 var shadowRect = new Rect(
-                    sEff.Offset - new Vector2(padding, padding),
+                    paddedRect.Position + sEff.Offset,
                     new Vector2(logicalWidth, logicalHeight));
                 DrawTextureOnMain(cachedTextures.Destination!, shadowRect, compositeTransform, fe.HitTestId);
 

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -3352,6 +3352,10 @@ DynamicBufferUploadComplete:
         // Rasterize all pending paths before starting the render pass.
         _pathAtlas.RasterizePendingPaths();
 
+        // Embedded effect visuals can be owned only by a retained command and
+        // have no parent chain. Retire entries that were not reached by this
+        // compilation before deciding whether the new scene is cacheable.
+        SweepUnusedEffectTextures(root, externalLayers, activeToolTip);
         CaptureCompiledScene(
             root,
             width,
@@ -3768,7 +3772,6 @@ SceneStateUploadComplete:
         _totalTime += 1f / 60f;
         EvictUnusedBindGroups();
         SweepUnusedLayerTextures(root, externalLayers, activeToolTip);
-        SweepUnusedEffectTextures(root, externalLayers, activeToolTip);
         _activeLayerTextureOwners.Clear();
 
         passSw.Stop();
@@ -4431,7 +4434,7 @@ SceneStateUploadComplete:
 
     private void SweepUnusedEffectTextures(Visual mainRoot, IReadOnlyList<Visual>? externalLayers, Visual? activeToolTip)
     {
-        if (_frameNumber % 60 == 0 && _effectTextures.Count > 0)
+        if (_effectTextures.Count > 0)
         {
             Visual[]? detached = null;
             int detachedCount = 0;

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1204,6 +1204,7 @@ public unsafe partial class Compositor : IDisposable
     private readonly Dictionary<GpuTexture, MaskBindGroupResource> _maskBindGroups = new();
     private readonly List<MaskBindGroupResource> _analyticMaskResourcePool = new();
     private readonly List<MaskBindGroupResource> _analyticMasksToReturnToPool = new();
+    private readonly List<MaskBindGroupResource> _compiledSceneAnalyticMaskResources = new();
     private readonly Dictionary<GpuTexture, MaskRenderResource> _maskRenderResources = new();
     private readonly Dictionary<GpuTexture, MaskPixelBounds> _maskTextureBounds = new();
 
@@ -2923,6 +2924,7 @@ public unsafe partial class Compositor : IDisposable
         // 2. Clear CPU collection batch lists and active brushes
         if (!reuseCompiledScene)
         {
+            ReleaseCompiledSceneAnalyticMaskResources();
             _currentSolidRoundedPrimitiveCount = 0;
             _activeBrushes.Clear();
             _activeTextStyles.Clear();
@@ -3847,7 +3849,8 @@ SceneStateUploadComplete:
             MaskBindGroupCount = _maskBindGroups.Count,
             AnalyticMaskBindGroupCount =
                 _analyticMaskResourcePool.Count +
-                _analyticMasksToReturnToPool.Count,
+                _analyticMasksToReturnToPool.Count +
+                _compiledSceneAnalyticMaskResources.Count,
             MaskRenderBindGroupCount = CountMaskRenderBindGroups(),
             MaskTexturePoolCount = _maskTexturePool.Count,
             MaskTextureRetentionLimit = _maskTextureRetentionLimit,
@@ -4063,6 +4066,10 @@ SceneStateUploadComplete:
             _compiledLayerOwners.Clear();
             return;
         }
+
+        _compiledSceneAnalyticMaskResources.AddRange(
+            _analyticMasksToReturnToPool);
+        _analyticMasksToReturnToPool.Clear();
 
         _compiledSceneRoot = root;
         _compiledSceneRootVersion = root.ChangeVersion;
@@ -14236,6 +14243,14 @@ SceneStateUploadComplete:
                     _analyticMasksToReturnToPool[index]);
             }
             _analyticMasksToReturnToPool.Clear();
+            for (int index = 0;
+                 index < _compiledSceneAnalyticMaskResources.Count;
+                 index++)
+            {
+                DisposeMaskBindGroupResource(
+                    _compiledSceneAnalyticMaskResources[index]);
+            }
+            _compiledSceneAnalyticMaskResources.Clear();
 
             if (_dummyMaskTexture != null) _dummyMaskTexture.Dispose();
             _dummyMaskSamplingBuffer?.Dispose();
@@ -16887,7 +16902,8 @@ SceneStateUploadComplete:
             MaskBindGroupCount = _maskBindGroups.Count,
             AnalyticMaskBindGroupCount =
                 _analyticMaskResourcePool.Count +
-                _analyticMasksToReturnToPool.Count,
+                _analyticMasksToReturnToPool.Count +
+                _compiledSceneAnalyticMaskResources.Count,
             MaskRenderBindGroupCount = CountMaskRenderBindGroups(),
             MaskTexturePoolCount = _maskTexturePool.Count,
             MaskTextureRetentionLimit = _maskTextureRetentionLimit,
@@ -19118,6 +19134,18 @@ SceneStateUploadComplete:
         }
     }
 
+    private void ReleaseCompiledSceneAnalyticMaskResources()
+    {
+        if (_compiledSceneAnalyticMaskResources.Count == 0)
+        {
+            return;
+        }
+
+        _analyticMaskResourcePool.AddRange(
+            _compiledSceneAnalyticMaskResources);
+        _compiledSceneAnalyticMaskResources.Clear();
+    }
+
     private void DisposeMaskBindGroupResource(
         MaskBindGroupResource resource)
     {
@@ -19831,7 +19859,12 @@ SceneStateUploadComplete:
             geometry,
             out contour,
             out ringInset);
+        bool isRectangularHoleRing = TryReadRectangularHoleRing(
+            geometry,
+            out RoundedRectanglePathContour rectangularHoleOuter,
+            out RoundedRectanglePathContour rectangularHoleInner);
         if (!isRoundedRing &&
+            !isRectangularHoleRing &&
             (geometry.Figures.Count != 1 ||
              !RoundedRectanglePathGeometry.TryReadCanonicalContour(
                  geometry.Figures[0],
@@ -19839,7 +19872,13 @@ SceneStateUploadComplete:
         {
             return false;
         }
-        if (!isRoundedRing && _maskStack.Count != 0)
+        if (!isRoundedRing && isRectangularHoleRing)
+        {
+            contour = rectangularHoleOuter;
+        }
+        if (!isRoundedRing &&
+            !isRectangularHoleRing &&
+            _maskStack.Count != 0)
         {
             return false;
         }
@@ -19882,12 +19921,16 @@ SceneStateUploadComplete:
                 physicalToLocal.M11,
                 physicalToLocal.M21,
                 physicalToLocal.M31,
-                0f),
+                isRectangularHoleRing
+                    ? rectangularHoleInner.Left
+                    : 0f),
             Coordinate1 = new Vector4(
                 physicalToLocal.M12,
                 physicalToLocal.M22,
                 physicalToLocal.M32,
-                0f),
+                isRectangularHoleRing
+                    ? rectangularHoleInner.Top
+                    : 0f),
             Bounds = new Vector4(
                 contour.Left,
                 contour.Top,
@@ -19896,16 +19939,37 @@ SceneStateUploadComplete:
             CornerRadiiX = contour.CornerRadiiX,
             CornerRadiiY = contour.CornerRadiiY,
             Options = new Vector4(
-                isRoundedRing ? 3f : 2f,
+                isRectangularHoleRing
+                    ? 4f
+                    : isRoundedRing
+                        ? 3f
+                        : 2f,
                 1f,
-                ringInset,
-                0f)
+                isRectangularHoleRing
+                    ? rectangularHoleInner.Right
+                    : ringInset,
+                isRectangularHoleRing
+                    ? rectangularHoleInner.Bottom
+                    : 0f)
         };
-        if (_maskStack.Count != 0 &&
-            (_maskStack.Count != 1 ||
-             !MatchesAnalyticOuter(_maskStack.Peek(), samplingUniforms)))
+        if (_maskStack.Count != 0)
         {
-            return false;
+            if (_maskStack.Count == 1 &&
+                isRectangularHoleRing &&
+                TryComposeAnalyticOuterWithRectangularHole(
+                    _maskStack.Peek(),
+                    samplingUniforms,
+                    rectangularHoleOuter,
+                    rectangularHoleInner,
+                    out MaskSamplingUniforms composedSamplingUniforms))
+            {
+                samplingUniforms = composedSamplingUniforms;
+            }
+            else if (_maskStack.Count != 1 ||
+                     !MatchesAnalyticOuter(_maskStack.Peek(), samplingUniforms))
+            {
+                return false;
+            }
         }
 
         CommitPendingDrawCalls();
@@ -19946,6 +20010,45 @@ SceneStateUploadComplete:
             outer.CornerRadiiY == ring.CornerRadiiY;
     }
 
+    private static bool TryComposeAnalyticOuterWithRectangularHole(
+        MaskTextureState parent,
+        MaskSamplingUniforms ring,
+        RoundedRectanglePathContour ringOuter,
+        RoundedRectanglePathContour ringInner,
+        out MaskSamplingUniforms composed)
+    {
+        composed = default;
+        if (parent.AnalyticResource is not { } resource)
+        {
+            return false;
+        }
+
+        MaskSamplingUniforms outer = resource.SamplingUniforms;
+        if (outer.Options.X != 2f ||
+            new Vector3(outer.Coordinate0.X, outer.Coordinate0.Y, outer.Coordinate0.Z) !=
+                new Vector3(ring.Coordinate0.X, ring.Coordinate0.Y, ring.Coordinate0.Z) ||
+            new Vector3(outer.Coordinate1.X, outer.Coordinate1.Y, outer.Coordinate1.Z) !=
+                new Vector3(ring.Coordinate1.X, ring.Coordinate1.Y, ring.Coordinate1.Z) ||
+            outer.Bounds != new Vector4(
+                ringOuter.Left,
+                ringOuter.Top,
+                ringOuter.Right,
+                ringOuter.Bottom))
+        {
+            return false;
+        }
+
+        composed = outer;
+        composed.Coordinate0.W = ringInner.Left;
+        composed.Coordinate1.W = ringInner.Top;
+        composed.Options = new Vector4(
+            4f,
+            outer.Options.Y,
+            ringInner.Right,
+            ringInner.Bottom);
+        return true;
+    }
+
     private static bool TryReadUniformRoundedRing(
         PathGeometry geometry,
         out RoundedRectanglePathContour outer,
@@ -19982,6 +20085,34 @@ SceneStateUploadComplete:
 
         inset = left;
         return true;
+    }
+
+    private static bool TryReadRectangularHoleRing(
+        PathGeometry geometry,
+        out RoundedRectanglePathContour outer,
+        out RoundedRectanglePathContour inner)
+    {
+        outer = default;
+        inner = default;
+        if (geometry.FillRule != FillRule.EvenOdd ||
+            geometry.Figures.Count != 2 ||
+            !RoundedRectanglePathGeometry.TryReadCanonicalContour(
+                geometry.Figures[0],
+                out outer) ||
+            !RoundedRectanglePathGeometry.TryReadCanonicalContour(
+                geometry.Figures[1],
+                out inner) ||
+            HasRoundedCorners(inner))
+        {
+            return false;
+        }
+
+        return inner.Left >= outer.Left &&
+            inner.Top >= outer.Top &&
+            inner.Right <= outer.Right &&
+            inner.Bottom <= outer.Bottom &&
+            inner.Left < inner.Right &&
+            inner.Top < inner.Bottom;
     }
 
     private static bool InsetRadiiMatch(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -15418,8 +15418,11 @@ SceneStateUploadComplete:
                     new Vector2(logicalWidth, logicalHeight));
                 DrawTextureOnMain(cachedTextures.Destination!, shadowRect, compositeTransform, fe.HitTestId);
 
-                // Draw original source on top (shifted back by padding)
-                DrawTextureOnMain(cachedTextures.Source, paddedRect, compositeTransform, fe.HitTestId);
+                if (sEff.DrawSource)
+                {
+                    // Draw original source on top (shifted back by padding).
+                    DrawTextureOnMain(cachedTextures.Source, paddedRect, compositeTransform, fe.HitTestId);
+                }
             }
             else if (fe.Effect is WpfShaderEffect shaderEffect)
             {

--- a/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
+++ b/src/ProGPU.Scene/Shaders/BackdropMaterial.wgsl
@@ -80,6 +80,14 @@ fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {
 	if (maskSampling.options.x < 2.5) {
 		return outerAlpha;
 	}
+	if (maskSampling.options.x > 3.5) {
+		let innerAlpha = rounded_mask_alpha_local(
+			local,
+			vec4<f32>(maskSampling.coordinate0.w, maskSampling.coordinate1.w, maskSampling.options.z, maskSampling.options.w),
+			vec4<f32>(0.0),
+			vec4<f32>(0.0));
+		return outerAlpha * (1.0 - innerAlpha);
+	}
 	let inset = maskSampling.options.z;
 	let innerAlpha = rounded_mask_alpha_local(
 		local,

--- a/src/ProGPU.Scene/Shaders/ImageEffect.wgsl
+++ b/src/ProGPU.Scene/Shaders/ImageEffect.wgsl
@@ -101,6 +101,14 @@ fn analytic_rounded_mask_alpha_for(
     if (sampling.options.x < 2.5) {
         return outerAlpha;
     }
+    if (sampling.options.x > 3.5) {
+        let innerAlpha = rounded_mask_alpha_local(
+            local,
+            vec4<f32>(sampling.coordinate0.w, sampling.coordinate1.w, sampling.options.z, sampling.options.w),
+            vec4<f32>(0.0),
+            vec4<f32>(0.0));
+        return outerAlpha * (1.0 - innerAlpha);
+    }
     let inset = sampling.options.z;
     let innerAlpha = rounded_mask_alpha_local(
         local,

--- a/src/ProGPU.Scene/Shaders/RetainedGlyph.wgsl
+++ b/src/ProGPU.Scene/Shaders/RetainedGlyph.wgsl
@@ -98,6 +98,14 @@ fn analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {
 	if (maskSampling.options.x < 2.5) {
 		return outerAlpha;
 	}
+	if (maskSampling.options.x > 3.5) {
+		let innerAlpha = rounded_mask_alpha_local(
+			local,
+			vec4<f32>(maskSampling.coordinate0.w, maskSampling.coordinate1.w, maskSampling.options.z, maskSampling.options.w),
+			vec4<f32>(0.0),
+			vec4<f32>(0.0));
+		return outerAlpha * (1.0 - innerAlpha);
+	}
 	let inset = maskSampling.options.z;
 	let innerAlpha = rounded_mask_alpha_local(
 		local,

--- a/src/ProGPU.Scene/Shaders/ShaderToyHeader.wgsl
+++ b/src/ProGPU.Scene/Shaders/ShaderToyHeader.wgsl
@@ -36,29 +36,29 @@ struct MaskSamplingUniforms {
 
 @group(2) @binding(2) var<uniform> activeMaskSampling: MaskSamplingUniforms;
 
-fn analytic_active_rounded_mask_alpha(position: vec2<f32>) -> f32 {
-    let local = vec2<f32>(
-        dot(vec3<f32>(position, 1.0), activeMaskSampling.coordinate0.xyz),
-        dot(vec3<f32>(position, 1.0), activeMaskSampling.coordinate1.xyz));
-    let bounds = activeMaskSampling.bounds;
+fn active_rounded_mask_alpha_local(
+    local: vec2<f32>,
+    bounds: vec4<f32>,
+    radiiX: vec4<f32>,
+    radiiY: vec4<f32>) -> f32 {
     let edge = max(max(bounds.x - local.x, local.x - bounds.z), max(bounds.y - local.y, local.y - bounds.w));
     var center = vec2<f32>(0.0);
     var radius = vec2<f32>(0.0);
     var usesCorner = false;
-    if (local.x < bounds.x + activeMaskSampling.cornerRadiiX.x && local.y < bounds.y + activeMaskSampling.cornerRadiiY.x) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.x, activeMaskSampling.cornerRadiiY.x);
+    if (local.x < bounds.x + radiiX.x && local.y < bounds.y + radiiY.x) {
+        radius = vec2<f32>(radiiX.x, radiiY.x);
         center = vec2<f32>(bounds.x + radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - activeMaskSampling.cornerRadiiX.y && local.y < bounds.y + activeMaskSampling.cornerRadiiY.y) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.y, activeMaskSampling.cornerRadiiY.y);
+    } else if (local.x > bounds.z - radiiX.y && local.y < bounds.y + radiiY.y) {
+        radius = vec2<f32>(radiiX.y, radiiY.y);
         center = vec2<f32>(bounds.z - radius.x, bounds.y + radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x > bounds.z - activeMaskSampling.cornerRadiiX.z && local.y > bounds.w - activeMaskSampling.cornerRadiiY.z) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.z, activeMaskSampling.cornerRadiiY.z);
+    } else if (local.x > bounds.z - radiiX.z && local.y > bounds.w - radiiY.z) {
+        radius = vec2<f32>(radiiX.z, radiiY.z);
         center = vec2<f32>(bounds.z - radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
-    } else if (local.x < bounds.x + activeMaskSampling.cornerRadiiX.w && local.y > bounds.w - activeMaskSampling.cornerRadiiY.w) {
-        radius = vec2<f32>(activeMaskSampling.cornerRadiiX.w, activeMaskSampling.cornerRadiiY.w);
+    } else if (local.x < bounds.x + radiiX.w && local.y > bounds.w - radiiY.w) {
+        radius = vec2<f32>(radiiX.w, radiiY.w);
         center = vec2<f32>(bounds.x + radius.x, bounds.w - radius.y);
         usesCorner = all(radius > vec2<f32>(0.0));
     }
@@ -68,6 +68,35 @@ fn analytic_active_rounded_mask_alpha(position: vec2<f32>) -> f32 {
     let implicit = select(edge, ellipse, usesCorner);
     let antialiasWidth = max(fwidth(implicit), 0.0001);
     return clamp(0.5 - implicit / antialiasWidth, 0.0, 1.0);
+}
+
+fn analytic_active_rounded_mask_alpha(position: vec2<f32>) -> f32 {
+    let local = vec2<f32>(
+        dot(vec3<f32>(position, 1.0), activeMaskSampling.coordinate0.xyz),
+        dot(vec3<f32>(position, 1.0), activeMaskSampling.coordinate1.xyz));
+    let outerAlpha = active_rounded_mask_alpha_local(
+        local,
+        activeMaskSampling.bounds,
+        activeMaskSampling.cornerRadiiX,
+        activeMaskSampling.cornerRadiiY);
+    if (activeMaskSampling.options.x < 2.5) {
+        return outerAlpha;
+    }
+    if (activeMaskSampling.options.x > 3.5) {
+        let innerAlpha = active_rounded_mask_alpha_local(
+            local,
+            vec4<f32>(activeMaskSampling.coordinate0.w, activeMaskSampling.coordinate1.w, activeMaskSampling.options.z, activeMaskSampling.options.w),
+            vec4<f32>(0.0),
+            vec4<f32>(0.0));
+        return outerAlpha * (1.0 - innerAlpha);
+    }
+    let inset = activeMaskSampling.options.z;
+    let innerAlpha = active_rounded_mask_alpha_local(
+        local,
+        activeMaskSampling.bounds + vec4<f32>(inset, inset, -inset, -inset),
+        max(activeMaskSampling.cornerRadiiX - vec4<f32>(inset), vec4<f32>(0.0)),
+        max(activeMaskSampling.cornerRadiiY - vec4<f32>(inset), vec4<f32>(0.0)));
+    return outerAlpha * (1.0 - innerAlpha);
 }
 
 fn sample_active_mask_alpha(position: vec2<f32>) -> f32 {

--- a/src/ProGPU.Scene/Shaders/WpfEffectMaskHelper.wgsl
+++ b/src/ProGPU.Scene/Shaders/WpfEffectMaskHelper.wgsl
@@ -39,6 +39,14 @@ fn wpf_analytic_rounded_mask_alpha(position: vec2<f32>) -> f32 {
 	if (activeMaskSampling.options.x < 2.5) {
 		return outerAlpha;
 	}
+	if (activeMaskSampling.options.x > 3.5) {
+		let innerAlpha = wpf_rounded_mask_alpha_local(
+			local,
+			vec4<f32>(activeMaskSampling.coordinate0.w, activeMaskSampling.coordinate1.w, activeMaskSampling.options.z, activeMaskSampling.options.w),
+			vec4<f32>(0.0),
+			vec4<f32>(0.0));
+		return outerAlpha * (1.0 - innerAlpha);
+	}
 	let inset = activeMaskSampling.options.z;
 	let innerAlpha = wpf_rounded_mask_alpha_local(
 		local,

--- a/src/ProGPU.Scene/Visual.cs
+++ b/src/ProGPU.Scene/Visual.cs
@@ -1453,6 +1453,7 @@ public class DropShadowEffect : EffectBase
     private float _blurRadius;
     private Vector2 _offset;
     private Vector4 _color;
+    private bool _drawSource = true;
     private Visual? _opacityMaskVisual;
 
     public float BlurRadius
@@ -1489,6 +1490,24 @@ public class DropShadowEffect : EffectBase
             if (_color != value)
             {
                 _color = value;
+                Invalidate();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether the uneffected source is composited above the
+    /// generated shadow. The default preserves conventional drop-shadow
+    /// behavior; shadow-only filter contracts can disable it.
+    /// </summary>
+    public bool DrawSource
+    {
+        get => _drawSource;
+        set
+        {
+            if (_drawSource != value)
+            {
+                _drawSource = value;
                 Invalidate();
             }
         }

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -6752,6 +6752,66 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void RoundedParentWithRectangularHoleAvoidsTexturePass()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new RoundedParentRectangularHoleClipVisual();
+
+        window.Render();
+        window.Render();
+
+        CompositorMetrics metrics = window.Compositor.Metrics;
+        Assert.Equal(0, metrics.MaskTexturePeakDemand);
+        Assert.Equal(2, metrics.AnalyticMaskBindGroupCount);
+        Assert.Equal(0, metrics.MaskRenderPassCount);
+        Assert.True(metrics.SceneCacheHit);
+
+        byte[] pixels = window.ReadPixels();
+        var border = ReadPixel(pixels, window.Width, x: 8, y: 32);
+        var hole = ReadPixel(pixels, window.Width, x: 32, y: 32);
+        var outerCorner = ReadPixel(pixels, window.Width, x: 4, y: 4);
+        Assert.True(
+            border.G >= 220 && border.R <= 35 && border.B <= 35,
+            $"Expected green coverage between the rounded edge and rectangular hole, found {border}.");
+        Assert.True(
+            hole.R <= 35 && hole.G <= 35 && hole.B <= 35,
+            $"Expected the rectangular analytic hole to stay clear, found {hole}.");
+        Assert.True(
+            outerCorner.R <= 35 && outerCorner.G <= 35 && outerCorner.B <= 35,
+            $"Expected the rounded parent corner to stay clear, found {outerCorner}.");
+    }
+
+    [Fact]
+    public void RoundedRectangularHoleRingUsesOneAnalyticMask()
+    {
+        using var window = new HeadlessWindow(64, 64);
+        window.Content = new RoundedRectangularHoleClipVisual();
+
+        window.Render();
+        window.Render();
+
+        CompositorMetrics metrics = window.Compositor.Metrics;
+        Assert.Equal(0, metrics.MaskTexturePeakDemand);
+        Assert.Equal(1, metrics.AnalyticMaskBindGroupCount);
+        Assert.Equal(0, metrics.MaskRenderPassCount);
+        Assert.True(metrics.SceneCacheHit);
+
+        byte[] pixels = window.ReadPixels();
+        var border = ReadPixel(pixels, window.Width, x: 8, y: 32);
+        var hole = ReadPixel(pixels, window.Width, x: 32, y: 32);
+        var outerCorner = ReadPixel(pixels, window.Width, x: 4, y: 4);
+        Assert.True(
+            border.G >= 220 && border.R <= 35 && border.B <= 35,
+            $"Expected green rounded-ring coverage, found {border}.");
+        Assert.True(
+            hole.R <= 35 && hole.G <= 35 && hole.B <= 35,
+            $"Expected the rectangular hole to stay clear, found {hole}.");
+        Assert.True(
+            outerCorner.R <= 35 && outerCorner.G <= 35 && outerCorner.B <= 35,
+            $"Expected the rounded-ring corner to stay clear, found {outerCorner}.");
+    }
+
+    [Fact]
     public void AnalyticClipDoesNotMaskPendingPrecedingDraws()
     {
         using var window = new HeadlessWindow(64, 64);
@@ -9824,6 +9884,90 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
             {
                 context.PopGeometryClip();
             }
+        }
+    }
+
+    private sealed class RoundedParentRectangularHoleClipVisual : FrameworkElement
+    {
+        public RoundedParentRectangularHoleClipVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.PushGeometryClip(
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    4f,
+                    4f,
+                    56f,
+                    56f,
+                    10f,
+                    10f));
+
+            PathGeometry rectangularRing =
+                PrimitivePathGeometry.CreateRectangle(
+                    4f,
+                    4f,
+                    56f,
+                    56f);
+            rectangularRing.FillRule = FillRule.EvenOdd;
+            PathGeometry hole = PrimitivePathGeometry.CreateRectangle(
+                18f,
+                14f,
+                26f,
+                32f);
+            foreach (PathFigure figure in hole.Figures)
+            {
+                rectangularRing.Figures.Add(figure);
+            }
+
+            context.PushGeometryClip(rectangularRing);
+            context.DrawRectangle(
+                new SolidColorBrush(new Vector4(0f, 1f, 0f, 1f)),
+                null,
+                new Rect(0f, 0f, 64f, 64f));
+            context.PopGeometryClip();
+            context.PopGeometryClip();
+        }
+    }
+
+    private sealed class RoundedRectangularHoleClipVisual : FrameworkElement
+    {
+        public RoundedRectangularHoleClipVisual()
+        {
+            Width = 64f;
+            Height = 64f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            PathGeometry ring =
+                PrimitivePathGeometry.CreateRoundedRectangle(
+                    4f,
+                    4f,
+                    56f,
+                    56f,
+                    10f,
+                    10f);
+            ring.FillRule = FillRule.EvenOdd;
+            PathGeometry hole = PrimitivePathGeometry.CreateRectangle(
+                18f,
+                14f,
+                26f,
+                32f);
+            foreach (PathFigure figure in hole.Figures)
+            {
+                ring.Figures.Add(figure);
+            }
+
+            context.PushGeometryClip(ring);
+            context.DrawRectangle(
+                new SolidColorBrush(new Vector4(0f, 1f, 0f, 1f)),
+                null,
+                new Rect(0f, 0f, 64f, 64f));
+            context.PopGeometryClip();
         }
     }
 

--- a/src/ProGPU.Tests/VisualChangeVersionTests.cs
+++ b/src/ProGPU.Tests/VisualChangeVersionTests.cs
@@ -157,6 +157,10 @@ public sealed class VisualChangeVersionTests
         shadow.Offset = new Vector2(3f, 4f);
         Assert.True(shadow.ChangeVersion > shadowVersion);
 
+        shadowVersion = shadow.ChangeVersion;
+        shadow.DrawSource = false;
+        Assert.True(shadow.ChangeVersion > shadowVersion);
+
         var shader = new WpfShaderEffect(new WpfShaderEffectParams());
         var shaderVersion = shader.ChangeVersion;
         shader.Padding = 6f;

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -232,6 +232,34 @@ public sealed class VisualEffectRenderTests
     }
 
     [Fact]
+    public void DropShadowCanRenderWithoutCompositingItsSource()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(100, 60);
+        window.Content = new ExplicitShadowBoundsVisual(drawSource: false);
+
+        try
+        {
+            window.Render();
+
+            var pixels = window.ReadPixels();
+            var omittedSource = ReadPixel(pixels, window.Width, x: 44, y: 24);
+            var shadow = ReadPixel(pixels, window.Width, x: 56, y: 24);
+
+            Assert.InRange(omittedSource.R, 0, 50);
+            Assert.InRange(omittedSource.G, 0, 50);
+            Assert.InRange(omittedSource.B, 0, 50);
+            Assert.InRange(shadow.R, 0, 10);
+            Assert.InRange(shadow.G, 0, 10);
+            Assert.InRange(shadow.B, 245, 255);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
     public void DetachedEffectTexturesDoNotBlockTheNextSceneCache()
     {
         var window = HeadlessWindow.Shared;
@@ -406,12 +434,13 @@ public sealed class VisualEffectRenderTests
         private readonly SolidColorBrush _red =
             new(new Vector4(1f, 0f, 0f, 1f));
 
-        public ExplicitShadowBoundsVisual()
+        public ExplicitShadowBoundsVisual(bool drawSource = true)
         {
             Effect = new DropShadowEffect(0f)
             {
                 Offset = new Vector2(8f, 0f),
-                Color = new Vector4(0f, 0f, 1f, 1f)
+                Color = new Vector4(0f, 0f, 1f, 1f),
+                DrawSource = drawSource
             };
             EffectContentBounds = new Rect(40f, 20f, 12f, 8f);
             EffectRasterPadding = 0f;

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -231,6 +231,32 @@ public sealed class VisualEffectRenderTests
         }
     }
 
+    [Fact]
+    public void DetachedEffectTexturesDoNotBlockTheNextSceneCache()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(100, 60);
+        window.Content = new ExplicitShadowBoundsVisual();
+
+        try
+        {
+            window.Render();
+            Assert.True(window.Compositor.Metrics.EffectTextureBytes > 0);
+
+            window.Content = new PlainBoundsVisual();
+            window.Render();
+            Assert.False(window.Compositor.Metrics.SceneCacheHit);
+            Assert.Equal(0UL, window.Compositor.Metrics.EffectTextureBytes);
+
+            window.Render();
+            Assert.True(window.Compositor.Metrics.SceneCacheHit);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -397,6 +423,26 @@ public sealed class VisualEffectRenderTests
                 _red,
                 null,
                 new Rect(40f, 20f, 12f, 8f));
+        }
+    }
+
+    private sealed class PlainBoundsVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _green =
+            new(new Vector4(0f, 1f, 0f, 1f));
+
+        public PlainBoundsVisual()
+        {
+            Width = 100f;
+            Height = 60f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _green,
+                null,
+                new Rect(20f, 10f, 60f, 40f));
         }
     }
 }

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -199,6 +199,38 @@ public sealed class VisualEffectRenderTests
         }
     }
 
+    [Fact]
+    public void DropShadowPreservesExplicitContentBoundsPosition()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(100, 60);
+        window.Content = new ExplicitShadowBoundsVisual();
+
+        try
+        {
+            window.Render();
+
+            var pixels = window.ReadPixels();
+            var content = ReadPixel(pixels, window.Width, x: 44, y: 24);
+            var shadow = ReadPixel(pixels, window.Width, x: 56, y: 24);
+            var staleOrigin = ReadPixel(pixels, window.Width, x: 12, y: 4);
+
+            Assert.InRange(content.R, 245, 255);
+            Assert.InRange(content.G, 0, 10);
+            Assert.InRange(content.B, 0, 10);
+            Assert.InRange(shadow.R, 0, 10);
+            Assert.InRange(shadow.G, 0, 10);
+            Assert.InRange(shadow.B, 245, 255);
+            Assert.InRange(staleOrigin.R, 0, 50);
+            Assert.InRange(staleOrigin.G, 0, 50);
+            Assert.InRange(staleOrigin.B, 0, 50);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -340,6 +372,31 @@ public sealed class VisualEffectRenderTests
                 _red,
                 null,
                 new Rect(25f, 15f, 30f, 20f));
+        }
+    }
+
+    private sealed class ExplicitShadowBoundsVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _red =
+            new(new Vector4(1f, 0f, 0f, 1f));
+
+        public ExplicitShadowBoundsVisual()
+        {
+            Effect = new DropShadowEffect(0f)
+            {
+                Offset = new Vector2(8f, 0f),
+                Color = new Vector4(0f, 0f, 1f, 1f)
+            };
+            EffectContentBounds = new Rect(40f, 20f, 12f, 8f);
+            EffectRasterPadding = 0f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _red,
+                null,
+                new Rect(40f, 20f, 12f, 8f));
         }
     }
 }


### PR DESCRIPTION
## Summary

- compose contained rectangular difference clips into a single analytic mask
- preserve explicit translated bounds when compositing effects
- retire detached effect textures before retained-scene cache admission
- add opt-in shadow-only drop-shadow composition while preserving the existing default
- cover clip encoding, effect placement, resource lifetime, and invalidation regressions

## Validation

- dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-restore --filter FullyQualifiedName!~ShapingContractsTests (3,700 passed)
- dotnet test src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj -c Release --no-restore (240 passed)