### PR TITLE
Optimize retained scene draw-call merging

### DIFF
--- a/src/ProGPU.Scene/Compositor.IncrementalPages.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalPages.cs
@@ -1041,9 +1041,9 @@ public unsafe partial class Compositor
                 DrawCallType.Texture => (uint)textureIndexStart,
                 _ => 0u
             };
-            CompositorDrawCall drawCall =
-                retainedDrawCall.Expand(indexBase);
-            AppendOrMergeIncrementalDrawCall(drawCall);
+            AppendOrMergeIncrementalDrawCall(
+                retainedDrawCall,
+                indexBase);
         }
 
         _currentSolidRoundedPrimitiveCount +=
@@ -1091,11 +1091,52 @@ public unsafe partial class Compositor
         }
     }
 
+    private void AppendOrMergeIncrementalDrawCall(
+        in IncrementalScenePageDrawCall retainedDrawCall,
+        uint indexBase)
+    {
+        if (_drawCalls.Count != 0 &&
+            TryMergeIncrementalDrawCall(
+                _drawCalls.Count - 1,
+                retainedDrawCall,
+                indexBase))
+        {
+            return;
+        }
+
+        _drawCalls.Add(retainedDrawCall.Expand(indexBase));
+    }
+
+    private bool TryMergeIncrementalDrawCall(
+        int previousIndex,
+        in IncrementalScenePageDrawCall current,
+        uint indexBase)
+    {
+        ref CompositorDrawCall previous = ref
+            CollectionsMarshal.AsSpan(_drawCalls)[previousIndex];
+        uint indexStart = current.IndexStart + indexBase;
+        if (previous.Type != current.Type ||
+            previous.Type is not (DrawCallType.Vector or DrawCallType.Text) ||
+            previous.IndexStart + previous.IndexCount != indexStart ||
+            previous.IsSolidRect != current.IsSolidRect ||
+            previous.IsSolidRounded != current.IsSolidRounded ||
+            previous.ClipRect != current.ClipRect ||
+            previous.MaskTexture != null ||
+            previous.BlendMode != current.BlendMode)
+        {
+            return false;
+        }
+
+        previous.IndexCount += current.IndexCount;
+        return true;
+    }
+
     private bool TryMergeIncrementalDrawCall(
         int previousIndex,
         in CompositorDrawCall current)
     {
-        CompositorDrawCall previous = _drawCalls[previousIndex];
+        ref CompositorDrawCall previous = ref
+            CollectionsMarshal.AsSpan(_drawCalls)[previousIndex];
         if (previous.Type != current.Type ||
             previous.Type is not (DrawCallType.Vector or DrawCallType.Text) ||
             previous.IndexStart + previous.IndexCount != current.IndexStart ||
@@ -1109,7 +1150,6 @@ public unsafe partial class Compositor
         }
 
         previous.IndexCount += current.IndexCount;
-        _drawCalls[previousIndex] = previous;
         return true;
     }
 

--- a/src/ProGPU.Tests/DiagnosticsLoggingSourceTests.cs
+++ b/src/ProGPU.Tests/DiagnosticsLoggingSourceTests.cs
@@ -872,7 +872,18 @@ public class DiagnosticsLoggingSourceTests
             source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "retainedDrawCall.Expand(indexBase)",
+            "AppendOrMergeIncrementalDrawCall(\n" +
+            "                retainedDrawCall,\n" +
+            "                indexBase)",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "_drawCalls.Add(retainedDrawCall.Expand(indexBase))",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ref CompositorDrawCall previous = ref\n" +
+            "            CollectionsMarshal.AsSpan(_drawCalls)[previousIndex]",
             source,
             StringComparison.Ordinal);
         Assert.DoesNotContain(

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -431,6 +431,7 @@ public sealed class LayerRenderTests
                 metrics.RetainedCompositionPictureCount,
                 31,
                 32);
+            Assert.Equal(2, metrics.DrawCallsCount);
 
             byte[] pixels = window.ReadPixels();
             AssertGreen(ReadPixel(pixels, window.Width, 4, 4));


### PR DESCRIPTION
## Summary

- merge compact retained page draw calls before expanding the full compositor draw-call structure
- mutate compatible accumulated draw calls in place instead of copying the large structure on every merge
- preserve full expansion for non-mergeable vector, text, and texture calls

## Performance

In the C++ UI sparse retained-row workload (eight fresh-process pairs, 100 measured frames and nine 60-frame batches per process):

- CPU submit process median: 0.205 ms to 0.192 ms per frame (-6.3%)
- scene compilation process median: 0.088 ms to 0.084 ms per frame (-4.7%)
- retained-page append sampled share: 4.09% to 0.22%
- output remained byte-identical

## Validation

- ProGPU.Tests: 3,700 passed
- ProGPU.Tests.Headless: 240 passed
- focused retained-page, draw-call contract, and context tests: 33 passed