### PR TITLE
Track texture changes for retained targets

### DIFF
--- a/src/ProGPU.Backend/GpuTexture.cs
+++ b/src/ProGPU.Backend/GpuTexture.cs
@@ -35,6 +35,7 @@ public unsafe class GpuTexture : IDisposable
     private IDisposable? _externalOwner;
     private bool _tracksContextDisposal;
     private string _label;
+    private GpuTextureAlphaMode _alphaMode;
 
     public ulong Id { get; }
     public WgpuContext Context => _context;
@@ -56,7 +57,23 @@ public unsafe class GpuTexture : IDisposable
     public TextureFormat Format { get; private set; }
     public TextureUsage Usage { get; private set; }
     public uint SampleCount { get; private set; } = 1;
-    public GpuTextureAlphaMode AlphaMode { get; set; }
+    public GpuTextureAlphaMode AlphaMode
+    {
+        get => _alphaMode;
+        set
+        {
+            if (_alphaMode == value)
+            {
+                return;
+            }
+
+            _alphaMode = value;
+            if (TexturePtr != null && ViewPtr != null)
+            {
+                AdvanceGeneration();
+            }
+        }
+    }
 
     private int _disposeState;
     public bool IsDisposed => Volatile.Read(ref _disposeState) != 0;
@@ -209,7 +226,7 @@ public unsafe class GpuTexture : IDisposable
         Usage = usage;
         _label = label;
         SampleCount = sampleCount;
-        AlphaMode = alphaMode;
+        _alphaMode = alphaMode;
 
         ValidateFormatCapability(context, format);
         if (SampleCount != 1 && MipLevelCount != 1)
@@ -284,10 +301,8 @@ public unsafe class GpuTexture : IDisposable
         Format = format;
         Usage = usage;
         _label = label;
-        AlphaMode = alphaMode;
+        _alphaMode = alphaMode;
         _externalOwner = externalOwner;
-        Generation = 1;
-        ViewGeneration = 1;
 
         ValidateFormatCapability(context, format);
         var viewDescriptor = new TextureViewDescriptor
@@ -325,12 +340,12 @@ public unsafe class GpuTexture : IDisposable
             WgpuContext.Disposing += OnContextDisposing;
             _tracksContextDisposal = true;
         }
+
+        AdvanceGeneration(viewChanged: true);
     }
 
     private void Allocate()
     {
-        Generation++;
-        ViewGeneration++;
         var labelPtr = SilkMarshal.StringToPtr(_label);
         
         var desc = new TextureDescriptor
@@ -377,6 +392,8 @@ public unsafe class GpuTexture : IDisposable
         {
             throw new InvalidOperationException($"Failed to create TextureView for GPU Texture {Width}x{Height}.");
         }
+
+        AdvanceGeneration(viewChanged: true);
     }
 
     public void Resize(uint width, uint height)
@@ -470,7 +487,7 @@ public unsafe class GpuTexture : IDisposable
             }
         }
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     /// <summary>
@@ -489,7 +506,7 @@ public unsafe class GpuTexture : IDisposable
             throw new ObjectDisposedException(nameof(GpuTexture));
         }
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     public void WritePixels<T>(ReadOnlySpan<T> pixels, uint mipLevel = 0) where T : unmanaged
@@ -536,7 +553,7 @@ public unsafe class GpuTexture : IDisposable
             _context.Api.QueueWriteTexture(_context.Queue, &destination, ptr, passedSize, &layout, &extent);
         }
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     public void WritePbgra32(Pbgra32PixelBuffer pixels)
@@ -573,7 +590,7 @@ public unsafe class GpuTexture : IDisposable
         }
 
         WritePixelsSubRect(pixels.CopyCompactRows(), x, y, subWidth, subHeight);
