### PR TITLE
perf(scene): Retain compiled effect scenes

### DIFF
--- a/docs/NATIVE_CPP_ENGINE_SPECIFICATION.md
+++ b/docs/NATIVE_CPP_ENGINE_SPECIFICATION.md
@@ -564,6 +564,26 @@ threaded regression proves recursive entry and cross-thread exclusion; the
 managed regressions prove shared wgpu-native domains, independent browser/Dawn
 domains, queue exclusion, and native-call/cache lock ordering.
 
+Stable managed effect scenes now apply the same ownership rule at the compiled
+draw-stream boundary. A cacheable compiled scene moves the drawing context's
+retained-resource leases into scene ownership, keeps persistent effect textures
+alive, and releases both when visual/resource generations invalidate the scene
+or the compositor is disposed. Reuse still submits the current target; it does
+not reuse populated target pixels. Effect mutation propagates through the
+visual change version, texture disposal invalidates the scene, and a focused
+real-device regression disposes the caller's original picture before replay to
+prove that the compiled lease is the sole valid owner until invalidation.
+
+No C++ renderer change is applicable for this ownership correction. Native
+semantic scenes already own pointer-free immutable resource records, fixed
+retained GPU slots, and generation-keyed effect outputs for the complete scene
+lifetime; they do not clone a managed `IDisposable` lease into a per-frame
+drawing context. Existing native real-device gates require a stable effect
+replay to execute one cached composite, zero content/effect passes, and zero
+retained upload, then reject reuse after scene, texture-generation, extent, or
+effect-operation changes. This is the concrete ownership distinction required
+by the parity rule, not a language-only exception.
+
 ## 6. Stable native engine ABI
 
 `include/progpu_native.h` is a C ABI so C++, C#, NativeAOT, V8, and other hosts

