### PR TITLE
Add isolated visual blend effect

### DIFF
--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -15437,6 +15437,15 @@ SceneStateUploadComplete:
                     paddedRect,
                     compositeTransform);
             }
+            else if (fe.Effect is BlendModeEffect blendModeEffect)
+            {
+                DrawTextureOnMain(
+                    cachedTextures.Source,
+                    paddedRect,
+                    compositeTransform,
+                    fe.HitTestId,
+                    blendModeEffect.BlendMode);
+            }
 
             AddDescendantVisualHitTestBounds(fe, compositeTransform);
         }
@@ -15920,7 +15929,12 @@ SceneStateUploadComplete:
         }
     }
 
-    private void DrawTextureOnMain(GpuTexture texture, Rect localRect, Matrix4x4 parentTransform, int hitTestId = 0)
+    private void DrawTextureOnMain(
+        GpuTexture texture,
+        Rect localRect,
+        Matrix4x4 parentTransform,
+        int hitTestId = 0,
+        GpuBlendMode? blendMode = null)
     {
         var cmd = new RenderCommand
         {
@@ -15933,7 +15947,23 @@ SceneStateUploadComplete:
             AddHitTestCommand(cmd, parentTransform, hitTestId);
         }
 
-        CompileTextureCommand(cmd, parentTransform);
+        var previousBlendMode = _activeBlendMode;
+        if (blendMode.HasValue)
+        {
+            // Flush preceding geometry with the blend mode under which it was
+            // recorded before temporarily overriding the texture composite.
+            CommitPendingDrawCalls();
+            _activeBlendMode = blendMode.Value;
+        }
+
+        try
+        {
+            CompileTextureCommand(cmd, parentTransform);
+        }
+        finally
+        {
+            _activeBlendMode = previousBlendMode;
+        }
     }
 
     private void DrawWpfShaderEffectOnMain(

--- a/src/ProGPU.Scene/Visual.cs
+++ b/src/ProGPU.Scene/Visual.cs
@@ -1382,6 +1382,38 @@ public sealed class ColorMatrixEffect : EffectBase
     }
 }
 
+/// <summary>
+/// Composites an isolated visual subtree onto its destination with one blend
+/// operation after the subtree has been rendered to a premultiplied surface.
+/// </summary>
+public sealed class BlendModeEffect : EffectBase
+{
+    private GpuBlendMode _blendMode;
+
+    public BlendModeEffect(GpuBlendMode blendMode)
+    {
+        _blendMode = blendMode;
+    }
+
+    public GpuBlendMode BlendMode
+    {
+        get => _blendMode;
+        set
+        {
+            if (_blendMode != value)
+            {
+                _blendMode = value;
+                Invalidate();
+            }
+        }
+    }
+
+    internal override int GetRenderCacheKey()
+    {
+        return HashCode.Combine(GetType(), ChangeVersion, BlendMode);
+    }
+}
+
 public sealed class WpfShaderEffect : EffectBase
 {
     private float _padding;

--- a/src/ProGPU.Tests/VisualChangeVersionTests.cs
+++ b/src/ProGPU.Tests/VisualChangeVersionTests.cs
@@ -180,6 +180,11 @@ public sealed class VisualChangeVersionTests
             Vector4.UnitW,
             Vector4.Zero);
         Assert.True(colorMatrix.ChangeVersion > colorMatrixVersion);
+
+        var blendMode = new BlendModeEffect(GpuBlendMode.Multiply);
+        var blendModeVersion = blendMode.ChangeVersion;
+        blendMode.BlendMode = GpuBlendMode.Screen;
+        Assert.True(blendMode.ChangeVersion > blendModeVersion);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -349,6 +349,7 @@ public sealed class VisualEffectRenderTests
             var outside = ReadPixel(pixels, window.Width, 4, 4);
             var redOnly = ReadPixel(pixels, window.Width, 12, 12);
             var overlap = ReadPixel(pixels, window.Width, 20, 12);
+            var followingSibling = ReadPixel(pixels, window.Width, 40, 12);
             Assert.InRange(outside.R, 122, 133);
             Assert.InRange(outside.G, 122, 133);
             Assert.InRange(outside.B, 122, 133);
@@ -359,6 +360,10 @@ public sealed class VisualEffectRenderTests
             Assert.InRange(overlap.G, 122, 133);
             Assert.InRange(overlap.B, 0, 10);
             Assert.Equal(255, overlap.A);
+            Assert.InRange(followingSibling.R, 0, 10);
+            Assert.InRange(followingSibling.G, 0, 10);
+            Assert.InRange(followingSibling.B, 245, 255);
+            Assert.Equal(255, followingSibling.A);
             Assert.Equal(24u * 16u * 4u, window.Compositor.Metrics.EffectTextureBytes);
 
             effect.BlendMode = GpuBlendMode.Screen;
@@ -622,6 +627,7 @@ public sealed class VisualEffectRenderTests
     private sealed class BlendModeHost : FrameworkElement
     {
         private readonly FrameworkElement _child;
+        private readonly FrameworkElement _followingSibling = new BlendModeSiblingVisual();
         private readonly SolidColorBrush _background =
             new(new Vector4(0.5f, 0.5f, 0.5f, 1f));
 
@@ -634,17 +640,20 @@ public sealed class VisualEffectRenderTests
             // artistic modes exercise the destination-sampling blend path.
             CacheAsLayer = true;
             AddChild(_child);
+            AddChild(_followingSibling);
         }
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
             _child.Measure(new Vector2(24f, 16f));
