### PR TITLE
feat(scene): Support anisotropic shadows

### DIFF
--- a/src/ProGPU.Backend.Native/NativeRendererTypes.cs
+++ b/src/ProGPU.Backend.Native/NativeRendererTypes.cs
@@ -2002,10 +2002,22 @@ public readonly struct NativeSceneEffect
         float sigma,
         Vector2 offset,
         Vector4 color,
+        uint revision) => DropShadow(
+            sigma,
+            sigma,
+            offset,
+            color,
+            revision);
+
+    public static NativeSceneEffect DropShadow(
+        float sigmaX,
+        float sigmaY,
+        Vector2 offset,
+        Vector4 color,
         uint revision) => new(
             NativeGroupEffectKind.DropShadow,
-            sigma,
-            sigma,
+            sigmaX,
+            sigmaY,
             offset,
             color,
             revision);
@@ -2280,10 +2292,22 @@ public readonly struct NativeGroupEffect
         float blurSigma,
         Vector2 offset,
         Vector4 color,
+        uint revision) => DropShadow(
+            blurSigma,
+            blurSigma,
+            offset,
+            color,
+            revision);
+
+    public static NativeGroupEffect DropShadow(
+        float blurSigmaX,
+        float blurSigmaY,
+        Vector2 offset,
+        Vector4 color,
         uint revision) => new(
             NativeGroupEffectKind.DropShadow,
-            blurSigma,
-            blurSigma,
+            blurSigmaX,
+            blurSigmaY,
             offset,
             color,
             revision);

--- a/src/ProGPU.Compute/ComputeAccelerator.cs
+++ b/src/ProGPU.Compute/ComputeAccelerator.cs
@@ -125,8 +125,7 @@ public unsafe class ComputeAccelerator : IDisposable
     {
         [FieldOffset(0)] public Vector2 Offset;
         [FieldOffset(16)] public Vector4 Color;
-        [FieldOffset(32)] public float BlurRadius;
-        [FieldOffset(36)] private float _padding;
+        [FieldOffset(32)] public Vector2 BlurRadius;
         [FieldOffset(40)] public Vector2 SourceSize;
         [FieldOffset(48)] private Vector4 _padding1;
 
@@ -136,11 +135,27 @@ public unsafe class ComputeAccelerator : IDisposable
             float blurRadius,
             uint sourceWidth = 0,
             uint sourceHeight = 0)
+            : this(
+                offset,
+                color,
+                blurRadius,
+                blurRadius,
+                sourceWidth,
+                sourceHeight)
+        {
+        }
+
+        public ShadowParams(
+            Vector2 offset,
+            Vector4 color,
+            float blurRadiusX,
+            float blurRadiusY,
+            uint sourceWidth = 0,
+            uint sourceHeight = 0)
         {
             Offset = offset;
             Color = color;
-            BlurRadius = blurRadius;
-            _padding = 0f;
+            BlurRadius = new Vector2(blurRadiusX, blurRadiusY);
             SourceSize = new Vector2(sourceWidth, sourceHeight);
             _padding1 = Vector4.Zero;
         }
@@ -1900,11 +1915,35 @@ public unsafe class ComputeAccelerator : IDisposable
         RunSharpDropShadow(source, destination, offset, shadowColor, blurRadius: 0f);
     }
 