--- a/docs/NATIVE_CPP_PERFORMANCE_BASELINE.md
+++ b/docs/NATIVE_CPP_PERFORMANCE_BASELINE.md
@@ -3034,3 +3034,67 @@ resvg 927/964 with 37 reviewed skips, the unchanged W3C inventory (native
 remaining 1,147/1,147 lane, and ten explicitly ProGPU-backed parallel passes of
 1,146/1,146 after excluding one unrelated external-font network test. The
 cross-context deadlock did not recur.
+
+## Managed compiled effect-scene ownership checkpoint
+
+An external retained-UI integration exposed a managed-only lifetime mismatch:
+unchanged anisotropic shadow pictures retained correct GPU effect output, but
+their deferred picture leases were moved into a frame-owned list. The compiled
+scene therefore failed closed on every frame and rebuilt 257 draw calls even
+though visual, effect, texture, target, glyph-atlas, and path-atlas generations
+were unchanged. Median scene compilation was approximately `0.75 ms` in the
+original strict redraw capture.
+
+The managed compositor now transfers those leases into compiled-scene
+ownership. Any cache miss releases the old scene leases before compilation;
+successful capture atomically adopts the new leases; disposal releases both
+frame and compiled ownership. Persistent effect textures remain keyed by their
+visual and effect render revision. Stable replay renders the current target
+while skipping only unchanged scene compilation and effect materialization.
+
+The clean-room decision used current primary contracts:
+
+- [Skia `SkPicture`](https://api.skia.org/classSkPicture.html) retains a
+  replayable command sequence with reference-counted lifetime;
+- [Win2D `CacheOutput`](https://microsoft.github.io/Win2D/WinUI2/html/P_Microsoft_Graphics_Canvas_Effects_CompositeEffect_CacheOutput.htm)
+  explicitly retains an unchanged effect result;
+- [Direct2D command lists and effect caching](https://learn.microsoft.com/en-us/windows/win32/api/_direct2d/)
+  separate replayable image commands from cached transform output;
+- [WebRender's rendering overview](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html#caching)
+  retains picture slices in invalidation-tracked texture-cache tiles;
+- [Vello's retained-scene direction](https://github.com/linebender/vello/blob/main/doc/vision.md#retained-scene-graph-fragments)
+  couples retained fragments with explicit GPU-resource ownership;
+- [HarfBuzz shape-plan caching](https://harfbuzz.github.io/shaping-plans-and-caching.html)
+  and [Skia shaped text](https://skia.org/docs/dev/design/text_shaper/) were
+  checked and are orthogonal because no shaping, glyph, font, or paragraph
+  identity changes in this correction.
+
+Three alternating fresh-process Apple M3 Pro/Metal pairs then rendered 128
+anisotropic shadows to retained 1280-by-720 BGRA8 GPU textures. The strict lane
+forced a current-target redraw, used 6 warmups, 100 synchronized samples, and
+seven 60-frame batches per process. Median-of-process medians were:
+
+| Metric | ProGPU managed | Skia/Metal reference | ProGPU result |
+|---|---:|---:|---:|
+| Completed batch throughput | 0.3884 ms/frame | 0.4578 ms/frame | 19.5% faster |
+| CPU frame | 0.3895 ms | 0.4538 ms | 16.5% faster |
+| GPU-completion wait | 0.4019 ms | 0.3092 ms | 30.0% higher |
+| Blocking total | 0.7962 ms | 0.7757 ms | 2.6% higher / near parity |
+| Managed scene compilation | 0.0024 ms | not exposed | 99.7% below the original capture |
+
+All 300 measured ProGPU frames report a compiled-scene hit, zero scene upload,
+and no populated-target reuse. The full strict 15-workload matrix is valid in
+all 90 process artifacts with zero unsupported operations: ProGPU wins every
+completed-batch comparison and 14 of 15 blocking-total comparisons. Per-backend
+pixel hashes are stable across all three pairs and the semantic-state hash is
+identical. The remaining shadow completion-fence difference is retained as a
+GPU scheduling investigation; it is not hidden by the stronger throughput and
+CPU results.
+
+Native C++ already satisfies the applicable algorithmic contract through its
+immutable scene/resource generations and retained effect-output cache. The
+real-device semantic effect gate proves one cached composite draw, zero child
+content/effect passes, zero stable upload/allocation, and invalidation on any
+scene/effect/extent/texture-generation change. Because native scenes never
+create the managed frame lease that caused this defect, adding a second C++
+lifetime layer would duplicate ownership rather than apply an optimization.

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1381,6 +1381,8 @@ public unsafe partial class Compositor : IDisposable
     private readonly List<CompositorDrawCall> _drawCalls = new();
     private readonly List<RetainedResourceLease>
         _frameRetainedResources = new();
+    private readonly List<RetainedResourceLease>
+        _compiledSceneRetainedResources = new();
     private readonly List<CompiledVisualVersion> _compiledExternalLayers = new();
     private readonly List<CompiledLayerVersion> _compiledLayerOwners = new();
     private readonly Dictionary<TextureCacheKey, CachedBindGroup> _persistentTextureBindGroups = new();
@@ -2949,6 +2951,7 @@ public unsafe partial class Compositor : IDisposable
         if (!reuseCompiledScene)
         {
             ReleaseCompiledSceneAnalyticMaskResources();
+            ReleaseCompiledSceneRetainedResources();
             _currentSolidRoundedPrimitiveCount = 0;
             _activeBrushes.Clear();
             _activeTextStyles.Clear();
@@ -4054,10 +4057,8 @@ SceneStateUploadComplete:
         _compiledSceneCacheStateReason =
             !Options.EnableCompiledSceneCache ? "Compiled scene cache disabled" :
             hasDynamicDiagnostics ? "Dynamic diagnostics active" :
-            _frameRetainedResources.Count != 0 ? "Frame-owned resources active" :
             _compiledSceneContainsDrawingVisual ? "Drawing visuals active" :
             _maskRenderPasses.Count != 0 ? "Mask render passes active" :
-            _effectTextures.Count != 0 ? "Effects active" :
             string.Empty;
         _compiledSceneReusable = _compiledSceneCacheStateReason.Length == 0;
 
@@ -4072,6 +4073,9 @@ SceneStateUploadComplete:
         _compiledSceneAnalyticMaskResources.AddRange(
             _analyticMasksToReturnToPool);
         _analyticMasksToReturnToPool.Clear();
+        _compiledSceneRetainedResources.AddRange(
+            _frameRetainedResources);
+        _frameRetainedResources.Clear();
 
         _compiledSceneRoot = root;
         _compiledSceneRootVersion = root.ChangeVersion;
@@ -14175,6 +14179,8 @@ SceneStateUploadComplete:
 
             _atlas.Dispose();
             _pathAtlas.Dispose();
+            ReleaseFrameRetainedResources();
+            ReleaseCompiledSceneRetainedResources();
 
             lock (_registeredExtensions)
             {
@@ -19257,6 +19263,17 @@ SceneStateUploadComplete:
         _analyticMaskResourcePool.AddRange(
             _compiledSceneAnalyticMaskResources);
         _compiledSceneAnalyticMaskResources.Clear();
+    }
+
+    private void ReleaseCompiledSceneRetainedResources()
+    {
+        for (int index = 0;
+             index < _compiledSceneRetainedResources.Count;
+             index++)
+        {
+            _compiledSceneRetainedResources[index].Dispose();
+        }
+        _compiledSceneRetainedResources.Clear();
     }
 
     private void DisposeMaskBindGroupResource(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -1385,6 +1385,7 @@ public unsafe partial class Compositor : IDisposable
         _compiledSceneRetainedResources = new();
     private readonly List<CompiledVisualVersion> _compiledExternalLayers = new();
     private readonly List<CompiledLayerVersion> _compiledLayerOwners = new();
+    private readonly List<CompiledEffectVersion> _compiledEffectOwners = new();
     private readonly Dictionary<TextureCacheKey, CachedBindGroup> _persistentTextureBindGroups = new();
     private readonly List<GpuBrush> _activeBrushes = new();
     private readonly List<GpuTextStyle> _activeTextStyles = new();
@@ -1441,6 +1442,11 @@ public unsafe partial class Compositor : IDisposable
 
     private readonly record struct CompiledVisualVersion(Visual Visual, long ChangeVersion);
     private readonly record struct CompiledLayerVersion(Visual Visual, GpuTexture Texture);
+    private readonly record struct CompiledEffectVersion(
+        Visual Visual,
+        EffectBase Effect,
+        int CacheKey,
+        EffectTextureSet Textures);
     private readonly record struct TextLayoutCacheKey(
         string Text,
         TtfFont Font,
@@ -4037,6 +4043,19 @@ SceneStateUploadComplete:
             }
         }
 
+        for (int i = 0; i < _compiledEffectOwners.Count; i++)
+        {
+            var compiled = _compiledEffectOwners[i];
+            if (!ReferenceEquals(compiled.Visual.Effect, compiled.Effect) ||
+                compiled.Effect.GetRenderCacheKey() != compiled.CacheKey ||
+                compiled.Textures.Source.IsDisposed ||
+                !_effectTextures.TryGetValue(compiled.Visual, out var textures) ||
+                !ReferenceEquals(compiled.Textures, textures))
+            {
+                return MissCompiledSceneCache("Effect changed");
+            }
+        }
+
         return true;
     }
 
@@ -4044,6 +4063,12 @@ SceneStateUploadComplete:
     {
         _currentSceneCacheMissReason = reason;
         return false;
+    }
+
+    internal void InvalidateCompiledScene(string reason)
+    {
+        _compiledSceneReusable = false;
+        _compiledSceneCacheStateReason = reason;
     }
 
     private void CaptureCompiledScene(
@@ -4067,6 +4092,7 @@ SceneStateUploadComplete:
             _compiledExternalLayers.Clear();
             _compiledEmbeddedVisuals.Clear();
             _compiledLayerOwners.Clear();
+            _compiledEffectOwners.Clear();
             return;
         }
 
@@ -4113,6 +4139,22 @@ SceneStateUploadComplete:
             if (owner.LayerTexture is { IsDisposed: false } texture)
             {
                 _compiledLayerOwners.Add(new CompiledLayerVersion(owner, texture));
+            }
+        }
+
+        _compiledEffectOwners.Clear();
+        foreach (var entry in _effectTextures)
+        {
+            Visual owner = entry.Key;
+            if (owner.Effect is { } effect &&
+                _effectCacheKeys.TryGetValue(owner, out int cacheKey))
+            {
+                _compiledEffectOwners.Add(
+                    new CompiledEffectVersion(
+                        owner,
+                        effect,
+                        cacheKey,
+                        entry.Value));
             }
         }
     }

--- a/src/ProGPU.Scene/Extensions/WpfShaderEffectExtensionPipeline.cs
+++ b/src/ProGPU.Scene/Extensions/WpfShaderEffectExtensionPipeline.cs
@@ -662,6 +662,8 @@ public sealed unsafe class WpfShaderEffectExtensionPipeline : ICompositorExtensi
             {
                 parameters.IsFailed = true;
                 parameters.LastError = errors;
+                compositor.InvalidateCompiledScene(
+                    "Effect pipeline state changed");
                 compositor.PipelineCache.ReleaseShader(shaderKey);
                 return null;
             }
@@ -711,6 +713,8 @@ public sealed unsafe class WpfShaderEffectExtensionPipeline : ICompositorExtensi
                         parameters.LastError = string.IsNullOrEmpty(parameters.LastError)
                             ? "WPF shader effect pipeline creation failed."
                             : parameters.LastError;
+                        compositor.InvalidateCompiledScene(
+                            "Effect pipeline state changed");
                         compositor.PipelineCache.ReleaseRenderPipeline(pipelineKey);
                         compositor.PipelineCache.ReleaseShader(shaderKey);
                         return null;
@@ -728,6 +732,8 @@ public sealed unsafe class WpfShaderEffectExtensionPipeline : ICompositorExtensi
         {
             parameters.IsFailed = true;
             parameters.LastError = ex.Message;
+            compositor.InvalidateCompiledScene(
+                "Effect pipeline state changed");
             compositor.PipelineCache.ReleaseRenderPipeline(pipelineKey);
             compositor.PipelineCache.ReleaseShader(shaderKey);
             return null;

--- a/src/ProGPU.Tests/VisualEffectRenderTests.cs
+++ b/src/ProGPU.Tests/VisualEffectRenderTests.cs
@@ -347,6 +347,56 @@ public sealed class VisualEffectRenderTests
     }
 
     [Fact]
+    public void StableEffectPictureReusesCompiledSceneAndRetainsResources()
+    {
+        using var window = new HeadlessWindow(48, 32);
+        var resource = new CountingDisposable();
+        var recorder = new GpuPictureRecorder();
+        DrawingContext pictureContext = recorder.BeginRecording(
+            new Rect(0f, 0f, 12f, 8f));
+        pictureContext.RetainResource(resource);
+        pictureContext.DrawRectangle(
+            new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f)),
+            pen: null,
+            new Rect(0f, 0f, 12f, 8f));
+        GpuPicture picture = recorder.EndRecording();
+        window.Content = new RetainedEffectPictureVisual(picture);
+
+        try
+        {
+            window.Render();
+            picture.Dispose();
+
+            Assert.Equal(0, resource.DisposeCount);
+
+            window.Render();
+
+            Assert.True(window.Compositor.Metrics.SceneCacheHit);
+            Assert.Null(window.Compositor.Metrics.SceneCacheMissReason);
+            Assert.Equal(0, resource.DisposeCount);
+            var retainedPixel = ReadPixel(
+                window.ReadPixels(),
+                window.Width,
+                x: 12,
+                y: 10);
+            Assert.InRange(retainedPixel.R, 245, 255);
+            Assert.InRange(retainedPixel.G, 0, 10);
+            Assert.InRange(retainedPixel.B, 0, 10);
+
+            window.Content = new PlainBoundsVisual();
+            window.Render();
+
+            Assert.False(window.Compositor.Metrics.SceneCacheHit);
+            Assert.Equal(1, resource.DisposeCount);
+        }
+        finally
+        {
+            picture.Dispose();
+            window.Content = null;
+        }
+    }
+
+    [Fact]
     public void ColorMatrixEffectTransformsTheIsolatedVisualOnGpu()
     {
         var window = HeadlessWindow.Shared;
@@ -724,6 +774,37 @@ public sealed class VisualEffectRenderTests
                 _red,
                 null,
                 new Rect(0f, 0f, 12f, 8f));
+        }
+    }
+
+    private sealed class RetainedEffectPictureVisual : FrameworkElement
+    {
+        private readonly GpuPicture _picture;
+
+        public RetainedEffectPictureVisual(GpuPicture picture)
+        {
+            _picture = picture;
+            Width = 12f;
+            Height = 8f;
+            Transform = Matrix4x4.CreateTranslation(8f, 6f, 0f);
+            Effect = new BlurEffect(0f);
+            EffectContentBounds = new Rect(0f, 0f, 12f, 8f);
+            EffectRasterPadding = 0f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawPicture(_picture);
+        }
+    }
+
+    private sealed class CountingDisposable : IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
         }
     }
 


### PR DESCRIPTION
## Summary

- transfer deferred resource leases into compiled-scene ownership
- reuse stable effect scenes with generation-key and texture-identity validation
- invalidate compiled scenes after shader pipeline failures
- document the native C++ parity decision and strict Metal performance evidence

## Validation

- managed tests: 3,787 passed
- headless tests: 240 passed
- native C++ CTest: 9/9 passed
- strict external Metal comparison: 90/90 artifacts valid across 15 scenarios
