### PR TITLE
fix(backend): Serialize WebGPU lifetimes

### DIFF
--- a/docs/NATIVE_CPP_ENGINE_SPECIFICATION.md
+++ b/docs/NATIVE_CPP_ENGINE_SPECIFICATION.md
@@ -540,6 +540,30 @@ for every runnable RID. This proves real C++ execution rather than merely
 compilation; it does not imply that one provider's opaque objects can enter the
 other adapter.
 
+### Managed/native optimization parity
+
+The managed C# and native C++ renderers are two implementations of one
+performance contract. Every managed rendering optimization receives an explicit
+native applicability audit before merge. Applicable work must land in both
+implementations with matched behavior, quality, complexity, resource lifetime,
+retention, upload, allocation, and failure-semantics evidence. A one-sided change
+is complete only when the other implementation has no equivalent ownership or
+execution boundary and that non-applicability is recorded with the validation
+result. Language or API shape alone is not a non-applicability reason.
+
+The native wgpu-native adapter therefore mirrors the managed process-wide
+synchronization domain. One recursive process scope encloses complete native
+renderer operations so queue submission, polling, resource creation, and
+resource destruction cannot form an inter-device lock cycle. Recursion is
+required because outer render dispatch calls nested resource helpers. The Dawn
+adapter remains independently synchronized because its provider owns a distinct
+device/resource domain. The managed persistent-texture cache has no native
+dictionary analogue: the C++ engine owns fixed retained resource slots, while
+the shared lifetime invariant is enforced by the native process scope. A native
+threaded regression proves recursive entry and cross-thread exclusion; the
+managed regressions prove shared wgpu-native domains, independent browser/Dawn
+domains, queue exclusion, and native-call/cache lock ordering.
+
 ## 6. Stable native engine ABI
 
 `include/progpu_native.h` is a C ABI so C++, C#, NativeAOT, V8, and other hosts

--- a/docs/NATIVE_CPP_PERFORMANCE_BASELINE.md
+++ b/docs/NATIVE_CPP_PERFORMANCE_BASELINE.md
@@ -2979,3 +2979,58 @@ the final run and PNG SHA-256 values are respectively
 `11ad381e90b25261cc2a4b6b663914e80d926a52c8598dfadd6b37d378ab1dfe`,
 `6ac74aec5d0a6560b6f29d1de2f4aaa1fe637c361cfcb370c6bf8504a27537c7`,
 and `a44d89b517aca672857b29a985adf7ec9313f49230cfb487622b1f0e1d5a0e05`.