-        AlphaMode = GpuTextureAlphaMode.Premultiplied;
+        _alphaMode = GpuTextureAlphaMode.Premultiplied;
     }
 
     public void WritePixelsSubRect<T>(
@@ -649,7 +666,7 @@ public unsafe class GpuTexture : IDisposable
             _context.Api.QueueWriteTexture(_context.Queue, &destination, ptr, passedSize, &layout, &extent);
         }
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     public void WritePixelsVolume<T>(
@@ -733,14 +750,14 @@ public unsafe class GpuTexture : IDisposable
             _context.Api.QueueWriteTexture(_context.Queue, &destination, ptr, passedSize, &layout, &extent);
         }
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     public void MarkContentsDirty()
     {
         if (IsDisposed) throw new ObjectDisposedException(nameof(GpuTexture));
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     public void GenerateMipmaps2DLinear(
@@ -808,7 +825,7 @@ public unsafe class GpuTexture : IDisposable
             }
         }
 
-        Generation++;
+        AdvanceGeneration();
     }
 
     private void GenerateMipLevel2DLinear(
@@ -1254,8 +1271,8 @@ public unsafe class GpuTexture : IDisposable
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 
-        AlphaMode = source.AlphaMode;
-        Generation++;
+        _alphaMode = source.AlphaMode;
+        AdvanceGeneration();
     }
 
     public void CopyBaseLevelFrom(GpuTexture source)
@@ -1335,8 +1352,8 @@ public unsafe class GpuTexture : IDisposable
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 
-        AlphaMode = source.AlphaMode;
-        Generation++;
+        _alphaMode = source.AlphaMode;
+        AdvanceGeneration();
     }
 
     /// <summary>
@@ -1438,8 +1455,18 @@ public unsafe class GpuTexture : IDisposable
         _context.Api.CommandBufferRelease(commandBuffer);
         _context.Api.CommandEncoderRelease(encoder);
 
-        AlphaMode = source.AlphaMode;
+        _alphaMode = source.AlphaMode;
+        AdvanceGeneration();
+    }
+
+    private void AdvanceGeneration(bool viewChanged = false)
+    {
         Generation++;
+        if (viewChanged)
+        {
+            ViewGeneration++;
+        }
+        _context.NotifyTextureContentChanged();
     }
 
     private void EnsurePbgra32CompatibleFormat()

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -142,6 +142,7 @@ public unsafe class WgpuContext : IDisposable
     private long _queueSubmissionCount;
     private long _drainedQueueSubmissionCount;
     private long _polledQueueSubmissionCount;
+    private long _textureContentVersion;
     private int _maximumDeferredQueueSubmissions =
         DefaultMaximumDeferredQueueSubmissions;
 
@@ -174,6 +175,21 @@ public unsafe class WgpuContext : IDisposable
                 value);
         }
     }