-    public void ApplyDropShadow(GpuTexture source, GpuTexture temp, GpuTexture destination, Vector2 offset, Vector4 shadowColor, float blurRadius)
+    public void ApplyDropShadow(
+        GpuTexture source,
+        GpuTexture temp,
+        GpuTexture destination,
+        Vector2 offset,
+        Vector4 shadowColor,
+        float blurRadius) =>
+        ApplyDropShadow(
+            source,
+            temp,
+            destination,
+            offset,
+            shadowColor,
+            blurRadius,
+            blurRadius);
+
+    public void ApplyDropShadow(
+        GpuTexture source,
+        GpuTexture temp,
+        GpuTexture destination,
+        Vector2 offset,
+        Vector4 shadowColor,
+        float blurRadiusX,
+        float blurRadiusY)
     {
         if (_isDisposed) throw new ObjectDisposedException(nameof(ComputeAccelerator));
 
-        float snappedBlurRadius = MathF.Round(blurRadius * 2f) / 2f;
+        float snappedBlurRadiusX = MathF.Round(blurRadiusX * 2f) / 2f;
+        float snappedBlurRadiusY = MathF.Round(blurRadiusY * 2f) / 2f;
 
         uint width = source.Width;
         uint height = source.Height;
@@ -1912,9 +1951,9 @@ public unsafe class ComputeAccelerator : IDisposable
         temp.Resize(checked((width + 3u) / 4u), height);
         destination.Resize(width, height);
 
-        if (snappedBlurRadius <= 0.01f)
+        if (snappedBlurRadiusX <= 0.01f && snappedBlurRadiusY <= 0.01f)
         {
-            RunSharpDropShadow(source, destination, offset, shadowColor, snappedBlurRadius);
+            RunSharpDropShadow(source, destination, offset, shadowColor, blurRadius: 0f);
             return;
         }
         EnsureShadowBlurResources();
@@ -1929,7 +1968,8 @@ public unsafe class ComputeAccelerator : IDisposable
         _shadowParams!.WriteSingle(new ShadowParams(
             offset,
             shadowColor,
-            snappedBlurRadius,
+            snappedBlurRadiusX,
+            snappedBlurRadiusY,
             width,
             height));
 

--- a/src/ProGPU.Compute/Shaders/DropShadow.wgsl
+++ b/src/ProGPU.Compute/Shaders/DropShadow.wgsl
@@ -1,17 +1,12 @@
 // Algorithm: Offset a blurred alpha mask, tint it, and composite the original source over the shadow.
-// Time complexity: O(1) per output texel.
-// Space complexity: O(1) local storage with a fixed texture-read footprint.
+// Time complexity: O(Rx * Ry) per output texel for horizontal and vertical radii Rx and Ry; the retained effect path uses this shader only for the zero-radius case.
+// Space complexity: O(1) local storage with exactly (2Rx+1)(2Ry+1) texture reads and one output write.
 struct Params {
     offset: vec2<f32>,
     color: vec4<f32>,
-    blurRadius: f32,
-    padding: f32,
-    pad0: f32,
-    pad1: f32,
-    pad2: f32,
-    pad3: f32,
-    pad4: f32,
-    pad5: f32,
+    blurRadius: vec2<f32>,
+    sourceSize: vec2<f32>,
+    padding1: vec4<f32>,
 };
 
 @group(0) @binding(0) var inputTex: texture_2d<f32>;
@@ -29,11 +24,11 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     }
 
     var alphaSum: f32 = 0.0;
-    let r = i32(params.blurRadius);
+    let radius = vec2<i32>(params.blurRadius);
     var count: f32 = 0.0;
 
