### PR TITLE
Optimize retained picture presentation

### DIFF
--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -1930,15 +1930,40 @@ public unsafe class WgpuContext : IDisposable
                     Device,
                     wait ? 1u : 0u,
                     null);
+                if (wait)
+                {
+                    MarkSubmittedWorkDrained();
+                }
             }
             else if (BackendKind ==
                          WgpuBackendKind.DawnNative &&
                      Device != null &&
                      !_isDisposed)
             {
-                _externalDeviceLifetime?.Poll(wait);
+                IWebGpuExternalDeviceLifetime? lifetime =
+                    _externalDeviceLifetime;
+                if (lifetime is not null)
+                {
+                    lifetime.Poll(wait);
+                    if (wait)
+                    {
+                        MarkSubmittedWorkDrained();
+                    }
+                }
             }
         }
+    }
+
+    private void MarkSubmittedWorkDrained()
+    {
+        long submittedQueueWork =
+            Volatile.Read(ref _queueSubmissionCount);
+        Volatile.Write(
+            ref _drainedQueueSubmissionCount,
+            submittedQueueWork);
+        Volatile.Write(
+            ref _polledQueueSubmissionCount,
+            submittedQueueWork);
     }
 
     public bool TryCaptureNativeResourceSnapshot(out WgpuNativeResourceSnapshot snapshot)

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -2544,6 +2544,16 @@ public class GpuPicture :
     internal long CommandStorageBytes =>
         _retainedCommands.ApproximateStorageBytes;
 
