### PR TITLE
feat(scene): add color matrix visual effect

### DIFF
--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -5566,7 +5566,7 @@ SceneStateUploadComplete:
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void CompileExtensionCommand(
-        DrawingContext context,
+        IRenderDataProvider? provider,
         RenderCommand command,
         Matrix4x4 activeTransform)
     {
@@ -5578,7 +5578,7 @@ SceneStateUploadComplete:
         RenderCommand localCommand = command;
         pipeline.Compile(
             this,
-            context,
+            provider,
             activeTransform,
             ref localCommand);
         _drawCalls.Add(new CompositorDrawCall
@@ -5591,7 +5591,7 @@ SceneStateUploadComplete:
             Texture = localCommand.Texture,
             TextureSamplingMode = localCommand.TextureSamplingMode,
             HasImageEffect = localCommand.HasImageEffect,
-            ImageEffect = localCommand.ResolveImageEffect(context),
+            ImageEffect = localCommand.ResolveImageEffect(provider),
             PointBufferOffset = (int)_pendingVectorStart,
             PointBufferCount =
                 (int)((uint)_vectorIndicesList.Count - _pendingVectorStart),
@@ -15428,6 +15428,15 @@ SceneStateUploadComplete:
             {
                 DrawWpfShaderEffectOnMain(fe, shaderEffect, cachedTextures.Source, paddedRect, compositeTransform);
             }
+            else if (fe.Effect is ColorMatrixEffect colorMatrixEffect)
+            {
+                DrawColorMatrixEffectOnMain(
+                    fe,
+                    colorMatrixEffect,
+                    cachedTextures.Source,
+                    paddedRect,
+                    compositeTransform);
+            }
 
             AddDescendantVisualHitTestBounds(fe, compositeTransform);
         }
@@ -16009,6 +16018,51 @@ SceneStateUploadComplete:
 
         _pendingVectorStart = (uint)_vectorIndicesList.Count;
         _pendingTextStart = (uint)_textVerticesList.Count;
+    }
+
+    private void DrawColorMatrixEffectOnMain(
+        Visual visual,
+        ColorMatrixEffect effect,
+        GpuTexture sourceTexture,
+        Rect localRect,
+        Matrix4x4 parentTransform)
+    {
+        if (visual.HitTestId != 0)
+        {
+            AddHitTestCommand(
+                new RenderCommand
+                {
+                    Type = RenderCommandType.DrawTexture,
+                    Rect = localRect
+                },
+                parentTransform,
+                visual.HitTestId);
+        }
+
+        var command = new RenderCommand
+        {
+            Type = RenderCommandType.DrawExtension,
+            ExtensionId = CompositorBuiltInExtensions.ImageEffect,
+            Texture = sourceTexture,
+            TextureSamplingMode = TextureSamplingMode.Linear,
+            Rect = localRect,
+            HasImageEffect = true,
+            ImageEffect = new ImageEffectCommandData(
+                brightness: 0f,
+                contrast: 1f,
+                saturation: 1f,
+                grayscale: 0f,
+                sepia: 0f,
+                invert: 0f,
+                blurSigma: 0f,
+                maskTexture: null,
+                colorMatrix: effect.ColorMatrix,
+                luminanceToAlpha: false)
+        };
+        CompileExtensionCommand(
+            provider: null,
+            command,
+            parentTransform);
     }
 
     public void RenderOffscreen(

--- a/src/ProGPU.Scene/Visual.cs
+++ b/src/ProGPU.Scene/Visual.cs
@@ -1338,6 +1338,50 @@ public abstract class EffectBase
     }
 }
 