+
+## Process-wide WebGPU synchronization checkpoint
+
+Parallel managed renderers previously owned independent outer locks even though
+their wgpu-native devices entered one process-wide internal resource-lock
+graph. A captured deadlock placed queue submission, buffer destruction, and
+texture creation on different native lock edges. The managed backend now shares
+one process synchronization domain for Silk/wgpu-native contexts, includes
+submission and resource lifetime in that domain, and creates a persistent
+texture bind group outside the managed cache lock before race-safe publication.
+Browser and externally provided Dawn devices keep independent domains.
+
+The native C++ renderer receives the same applicable optimization rather than a
+reduced fix: every non-Dawn dispatch owns one process-wide recursive scope.
+Recursion preserves nested renderer/resource helpers while serializing complete
+wgpu-native operations across native engines. The C++ retained resource model
+has no managed bind-group dictionary, so the dictionary lock-order change is
+not applicable there; its equivalent resource-lifetime boundary is covered by
+the dispatch scope. This conclusion was checked against public wgpu device
+locking and queue-polling reports and the public wgpu device implementation,
+including [wgpu discussion 4814](https://github.com/gfx-rs/wgpu/discussions/4814),
+[wgpu issue 5279](https://github.com/gfx-rs/wgpu/issues/5279), and
+[the public device source](https://github.com/gfx-rs/wgpu/blob/trunk/wgpu/src/api/device.rs).
+
+Six alternating fresh-process Apple M3 Pro/Metal Release runs used 384 public-
+picture primitives, 60 warm-ups, and 300 measurements. Median-of-run results
+show no measurable regression:
+
+| Metric | Baseline | Synchronized candidate | Delta |
+|---|---:|---:|---:|
+| Native CPU submission p50 | 0.08775 ms | 0.08440 ms | -3.82% |
+| Managed CPU submission p50 | 0.51930 ms | 0.51825 ms | -0.20% |
+| Native GPU-complete total p50 | 1.61735 ms | 1.60715 ms | -0.63% |
+| Managed GPU-complete total p50 | 2.54845 ms | 2.45995 ms | -3.47% |
+| Stable managed allocation/frame | 0 bytes | 0 bytes | equal |
+
+The deterministic differential retained the existing quality band: maximum
+channel difference was 11/255, three pixels exceeded 3/255, and mean absolute
+channel difference was approximately 0.000311/255. Matched direct-apphost Time
+Profiler captures measured 3.1999 ms/frame baseline and 3.2080 ms/frame
+candidate (+0.25%, treated as noise). Matched Metal System Trace captures
+measured 3.1664 and 3.1677 ms/frame (+0.04%) with exactly 8,434 submissions in
+each run; peak and final tracked Metal allocation were identical. Allocation/
+VM Tracker could not qualify the unsigned direct apphost because the process
+was suspended before recording, so no Instruments native-allocation claim is
+made. The benchmark's own stable managed counter remains the stated zero-byte
+evidence.
+
+Correctness gates include 3,786 managed tests, 240 headless tests, nine native
+CTest executables, the complete native/managed differential matrix, Svg.Skia
+resvg 927/964 with 37 reviewed skips, the unchanged W3C inventory (native
+530/533; ProGPU 486/533 with 44 reviewed differences; three skips in each), the
+remaining 1,147/1,147 lane, and ten explicitly ProGPU-backed parallel passes of
+1,146/1,146 after excluding one unrelated external-font network test. The
+cross-context deadlock did not recur.

--- a/src/ProGPU.Backend/IWebGpuApi.cs
+++ b/src/ProGPU.Backend/IWebGpuApi.cs
@@ -112,7 +112,9 @@ public interface IWebGpuExternalDeviceLifetime : IDisposable
     void Poll(bool wait);
 }
 
-internal unsafe sealed class SilkWebGpuApi(WebGPU api) : IWebGpuApi
+internal unsafe sealed class SilkWebGpuApi(
+    WebGPU api,
+    object synchronizationRoot) : IWebGpuApi
 {
     private sealed class MapCompletion
     {
@@ -134,26 +136,74 @@ internal unsafe sealed class SilkWebGpuApi(WebGPU api) : IWebGpuApi
         }
     }
 
-    public BindGroup* DeviceCreateBindGroup(Device* d, BindGroupDescriptor* x) => api.DeviceCreateBindGroup(d, x);
-    public BindGroupLayout* DeviceCreateBindGroupLayout(Device* d, BindGroupLayoutDescriptor* x) => api.DeviceCreateBindGroupLayout(d, x);
-    public WgpuBuffer* DeviceCreateBuffer(Device* d, BufferDescriptor* x) => api.DeviceCreateBuffer(d, x);
-    public CommandEncoder* DeviceCreateCommandEncoder(Device* d, CommandEncoderDescriptor* x) => api.DeviceCreateCommandEncoder(d, x);
-    public ComputePipeline* DeviceCreateComputePipeline(Device* d, ComputePipelineDescriptor* x) => api.DeviceCreateComputePipeline(d, x);
-    public PipelineLayout* DeviceCreatePipelineLayout(Device* d, PipelineLayoutDescriptor* x) => api.DeviceCreatePipelineLayout(d, x);
-    public RenderPipeline* DeviceCreateRenderPipeline(Device* d, RenderPipelineDescriptor* x) => api.DeviceCreateRenderPipeline(d, x);
-    public Sampler* DeviceCreateSampler(Device* d, SamplerDescriptor* x) => api.DeviceCreateSampler(d, x);
-    public ShaderModule* DeviceCreateShaderModule(Device* d, ShaderModuleDescriptor* x) => api.DeviceCreateShaderModule(d, x);
-    public Texture* DeviceCreateTexture(Device* d, TextureDescriptor* x) => api.DeviceCreateTexture(d, x);
-    public TextureView* TextureCreateView(Texture* t, TextureViewDescriptor* x) => api.TextureCreateView(t, x);
-    public BindGroupLayout* ComputePipelineGetBindGroupLayout(ComputePipeline* p, uint i) => api.ComputePipelineGetBindGroupLayout(p, i);
-    public BindGroupLayout* RenderPipelineGetBindGroupLayout(RenderPipeline* p, uint i) => api.RenderPipelineGetBindGroupLayout(p, i);
-    public ComputePassEncoder* CommandEncoderBeginComputePass(CommandEncoder* e, ComputePassDescriptor* x) => api.CommandEncoderBeginComputePass(e, x);
-    public RenderPassEncoder* CommandEncoderBeginRenderPass(CommandEncoder* e, RenderPassDescriptor* x) => api.CommandEncoderBeginRenderPass(e, x);
+    public BindGroup* DeviceCreateBindGroup(Device* d, BindGroupDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateBindGroup(d, x);
+    }
+    public BindGroupLayout* DeviceCreateBindGroupLayout(Device* d, BindGroupLayoutDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateBindGroupLayout(d, x);
+    }
+    public WgpuBuffer* DeviceCreateBuffer(Device* d, BufferDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateBuffer(d, x);
+    }
+    public CommandEncoder* DeviceCreateCommandEncoder(Device* d, CommandEncoderDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateCommandEncoder(d, x);
+    }
+    public ComputePipeline* DeviceCreateComputePipeline(Device* d, ComputePipelineDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateComputePipeline(d, x);
+    }
+    public PipelineLayout* DeviceCreatePipelineLayout(Device* d, PipelineLayoutDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreatePipelineLayout(d, x);
+    }
+    public RenderPipeline* DeviceCreateRenderPipeline(Device* d, RenderPipelineDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateRenderPipeline(d, x);
+    }
+    public Sampler* DeviceCreateSampler(Device* d, SamplerDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateSampler(d, x);
+    }
+    public ShaderModule* DeviceCreateShaderModule(Device* d, ShaderModuleDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateShaderModule(d, x);
+    }
+    public Texture* DeviceCreateTexture(Device* d, TextureDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateTexture(d, x);
+    }
+    public TextureView* TextureCreateView(Texture* t, TextureViewDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.TextureCreateView(t, x);
+    }
+    public BindGroupLayout* ComputePipelineGetBindGroupLayout(ComputePipeline* p, uint i)
+    {
+        lock (synchronizationRoot) return api.ComputePipelineGetBindGroupLayout(p, i);
+    }
+    public BindGroupLayout* RenderPipelineGetBindGroupLayout(RenderPipeline* p, uint i)
+    {
+        lock (synchronizationRoot) return api.RenderPipelineGetBindGroupLayout(p, i);
+    }
+    public ComputePassEncoder* CommandEncoderBeginComputePass(CommandEncoder* e, ComputePassDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.CommandEncoderBeginComputePass(e, x);
+    }
+    public RenderPassEncoder* CommandEncoderBeginRenderPass(CommandEncoder* e, RenderPassDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.CommandEncoderBeginRenderPass(e, x);
+    }
     public void CommandEncoderCopyBufferToBuffer(CommandEncoder* e, WgpuBuffer* s, ulong so, WgpuBuffer* d, ulong @do, ulong z) => api.CommandEncoderCopyBufferToBuffer(e, s, so, d, @do, z);
     public void CommandEncoderCopyBufferToTexture(CommandEncoder* e, ImageCopyBuffer* s, ImageCopyTexture* d, Extent3D* z) => api.CommandEncoderCopyBufferToTexture(e, s, d, z);
     public void CommandEncoderCopyTextureToBuffer(CommandEncoder* e, ImageCopyTexture* s, ImageCopyBuffer* d, Extent3D* z) => api.CommandEncoderCopyTextureToBuffer(e, s, d, z);
     public void CommandEncoderCopyTextureToTexture(CommandEncoder* e, ImageCopyTexture* s, ImageCopyTexture* d, Extent3D* z) => api.CommandEncoderCopyTextureToTexture(e, s, d, z);
-    public CommandBuffer* CommandEncoderFinish(CommandEncoder* e, CommandBufferDescriptor* x) => api.CommandEncoderFinish(e, x);
+    public CommandBuffer* CommandEncoderFinish(CommandEncoder* e, CommandBufferDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.CommandEncoderFinish(e, x);
+    }
     public void ComputePassEncoderSetPipeline(ComputePassEncoder* p, ComputePipeline* x) => api.ComputePassEncoderSetPipeline(p, x);
     public void ComputePassEncoderSetBindGroup(ComputePassEncoder* p, uint i, BindGroup* g, nuint c, uint* o) => api.ComputePassEncoderSetBindGroup(p, i, g, c, o);
     public void ComputePassEncoderDispatchWorkgroups(ComputePassEncoder* p, uint x, uint y, uint z) => api.ComputePassEncoderDispatchWorkgroups(p, x, y, z);
@@ -168,23 +218,38 @@ internal unsafe sealed class SilkWebGpuApi(WebGPU api) : IWebGpuApi
     public void RenderPassEncoderDraw(RenderPassEncoder* p, uint v, uint i, uint fv, uint fi) => api.RenderPassEncoderDraw(p, v, i, fv, fi);
     public void RenderPassEncoderDrawIndexed(RenderPassEncoder* p, uint i, uint c, uint f, int b, uint fi) => api.RenderPassEncoderDrawIndexed(p, i, c, f, b, fi);
     public void RenderPassEncoderEnd(RenderPassEncoder* p) => api.RenderPassEncoderEnd(p);
-    public void QueueWriteBuffer(Queue* q, WgpuBuffer* b, ulong o, void* d, nuint z) => api.QueueWriteBuffer(q, b, o, d, z);
-    public void QueueWriteTexture(Queue* q, ImageCopyTexture* d, void* p, nuint z, TextureDataLayout* l, Extent3D* s) => api.QueueWriteTexture(q, d, p, z, l, s);
-    public void QueueSubmit(Queue* q, nuint c, CommandBuffer** b) => api.QueueSubmit(q, c, b);
-    public void BufferMapAsync(WgpuBuffer* b, MapMode m, nuint o, nuint z, PfnBufferMapCallback c, void* u) => api.BufferMapAsync(b, m, o, z, c, u);
+    public void QueueWriteBuffer(Queue* q, WgpuBuffer* b, ulong o, void* d, nuint z)
+    {
+        lock (synchronizationRoot) api.QueueWriteBuffer(q, b, o, d, z);
+    }
+    public void QueueWriteTexture(Queue* q, ImageCopyTexture* d, void* p, nuint z, TextureDataLayout* l, Extent3D* s)
+    {
+        lock (synchronizationRoot) api.QueueWriteTexture(q, d, p, z, l, s);
+    }
+    public void QueueSubmit(Queue* q, nuint c, CommandBuffer** b)
+    {
+        lock (synchronizationRoot) api.QueueSubmit(q, c, b);
+    }
+    public void BufferMapAsync(WgpuBuffer* b, MapMode m, nuint o, nuint z, PfnBufferMapCallback c, void* u)
+    {
+        lock (synchronizationRoot) api.BufferMapAsync(b, m, o, z, c, u);
+    }
     public Task<BufferMapAsyncStatus> BufferMapAsyncTask(WgpuBuffer* b, MapMode m, nuint o, nuint z)
     {
         var completion = new MapCompletion();
         completion.Handle = GCHandle.Alloc(completion);
         try
         {
-            api.BufferMapAsync(
-                b,
-                m,
-                o,
-                z,
-                new PfnBufferMapCallback(&CompleteBufferMap),
-                (void*)GCHandle.ToIntPtr(completion.Handle));
+            lock (synchronizationRoot)
+            {
+                api.BufferMapAsync(
+                    b,
+                    m,
+                    o,
+                    z,
+                    new PfnBufferMapCallback(&CompleteBufferMap),
+                    (void*)GCHandle.ToIntPtr(completion.Handle));
+            }
         }
         catch
         {
@@ -196,26 +261,92 @@ internal unsafe sealed class SilkWebGpuApi(WebGPU api) : IWebGpuApi
         }
         return completion.Source.Task;
     }
-    public void* BufferGetMappedRange(WgpuBuffer* b, nuint o, nuint z) => api.BufferGetMappedRange(b, o, z);
-    public void* BufferGetConstMappedRange(WgpuBuffer* b, nuint o, nuint z) => api.BufferGetConstMappedRange(b, o, z);
-    public void BufferUnmap(WgpuBuffer* b) => api.BufferUnmap(b);
-    public void BufferDestroy(WgpuBuffer* b) => api.BufferDestroy(b);
-    public void SurfaceGetCurrentTexture(Surface* s, SurfaceTexture* t) => api.SurfaceGetCurrentTexture(s, t);
-    public void SurfacePresent(Surface* s) => api.SurfacePresent(s);
-    public void SurfaceRelease(Surface* s) => api.SurfaceRelease(s);
-    public void BindGroupRelease(BindGroup* v) => api.BindGroupRelease(v);
-    public void BindGroupLayoutRelease(BindGroupLayout* v) => api.BindGroupLayoutRelease(v);
-    public void BufferRelease(WgpuBuffer* v) => api.BufferRelease(v);
-    public void CommandBufferRelease(CommandBuffer* v) => api.CommandBufferRelease(v);
-    public void CommandEncoderRelease(CommandEncoder* v) => api.CommandEncoderRelease(v);
-    public void ComputePassEncoderRelease(ComputePassEncoder* v) => api.ComputePassEncoderRelease(v);
-    public void ComputePipelineRelease(ComputePipeline* v) => api.ComputePipelineRelease(v);
-    public void PipelineLayoutRelease(PipelineLayout* v) => api.PipelineLayoutRelease(v);
-    public void RenderPassEncoderRelease(RenderPassEncoder* v) => api.RenderPassEncoderRelease(v);
-    public void RenderPipelineRelease(RenderPipeline* v) => api.RenderPipelineRelease(v);
-    public void SamplerRelease(Sampler* v) => api.SamplerRelease(v);
-    public void ShaderModuleRelease(ShaderModule* v) => api.ShaderModuleRelease(v);
-    public void TextureDestroy(Texture* v) => api.TextureDestroy(v);
-    public void TextureRelease(Texture* v) => api.TextureRelease(v);
-    public void TextureViewRelease(TextureView* v) => api.TextureViewRelease(v);
+    public void* BufferGetMappedRange(WgpuBuffer* b, nuint o, nuint z)
+    {
+        lock (synchronizationRoot) return api.BufferGetMappedRange(b, o, z);
+    }
+    public void* BufferGetConstMappedRange(WgpuBuffer* b, nuint o, nuint z)
+    {
+        lock (synchronizationRoot) return api.BufferGetConstMappedRange(b, o, z);
+    }
+    public void BufferUnmap(WgpuBuffer* b)
+    {
+        lock (synchronizationRoot) api.BufferUnmap(b);
+    }
+    public void BufferDestroy(WgpuBuffer* b)
+    {
+        lock (synchronizationRoot) api.BufferDestroy(b);
+    }
+    public void SurfaceGetCurrentTexture(Surface* s, SurfaceTexture* t)
+    {
+        lock (synchronizationRoot) api.SurfaceGetCurrentTexture(s, t);
+    }
+    public void SurfacePresent(Surface* s)
+    {
+        lock (synchronizationRoot) api.SurfacePresent(s);
+    }
+    public void SurfaceRelease(Surface* s)
+    {
+        lock (synchronizationRoot) api.SurfaceRelease(s);
+    }
+    public void BindGroupRelease(BindGroup* v)
+    {
+        lock (synchronizationRoot) api.BindGroupRelease(v);
+    }
+    public void BindGroupLayoutRelease(BindGroupLayout* v)
+    {
+        lock (synchronizationRoot) api.BindGroupLayoutRelease(v);
+    }
+    public void BufferRelease(WgpuBuffer* v)
+    {
+        lock (synchronizationRoot) api.BufferRelease(v);
+    }
+    public void CommandBufferRelease(CommandBuffer* v)
+    {
+        lock (synchronizationRoot) api.CommandBufferRelease(v);
+    }
+    public void CommandEncoderRelease(CommandEncoder* v)
+    {
+        lock (synchronizationRoot) api.CommandEncoderRelease(v);
+    }
+    public void ComputePassEncoderRelease(ComputePassEncoder* v)
+    {
+        lock (synchronizationRoot) api.ComputePassEncoderRelease(v);
+    }
+    public void ComputePipelineRelease(ComputePipeline* v)
+    {
+        lock (synchronizationRoot) api.ComputePipelineRelease(v);
+    }
+    public void PipelineLayoutRelease(PipelineLayout* v)
+    {
+        lock (synchronizationRoot) api.PipelineLayoutRelease(v);
+    }
+    public void RenderPassEncoderRelease(RenderPassEncoder* v)
+    {
+        lock (synchronizationRoot) api.RenderPassEncoderRelease(v);
+    }
+    public void RenderPipelineRelease(RenderPipeline* v)
+    {
+        lock (synchronizationRoot) api.RenderPipelineRelease(v);
+    }
+    public void SamplerRelease(Sampler* v)
+    {
+        lock (synchronizationRoot) api.SamplerRelease(v);
+    }
+    public void ShaderModuleRelease(ShaderModule* v)
+    {
+        lock (synchronizationRoot) api.ShaderModuleRelease(v);
+    }
+    public void TextureDestroy(Texture* v)
+    {
+        lock (synchronizationRoot) api.TextureDestroy(v);
+    }
+    public void TextureRelease(Texture* v)
+    {
+        lock (synchronizationRoot) api.TextureRelease(v);
+    }
+    public void TextureViewRelease(TextureView* v)
+    {
+        lock (synchronizationRoot) api.TextureViewRelease(v);
+    }
 }

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -116,15 +116,20 @@ public unsafe class WgpuContext : IDisposable
     private nint _devicePollAddress;
     private nint _generateReportAddress;
 
+    private static readonly object s_silkNativeRenderLock = new();
+
     /// <summary>
-    /// Serializes command recording, queue submission, and device polling for
-    /// every presentation context that shares this native WebGPU device.
+    /// Serializes command recording, queue submission, resource destruction,
+    /// and device polling within the active WebGPU synchronization domain.
     /// </summary>
     /// <remarks>
-    /// Kept as a field for binary compatibility. Shared-device initialization
-    /// replaces it with the owner's lock before the child becomes observable.
+    /// Current wgpu-native instances share an internal process-wide resource
+    /// lock graph, so independently created Silk-native devices use one lock.
+    /// Browser and externally owned native devices receive independent locks;
+    /// shared-device initialization replaces the field with the owner's lock.
+    /// The field remains public for binary compatibility.
     /// </remarks>
-    public object RenderLock = new();
+    public object RenderLock = s_silkNativeRenderLock;
     public readonly object DisposalLock = new();
     public readonly List<IntPtr> PendingBuffers = new();
     public readonly List<IntPtr> PendingTextures = new();
@@ -205,8 +210,12 @@ public unsafe class WgpuContext : IDisposable
             throw new ArgumentNullException(nameof(commandBuffers));
         }
 