+            _followingSibling.Measure(new Vector2(8f, 16f));
             return availableSize;
         }
 
         protected override void ArrangeOverride(Rect arrangeRect)
         {
             _child.Arrange(new Rect(8f, 8f, 24f, 16f));
+            _followingSibling.Arrange(new Rect(36f, 8f, 8f, 16f));
         }
 
         public override void OnRender(DrawingContext context)
@@ -653,6 +662,26 @@ public sealed class VisualEffectRenderTests
                 _background,
                 null,
                 new Rect(0f, 0f, 48f, 32f));
+        }
+    }
+
+    private sealed class BlendModeSiblingVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _blue =
+            new(new Vector4(0f, 0f, 1f, 1f));
+
+        public BlendModeSiblingVisual()
+        {
+            Width = 8f;
+            Height = 16f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _blue,
+                null,
+                new Rect(0f, 0f, 8f, 16f));
         }
     }
 }

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -333,6 +333,50 @@ public sealed class VisualEffectRenderTests
         }
     }
 
+    [Fact]
+    public void BlendModeEffectCompositesTheIsolatedVisualOnceOnGpu()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(48, 32);
+        var effect = new BlendModeEffect(GpuBlendMode.Multiply);
+        window.Content = new BlendModeHost(new BlendModeVisual(effect));
+
+        try
+        {
+            window.Render();
+
+            var pixels = window.ReadPixels();
+            var outside = ReadPixel(pixels, window.Width, 4, 4);
+            var redOnly = ReadPixel(pixels, window.Width, 12, 12);
+            var overlap = ReadPixel(pixels, window.Width, 20, 12);
+            Assert.InRange(outside.R, 122, 133);
+            Assert.InRange(outside.G, 122, 133);
+            Assert.InRange(outside.B, 122, 133);
+            Assert.InRange(redOnly.R, 122, 133);
+            Assert.InRange(redOnly.G, 0, 10);
+            Assert.InRange(redOnly.B, 0, 10);
+            Assert.InRange(overlap.R, 0, 10);
+            Assert.InRange(overlap.G, 122, 133);
+            Assert.InRange(overlap.B, 0, 10);
+            Assert.Equal(255, overlap.A);
+            Assert.Equal(24u * 16u * 4u, window.Compositor.Metrics.EffectTextureBytes);
+
+            effect.BlendMode = GpuBlendMode.Screen;
+            window.Render();
+
+            var screened = ReadPixel(window.ReadPixels(), window.Width, 20, 12);
+            Assert.InRange(screened.R, 122, 133);
+            Assert.InRange(screened.G, 245, 255);
+            Assert.InRange(screened.B, 122, 133);
+            Assert.Equal(255, screened.A);
+            Assert.False(window.Compositor.Metrics.SceneCacheHit);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -543,6 +587,72 @@ public sealed class VisualEffectRenderTests
                 _red,
                 null,
                 new Rect(0f, 0f, 12f, 8f));
+        }
+    }
+
+    private sealed class BlendModeVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _red =
+            new(new Vector4(1f, 0f, 0f, 1f));
+        private readonly SolidColorBrush _green =
+            new(new Vector4(0f, 1f, 0f, 1f));
+
+        public BlendModeVisual(BlendModeEffect effect)
+        {
+            Width = 24f;
+            Height = 16f;
+            Effect = effect;
+            EffectContentBounds = new Rect(0f, 0f, 24f, 16f);
+            EffectRasterPadding = 0f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _red,
+                null,
+                new Rect(0f, 0f, 16f, 16f));
+            context.DrawRectangle(
+                _green,
+                null,
+                new Rect(8f, 0f, 16f, 16f));
+        }
+    }
+
+    private sealed class BlendModeHost : FrameworkElement
+    {
+        private readonly FrameworkElement _child;
+        private readonly SolidColorBrush _background =
+            new(new Vector4(0.5f, 0.5f, 0.5f, 1f));
+
+        public BlendModeHost(FrameworkElement child)
+        {
+            _child = child;
+            Width = 48f;
+            Height = 32f;
+            // The cached parent supplies a texture-bindable destination, so
+            // artistic modes exercise the destination-sampling blend path.
+            CacheAsLayer = true;
+            AddChild(_child);
+        }
+
+        protected override Vector2 MeasureOverride(Vector2 availableSize)
+        {
+            _child.Measure(new Vector2(24f, 16f));
+            return availableSize;
+        }
+
+        protected override void ArrangeOverride(Rect arrangeRect)
+        {
+            _child.Arrange(new Rect(8f, 8f, 24f, 16f));
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _background,
+                null,
+                new Rect(0f, 0f, 48f, 32f));
         }
     }
 }


### PR DESCRIPTION
## Summary

- add a reusable BlendModeEffect for isolated retained visual subtrees
- composite the cached premultiplied source exactly once through the existing GPU blend pipelines
- preserve preceding draw ordering when temporarily overriding the composite mode
- invalidate owners and retained effect caches when the live blend mode changes
- retain only the source effect surface when no filter destination is required

## Validation

- Release build: 0 warnings, 0 errors
- focused visual-effect and change-version tests: 29 passed
- main test suite: 3,712 passed
- headless test suite: 240 passed
- GPU readback covers Multiply, Screen, overlap isolation, destination preservation, texture-bindable destination sampling, retained residency, and live mutation