+/// <summary>
+/// Applies an affine 4x5 color transform to a visual after its subtree has
+/// been rendered into an isolated premultiplied surface.
+/// </summary>
+public sealed class ColorMatrixEffect : EffectBase
+{
+    private ImageEffectColorMatrix _colorMatrix;
+
+    public ColorMatrixEffect(ImageEffectColorMatrix colorMatrix)
+    {
+        _colorMatrix = colorMatrix;
+    }
+
+    public ImageEffectColorMatrix ColorMatrix
+    {
+        get => _colorMatrix;
+        set
+        {
+            if (_colorMatrix.Red != value.Red ||
+                _colorMatrix.Green != value.Green ||
+                _colorMatrix.Blue != value.Blue ||
+                _colorMatrix.Alpha != value.Alpha ||
+                _colorMatrix.Offset != value.Offset)
+            {
+                _colorMatrix = value;
+                Invalidate();
+            }
+        }
+    }
+
+    internal override int GetRenderCacheKey()
+    {
+        var hash = new HashCode();
+        hash.Add(GetType());
+        hash.Add(ChangeVersion);
+        hash.Add(ColorMatrix.Red);
+        hash.Add(ColorMatrix.Green);
+        hash.Add(ColorMatrix.Blue);
+        hash.Add(ColorMatrix.Alpha);
+        hash.Add(ColorMatrix.Offset);
+        return hash.ToHashCode();
+    }
+}
+
 public sealed class WpfShaderEffect : EffectBase
 {
     private float _padding;

--- a/src/ProGPU.Tests/VisualChangeVersionTests.cs
+++ b/src/ProGPU.Tests/VisualChangeVersionTests.cs
@@ -165,6 +165,21 @@ public sealed class VisualChangeVersionTests
         var shaderVersion = shader.ChangeVersion;
         shader.Padding = 6f;
         Assert.True(shader.ChangeVersion > shaderVersion);
+
+        var colorMatrix = new ColorMatrixEffect(new ImageEffectColorMatrix(
+            Vector4.UnitX,
+            Vector4.UnitY,
+            Vector4.UnitZ,
+            Vector4.UnitW,
+            Vector4.Zero));
+        var colorMatrixVersion = colorMatrix.ChangeVersion;
+        colorMatrix.ColorMatrix = new ImageEffectColorMatrix(
+            Vector4.UnitZ,
+            Vector4.UnitY,
+            Vector4.UnitX,
+            Vector4.UnitW,
+            Vector4.Zero);
+        Assert.True(colorMatrix.ChangeVersion > colorMatrixVersion);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -285,6 +285,54 @@ public sealed class VisualEffectRenderTests
         }
     }
 
+    [Fact]
+    public void ColorMatrixEffectTransformsTheIsolatedVisualOnGpu()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(48, 32);
+        var effect = new ColorMatrixEffect(
+            new ImageEffectColorMatrix(
+                new Vector4(0f, 0f, 1f, 0f),
+                Vector4.UnitY,
+                new Vector4(1f, 0f, 0f, 0f),
+                Vector4.UnitW,
+                Vector4.Zero));
+        var visual = new ColorMatrixVisual(effect);
+        visual.Transform = Matrix4x4.CreateTranslation(8f, 6f, 0f);
+        window.Content = visual;
+
+        try
+        {
+            window.Render();
+
+            var transformed = ReadPixel(window.ReadPixels(), window.Width, 12, 10);
+            Assert.InRange(transformed.R, 0, 10);
+            Assert.InRange(transformed.G, 0, 10);
+            Assert.InRange(transformed.B, 245, 255);
+            Assert.Equal(255, transformed.A);
+            Assert.Equal(12u * 8u * 4u, window.Compositor.Metrics.EffectTextureBytes);
+
+            effect.ColorMatrix = new ImageEffectColorMatrix(
+                Vector4.UnitX,
+                Vector4.UnitY,
+                Vector4.UnitZ,
+                Vector4.UnitW,
+                Vector4.Zero);
+            window.Render();
+
+            var restored = ReadPixel(window.ReadPixels(), window.Width, 12, 10);
+            Assert.InRange(restored.R, 245, 255);
+            Assert.InRange(restored.G, 0, 10);
+            Assert.InRange(restored.B, 0, 10);
+            Assert.Equal(255, restored.A);
+            Assert.False(window.Compositor.Metrics.SceneCacheHit);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -472,6 +520,29 @@ public sealed class VisualEffectRenderTests
                 _green,
                 null,
                 new Rect(20f, 10f, 60f, 40f));
+        }
+    }
+
+    private sealed class ColorMatrixVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _red =
+            new(new Vector4(1f, 0f, 0f, 1f));
+
+        public ColorMatrixVisual(ColorMatrixEffect effect)
+        {
+            Width = 12f;
+            Height = 8f;
+            Effect = effect;
+            EffectContentBounds = new Rect(0f, 0f, 12f, 8f);
+            EffectRasterPadding = 0f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _red,
+                null,
+                new Rect(0f, 0f, 12f, 8f));
         }
     }
 }


### PR DESCRIPTION
## Summary

- add a GPU-resident color-matrix effect for isolated visual subtrees
- reuse the image-effect shader while preserving transforms, clips, opacity, and hit testing
- invalidate retained effect caches when matrix values change
- retain only the source effect texture when no intermediate surface is required

## Validation

- `ProGPU.Tests`: 3,777 passed
- `ProGPU.Tests.Headless`: 240 passed
- GPU readback verifies channel transformation and live matrix mutation