+
+    /// <summary>
+    /// Gets a context-wide version that advances whenever an owned texture's
+    /// content or native view identity changes.
+    /// </summary>
+    /// <remarks>
+    /// Retained hosts can capture this value after rendering and require an
+    /// exact match before reusing an already populated output target. Changes
+    /// to unrelated textures may conservatively invalidate that reuse.
+    /// </remarks>
+    public long TextureContentVersion =>
+        Volatile.Read(ref _textureContentVersion);
+
+    internal void NotifyTextureContentChanged() =>
+        Interlocked.Increment(ref _textureContentVersion);
 
     public void Submit(
         nuint commandCount,

--- a/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
+++ b/src/ProGPU.Tests/CompositorReviewRegressionTests.cs
@@ -4462,6 +4462,102 @@ fn mainImage(fragCoord: vec2<f32>) -> vec4<f32> {
     }
 
     [Fact]
+    public void TextureContentVersionTracksSuccessfulTextureMutations()
+    {
+        using var window = new HeadlessWindow(1, 1);
+        long beforeAllocation = window.Context.TextureContentVersion;
+        using var texture = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Content Version Texture");
+
+        long afterAllocation = window.Context.TextureContentVersion;
+        Assert.Equal(beforeAllocation + 1, afterAllocation);
+
+        texture.WritePixels(new byte[] { 1, 2, 3, 255 });
+        Assert.Equal(afterAllocation + 1, window.Context.TextureContentVersion);
+
+        texture.NotifyExternalContentChanged();
+        Assert.Equal(afterAllocation + 2, window.Context.TextureContentVersion);
+
+        texture.MarkContentsDirty();
+        Assert.Equal(afterAllocation + 3, window.Context.TextureContentVersion);
+    }
+
+    [Fact]
+    public void TextureAlphaModeMutationTracksContentExactlyOnce()
+    {
+        using var window = new HeadlessWindow(1, 1);
+        using var texture = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Alpha Mode Content Version Texture");
+        var textureGeneration = texture.Generation;
+        var contentVersion = window.Context.TextureContentVersion;
+
+        texture.AlphaMode = GpuTextureAlphaMode.Premultiplied;
+
+        Assert.Equal(textureGeneration + 1, texture.Generation);
+        Assert.Equal(contentVersion + 1, window.Context.TextureContentVersion);
+
+        texture.AlphaMode = GpuTextureAlphaMode.Premultiplied;
+
+        Assert.Equal(textureGeneration + 1, texture.Generation);
+        Assert.Equal(contentVersion + 1, window.Context.TextureContentVersion);
+    }
+
+    [Fact]
+    public void RejectedTextureMutationDoesNotAdvanceContentVersion()
+    {
+        using var window = new HeadlessWindow(1, 1);
+        using var texture = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Rejected Content Version Texture");
+        long contentVersion = window.Context.TextureContentVersion;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            texture.WritePixelsSubRect(
+                new byte[4],
+                x: 1,
+                y: 0,
+                subWidth: 1,
+                subHeight: 1));
+
+        Assert.Equal(contentVersion, window.Context.TextureContentVersion);
+    }
+
+    [Fact]
+    public void TextureContentVersionIsContextScoped()
+    {
+        using var firstWindow = new HeadlessWindow(1, 1);
+        using var secondWindow = new HeadlessWindow(1, 1);
+        using var texture = new GpuTexture(
+            firstWindow.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Scoped Content Version Texture");
+        long firstVersion = firstWindow.Context.TextureContentVersion;
+        long secondVersion = secondWindow.Context.TextureContentVersion;
+
+        texture.MarkContentsDirty();
+
+        Assert.Equal(firstVersion + 1, firstWindow.Context.TextureContentVersion);
+        Assert.Equal(secondVersion, secondWindow.Context.TextureContentVersion);
+    }
+
+    [Fact]
     public void GpuTextureReadPixelsRejectsTextureWithoutCopySrcUsage()
     {
         using var window = new HeadlessWindow(1, 1);

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -303,6 +303,42 @@ public sealed class WgpuContextTests
     }
 
     [Fact]
+    public unsafe void WrappedExternalTextureAdvancesContentVersionAfterViewCreation()
+    {
+        using var context = new WgpuContext();
+        context.Initialize(null);
+        var descriptor = new TextureDescriptor
+        {
+            Usage = TextureUsage.TextureBinding,
+            Dimension = TextureDimension.Dimension2D,
+            Size = new Extent3D
+            {
+                Width = 1,
+                Height = 1,
+                DepthOrArrayLayers = 1
+            },
+            Format = TextureFormat.Rgba8Unorm,
+            MipLevelCount = 1,
+            SampleCount = 1
+        };
+        Texture* nativeTexture = context.Api.DeviceCreateTexture(context.Device, &descriptor);
+        Assert.True(nativeTexture != null);
+        var contentVersion = context.TextureContentVersion;
+
+        using var texture = GpuTexture.WrapOwnedExternal(
+            context,
+            nativeTexture,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding);
+
+        Assert.Equal(1u, texture.Generation);
+        Assert.Equal(1u, texture.ViewGeneration);
+        Assert.Equal(contentVersion + 1, context.TextureContentVersion);
+    }
+
+    [Fact]
     public unsafe void ContextDisposalReleasesLiveExternalTextureOwner()
     {
         var context = new WgpuContext();


### PR DESCRIPTION
## Summary

- expose a context-wide monotonic texture-content version for retained hosts
- advance the version after successful allocation, wrapping, uploads, copies, clears, mip generation, external writes, and alpha-mode changes
- preserve per-texture content/view generations while avoiding duplicate internal mutation stamps
- cover successful, rejected, context-scoped, alpha-mode, and wrapped-texture paths

This gives the C++ UI retained-output path an allocation-free correctness gate before reusing an already populated render target. Unrelated texture changes conservatively invalidate reuse.

## Validation

- strict Release build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- `ProGPU.Tests`: 3,776 passed
- `ProGPU.Tests.Headless`: 240 passed