-    for (var dy = -r; dy <= r; dy++) {
-        for (var dx = -r; dx <= r; dx++) {
+    for (var dy = -radius.y; dy <= radius.y; dy++) {
+        for (var dx = -radius.x; dx <= radius.x; dx++) {
             let srcX = clamp(x - dx, 0, i32(size.x) - 1);
             let srcY = clamp(y - dy, 0, i32(size.y) - 1);
 

--- a/src/ProGPU.Compute/Shaders/ShadowBlurHorizontal.wgsl
+++ b/src/ProGPU.Compute/Shaders/ShadowBlurHorizontal.wgsl
@@ -1,11 +1,10 @@
 // Algorithm: Horizontally blur source alpha and pack four scalar coverages into one RGBA8 texel.
-// Time complexity: O(4R) per packed texel, equivalent to O(R) per source texel for blur radius R; weights use two transcendental evaluations plus an O(R) recurrence.
+// Time complexity: O(4R) per packed texel, equivalent to O(R) per source texel for blur radius R; a zero horizontal sigma performs four direct alpha loads with no transcendental work.
 // Space complexity: O(1) local storage with exactly 4(2R+1) reads and one RGBA8 output per four source texels.
 struct Params {
     offset: vec2<f32>,
     color: vec4<f32>,
-    blurRadius: f32,
-    padding: f32,
+    blurRadius: vec2<f32>,
     sourceSize: vec2<f32>,
     padding1: vec4<f32>,
 };
@@ -18,9 +17,16 @@ fn blur_coverage(x: i32, y: i32, size: vec2<u32>) -> f32 {
     if (x >= i32(size.x)) {
         return 0.0;
     }
-    let sigma = max(params.blurRadius, 0.5);
+    let requestedSigma = params.blurRadius.x;
+    let sourceX = clamp(x, 0, i32(size.x) - 1);
+    let sourceAlpha = textureLoad(inputTex, vec2<i32>(sourceX, y), 0).a;
+    if (requestedSigma <= 0.01) {
+        return sourceAlpha;
+    }
+
+    let sigma = max(requestedSigma, 0.5);
     let radius = min(i32(ceil(sigma * 3.0)), 64);
-    var alphaSum = textureLoad(inputTex, vec2<i32>(clamp(x, 0, i32(size.x) - 1), y), 0).a;
+    var alphaSum = sourceAlpha;
     var weightSum = 1.0;
     let inverseVariance = 0.5 / (sigma * sigma);
     var weight = exp(-inverseVariance);

--- a/src/ProGPU.Compute/Shaders/ShadowBlurVertical.wgsl
+++ b/src/ProGPU.Compute/Shaders/ShadowBlurVertical.wgsl
@@ -1,11 +1,10 @@
 // Algorithm: Vertically blur a four-coverages-per-RGBA8 packed alpha mask, then tint it.
-// Time complexity: O(R) per output texel for blur radius R; weights use two transcendental evaluations plus an O(R) recurrence.
+// Time complexity: O(R) per output texel for blur radius R; a zero vertical sigma performs one packed-coverage load with no transcendental work.
 // Space complexity: O(1) local storage with exactly 2R+1 reads from the packed coverage intermediate.
 struct Params {
     offset: vec2<f32>,
     color: vec4<f32>,
-    blurRadius: f32,
-    padding: f32,
+    blurRadius: vec2<f32>,
     sourceSize: vec2<f32>,
     padding1: vec4<f32>,
 };
@@ -34,9 +33,18 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
         return;
     }
 
-    let sigma = max(params.blurRadius, 0.5);
+    let requestedSigma = params.blurRadius.y;
+    let sourceAlpha = load_coverage(x, y);
+    if (requestedSigma <= 0.01) {
+        let shadowAlpha = params.color.a * sourceAlpha;
+        let shadowColor = vec4<f32>(params.color.rgb * shadowAlpha, shadowAlpha);
+        textureStore(outputTex, vec2<i32>(x, y), shadowColor);
+        return;
+    }
+
+    let sigma = max(requestedSigma, 0.5);
     let radius = min(i32(ceil(sigma * 3.0)), 64);
-    var alphaSum = load_coverage(x, y);
+    var alphaSum = sourceAlpha;
     var weightSum = 1.0;
     let inverseVariance = 0.5 / (sigma * sigma);
     var weight = exp(-inverseVariance);

--- a/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_webscene_provider_tests.cpp
@@ -5452,7 +5452,7 @@ int main(int argc, char** argv) {
     group_effect.kind = PROGPU_NATIVE_GROUP_EFFECT_DROP_SHADOW;
     group_effect.revision = 3U;
     group_effect.sigma_x = 2.0F;
-    group_effect.sigma_y = 2.0F;
+    group_effect.sigma_y = 1.25F;
     group_effect.offset_x = 3.5F;
     group_effect.offset_y = -1.25F;
     group_effect.color_r = 0.1F;
@@ -5466,8 +5466,10 @@ int main(int argc, char** argv) {
     require(progpu_native_engine_render(engine, &frame, &metrics) ==
         PROGPU_NATIVE_STATUS_SUCCESS && metrics.draw_call_count == 0U,
         "retained drop-shadow group-effect replay failed");
-    require(progpu_native_engine_get_layer_metrics(
-        engine, &layer_metrics) == PROGPU_NATIVE_STATUS_SUCCESS &&
+    const auto drop_shadow_metrics_status =
+        progpu_native_engine_get_layer_metrics(engine, &layer_metrics);
+    const bool drop_shadow_metrics_valid =
+        drop_shadow_metrics_status == PROGPU_NATIVE_STATUS_SUCCESS &&
         layer_metrics.content_pass_count == 0U &&
         layer_metrics.composite_pass_count == 1U &&
         layer_metrics.cache_hit == 1U &&
@@ -5476,8 +5478,28 @@ int main(int argc, char** argv) {
         layer_metrics.effect_revision == 3U &&
         layer_metrics.effect_pass_count == 3U &&
         layer_metrics.effect_cache_hit == 0U &&
-        layer_metrics.effect_uniform_upload_bytes == 48U &&
-        layer_metrics.effect_texture_bytes == 64U * 48U * 8U,
+        layer_metrics.effect_uniform_upload_bytes == 64U &&
+        layer_metrics.effect_texture_bytes == 64U * 48U * 8U;
+    if (!drop_shadow_metrics_valid) {
+        std::fprintf(
+            stderr,
+            "drop-shadow metrics status=%u content=%u composite=%u "
+            "cache=%u kind=%u revision=%llu passes=%u effect-cache=%u "
+            "uniform-bytes=%llu texture-bytes=%llu\n",
+            static_cast<unsigned>(drop_shadow_metrics_status),
+            layer_metrics.content_pass_count,
+            layer_metrics.composite_pass_count,
+            layer_metrics.cache_hit,
+            layer_metrics.effect_kind,
+            static_cast<unsigned long long>(layer_metrics.effect_revision),
+            layer_metrics.effect_pass_count,
+            layer_metrics.effect_cache_hit,
+            static_cast<unsigned long long>(
+                layer_metrics.effect_uniform_upload_bytes),
+            static_cast<unsigned long long>(
+                layer_metrics.effect_texture_bytes));
+    }
+    require(drop_shadow_metrics_valid,
         "changed drop-shadow group-effect metrics are invalid");
     require(progpu_native_engine_render(engine, &frame, &metrics) ==
         PROGPU_NATIVE_STATUS_SUCCESS && metrics.draw_call_count == 0U,

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1898,10 +1898,34 @@ public unsafe partial class Compositor : IDisposable
         Vector2 offset,
         Vector4 color,
         float blurRadius)
+        => ApplyDropShadow(
+            source,
+            temporary,
+            destination,
+            offset,
+            color,
+            blurRadius,
+            blurRadius);
+
+    public void ApplyDropShadow(
+        GpuTexture source,
+        GpuTexture temporary,
+        GpuTexture destination,
+        Vector2 offset,
+        Vector4 color,
+        float blurRadiusX,
+        float blurRadiusY)
     {
         lock (_context.RenderLock)
         {
-            _compute.ApplyDropShadow(source, temporary, destination, offset, color, blurRadius);
+            _compute.ApplyDropShadow(
+                source,
+                temporary,
+                destination,
+                offset,
+                color,
+                blurRadiusX,
+                blurRadiusY);
         }
     }
 
@@ -15201,29 +15225,34 @@ SceneStateUploadComplete:
         var effect = fe.Effect;
         if (effect == null) return;
 
-        float blurRadius = 0f;
-        float padding = 0f;
+        float paddingX = 0f;
+        float paddingY = 0f;
 
         if (effect is BlurEffect blur)
         {
-            blurRadius = blur.BlurRadius;
-            padding = MathF.Ceiling(blurRadius * 2f);
+            float padding = MathF.Ceiling(blur.BlurRadius * 2f);
+            paddingX = padding;
+            paddingY = padding;
         }
         else if (effect is DropShadowEffect shadow)
         {
-            blurRadius = shadow.BlurRadius;
-            padding = MathF.Ceiling(blurRadius * 2f);
+            paddingX = MathF.Ceiling(MathF.Max(0f, shadow.BlurRadiusX) * 2f);
+            paddingY = MathF.Ceiling(MathF.Max(0f, shadow.BlurRadiusY) * 2f);
         }
         else if (effect is WpfShaderEffect shaderEffect)
         {
-            padding = MathF.Ceiling(MathF.Max(0f, shaderEffect.Padding));
+            float padding = MathF.Ceiling(MathF.Max(0f, shaderEffect.Padding));
+            paddingX = padding;
+            paddingY = padding;
         }
 
         if (fe.EffectRasterPadding is { } requestedPadding)
         {
-            padding = float.IsFinite(requestedPadding)
+            float padding = float.IsFinite(requestedPadding)
                 ? MathF.Max(0f, requestedPadding)
                 : 0f;
+            paddingX = padding;
+            paddingY = padding;
         }
 
         Rect contentBounds = fe.EffectContentBounds ??
@@ -15232,10 +15261,10 @@ SceneStateUploadComplete:
             return;
 
         var paddedRect = new Rect(
-            contentBounds.X - padding,
-            contentBounds.Y - padding,
-            contentBounds.Width + padding * 2f,
-            contentBounds.Height + padding * 2f);
+            contentBounds.X - paddingX,
+            contentBounds.Y - paddingY,
+            contentBounds.Width + paddingX * 2f,
+            contentBounds.Height + paddingY * 2f);
         float dpiScale = _currentDpiScale > 0f ? _currentDpiScale : 1f;
         float logicalWidth = MathF.Max(1f, paddedRect.Width);
         float logicalHeight = MathF.Max(1f, paddedRect.Height);
@@ -15294,7 +15323,8 @@ SceneStateUploadComplete:
                 {
                     activeTextures.ReleaseMaskSource();
                 }
-                if (shadowResources.BlurRadius > 0.01f)
+                if (shadowResources.BlurRadiusX > 0.01f ||
+                    shadowResources.BlurRadiusY > 0.01f)
                 {
                     activeTextures.EnsureTemporary(
                         _context,
@@ -15362,7 +15392,8 @@ SceneStateUploadComplete:
                     shadowSource = activeTextures.MaskSource!;
                 }
                 // We pass zero offset to the compute shader because we handle offset dynamically in DrawTextureOnMain on the CPU
-                if (shadowEffect.BlurRadius > 0.01f)
+                if (shadowEffect.BlurRadiusX > 0.01f ||
+                    shadowEffect.BlurRadiusY > 0.01f)
                 {
                     _compute.ApplyDropShadow(
                         shadowSource,
@@ -15370,7 +15401,8 @@ SceneStateUploadComplete:
                         activeTextures.Destination!,
                         Vector2.Zero,
                         shadowEffect.Color,
-                        shadowEffect.BlurRadius * dpiScale);
+                        shadowEffect.BlurRadiusX * dpiScale,
+                        shadowEffect.BlurRadiusY * dpiScale);
                 }
                 else
                 {

--- a/src/ProGPU.Scene/Visual.cs
+++ b/src/ProGPU.Scene/Visual.cs
@@ -1526,7 +1526,8 @@ public class BlurEffect : EffectBase
 
 public class DropShadowEffect : EffectBase
 {
-    private float _blurRadius;
+    private float _blurRadiusX;
+    private float _blurRadiusY;
     private Vector2 _offset;
     private Vector4 _color;
     private bool _drawSource = true;
@@ -1534,12 +1535,47 @@ public class DropShadowEffect : EffectBase
 
     public float BlurRadius
     {
-        get => _blurRadius;
+        get => MathF.Max(_blurRadiusX, _blurRadiusY);
         set
         {
-            if (_blurRadius != value)
+            if (_blurRadiusX != value || _blurRadiusY != value)
             {
-                _blurRadius = value;
+                _blurRadiusX = value;
+                _blurRadiusY = value;
+                Invalidate();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the horizontal Gaussian standard deviation. Setting
+    /// <see cref="BlurRadius"/> assigns both axes for scalar compatibility.
+    /// </summary>
+    public float BlurRadiusX
+    {
+        get => _blurRadiusX;
+        set
+        {
+            if (_blurRadiusX != value)
+            {
+                _blurRadiusX = value;
+                Invalidate();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the vertical Gaussian standard deviation. Setting
+    /// <see cref="BlurRadius"/> assigns both axes for scalar compatibility.
+    /// </summary>
+    public float BlurRadiusY
+    {
+        get => _blurRadiusY;
+        set
+        {
+            if (_blurRadiusY != value)
+            {
+                _blurRadiusY = value;
                 Invalidate();
             }
         }
@@ -1610,6 +1646,18 @@ public class DropShadowEffect : EffectBase
     public DropShadowEffect(float blurRadius = 5f, Vector2 offset = default, Vector4 color = default)
     {
         BlurRadius = blurRadius;
+        Offset = offset;
+        Color = color == default ? new Vector4(0f, 0f, 0f, 0.5f) : color;
+    }
+
+    public DropShadowEffect(
+        float blurRadiusX,
+        float blurRadiusY,
+        Vector2 offset = default,
+        Vector4 color = default)
+    {
+        _blurRadiusX = blurRadiusX;
+        _blurRadiusY = blurRadiusY;
         Offset = offset;
         Color = color == default ? new Vector4(0f, 0f, 0f, 0.5f) : color;
     }

--- a/src/ProGPU.Tests/NativeRendererInteropTests.cs
+++ b/src/ProGPU.Tests/NativeRendererInteropTests.cs
@@ -627,15 +627,39 @@ public class NativeRendererInteropTests
     {
         var effect = NativeGroupEffect.DropShadow(
             3.5f,
+            1.25f,
             new Vector2(7f, -2f),
             new Vector4(0.1f, 0.2f, 0.3f, 0.75f),
             29U);
 
         Assert.Equal(NativeGroupEffectKind.DropShadow, effect.Kind);
         Assert.Equal(3.5f, effect.SigmaX);
+        Assert.Equal(1.25f, effect.SigmaY);
         Assert.Equal(new Vector2(7f, -2f), effect.Offset);
         Assert.Equal(new Vector4(0.1f, 0.2f, 0.3f, 0.75f), effect.Color);
         Assert.Equal(29U, effect.Revision);
+    }
+
+    [Fact]
+    public void PublicSemanticSceneCarriesTypedDropShadowEffectAxes()
+    {
+        var effect = NativeSceneEffect.DropShadow(
+            2.75f,
+            0.5f,
+            new Vector2(-3f, 6f),
+            new Vector4(0.4f, 0.3f, 0.2f, 0.8f),
+            31U);
+
+        Assert.Equal(NativeGroupEffectKind.DropShadow, effect.Kind);
+        Assert.Equal(2.75f, effect.SigmaX);
+        Assert.Equal(0.5f, effect.SigmaY);
+        Assert.Equal(-3f, effect.OffsetX);
+        Assert.Equal(6f, effect.OffsetY);
+        Assert.Equal(0.4f, effect.ColorR);
+        Assert.Equal(0.3f, effect.ColorG);
+        Assert.Equal(0.2f, effect.ColorB);
+        Assert.Equal(0.8f, effect.ColorA);
+        Assert.Equal(31U, effect.Revision);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/VisualChangeVersionTests.cs
+++ b/src/ProGPU.Tests/VisualChangeVersionTests.cs
@@ -188,6 +188,33 @@ public sealed class VisualChangeVersionTests
     }
 
     [Fact]
+    public void DropShadowAxesPreserveScalarCompatibilityAndInvalidation()
+    {
+        var effect = new DropShadowEffect(2f, 4f);
+
+        Assert.Equal(2f, effect.BlurRadiusX);
+        Assert.Equal(4f, effect.BlurRadiusY);
+        Assert.Equal(4f, effect.BlurRadius);
+
+        var version = effect.ChangeVersion;
+        effect.BlurRadiusX = 3f;
+        Assert.True(effect.ChangeVersion > version);
+        Assert.Equal(3f, effect.BlurRadiusX);
+        Assert.Equal(4f, effect.BlurRadiusY);
+
+        version = effect.ChangeVersion;
+        effect.BlurRadius = 5f;
+        Assert.True(effect.ChangeVersion > version);
+        Assert.Equal(5f, effect.BlurRadiusX);
+        Assert.Equal(5f, effect.BlurRadiusY);
+        Assert.Equal(5f, effect.BlurRadius);
+
+        version = effect.ChangeVersion;
+        effect.BlurRadius = 5f;
+        Assert.Equal(version, effect.ChangeVersion);
+    }
+
+    [Fact]
     public void EffectPropertyChangesInvalidateOwnerAndCachedAncestor()
     {
         var parent = new ContainerVisual { CacheAsLayer = true };

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -148,6 +148,67 @@ public sealed class VisualEffectRenderTests
     }
 
     [Fact]
+    public void AnisotropicShadowUsesAxisSpecificRasterPadding()
+    {
+        using var window = new HeadlessWindow(40, 32);
+        using var target = new GpuTexture(
+            window.Context,
+            40,
+            32,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.RenderAttachment | TextureUsage.TextureBinding,
+            "Anisotropic Shadow Residency Test Target");
+        var visual = CreateEffectVisual(new DropShadowEffect(4f, 0f));
+
+        window.Compositor.RenderOffscreen(
+            visual,
+            width: 40,
+            height: 32,
+            targetTexture: target,
+            padding: 0f,
+            dpiScale: 1f);
+
+        const ulong paddedWidth = 28u;
+        const ulong paddedHeight = 8u;
+        const ulong sourceAndDestinationBytes = paddedWidth * paddedHeight * 8u;
+        const ulong packedTemporaryBytes = ((paddedWidth + 3u) / 4u) * paddedHeight * 4u;
+        Assert.Equal(
+            sourceAndDestinationBytes + packedTemporaryBytes,
+            window.Compositor.Metrics.EffectTextureBytes);
+    }
+
+    [Fact]
+    public void DropShadowRetainsIndependentHorizontalAndVerticalSigma()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(64, 64);
+
+        try
+        {
+            window.Content = CreateAnisotropicShadowVisual(6f, 0f);
+            window.Render();
+            var horizontalPixels = window.ReadPixels();
+            var horizontalMoments = ComputeRedMoments(horizontalPixels, window.Width);
+
+            window.Content = CreateAnisotropicShadowVisual(0f, 6f);
+            window.Render();
+            var verticalPixels = window.ReadPixels();
+            var verticalMoments = ComputeRedMoments(verticalPixels, window.Width);
+
+            Assert.True(
+                horizontalMoments.X > horizontalMoments.Y * 4f,
+                $"Expected horizontal shadow variance to dominate, got {horizontalMoments}.");
+            Assert.True(
+                verticalMoments.Y > verticalMoments.X * 4f,
+                $"Expected vertical shadow variance to dominate, got {verticalMoments}.");
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
     public void VisualEffectHitTestCachePreservesDescendantOwners()
     {
         var window = HeadlessWindow.Shared;
@@ -422,7 +483,78 @@ public sealed class VisualEffectRenderTests
         return visual;
     }
 
+    private static FrameworkElement CreateAnisotropicShadowVisual(
+        float sigmaX,
+        float sigmaY) => new AnisotropicShadowVisual(sigmaX, sigmaY);
+
+    private static Vector2 ComputeRedMoments(byte[] pixels, uint width)
+    {
+        var height = pixels.Length / checked((int)width * 4);
+        byte background = byte.MaxValue;
+        for (var offset = 0; offset < pixels.Length; offset += 4)
+        {
+            background = Math.Min(background, pixels[offset]);
+        }
+
+        var weightedX = 0d;
+        var weightedY = 0d;
+        var total = 0d;
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var weight = pixels[((y * (int)width) + x) * 4] - background;
+                weightedX += x * weight;
+                weightedY += y * weight;
+                total += weight;
+            }
+        }
+
+        Assert.True(total > 0d, "The shadow capture must contain visible coverage.");
+        var meanX = weightedX / total;
+        var meanY = weightedY / total;
+        var momentX = 0d;
+        var momentY = 0d;
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var weight = pixels[((y * (int)width) + x) * 4] - background;
+                momentX += (x - meanX) * (x - meanX) * weight;
+                momentY += (y - meanY) * (y - meanY) * weight;
+            }
+        }
+
+        return new Vector2((float)(momentX / total), (float)(momentY / total));
+    }
+
     private readonly record struct RgbaPixel(byte R, byte G, byte B, byte A);
+
+    private sealed class AnisotropicShadowVisual : FrameworkElement
+    {
+        private readonly SolidColorBrush _white = new(Vector4.One);
+
+        public AnisotropicShadowVisual(float sigmaX, float sigmaY)
+        {
+            Width = 2f;
+            Height = 2f;
+            Transform = Matrix4x4.CreateTranslation(31f, 31f, 0f);
+            EffectContentBounds = new Rect(0f, 0f, 2f, 2f);
+            Effect = new DropShadowEffect(sigmaX, sigmaY)
+            {
+                Color = Vector4.One,
+                DrawSource = false
+            };
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawRectangle(
+                _white,
+                pen: null,
+                new Rect(0f, 0f, 2f, 2f));
+        }
+    }
 
     private sealed class VisualCompositeScopeHost : FrameworkElement
     {


### PR DESCRIPTION
## Summary

- add independent horizontal and vertical Gaussian standard deviations to retained drop shadows while preserving the scalar API
- carry both axes through managed compute uniforms and the typed native scene wrappers
- size retained effect textures per axis and skip transcendental blur setup on a zero axis
- add real-device render, residency, invalidation, managed/native contract, and native C++ coverage

## Root cause and implementation

The stable native effect contract and renderer already retained `sigma_x` and `sigma_y`, but the managed scene effect exposed one scalar and used symmetric raster padding. That broke managed/native semantic parity and forced unnecessary offscreen pixels for an axis-aligned blur.

`DropShadowEffect` now owns both axes. The existing `BlurRadius` property and constructor remain scalar-compatible by assigning both values, while `BlurRadiusX`/`BlurRadiusY` and a two-axis constructor expose the complete contract. The managed packed-alpha compute path keeps its four-coverages-per-RGBA texel intermediate, uses the requested axis in each separable pass, directly loads coverage when an axis is zero, and keeps its uniform layout at 64 bytes. Retained texture bounds now use independent X/Y padding. Typed native wrappers expose matching overloads; the native renderer itself required no algorithm change because its C ABI and two-pass implementation were already anisotropic.

## Performance and quality evidence

- A 12×8 source with sigma `(4, 0)` now reserves 2,016 effect-texture bytes instead of the previous conservative 6,048-byte symmetric allocation: 66.7% less.
- Six alternating Release baseline/candidate processes, each with 8 warmups and 60 synchronized samples, retained the exact managed and native hashes, maximum channel difference `1/255`, zero pixels beyond tolerance, and zero managed allocation.
- Process-median synchronized managed frame time was 1.58605 ms at baseline and 1.58795 ms for the candidate (+0.12%, within run variance). Median CPU submission was 0.07035 ms and 0.06920 ms respectively (-1.6%).
- Matched Xcode 26.4.1 Time Profiler and Metal System Trace recordings completed with target exit status 0 for 20 warmups plus 200 synchronized samples. The benchmark artifacts retain the raw traces and JSON reports.

## Clean-room research

Primary sources consulted:

- [Skia image filters](https://api.skia.org/classSkImageFilters.html): separate `sigmaX` and `sigmaY` drop-shadow parameters.
- [W3C Filter Effects Level 1](https://www.w3.org/TR/filter-effects-1/): optional-number-pair standard deviation and shadow construction order.
- [Direct2D shadow effect](https://learn.microsoft.com/en-us/windows/win32/direct2d/drop-shadow) and [Win2D ShadowEffect](https://microsoft.github.io/Win2D/WinUI2/html/T_Microsoft_Graphics_Canvas_Effects_ShadowEffect.htm): scalar compatibility subset and retained effect output.
- [Vello roadmap](https://github.com/linebender/vello/blob/main/doc/roadmap_2023.md) and [Vello releases](https://github.com/linebender/vello/releases): offscreen filter targets, lazy intermediates, and shadow-only support.
- [WebRender overview](https://github.com/servo/servo/wiki/Webrender-Overview): cached render targets and multipass blur organization.
- [SkParagraph paint path](https://skia.googlesource.com/skia/+/64c5ab69997f/modules/skparagraph/src/TextLine.cpp), [DirectWrite glyph runs](https://learn.microsoft.com/en-us/windows/win32/directwrite/glyphs-and-glyph-runs), and [HarfBuzz](https://github.com/harfbuzz/harfbuzz): text layout/shaping remains upstream of post-raster effects.

Adopted: two-axis standard deviation, shadow-only semantics, retained/lazy intermediates. Adapted: the existing ProGPU-owned packed-alpha compute path and axis-specific retained padding. Rejected: reducing the public contract to a scalar-only compatibility subset or exposing an internal multipass graph. No third-party implementation text or structure was used.

## Validation

- `ProGPU.Tests`: 3,782 passed
- `ProGPU.Tests.Headless`: 240 passed
- focused shadow and shader-resource lane: 24 passed
- native C++: 9/9 suites passed, exported-symbol allowlist verified, real Metal sample rendered
- Svg.Skia resvg lane: 927 passed, 37 established inventory skips
- Svg.Skia remaining lane: 1,148 passed with test-collection parallelism disabled to avoid unrelated shared-device contention
- `git diff --check`: clean