+    /// <summary>
+    /// Returns whether two pictures share the same immutable retained command
+    /// storage. Clones share storage while owning independent resource leases.
+    /// Hosts can use this identity check to avoid invalidating a visual when a
+    /// short-lived ownership clone replaces an otherwise identical picture.
+    /// </summary>
+    public bool SharesRetainedCommandStorageWith(GpuPicture? other) =>
+        other is not null &&
+        ReferenceEquals(_retainedCommands, other._retainedCommands);
+
     public GpuPicture(
         RenderCommand[] commands,
         Vector2[] pointBuffer,
@@ -2725,6 +2735,12 @@ public class GpuPictureRecorder
 
     public GpuPicture EndRecording()
     {
+        if (TryCloneSingleIdentityPicture(out GpuPicture? flattened))
+        {
+            _recordingContext.Clear();
+            return flattened;
+        }
+
         var picture = new GpuPicture(
             _recordingContext.Commands.AsSpan(),
             CopyList(_recordingContext.PointBuffer),
@@ -2736,6 +2752,31 @@ public class GpuPictureRecorder
         );
         _recordingContext.Clear();
         return picture;
+    }
+
+    private bool TryCloneSingleIdentityPicture(out GpuPicture picture)
+    {
+        picture = null!;
+        if (_recordingContext.Commands.Count != 1 ||
+            _recordingContext.HasCommandSideBuffers)
+        {
+            return false;
+        }
+
+        RenderCommand command = _recordingContext.Commands[0];
+        GpuPicture? child = command.Picture;
+        if (command.Type != RenderCommandType.DrawPicture ||
+            child is null ||
+            command.UseGpuTransforms ||
+            command.Transform != default ||
+            _recordingContext.RetainedResourceCount !=
+                child.RetainedResourceCount)
+        {
+            return false;
+        }
+
+        picture = child.Clone();
+        return true;
     }
 
     private static T[] CopyList<T>(List<T> values)

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -2438,6 +2438,112 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void GpuPictureRecorderFlattensSingleIdentityPicture()
+    {
+        var childRecorder = new GpuPictureRecorder();
+        DrawingContext childContext = childRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        childContext.DrawRectangle(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            null,
+            new Rect(0f, 0f, 16f, 16f));
+        using GpuPicture child = childRecorder.EndRecording();
+
+        var parentRecorder = new GpuPictureRecorder();
+        DrawingContext parentContext = parentRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        parentContext.DrawPicture(child);
+        using GpuPicture parent = parentRecorder.EndRecording();
+
+        Assert.Equal(child.CommandCount, parent.CommandCount);
+        Assert.Equal(RenderCommandType.DrawRect, parent.GetCommand(0).Type);
+        Assert.True(parent.SharesRetainedCommandStorageWith(child));
+    }
+
+    [Fact]
+    public void FlattenedIdentityPicturePreservesRetainedResourceLifetime()
+    {
+        var resource = new CountingDisposable();
+        var childRecorder = new GpuPictureRecorder();
+        DrawingContext childContext = childRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        childContext.RetainResource(resource);
+        childContext.DrawRectangle(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            null,
+            new Rect(0f, 0f, 16f, 16f));
+        GpuPicture child = childRecorder.EndRecording();
+
+        var parentRecorder = new GpuPictureRecorder();
+        DrawingContext parentContext = parentRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        parentContext.DrawPicture(child);
+        GpuPicture parent = parentRecorder.EndRecording();
+
+        Assert.Equal(1, parent.RetainedResourceCount);
+        child.Dispose();
+        Assert.True(parent.SharesRetainedCommandStorageWith(child));
+        Assert.Equal(0, resource.DisposeCount);
+        parent.Dispose();
+        Assert.Equal(1, resource.DisposeCount);
+    }
+
+    [Fact]
+    public void GpuPictureRecorderPreservesAdditionalParentResource()
+    {
+        var childRecorder = new GpuPictureRecorder();
+        DrawingContext childContext = childRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        childContext.DrawRectangle(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            null,
+            new Rect(0f, 0f, 16f, 16f));
+        using GpuPicture child = childRecorder.EndRecording();
+
+        var resource = new CountingDisposable();
+        var parentRecorder = new GpuPictureRecorder();
+        DrawingContext parentContext = parentRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        parentContext.RetainResource(resource);
+        parentContext.DrawPicture(child);
+        GpuPicture parent = parentRecorder.EndRecording();
+
+        Assert.Equal(1, parent.CommandCount);
+        Assert.Equal(
+            RenderCommandType.DrawPicture,
+            parent.GetCommand(0).Type);
+        Assert.False(parent.SharesRetainedCommandStorageWith(child));
+        parent.Dispose();
+        Assert.Equal(1, resource.DisposeCount);
+    }
+
+    [Fact]
+    public void GpuPictureRecorderPreservesTransformedPictureWrapper()
+    {
+        var childRecorder = new GpuPictureRecorder();
+        DrawingContext childContext = childRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        childContext.DrawRectangle(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            null,
+            new Rect(0f, 0f, 16f, 16f));
+        using GpuPicture child = childRecorder.EndRecording();
+
+        Matrix4x4 transform = Matrix4x4.CreateTranslation(4f, 6f, 0f);
+        var parentRecorder = new GpuPictureRecorder();
+        DrawingContext parentContext = parentRecorder.BeginRecording(
+            new Rect(0f, 0f, 16f, 16f));
+        parentContext.DrawPictureTransformed(child, transform);
+        using GpuPicture parent = parentRecorder.EndRecording();
+
+        Assert.Equal(1, parent.CommandCount);
+        RenderCommand command = parent.GetCommand(0);
+        Assert.Equal(RenderCommandType.DrawPicture, command.Type);
+        Assert.Equal(transform, command.Transform);
+        Assert.False(parent.SharesRetainedCommandStorageWith(child));
+    }
+
+    [Fact]
     public void PictureOpacityMaskRetainsNestedPictureResources()
     {
         var resource = new CountingDisposable();

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -200,6 +200,36 @@ public sealed class WgpuContextTests
     }
 
     [Fact]
+    public unsafe void ExplicitQueueWaitResetsDeferredSubmissionWindow()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext
+        {
+            MaximumDeferredQueueSubmissions = 2
+        };
+        context.InitializeExternalNativeDevice(
+            api,
+            lifetime,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm);
+
+        var commandBuffer = (CommandBuffer*)1;
+        context.Submit(1, &commandBuffer);
+        context.WaitIdle();
+        context.Submit(1, &commandBuffer);
+        context.CleanupPendingResources();
+
+        Assert.Equal(1, lifetime.WaitingPollCount);
+
+        context.Submit(1, &commandBuffer);
+        context.CleanupPendingResources();
+
+        Assert.Equal(2, lifetime.WaitingPollCount);
+    }
+
+    [Fact]
     public void Tier1TextureFormatsFailBeforeBackendAllocationWhenUnsupported()
     {
         using var context = new WgpuContext();


### PR DESCRIPTION
## Summary

- flatten identity-only retained picture wrappers while preserving independent resource leases
- expose retained command-storage identity so hosts can avoid false visual invalidation
- mark blocking device polls as completed submission drains to prevent redundant bounded safety waits
- cover flattening, transforms, extra resources, disposal, and drain-window reset

## Performance

Eight alternating C++ UI cached-frame process pairs on macOS/Metal:

- CPU frame median: -26.0%
- record median: -47.1%
- submit median: -19.4%
- batched CPU/frame median: -62.1%
- completed batched frame median: -12.5%
- blocking total median: -2.2%

All paired captures retained the same pixel hash and zero unsupported operations.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-restore --filter FullyQualifiedName!~ShapingContractsTests` (3,705 passed)
- `dotnet test src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj -c Release --no-build --no-restore` (240 passed)
- real-device WebGPU smoke and stable-cache gate passed