-        Api.QueueSubmit(Queue, commandCount, commandBuffers);
-        Interlocked.Increment(ref _queueSubmissionCount);
+        lock (RenderLock)
+        {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+            Api.QueueSubmit(Queue, commandCount, commandBuffers);
+            Interlocked.Increment(ref _queueSubmissionCount);
+        }
     }
 
     public void QueueBufferDisposal(IntPtr ptr)
@@ -803,6 +812,24 @@ public unsafe class WgpuContext : IDisposable
         uint framebufferWidth,
         uint framebufferHeight)
     {
+        lock (RenderLock)
+        {
+            InitializeNativeCore(
+                window,
+                metalLayer,
+                androidNativeWindow,
+                framebufferWidth,
+                framebufferHeight);
+        }
+    }
+
+    private void InitializeNativeCore(
+        IWindow? window,
+        void* metalLayer,
+        void* androidNativeWindow,
+        uint framebufferWidth,
+        uint framebufferHeight)
+    {
         string logPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ProGPU_test_run.log");
         void SafeLog(string msg)
         {
@@ -819,7 +846,7 @@ public unsafe class WgpuContext : IDisposable
         SafeLog($"[WGPUCONTEXT] Initialize started, window exists={window != null}\n");
         _window = window;
         Wgpu = CreateNativeWebGpuApi();
-        Api = new SilkWebGpuApi(Wgpu);
+        Api = new SilkWebGpuApi(Wgpu, RenderLock);
         
         // 1. Create WebGPU Instance (isolated per context)
         SafeLog("[WGPUCONTEXT] Creating WebGPU Instance\n");
@@ -1355,6 +1382,7 @@ public unsafe class WgpuContext : IDisposable
 
         Api = api;
         BackendKind = WgpuBackendKind.BrowserWebGpu;
+        RenderLock = new object();
         Device = device;
         Queue = queue;
         Surface = surface;
@@ -1429,6 +1457,7 @@ public unsafe class WgpuContext : IDisposable
 
         Api = api;
         BackendKind = WgpuBackendKind.DawnNative;
+        RenderLock = new object();
         Device = device;
         Queue = queue;
         SwapChainFormat = preferredRenderTargetFormat;

--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -514,6 +514,7 @@ set(PROGPU_NATIVE_BACKEND_SOURCES
     src/Backend/progpu_native_pipeline.cpp
     src/Backend/progpu_native_pipeline.hpp
     src/Backend/progpu_native_replay_execution.hpp
+    src/Backend/progpu_native_webgpu_synchronization.hpp
     src/Backend/progpu_native_webgpu_resources.hpp
     src/Backend/progpu_native_vector_execution.cpp
     src/Backend/progpu_webgpu_compat.hpp

--- a/src/ProGPU.Native/src/Backend/progpu_native_webgpu_synchronization.hpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_webgpu_synchronization.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <mutex>
+
+namespace progpu::native::webgpu {
+
+// wgpu-native devices share an internal process-wide resource lock graph.
+// Keep complete native renderer operations in the same synchronization domain
+// so submission, polling, and resource lifetime cannot form an inter-device
+// lock cycle. Dawn and browser providers own independent synchronization.
+#if !defined(PROGPU_NATIVE_DAWN_ABI)
+inline std::recursive_mutex& process_render_mutex() noexcept {
+    static std::recursive_mutex mutex;
+    return mutex;
+}
+#endif
+
+class process_render_scope final {
+public:
+    process_render_scope() noexcept
+#if !defined(PROGPU_NATIVE_DAWN_ABI)
+        : lock_(process_render_mutex())
+#endif
+    {
+    }
+
+    process_render_scope(const process_render_scope&) = delete;
+    process_render_scope& operator=(const process_render_scope&) = delete;
+
+private:
+#if !defined(PROGPU_NATIVE_DAWN_ABI)
+    std::unique_lock<std::recursive_mutex> lock_;
+#endif
+};
+
+} // namespace progpu::native::webgpu

--- a/src/ProGPU.Native/src/Backend/progpu_webgpu_compat.hpp
+++ b/src/ProGPU.Native/src/Backend/progpu_webgpu_compat.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "progpu_native_webgpu_synchronization.hpp"
+
 #include <webgpu.h>
 
 #include <atomic>
@@ -351,6 +353,12 @@ class dispatch_scope final {
 public:
     explicit dispatch_scope(const dispatch*) noexcept {
     }
+
+    dispatch_scope(const dispatch_scope&) = delete;
+    dispatch_scope& operator=(const dispatch_scope&) = delete;
+
+private:
+    process_render_scope synchronization_scope_;
 };
 
 template<std::size_t Size>

--- a/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
@@ -17,13 +17,17 @@
 #include "progpu_native_semantic_state.hpp"
 #include "progpu_native_semantic_text_style.hpp"
 #include "progpu_native_semantic_validation.hpp"
+#include "progpu_native_webgpu_synchronization.hpp"
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <future>
 #include <limits>
+#include <thread>
 
 namespace {
 
@@ -31,6 +35,45 @@ void require(bool condition) {
     if (!condition) {
         std::abort();
     }
+}
+
+void native_webgpu_scopes_share_one_process_lock() {
+    using namespace std::chrono_literals;
+    using progpu::native::webgpu::process_render_scope;
+
+    // Native renderer operations nest helpers under one outer dispatch scope.
+    // The synchronization primitive must therefore be recursive.
+    {
+        process_render_scope outer;
+        process_render_scope nested;
+    }
+
+    std::promise<void> first_entered;
+    std::promise<void> release_first;
+    std::promise<void> second_entered;
+    auto first_entered_future = first_entered.get_future();
+    auto release_first_future = release_first.get_future();
+    auto second_entered_future = second_entered.get_future();
+
+    std::thread first([&] {
+        process_render_scope scope;
+        first_entered.set_value();
+        release_first_future.wait();
+    });
+    first_entered_future.wait();
+
+    std::thread second([&] {
+        process_render_scope scope;
+        second_entered.set_value();
+    });
+
+    require(second_entered_future.wait_for(50ms) ==
+        std::future_status::timeout);
+    release_first.set_value();
+    require(second_entered_future.wait_for(1s) ==
+        std::future_status::ready);
+    first.join();
+    second.join();
 }
 
 void semantic_contiguous_draws_merge_without_reordering() {
@@ -809,6 +852,7 @@ void draw_state_resolution_is_cpu_only_and_bounded() {
 } // namespace
 
 int main() {
+    native_webgpu_scopes_share_one_process_lock();
     semantic_contiguous_draws_merge_without_reordering();
     effect_plan_uses_three_bounded_intermediates();
     semantic_budget_counts_effected_depth_once();

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -3459,7 +3459,6 @@ SceneStateUploadComplete:
         BindGroup* currentMaskBindGroup = null;
         bool? currentPipelineHasMask = null;
         byte? currentVectorPipelineKind = null;
-        var textureEntries = stackalloc BindGroupEntry[2];
 
         var drawCallCount = _drawCalls.Count;
         for (var drawCallIndex = 0; drawCallIndex < drawCallCount; drawCallIndex++)
@@ -3583,36 +3582,12 @@ SceneStateUploadComplete:
                 currentBlendMode = dc.BlendMode;
                 currentPipelineHasMask = hasMask;
 
-                var viewPtr = texture.ViewPtr;
-                var cacheKey = new TextureCacheKey(
-                    texture.Id,
-                    texture.ViewGeneration,
+                var cachedBg = GetOrCreatePersistentTextureBindGroup(
+                    texture,
                     isOffscreen: false,
                     dc.TextureSamplingMode,
-                    dc.TextureMaxAnisotropy);
-
-                CachedBindGroup? cachedBg;
-                lock (_persistentTextureBindGroups)
-                {
-                    if (!_persistentTextureBindGroups.TryGetValue(cacheKey, out cachedBg))
-                    {
-                        textureEntries[0] = new BindGroupEntry
-                        {
-                            Binding = 0,
-                            Sampler = GetTextureSampler(dc.TextureSamplingMode, dc.TextureMaxAnisotropy)
-                        };
-                        textureEntries[1] = new BindGroupEntry { Binding = 1, TextureView = viewPtr };
-
-                        var bgDesc = new BindGroupDescriptor { Layout = _textureBindGroupLayout, EntryCount = 2, Entries = textureEntries };
-                        var bg = _context.Api.DeviceCreateBindGroup(_context.Device, &bgDesc);
-                        cachedBg = new CachedBindGroup((nint)bg, _frameNumber);
-                        _persistentTextureBindGroups[cacheKey] = cachedBg;
-                    }
-                    else
-                    {
-                        cachedBg.LastUsedFrame = _frameNumber;
-                    }
-                }
+                    dc.TextureMaxAnisotropy,
+                    _textureBindGroupLayout);
 
                 var bindGroup = (BindGroup*)cachedBg.BindGroupPtr;
                 _context.Api.RenderPassEncoderSetBindGroup(pass, 1, bindGroup, 0, null);
@@ -4157,6 +4132,80 @@ SceneStateUploadComplete:
             && textureContext.SharesDeviceWith(_context)
             && texture.TexturePtr != null
             && texture.ViewPtr != null;
+    }
+
+    private CachedBindGroup GetOrCreatePersistentTextureBindGroup(
+        GpuTexture texture,
+        bool isOffscreen,
+        TextureSamplingMode samplingMode,
+        byte maxAnisotropy,
+        BindGroupLayout* layout)
+    {
+        var cacheKey = new TextureCacheKey(
+            texture.Id,
+            texture.ViewGeneration,
+            isOffscreen,
+            samplingMode,
+            maxAnisotropy);
+        lock (_persistentTextureBindGroups)
+        {
+            if (_persistentTextureBindGroups.TryGetValue(
+                    cacheKey,
+                    out var cached))
+            {
+                cached.LastUsedFrame = _frameNumber;
+                return cached;
+            }
+        }
+
+        var entries = stackalloc BindGroupEntry[2];
+        entries[0] = new BindGroupEntry
+        {
+            Binding = 0,
+            Sampler = GetTextureSampler(samplingMode, maxAnisotropy)
+        };
+        entries[1] = new BindGroupEntry
+        {
+            Binding = 1,
+            TextureView = texture.ViewPtr
+        };
+        var descriptor = new BindGroupDescriptor
+        {
+            Layout = layout,
+            EntryCount = 2,
+            Entries = entries
+        };
+        var created = new CachedBindGroup(
+            (nint)_context.Api.DeviceCreateBindGroup(
+                _context.Device,
+                &descriptor),
+            _frameNumber);
+
+        nint redundantBindGroup = 0;
+        CachedBindGroup result;
+        lock (_persistentTextureBindGroups)
+        {
+            if (_persistentTextureBindGroups.TryGetValue(
+                    cacheKey,
+                    out var raced))
+            {
+                raced.LastUsedFrame = _frameNumber;
+                redundantBindGroup = created.BindGroupPtr;
+                result = raced;
+            }
+            else
+            {
+                _persistentTextureBindGroups[cacheKey] = created;
+                result = created;
+            }
+        }
+
+        if (redundantBindGroup != 0)
+        {
+            QueueBindGroupRelease(redundantBindGroup);
+        }
+
+        return result;
     }
 
     private void HandleTextureDisposed(ulong textureId)
@@ -14897,45 +14946,12 @@ SceneStateUploadComplete:
                 _textureIndexBuffer.Size);
             _context.Api.RenderPassEncoderSetBindGroup(pass, 2, maskBindGroup, 0, null);
 
-            var cacheKey = new TextureCacheKey(
-                texture.Id,
-                texture.ViewGeneration,
+            var cachedBindGroup = GetOrCreatePersistentTextureBindGroup(
+                texture,
                 isOffscreen: true,
                 drawCall.TextureSamplingMode,
-                drawCall.TextureMaxAnisotropy);
-            CachedBindGroup? cachedBindGroup;
-            lock (_persistentTextureBindGroups)
-            {
-                if (!_persistentTextureBindGroups.TryGetValue(cacheKey, out cachedBindGroup))
-                {
-                    var entries = stackalloc BindGroupEntry[2];
-                    entries[0] = new BindGroupEntry
-                    {
-                        Binding = 0,
-                        Sampler = GetTextureSampler(
-                            drawCall.TextureSamplingMode,
-                            drawCall.TextureMaxAnisotropy)
-                    };
-                    entries[1] = new BindGroupEntry
-                    {
-                        Binding = 1,
-                        TextureView = texture.ViewPtr
-                    };
-                    var descriptor = new BindGroupDescriptor
-                    {
-                        Layout = _textureBindGroupLayoutOffscreen,
-                        EntryCount = 2,
-                        Entries = entries
-                    };
-                    var bindGroup = _context.Api.DeviceCreateBindGroup(_context.Device, &descriptor);
-                    cachedBindGroup = new CachedBindGroup((nint)bindGroup, _frameNumber);
-                    _persistentTextureBindGroups[cacheKey] = cachedBindGroup;
-                }
-                else
-                {
-                    cachedBindGroup.LastUsedFrame = _frameNumber;
-                }
-            }
+                drawCall.TextureMaxAnisotropy,
+                _textureBindGroupLayoutOffscreen);
 
             _context.Api.RenderPassEncoderSetBindGroup(
                 pass,
@@ -16528,7 +16544,6 @@ SceneStateUploadComplete:
         BindGroup* currentMaskBindGroup = null;
         bool? currentPipelineHasMask = null;
         byte? currentVectorPipelineKind = null;
-        var textureEntries = stackalloc BindGroupEntry[2];
         _advancedBlendPassResourceCount = 0;
         bool hasHostBackdrop = HasHostBackdropDrawCall(targetTexture);
         bool hasAdvancedBlend = TryGetAdvancedBlendSourceCapacity(
@@ -16778,36 +16793,12 @@ SceneStateUploadComplete:
                 currentBlendMode = dc.BlendMode;
                 currentPipelineHasMask = hasMask;
 
-                var viewPtr = texture.ViewPtr;
-                var cacheKey = new TextureCacheKey(
-                    texture.Id,
-                    texture.ViewGeneration,
+                var cachedBg = GetOrCreatePersistentTextureBindGroup(
+                    texture,
                     isOffscreen: true,
                     dc.TextureSamplingMode,
-                    dc.TextureMaxAnisotropy);
-
-                CachedBindGroup? cachedBg;
-                lock (_persistentTextureBindGroups)
-                {
-                    if (!_persistentTextureBindGroups.TryGetValue(cacheKey, out cachedBg))
-                    {
-                        textureEntries[0] = new BindGroupEntry
-                        {
-                            Binding = 0,
-                            Sampler = GetTextureSampler(dc.TextureSamplingMode, dc.TextureMaxAnisotropy)
-                        };
-                        textureEntries[1] = new BindGroupEntry { Binding = 1, TextureView = viewPtr };
-
-                        var bgDesc = new BindGroupDescriptor { Layout = _textureBindGroupLayoutOffscreen, EntryCount = 2, Entries = textureEntries };
-                        var bg = _context.Api.DeviceCreateBindGroup(_context.Device, &bgDesc);
-                        cachedBg = new CachedBindGroup((nint)bg, _frameNumber);
-                        _persistentTextureBindGroups[cacheKey] = cachedBg;
-                    }
-                    else
-                    {
-                        cachedBg.LastUsedFrame = _frameNumber;
-                    }
-                }
+                    dc.TextureMaxAnisotropy,
+                    _textureBindGroupLayoutOffscreen);
 
                 var bindGroup = (BindGroup*)cachedBg.BindGroupPtr;
                 _context.Api.RenderPassEncoderSetBindGroup(pass, 1, bindGroup, 0, null);
@@ -20843,7 +20834,6 @@ SceneStateUploadComplete:
 
             DrawCallType? currentType = null;
             byte? currentVectorPipelineKind = null;
-            var textureEntries = stackalloc BindGroupEntry[2];
 
             var maskDrawCalls = maskPass.DrawCalls;
             var maskDrawCallCount = maskDrawCalls.Count;
@@ -20937,36 +20927,12 @@ SceneStateUploadComplete:
 
                     _context.Api.RenderPassEncoderSetBindGroup(pass, 2, maskBindGroup, 0, null);
 
-                    var viewPtr = texture.ViewPtr;
-                    var cacheKey = new TextureCacheKey(
-                        texture.Id,
-                        texture.ViewGeneration,
+                    var cachedBg = GetOrCreatePersistentTextureBindGroup(
+                        texture,
                         isOffscreen: true,
                         dc.TextureSamplingMode,
-                        dc.TextureMaxAnisotropy);
-
-                    CachedBindGroup? cachedBg;
-                    lock (_persistentTextureBindGroups)
-                    {
-                        if (!_persistentTextureBindGroups.TryGetValue(cacheKey, out cachedBg))
-                        {
-                            textureEntries[0] = new BindGroupEntry
-                            {
-                                Binding = 0,
-                                Sampler = GetTextureSampler(dc.TextureSamplingMode, dc.TextureMaxAnisotropy)
-                            };
-                            textureEntries[1] = new BindGroupEntry { Binding = 1, TextureView = viewPtr };
-
-                            var bgDesc = new BindGroupDescriptor { Layout = _textureBindGroupLayoutOffscreen, EntryCount = 2, Entries = textureEntries };
-                            var bg = _context.Api.DeviceCreateBindGroup(_context.Device, &bgDesc);
-                            cachedBg = new CachedBindGroup((nint)bg, _frameNumber);
-                            _persistentTextureBindGroups[cacheKey] = cachedBg;
-                        }
-                        else
-                        {
-                            cachedBg.LastUsedFrame = _frameNumber;
-                        }
-                    }
+                        dc.TextureMaxAnisotropy,
+                        _textureBindGroupLayoutOffscreen);
 
                     var bindGroup = (BindGroup*)cachedBg.BindGroupPtr;
                     _context.Api.RenderPassEncoderSetBindGroup(pass, 1, bindGroup, 0, null);

--- a/src/ProGPU.Tests/DiagnosticsLoggingSourceTests.cs
+++ b/src/ProGPU.Tests/DiagnosticsLoggingSourceTests.cs
@@ -6,6 +6,42 @@ using Xunit;
 
 public class DiagnosticsLoggingSourceTests
 {
+    [Fact]
+    public void PersistentTextureBindGroupCreationStaysOutsideCacheLock()
+    {
+        string source = ReadSource("src", "ProGPU.Scene", "Compositor.cs");
+        int helperStart = source.IndexOf(
+            "private CachedBindGroup GetOrCreatePersistentTextureBindGroup(",
+            StringComparison.Ordinal);
+        int helperEnd = source.IndexOf(
+            "private void HandleTextureDisposed(",
+            helperStart,
+            StringComparison.Ordinal);
+        Assert.True(helperStart >= 0 && helperEnd > helperStart);
+        string helper = source[helperStart..helperEnd];
+
+        int initialCacheLock = helper.IndexOf(
+            "lock (_persistentTextureBindGroups)",
+            StringComparison.Ordinal);
+        int nativeCreate = helper.IndexOf(
+            "_context.Api.DeviceCreateBindGroup(",
+            StringComparison.Ordinal);
+        int publishCacheLock = helper.IndexOf(
+            "lock (_persistentTextureBindGroups)",
+            nativeCreate,
+            StringComparison.Ordinal);
+
+        Assert.True(initialCacheLock >= 0);
+        Assert.Contains(
+            "}\n\n        var entries = stackalloc BindGroupEntry[2];",
+            helper[initialCacheLock..nativeCreate],
+            StringComparison.Ordinal);
+        Assert.True(nativeCreate > initialCacheLock);
+        Assert.True(publishCacheLock > nativeCreate);
+        Assert.Contains("redundantBindGroup = created.BindGroupPtr;", helper, StringComparison.Ordinal);
+        Assert.Contains("QueueBindGroupRelease(redundantBindGroup);", helper, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("src", "ProGPU.Backend", "WgpuContext.cs", "ProGpuBackendDiagnostics.WriteLine(", "Configuring SwapChain", "Console.WriteLine($\"[WebGPU Context] Configuring SwapChain")]
     [InlineData("src", "ProGPU.Scene", "Extensions/ShaderToyExtensionPipeline.cs", "ProGpuSceneDiagnostics.WriteLine(", "ShaderToy Render", "Console.WriteLine(")]

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -11,6 +11,39 @@ namespace ProGPU.Tests;
 public sealed class WgpuContextTests
 {
     [Fact]
+    public void SilkNativeContextsShareProcessWideRenderLock()
+    {
+        using var first = new WgpuContext();
+        using var second = new WgpuContext();
+
+        Assert.Same(first.RenderLock, second.RenderLock);
+    }
+
+    [Fact]
+    public unsafe void BrowserContextsKeepIndependentRenderLocks()
+    {
+        using var firstApi = new BrowserWebGpuApi();
+        using var secondApi = new BrowserWebGpuApi();
+        using var first = new WgpuContext();
+        using var second = new WgpuContext();
+
+        first.InitializeExternal(
+            firstApi,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm);
+        second.InitializeExternal(
+            secondApi,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm);
+
+        Assert.NotSame(first.RenderLock, second.RenderLock);
+    }
+
+    [Fact]
     public void DeviceLossInvalidatesExistingContextsButNotReplacements()
     {
         var existing = new WgpuContext();
@@ -81,6 +114,55 @@ public sealed class WgpuContextTests
         Assert.True(lifetime.IsDisposed);
         Assert.Equal(2, lifetime.WaitingPollCount);
         Assert.False(context.IsInitialized);
+    }
+
+    [Fact]
+    public async Task QueueSubmissionWaitsForDeviceRenderLock()
+    {
+        using var submitStarting = new ManualResetEventSlim();
+        using var queueEntered = new ManualResetEventSlim();
+        using var releaseQueue = new ManualResetEventSlim();
+        using var api = new BrowserWebGpuApi(_ =>
+        {
+            queueEntered.Set();
+            Assert.True(releaseQueue.Wait(TimeSpan.FromSeconds(5)));
+        });
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext();
+        unsafe
+        {
+            context.InitializeExternalNativeDevice(
+                api,
+                lifetime,
+                BrowserWebGpuApi.DeviceHandle,
+                BrowserWebGpuApi.QueueHandle,
+                TextureFormat.Bgra8Unorm);
+        }
+
+        Task submitTask;
+        System.Threading.Monitor.Enter(context.RenderLock);
+        try
+        {
+            submitTask = Task.Run(() =>
+            {
+                submitStarting.Set();
+                unsafe
+                {
+                    var commandBuffer = (CommandBuffer*)1;
+                    context.Submit(1, &commandBuffer);
+                }
+            });
+            Assert.True(submitStarting.Wait(TimeSpan.FromSeconds(5)));
+            Assert.False(queueEntered.Wait(TimeSpan.FromMilliseconds(250)));
+        }
+        finally
+        {
+            System.Threading.Monitor.Exit(context.RenderLock);
+            releaseQueue.Set();
+        }
+
+        await submitTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(queueEntered.IsSet);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- serialize Silk/wgpu-native initialization, resource lifetime, queue submission, and polling through one process-wide synchronization domain while keeping browser and externally owned Dawn domains independent
- create persistent texture bind groups outside the managed cache monitor, then publish with a race-safe second lookup and defer any redundant release
- apply the same applicable optimization to the native C++ renderer through one recursive non-Dawn dispatch scope, with matched managed/native regressions and specification/performance documentation

## Root cause

Independent managed contexts owned different outer monitors even though wgpu-native operations entered one process-wide internal resource-lock graph. Queue submission was also outside the context render monitor. Captured native stacks placed queue submission, buffer destruction, and texture creation on different internal lock edges while a managed cache monitor remained held across native bind-group creation. That permitted an inter-context native lock cycle and a managed/native lock-order inversion.

The fix restores one invariant: every wgpu-native resource/submission/lifetime operation participating in that graph belongs to the same outer synchronization domain, and no managed cache monitor is held while entering native resource creation.

## Mandatory managed/native parity audit

| Optimization | Managed C# | Native C++ |
|---|---|---|
| process-wide wgpu-native synchronization | `WgpuContext` shares the Silk-native render root; browser/Dawn external contexts remain independent | every non-Dawn `dispatch_scope` owns the shared recursive process scope; Dawn remains provider-local |
| queue/resource lifetime exclusion | `Submit` and the Silk resource/write/map/present/release boundaries enter the domain | complete renderer dispatch already encloses submit, polling, creation, and destruction through the new scope |
| persistent bind-group lock order | create outside the dictionary monitor, then race-publish and defer redundant release | not applicable: the native engine uses fixed retained resource slots and has no callback-driven managed dictionary; its equivalent lifetime boundary is covered by the process scope |

The C++ scope is recursive because complete dispatches call nested resource helpers. A native threaded regression proves recursive entry and cross-thread exclusion. Managed regressions prove shared wgpu-native domains, independent browser domains, queue exclusion, and cache/native call order.

## Research record

Primary public sources consulted:

- https://github.com/gfx-rs/wgpu/discussions/4814
- https://github.com/gfx-rs/wgpu/issues/5279
- https://github.com/gfx-rs/wgpu/issues/9981
- https://github.com/gfx-rs/wgpu/blob/trunk/wgpu/src/api/device.rs

Adopted: explicit higher-level serialization for related resource/submission/lifetime work and explicit queue/device progress ordering. Adapted: the outer scope is process-wide only for the pinned wgpu-native provider, based on captured inter-context stacks and the observed shared internal graph. Rejected: serializing independent browser/Dawn providers, per-draw monitor entry, or weakening resource ownership to avoid the lock cycle.

## Validation

- `ProGPU.Tests`: 3,786 passed
- `ProGPU.Tests.Headless`: 240 passed
- native CMake/Clang build, sample, and complete differential matrix: passed
- native CTest: 9/9 passed
- Svg.Skia ProGPU resvg: 927 passed, 37 reviewed skips
- Svg.Skia remaining lane: 1,147/1,147 passed
- Svg.Skia W3C inventory verifier: native 530/533 and ProGPU 486/533 with the unchanged 44 reviewed differences; three skips in each lane
- explicitly ProGPU-backed parallel stress: 10/10 passes, 1,146/1,146 per pass after excluding one unrelated external-font network test

The cross-context deadlock did not recur.

## Performance and quality

Six alternating fresh-process Apple M3 Pro/Metal Release runs used 384 public-picture primitives, 60 warm-ups, and 300 measurements. Both paths remained at zero managed bytes per stable frame. Median-of-run candidate deltas versus the merged baseline were:

- native CPU submission p50: 0.08775 -> 0.08440 ms (-3.82%)
- managed CPU submission p50: 0.51930 -> 0.51825 ms (-0.20%)
- native GPU-complete total p50: 1.61735 -> 1.60715 ms (-0.63%)
- managed GPU-complete total p50: 2.54845 -> 2.45995 ms (-3.47%)

These results support a no-regression conclusion, not a speedup claim. The deterministic differential retained the existing quality band: maximum channel difference 11/255, three pixels over 3/255, and mean absolute channel difference about 0.000311/255.

Matched direct-apphost Time Profiler captures measured 3.1999 versus 3.2080 ms/frame (+0.25%, noise). Matched Metal System Trace captures measured 3.1664 versus 3.1677 ms/frame (+0.04%) with exactly 8,434 submissions in each run, identical peak/final tracked Metal allocation, and slightly lower candidate encoder/command p50 and p95 values.

Allocation/VM Tracker repeatedly suspended the unsigned direct apphost before recording, so no Instruments native-allocation claim is made. The renderer's own Release counter is the stated zero-managed-byte evidence.
