### PR TITLE
perf(gpu): Optimize retained scene submission

### DIFF
--- a/docs/RETAINED_GPU_SUBMISSION_OPTIMIZATION.md
+++ b/docs/RETAINED_GPU_SUBMISSION_OPTIMIZATION.md
@@ -1,0 +1,142 @@
+# Retained GPU submission optimization
+
+Status: implemented and correctness-gated on managed and native C++ renderers,
+2026-08-24
+
+## Purpose
+
+This work reduces stable-frame CPU and synchronization overhead without
+weakening completion, resource lifetime, or pixel-correctness guarantees. It
+combines three independent changes:
+
+1. bounded retirement polling instead of polling after every submission;
+2. compatible consecutive texture-draw batching;
+3. retained WebGPU render-bundle replay for immutable compiled scenes.
+
+The changes are renderer features rather than host-specific shortcuts. The
+managed compositor, the Dawn and Silk.NET providers, and the native C++ engine
+all have an explicit applicability and validation result.
+
+## Invariants
+
+- A reported completion wait still drains all work submitted before the wait.
+- Deferred releases remain bounded even if the host never requests an explicit
+  completion wait.
+- A render bundle never outlives the exact pipelines, buffers, bind groups,
+  textures, samplers, masks, or effect resources captured while recording it.
+- Scene, target format, target extent, sample count, and DPI changes invalidate
+  bundle replay before captured resources are released.
+- Batching preserves draw order, blend semantics, sampling, texture identity,
+  effect identity, clip/mask ownership, and page ownership.
+- Unsupported or mutable scenes fail closed to ordinary render-pass encoding.
+- Every managed optimization is either present in native C++ or has a concrete
+  ownership reason proving that it is not applicable.
+
+## Bounded retirement polling
+
+The managed WebGPU context now performs non-blocking retirement polling every
+eight queue submissions instead of after each submission. The deferred-release
+queue remains capped at 64 submissions, so a burst that reaches the cap forces
+progress rather than allowing unbounded resource retention. Explicit
+completion waits continue to provide the strong drain boundary.
+
+The native C++ engine uses the same interval and bound through its submission
+tracker. Managed native interop no longer adds a second unconditional polling
+layer around the C++ engine. Tests cover the interval boundary, the forced
+retirement bound, explicit waits, teardown, and concurrent submission/lifetime
+serialization.
+
+An experiment that attempted to wait for an exact per-submission token was
+reverted. The available provider contract did not establish a portable token
+lifetime and ordering improvement over the existing explicit completion
+boundary. Retaining the experiment would have increased contract complexity
+without measured benefit.
+
+## Compatible texture-draw batching
+
+The managed compiler merges consecutive texture draws only when the complete
+GPU state is compatible. The native scene compiler applies the equivalent
+patch merge to ordinary and external-image records. Both paths preserve the
+first vertex/index ownership floor used by incremental pages; this prevents a
+later patch from incorrectly claiming storage owned by an earlier retained
+page.
+
+The native C++ scene builder implements the same semantic merge rather than
+depending on managed preprocessing. Focused tests cover compatible merges,
+state mismatches, external images, incremental-page ownership, draw order, and
+pixel output.
+
+## Retained render bundles
+
+`IWebGpuRenderBundleApi` is an optional provider capability. When enabled, the
+managed compositor records a strictly eligible immutable compiled scene once
+and replays it with `RenderPassEncoderExecuteBundles` on subsequent frames.
+Eligibility rejects work that requires mutable uploads, target-dependent
+copies, generated masks, intermediate effects, or other commands whose
+resources or ordering cannot be retained safely.
+
+The compositor stores the bundle beside the compiled scene generation. During
+invalidation and disposal, it releases the bundle before releasing any
+resource that the bundle may reference. Metrics distinguish scene-cache hits,
+bundle-cache hits, newly recorded bundles, and the draw count represented by a
+bundle.
+
+Provider coverage is:
+
+| Provider/engine | Result | Reason |
+|---|---|---|
+| Silk.NET WebGPU | supported | Direct WebGPU render-bundle entry points |
+| Dawn managed provider | supported | Descriptor translation and Dawn handle ownership are explicit |
+| Native C++ engine | supported | Retained semantic spans already record and replay native render bundles |
+| Browser command-packet provider | intentionally not applicable | The packet/event-loop boundary owns transient encoder commands and cannot retain a native encoder object across host frames |
+
+The browser path therefore uses ordinary pass encoding. This is a documented
+ownership mismatch, not an untracked managed/native parity gap.
+
+## Managed/native C++ parity
+
+| Optimization | Managed implementation | Native C++ implementation | Gate |
+|---|---|---|---|
+| Bounded retirement polling | interval 8, hard bound 64 | equivalent submission tracker and bound | interval, drain, teardown, concurrency tests |
+| Texture batching | compatible consecutive draw merge | semantic compiler and pure C++ builder merge | state mismatch, external image, incremental ownership, pixels |
+| Retained bundle replay | optional provider interface and scene-generation lifetime | retained semantic bundle spans and native WebGPU dispatch | cache hit/miss, invalidation, lifetime, native internal tests |
+| Dawn provider adapter | managed ABI/descriptor translation | native engine already calls provider-resolved WebGPU bundle ABI | real Metal device replay and red-pixel readback |
+
+## Evidence
+
+The focused Dawn/Metal test creates a real device, records a retained scene on
+the first frame, replays its bundle on the second frame, and verifies both
+bundle metrics and output pixels. The complete managed renderer suite and the
+headless pixel suite remain the release gates. Native C++ qualification builds
+the library and consumers, runs internal CTest coverage, verifies the export
+allowlist, and executes the pure C++ sample on the physical adapter.
+
+A managed-host, forced-redraw Metal matrix used three alternating fresh-process
+pairs and 15 representative workloads. Both lanes used the same Apple M3 Pro,
+1280 by 720 BGRA8 GPU targets, explicit GPU-completion boundaries, stable
+semantic hashes, zero unsupported operations, and final-target readback. The
+optimized renderer won synchronized total latency and completed bounded-batch
+time in all 15 workloads. Bundle-ineligible sparse, layer, clip, and effect
+scenes also won, which prevents bundle replay from hiding a fallback
+regression. Bundle-enabled output was byte-identical to the same renderer
+revision before bundle support.
+
+A matched Metal System Trace exposed a tradeoff worth optimizing next. The
+managed WebGPU provider completed the bounded shadow workload faster, but its
+whole-process trace contained more Metal command-buffer and resource-allocation
+events than the direct reference lane. Startup-inclusive peak Metal allocated
+size was approximately 25.4 MiB versus 7.84 MiB. These are process-level
+Instruments counters, not steady-frame renderer residency, but they identify
+provider-side command-buffer/resource reuse as the next evidence-backed area.
+
+## Primary references
+
+- [WebGPU render bundles and queue completion](https://www.w3.org/TR/webgpu/)
+- [Apple Metal command structure](https://developer.apple.com/documentation/metal/setting-up-a-command-structure)
+- [Metal command-buffer completion wait](https://developer.apple.com/documentation/metal/mtlcommandbuffer/waituntilcompleted%28%29)
+- [Skia `GrDirectContext` submission API](https://api.skia.org/classGrDirectContext.html)
+
+These sources define the public synchronization and command-recording
+contracts. The implementation and measurements above are independent
+engineering conclusions derived from those contracts and local runtime
+evidence.

--- a/src/ProGPU.Backend.Dawn/DawnWebGpuApi.cs
+++ b/src/ProGPU.Backend.Dawn/DawnWebGpuApi.cs
@@ -19,6 +19,7 @@ namespace ProGPU.Backend.Dawn;
 /// </remarks>
 public sealed unsafe class DawnWebGpuApi :
     IWebGpuApi,
+    IWebGpuRenderBundleApi,
     IWebGpuExternalSurfaceApi
 {
     private const int MaxDescriptorItems = 256;
@@ -155,6 +156,37 @@ public sealed unsafe class DawnWebGpuApi :
         };
         return Pointer(
             DeviceHandle(device).CreateCommandEncoder(&native));
+    }
+
+    public SW.RenderBundleEncoder* DeviceCreateRenderBundleEncoder(
+        SW.Device* device,
+        SW.RenderBundleEncoderDescriptor* descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        int colorFormatCount = DescriptorCount(
+            descriptor->ColorFormatCount,
+            "render bundle color format count");
+        W.TextureFormat* colorFormats =
+            stackalloc W.TextureFormat[colorFormatCount];
+        for (int index = 0; index < colorFormatCount; index++)
+        {
+            colorFormats[index] = TextureFormat(
+                descriptor->ColorFormats[index]);
+        }
+
+        var native = new DawnFfi.RenderBundleEncoderDescriptorFFI
+        {
+            Label = StringView(descriptor->Label),
+            ColorFormatCount = descriptor->ColorFormatCount,
+            ColorFormats = colorFormats,
+            DepthStencilFormat = TextureFormat(
+                descriptor->DepthStencilFormat),
+            SampleCount = descriptor->SampleCount,
+            DepthReadOnly = (bool)descriptor->DepthReadOnly,
+            StencilReadOnly = (bool)descriptor->StencilReadOnly
+        };
+        return Pointer(
+            DeviceHandle(device).CreateRenderBundleEncoder(&native));
     }
 
     public SW.ComputePipeline* DeviceCreateComputePipeline(
@@ -799,6 +831,104 @@ public sealed unsafe class DawnWebGpuApi :
             baseVertex,
             firstInstance);
 
+    public void RenderBundleEncoderSetPipeline(
+        SW.RenderBundleEncoder* encoder,
+        SW.RenderPipeline* pipeline) =>
+        RenderBundleEncoderHandle(encoder).SetPipeline(
+            RenderPipelineHandle(pipeline));
+
+    public void RenderBundleEncoderSetBindGroup(
+        SW.RenderBundleEncoder* encoder,
+        uint groupIndex,
+        SW.BindGroup* group,
+        nuint dynamicOffsetCount,
+        uint* dynamicOffsets) =>
+        RenderBundleEncoderHandle(encoder).SetBindGroup(
+            groupIndex,
+            BindGroupHandle(group),
+            dynamicOffsetCount,
+            dynamicOffsets);
+
+    public void RenderBundleEncoderSetVertexBuffer(
+        SW.RenderBundleEncoder* encoder,
+        uint slot,
+        SilkBuffer* buffer,
+        ulong offset,
+        ulong size) =>
+        RenderBundleEncoderHandle(encoder).SetVertexBuffer(
+            slot,
+            BufferHandle(buffer),
+            offset,
+            size);
+
+    public void RenderBundleEncoderSetIndexBuffer(
+        SW.RenderBundleEncoder* encoder,
+        SilkBuffer* buffer,
+        SW.IndexFormat format,
+        ulong offset,
+        ulong size) =>
+        RenderBundleEncoderHandle(encoder).SetIndexBuffer(
+            BufferHandle(buffer),
+            IndexFormat(format),
+            offset,
+            size);
+
+    public void RenderBundleEncoderDraw(
+        SW.RenderBundleEncoder* encoder,
+        uint vertexCount,
+        uint instanceCount,
+        uint firstVertex,
+        uint firstInstance) =>
+        RenderBundleEncoderHandle(encoder).Draw(
+            vertexCount,
+            instanceCount,
+            firstVertex,
+            firstInstance);
+
+    public void RenderBundleEncoderDrawIndexed(
+        SW.RenderBundleEncoder* encoder,
+        uint indexCount,
+        uint instanceCount,
+        uint firstIndex,
+        int baseVertex,
+        uint firstInstance) =>
+        RenderBundleEncoderHandle(encoder).DrawIndexed(
+            indexCount,
+            instanceCount,
+            firstIndex,
+            baseVertex,
+            firstInstance);
+
+    public SW.RenderBundle* RenderBundleEncoderFinish(
+        SW.RenderBundleEncoder* encoder,
+        SW.RenderBundleDescriptor* descriptor)
+    {
+        var native = new DawnFfi.RenderBundleDescriptorFFI
+        {
+            Label = descriptor == null
+                ? DawnFfi.StringViewFFI.NullValue
+                : StringView(descriptor->Label)
+        };
+        return Pointer(RenderBundleEncoderHandle(encoder).Finish(&native));
+    }
+
+    public void RenderPassEncoderExecuteBundles(
+        SW.RenderPassEncoder* pass,
+        nuint bundleCount,
+        SW.RenderBundle** bundles)
+    {
+        int count = DescriptorCount(bundleCount, nameof(bundleCount));
+        DawnFfi.RenderBundleHandle* nativeBundles =
+            stackalloc DawnFfi.RenderBundleHandle[count];
+        for (int index = 0; index < count; index++)
+        {
+            nativeBundles[index] = RenderBundleHandle(bundles[index]);
+        }
+        RenderPassEncoderHandle(pass).ExecuteBundles(
+            bundleCount,
+            nativeBundles);
+    }
+
     public void RenderPassEncoderEnd(
         SW.RenderPassEncoder* pass) =>
         RenderPassEncoderHandle(pass).End();
@@ -1003,6 +1133,14 @@ public sealed unsafe class DawnWebGpuApi :
     public void RenderPassEncoderRelease(
         SW.RenderPassEncoder* value) =>
         RenderPassEncoderHandle(value).Release();
+
+    public void RenderBundleEncoderRelease(
+        SW.RenderBundleEncoder* value) =>
+        RenderBundleEncoderHandle(value).Release();
+
+    public void RenderBundleRelease(
+        SW.RenderBundle* value) =>
+        RenderBundleHandle(value).Release();
 
     public void RenderPipelineRelease(
         SW.RenderPipeline* value) =>
@@ -1627,6 +1765,11 @@ public sealed unsafe class DawnWebGpuApi :
     private static DawnFfi.RenderPassEncoderHandle
         RenderPassEncoderHandle(
             SW.RenderPassEncoder* value) => new((nuint)value);
+    private static DawnFfi.RenderBundleEncoderHandle
+        RenderBundleEncoderHandle(
+            SW.RenderBundleEncoder* value) => new((nuint)value);
+    private static DawnFfi.RenderBundleHandle RenderBundleHandle(
+        SW.RenderBundle* value) => new((nuint)value);
     private static DawnFfi.ComputePipelineHandle ComputePipelineHandle(
         SW.ComputePipeline* value) => new((nuint)value);
     private static DawnFfi.RenderPipelineHandle RenderPipelineHandle(
@@ -1658,6 +1801,12 @@ public sealed unsafe class DawnWebGpuApi :
     private static SW.RenderPassEncoder* Pointer(
         DawnFfi.RenderPassEncoderHandle value) =>
         (SW.RenderPassEncoder*)value.GetAddress();
+    private static SW.RenderBundleEncoder* Pointer(
+        DawnFfi.RenderBundleEncoderHandle value) =>
+        (SW.RenderBundleEncoder*)value.GetAddress();
+    private static SW.RenderBundle* Pointer(
+        DawnFfi.RenderBundleHandle value) =>
+        (SW.RenderBundle*)value.GetAddress();
     private static SW.ComputePipeline* Pointer(
         DawnFfi.ComputePipelineHandle value) =>
         (SW.ComputePipeline*)value.GetAddress();

--- a/src/ProGPU.Backend.Native/NativeCompositor.cs
+++ b/src/ProGPU.Backend.Native/NativeCompositor.cs
@@ -656,7 +656,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                 throw new NativeRendererException(status, ReadLastError());
             }
             target.NotifyExternalContentChanged();
-            _context.PollDevice(wait: false);
         }
         return new NativeSceneFrameMetrics(
             metrics.CommandCount,
@@ -774,7 +773,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                     throw new NativeRendererException(status, ReadLastError());
                 }
                 target.NotifyExternalContentChanged();
-                _context.PollDevice(wait: false);
             }
             return new NativeFrameMetrics(
                 metrics.DrawCallCount,
@@ -848,7 +846,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                     throw new NativeRendererException(status, ReadLastError());
                 }
                 target.NotifyExternalContentChanged();
-                _context.PollDevice(wait: false);
             }
             return new NativeAnalyticFrameMetrics(
                 metrics.DrawCallCount,
@@ -1031,7 +1028,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                     throw new NativeRendererException(status, ReadLastError());
                 }
                 target.NotifyExternalContentChanged();
-                _context.PollDevice(wait: false);
             }
             return new NativeGeometryFrameMetrics(
                 metrics.DrawCallCount,
@@ -1123,7 +1119,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                     throw new NativeRendererException(status, ReadLastError());
                 }
                 target.NotifyExternalContentChanged();
-                _context.PollDevice(wait: false);
             }
             return new NativePathFrameMetrics(
                 metrics.DrawCallCount,
@@ -1224,7 +1219,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                     throw new NativeRendererException(status, ReadLastError());
                 }
                 target.NotifyExternalContentChanged();
-                _context.PollDevice(wait: false);
             }
             return new NativeGlyphFrameMetrics(
                 metrics.DrawCallCount,
@@ -1383,7 +1377,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                     throw new NativeRendererException(status, ReadLastError());
                 }
                 target.NotifyExternalContentChanged();
-                _context.PollDevice(wait: false);
             }
             return new NativeImageFrameMetrics(
                 metrics.DrawCallCount,
@@ -1536,7 +1529,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                 throw new NativeRendererException(status, ReadLastError());
             }
             target.NotifyExternalContentChanged();
-            _context.PollDevice(wait: false);
         }
         return new NativeImageFrameMetrics(
             metrics.DrawCallCount,
@@ -1693,7 +1685,6 @@ public sealed unsafe class NativeCompositor : IDisposable
                 throw new NativeRendererException(status, ReadLastError());
             }
             target.NotifyExternalContentChanged();
-            _context.PollDevice(wait: false);
         }
         return new NativeImageFrameMetrics(
             metrics.DrawCallCount,

--- a/src/ProGPU.Backend/IWebGpuApi.cs
+++ b/src/ProGPU.Backend/IWebGpuApi.cs
@@ -83,6 +83,66 @@ public unsafe interface IWebGpuApi
 }
 
 /// <summary>
+/// Optional render-bundle operations for providers that can retain encoded
+/// draw state across otherwise identical frames.
+/// </summary>
+/// <remarks>
+/// The core renderer continues to use <see cref="IWebGpuApi"/> when this
+/// capability is unavailable. Render bundles retain the buffers, bind groups,
+/// and pipelines referenced while recording, so callers must release a bundle
+/// before replacing any captured scene resource.
+/// </remarks>
+public unsafe interface IWebGpuRenderBundleApi
+{
+    RenderBundleEncoder* DeviceCreateRenderBundleEncoder(
+        Device* device,
+        RenderBundleEncoderDescriptor* descriptor);
+    void RenderBundleEncoderSetPipeline(
+        RenderBundleEncoder* encoder,
+        RenderPipeline* pipeline);
+    void RenderBundleEncoderSetBindGroup(
+        RenderBundleEncoder* encoder,
+        uint groupIndex,
+        BindGroup* group,
+        nuint dynamicOffsetCount,
+        uint* dynamicOffsets);
+    void RenderBundleEncoderSetVertexBuffer(
+        RenderBundleEncoder* encoder,
+        uint slot,
+        WgpuBuffer* buffer,
+        ulong offset,
+        ulong size);
+    void RenderBundleEncoderSetIndexBuffer(
+        RenderBundleEncoder* encoder,
+        WgpuBuffer* buffer,
+        IndexFormat format,
+        ulong offset,
+        ulong size);
+    void RenderBundleEncoderDraw(
+        RenderBundleEncoder* encoder,
+        uint vertexCount,
+        uint instanceCount,
+        uint firstVertex,
+        uint firstInstance);
+    void RenderBundleEncoderDrawIndexed(
+        RenderBundleEncoder* encoder,
+        uint indexCount,
+        uint instanceCount,
+        uint firstIndex,
+        int baseVertex,
+        uint firstInstance);
+    RenderBundle* RenderBundleEncoderFinish(
+        RenderBundleEncoder* encoder,
+        RenderBundleDescriptor* descriptor);
+    void RenderBundleEncoderRelease(RenderBundleEncoder* encoder);
+    void RenderPassEncoderExecuteBundles(
+        RenderPassEncoder* pass,
+        nuint bundleCount,
+        RenderBundle** bundles);
+    void RenderBundleRelease(RenderBundle* bundle);
+}
+
+/// <summary>
 /// Optional native-presentation contract for an exact-ABI external WebGPU
 /// backend. It lets a host resize an already selected external device without
 /// routing surface descriptors through a second ABI.
@@ -114,7 +174,7 @@ public interface IWebGpuExternalDeviceLifetime : IDisposable
 
 internal unsafe sealed class SilkWebGpuApi(
     WebGPU api,
-    object synchronizationRoot) : IWebGpuApi
+    object synchronizationRoot) : IWebGpuApi, IWebGpuRenderBundleApi
 {
     private sealed class MapCompletion
     {
@@ -196,6 +256,10 @@ internal unsafe sealed class SilkWebGpuApi(
     {
         lock (synchronizationRoot) return api.CommandEncoderBeginRenderPass(e, x);
     }
+    public RenderBundleEncoder* DeviceCreateRenderBundleEncoder(Device* d, RenderBundleEncoderDescriptor* x)
+    {
+        lock (synchronizationRoot) return api.DeviceCreateRenderBundleEncoder(d, x);
+    }
     public void CommandEncoderCopyBufferToBuffer(CommandEncoder* e, WgpuBuffer* s, ulong so, WgpuBuffer* d, ulong @do, ulong z) => api.CommandEncoderCopyBufferToBuffer(e, s, so, d, @do, z);
     public void CommandEncoderCopyBufferToTexture(CommandEncoder* e, ImageCopyBuffer* s, ImageCopyTexture* d, Extent3D* z) => api.CommandEncoderCopyBufferToTexture(e, s, d, z);
     public void CommandEncoderCopyTextureToBuffer(CommandEncoder* e, ImageCopyTexture* s, ImageCopyBuffer* d, Extent3D* z) => api.CommandEncoderCopyTextureToBuffer(e, s, d, z);
@@ -218,6 +282,17 @@ internal unsafe sealed class SilkWebGpuApi(
     public void RenderPassEncoderDraw(RenderPassEncoder* p, uint v, uint i, uint fv, uint fi) => api.RenderPassEncoderDraw(p, v, i, fv, fi);
     public void RenderPassEncoderDrawIndexed(RenderPassEncoder* p, uint i, uint c, uint f, int b, uint fi) => api.RenderPassEncoderDrawIndexed(p, i, c, f, b, fi);
     public void RenderPassEncoderEnd(RenderPassEncoder* p) => api.RenderPassEncoderEnd(p);
+    public void RenderBundleEncoderSetPipeline(RenderBundleEncoder* e, RenderPipeline* p) => api.RenderBundleEncoderSetPipeline(e, p);
+    public void RenderBundleEncoderSetBindGroup(RenderBundleEncoder* e, uint i, BindGroup* g, nuint c, uint* o) => api.RenderBundleEncoderSetBindGroup(e, i, g, c, o);
+    public void RenderBundleEncoderSetVertexBuffer(RenderBundleEncoder* e, uint s, WgpuBuffer* b, ulong o, ulong z) => api.RenderBundleEncoderSetVertexBuffer(e, s, b, o, z);
+    public void RenderBundleEncoderSetIndexBuffer(RenderBundleEncoder* e, WgpuBuffer* b, IndexFormat f, ulong o, ulong z) => api.RenderBundleEncoderSetIndexBuffer(e, b, f, o, z);
+    public void RenderBundleEncoderDraw(RenderBundleEncoder* e, uint v, uint i, uint fv, uint fi) => api.RenderBundleEncoderDraw(e, v, i, fv, fi);
+    public void RenderBundleEncoderDrawIndexed(RenderBundleEncoder* e, uint i, uint c, uint f, int b, uint fi) => api.RenderBundleEncoderDrawIndexed(e, i, c, f, b, fi);
+    public RenderBundle* RenderBundleEncoderFinish(RenderBundleEncoder* e, RenderBundleDescriptor* d)
+    {
+        lock (synchronizationRoot) return api.RenderBundleEncoderFinish(e, d);
+    }
+    public void RenderPassEncoderExecuteBundles(RenderPassEncoder* p, nuint c, RenderBundle** b) => api.RenderPassEncoderExecuteBundles(p, c, b);
     public void QueueWriteBuffer(Queue* q, WgpuBuffer* b, ulong o, void* d, nuint z)
     {
         lock (synchronizationRoot) api.QueueWriteBuffer(q, b, o, d, z);
@@ -324,6 +399,14 @@ internal unsafe sealed class SilkWebGpuApi(
     public void RenderPassEncoderRelease(RenderPassEncoder* v)
     {
         lock (synchronizationRoot) api.RenderPassEncoderRelease(v);
+    }
+    public void RenderBundleEncoderRelease(RenderBundleEncoder* v)
+    {
+        lock (synchronizationRoot) api.RenderBundleEncoderRelease(v);
+    }
+    public void RenderBundleRelease(RenderBundle* v)
+    {
+        lock (synchronizationRoot) api.RenderBundleRelease(v);
     }
     public void RenderPipelineRelease(RenderPipeline* v)
     {

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -117,7 +117,9 @@ public unsafe class WgpuContext : IDisposable
 
     private PfnErrorCallback _errorCallback;
     private nint _devicePollAddress;
+    private nint _queueSubmitForIndexAddress;
     private nint _generateReportAddress;
+    private ulong _lastSubmissionIndex;
 
     private static readonly object s_silkNativeRenderLock = new();
 
@@ -216,7 +218,44 @@ public unsafe class WgpuContext : IDisposable
         lock (RenderLock)
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
-            Api.QueueSubmit(Queue, commandCount, commandBuffers);
+            if (BackendKind == WgpuBackendKind.SilkNative)
+            {
+                if (_queueSubmitForIndexAddress == 0)
+                {
+                    _queueSubmitForIndexAddress =
+                        Wgpu.Context.GetProcAddress(
+                            "wgpuQueueSubmitForIndex");
+                }
+
+                if (_queueSubmitForIndexAddress != 0)
+                {
+                    var submitForIndex =
+                        (delegate* unmanaged[Cdecl]<
+                            Queue*,
+                            nuint,
+                            CommandBuffer**,
+                            ulong>)_queueSubmitForIndexAddress;
+                    _lastSubmissionIndex = submitForIndex(
+                        Queue,
+                        commandCount,
+                        commandBuffers);
+                }
+                else
+                {
+                    Api.QueueSubmit(
+                        Queue,
+                        commandCount,
+                        commandBuffers);
+                    _lastSubmissionIndex = 0;
+                }
+            }
+            else
+            {
+                Api.QueueSubmit(
+                    Queue,
+                    commandCount,
+                    commandBuffers);
+            }
             Interlocked.Increment(ref _queueSubmissionCount);
         }
     }
@@ -1974,11 +2013,20 @@ public unsafe class WgpuContext : IDisposable
                         uint,
                         void*,
                         uint>)_devicePollAddress;
-                _ = poll(
+                WrappedSubmissionIndex wrappedSubmission = default;
+                void* wrappedSubmissionPointer = null;
+                if (_lastSubmissionIndex != 0)
+                {
+                    wrappedSubmission = new WrappedSubmissionIndex(
+                        Queue,
+                        _lastSubmissionIndex);
+                    wrappedSubmissionPointer = &wrappedSubmission;
+                }
+                var completed = poll(
                     Device,
                     wait ? 1u : 0u,
-                    null);
-                if (wait)
+                    wrappedSubmissionPointer);
+                if (wait || completed != 0)
                 {
                     MarkSubmittedWorkDrained();
                 }
@@ -2012,6 +2060,21 @@ public unsafe class WgpuContext : IDisposable
         Volatile.Write(
             ref _polledQueueSubmissionCount,
             submittedQueueWork);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly struct WrappedSubmissionIndex
+    {
+        internal WrappedSubmissionIndex(
+            Queue* queue,
+            ulong submissionIndex)
+        {
+            Queue = queue;
+            SubmissionIndex = submissionIndex;
+        }
+
+        internal readonly Queue* Queue;
+        internal readonly ulong SubmissionIndex;
     }
 
     public bool TryCaptureNativeResourceSnapshot(out WgpuNativeResourceSnapshot snapshot)

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -117,9 +117,7 @@ public unsafe class WgpuContext : IDisposable
 
     private PfnErrorCallback _errorCallback;
     private nint _devicePollAddress;
-    private nint _queueSubmitForIndexAddress;
     private nint _generateReportAddress;
-    private ulong _lastSubmissionIndex;
 
     private static readonly object s_silkNativeRenderLock = new();
 
@@ -218,44 +216,7 @@ public unsafe class WgpuContext : IDisposable
         lock (RenderLock)
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
-            if (BackendKind == WgpuBackendKind.SilkNative)
-            {
-                if (_queueSubmitForIndexAddress == 0)
-                {
-                    _queueSubmitForIndexAddress =
-                        Wgpu.Context.GetProcAddress(
-                            "wgpuQueueSubmitForIndex");
-                }
-
-                if (_queueSubmitForIndexAddress != 0)
-                {
-                    var submitForIndex =
-                        (delegate* unmanaged[Cdecl]<
-                            Queue*,
-                            nuint,
-                            CommandBuffer**,
-                            ulong>)_queueSubmitForIndexAddress;
-                    _lastSubmissionIndex = submitForIndex(
-                        Queue,
-                        commandCount,
-                        commandBuffers);
-                }
-                else
-                {
-                    Api.QueueSubmit(
-                        Queue,
-                        commandCount,
-                        commandBuffers);
-                    _lastSubmissionIndex = 0;
-                }
-            }
-            else
-            {
-                Api.QueueSubmit(
-                    Queue,
-                    commandCount,
-                    commandBuffers);
-            }
+            Api.QueueSubmit(Queue, commandCount, commandBuffers);
             Interlocked.Increment(ref _queueSubmissionCount);
         }
     }
@@ -2013,20 +1974,11 @@ public unsafe class WgpuContext : IDisposable
                         uint,
                         void*,
                         uint>)_devicePollAddress;
-                WrappedSubmissionIndex wrappedSubmission = default;
-                void* wrappedSubmissionPointer = null;
-                if (_lastSubmissionIndex != 0)
-                {
-                    wrappedSubmission = new WrappedSubmissionIndex(
-                        Queue,
-                        _lastSubmissionIndex);
-                    wrappedSubmissionPointer = &wrappedSubmission;
-                }
-                var completed = poll(
+                _ = poll(
                     Device,
                     wait ? 1u : 0u,
-                    wrappedSubmissionPointer);
-                if (wait || completed != 0)
+                    null);
+                if (wait)
                 {
                     MarkSubmittedWorkDrained();
                 }
@@ -2060,21 +2012,6 @@ public unsafe class WgpuContext : IDisposable
         Volatile.Write(
             ref _polledQueueSubmissionCount,
             submittedQueueWork);
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private readonly struct WrappedSubmissionIndex
-    {
-        internal WrappedSubmissionIndex(
-            Queue* queue,
-            ulong submissionIndex)
-        {
-            Queue = queue;
-            SubmissionIndex = submissionIndex;
-        }
-
-        internal readonly Queue* Queue;
-        internal readonly ulong SubmissionIndex;
     }
 
     public bool TryCaptureNativeResourceSnapshot(out WgpuNativeResourceSnapshot snapshot)

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -29,8 +29,11 @@ public enum WgpuBackendKind
 
 public unsafe class WgpuContext : IDisposable
 {
-    private const int QueuePollSubmissionInterval = 2;
-    private const int DefaultMaximumDeferredQueueSubmissions = 8;
+    // Device polling can materialize internal Metal signal/transition command
+    // buffers even when the renderer has no callbacks to service. Keep progress
+    // bounded without injecting that work into every retained frame.
+    private const int QueuePollSubmissionInterval = 8;
+    private const int DefaultMaximumDeferredQueueSubmissions = 64;
     private SharedDeviceLifetime? _sharedDeviceLifetime;
     private IWebGpuExternalDeviceLifetime? _externalDeviceLifetime;
     private WgpuDeviceResourceDomain? _deviceResourceDomain;

--- a/src/ProGPU.Native/src/Backend/progpu_native.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native.cpp
@@ -574,14 +574,17 @@ progpu_native_status progpu_native_engine_poll_submission(
             PROGPU_NATIVE_STATUS_DEVICE_LOST,
             "Submissions from the lost native device cannot be polled.");
     }
-    *complete = progpu::native::webgpu::poll_submission(
+    const bool completed = progpu::native::webgpu::poll_submission(
         engine->instance,
         engine->device,
         engine->queue,
         submission_index,
-        wait != 0U)
-        ? 1U
-        : 0U;
+        wait != 0U);
+    *complete = completed ? 1U : 0U;
+    if (completed && submission_index == engine->last_submission_index) {
+        engine->submission_retirement.observe_latest_completion(
+            engine->submission_count);
+    }
     engine->last_error.clear();
     return PROGPU_NATIVE_STATUS_SUCCESS;
 }

--- a/src/ProGPU.Native/src/Backend/progpu_native_engine.hpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_engine.hpp
@@ -467,6 +467,8 @@ struct progpu_native_engine {
     std::string last_error;
     std::uint64_t submission_count = 0;
     std::uint64_t last_submission_index = 0U;
+    progpu::native::webgpu::submission_retirement_tracker
+        submission_retirement;
     std::uint64_t device_loss_generation = 0U;
     bool device_lost = false;
 
@@ -476,6 +478,25 @@ struct progpu_native_engine {
             1U,
             &command);
         ++submission_count;
+#if !defined(PROGPU_NATIVE_BROWSER)
+        const auto retirement_action =
+            submission_retirement.on_submission(submission_count);
+        if (retirement_action !=
+            progpu::native::webgpu::submission_retirement_action::none) {
+            const bool completed =
+                progpu::native::webgpu::poll_submission(
+                    instance,
+                    device,
+                    queue,
+                    last_submission_index,
+                    retirement_action == progpu::native::webgpu::
+                        submission_retirement_action::wait);
+            if (completed) {
+                submission_retirement.observe_latest_completion(
+                    submission_count);
+            }
+        }
+#endif
     }
 
     bool upload_uniform_if_changed(

--- a/src/ProGPU.Native/src/Backend/progpu_native_webgpu_synchronization.hpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_webgpu_synchronization.hpp
@@ -1,8 +1,56 @@
 #pragma once
 
+#include <cstdint>
 #include <mutex>
 
 namespace progpu::native::webgpu {
+
+enum class submission_retirement_action : std::uint8_t {
+    none,
+    poll,
+    wait
+};
+
+// Keep native queue retirement aligned with the managed backend: poll exact
+// submission tokens periodically, but force a bounded drain when the producer
+// outruns the GPU. Exact-token completion retires every earlier queue item.
+class submission_retirement_tracker final {
+public:
+    static constexpr std::uint64_t poll_interval = 8U;
+    static constexpr std::uint64_t maximum_deferred_submissions = 64U;
+
+    [[nodiscard]] submission_retirement_action on_submission(
+        std::uint64_t submitted_count) noexcept {
+        if (submitted_count - retired_count_ >=
+            maximum_deferred_submissions) {
+            polled_count_ = submitted_count;
+            return submission_retirement_action::wait;
+        }
+        if (submitted_count - polled_count_ >= poll_interval) {
+            polled_count_ = submitted_count;
+            return submission_retirement_action::poll;
+        }
+        return submission_retirement_action::none;
+    }
+
+    void observe_latest_completion(
+        std::uint64_t submitted_count) noexcept {
+        retired_count_ = submitted_count;
+        polled_count_ = submitted_count;
+    }
+
+    [[nodiscard]] std::uint64_t retired_count() const noexcept {
+        return retired_count_;
+    }
+
+    [[nodiscard]] std::uint64_t polled_count() const noexcept {
+        return polled_count_;
+    }
+
+private:
+    std::uint64_t retired_count_ = 0U;
+    std::uint64_t polled_count_ = 0U;
+};
 
 // wgpu-native devices share an internal process-wide resource lock graph.
 // Keep complete native renderer operations in the same synchronization domain

--- a/src/ProGPU.Native/src/Scene/Builder/progpu_native_scene_builder_image.cpp
+++ b/src/ProGPU.Native/src/Scene/Builder/progpu_native_scene_builder_image.cpp
@@ -3,6 +3,7 @@
 #include "progpu_native_semantic_image.hpp"
 #include "progpu_native_semantic_validation.hpp"
 
+#include <algorithm>
 #include <cstring>
 #include <limits>
 #include <new>
@@ -10,6 +11,200 @@
 
 namespace progpu::native {
 using scene_builder_detail::finite_rect;
+
+namespace {
+
+bool same_float(float left, float right) noexcept {
+    return std::bit_cast<std::uint32_t>(left) ==
+        std::bit_cast<std::uint32_t>(right);
+}
+
+bool same_transform(
+    const progpu_native_affine_2d& left,
+    const progpu_native_affine_2d& right) noexcept {
+    return same_float(left.m11, right.m11) &&
+        same_float(left.m12, right.m12) &&
+        same_float(left.m21, right.m21) &&
+        same_float(left.m22, right.m22) &&
+        same_float(left.m31, right.m31) &&
+        same_float(left.m32, right.m32);
+}
+
+bool can_share_image_patch_batch(
+    const progpu_native_scene_image_draw& left,
+    const progpu_native_scene_image_draw& right) noexcept {
+    constexpr std::uint32_t patch_flag =
+        PROGPU_NATIVE_SCENE_IMAGE_PATCH_BATCH;
+    constexpr std::uint32_t excluded_flags =
+        PROGPU_NATIVE_SCENE_IMAGE_COLOR_MATRIX |
+        PROGPU_NATIVE_SCENE_IMAGE_EFFECT;
+    return (left.flags & excluded_flags) == 0U &&
+        (right.flags & (excluded_flags | patch_flag)) == 0U &&
+        left.image_width == right.image_width &&
+        left.image_height == right.image_height &&
+        left.row_bytes == right.row_bytes &&
+        left.sampling == right.sampling &&
+        left.max_anisotropy == right.max_anisotropy &&
+        (left.flags & ~patch_flag) == right.flags &&
+        same_float(left.opacity, right.opacity) &&
+        same_transform(left.transform, right.transform);
+}
+
+bool same_sampling_options(
+    const progpu_native_scene_image_sampling_options* left,
+    const progpu_native_scene_image_sampling_options* right) noexcept {
+    if (left == nullptr || right == nullptr) {
+        return left == right;
+    }
+    return left->struct_size == right->struct_size &&
+        left->flags == right->flags &&
+        same_float(left->cubic_b, right->cubic_b) &&
+        same_float(left->cubic_c, right->cubic_c);
+}
+
+progpu_native_scene_image_patch make_texture_patch(
+    const progpu_native_scene_image_draw& image) noexcept {
+    progpu_native_scene_image_patch patch{};
+    patch.struct_size = sizeof(patch);
+    patch.kind = PROGPU_NATIVE_SCENE_IMAGE_PATCH_TEXTURE;
+    patch.source_rect = image.source_rect;
+    patch.destination_rect = image.destination_rect;
+    patch.transform = semantic_scene_builder::identity_transform();
+    return patch;
+}
+
+progpu_native_image_rect union_bounds(
+    progpu_native_image_rect left,
+    progpu_native_image_rect right) noexcept {
+    const float x = std::min(left.x, right.x);
+    const float y = std::min(left.y, right.y);
+    const float right_edge = std::max(
+        left.x + left.width,
+        right.x + right.width);
+    const float bottom_edge = std::max(
+        left.y + left.height,
+        right.y + right.height);
+    return {x, y, right_edge - x, bottom_edge - y};
+}
+
+} // namespace
+
+bool semantic_scene_builder::implementation::try_merge_image_draw(
+    std::uint32_t image_resource_index,
+    const progpu_native_scene_image_draw& image,
+    progpu_native_image_rect bounds,
+    std::uint32_t state_resource_index,
+    const progpu_native_scene_image_sampling_options* sampling_options) {
+    if (commands.empty()) {
+        return false;
+    }
+    auto& previous = commands.back();
+    if (previous.record.kind != PROGPU_NATIVE_SCENE_COMMAND_DRAW_IMAGE ||
+        previous.record.resource_index != image_resource_index ||
+        previous.record.state_index != state_resource_index ||
+        previous.payload.size() < sizeof(progpu_native_scene_image_draw)) {
+        return false;
+    }
+
+    progpu_native_scene_image_draw previous_image{};
+    std::memcpy(
+        &previous_image,
+        previous.payload.data(),
+        sizeof(previous_image));
+    if (!can_share_image_patch_batch(previous_image, image)) {
+        return false;
+    }
+    const bool cubic = image.sampling == PROGPU_NATIVE_IMAGE_SAMPLING_CUBIC;
+    const std::size_t suffix_offset = sizeof(previous_image);
+    progpu_native_scene_image_sampling_options previous_sampling{};
+    const auto* previous_sampling_pointer =
+        cubic ? &previous_sampling : nullptr;
+    if (cubic) {
+        if (previous.payload.size() <
+            suffix_offset + sizeof(previous_sampling)) {
+            return false;
+        }
+        std::memcpy(
+            &previous_sampling,
+            previous.payload.data() + suffix_offset,
+            sizeof(previous_sampling));
+    }
+    if (!same_sampling_options(
+            previous_sampling_pointer,
+            sampling_options)) {
+        return false;
+    }
+
+    const std::size_t batch_offset = suffix_offset +
+        (cubic ? sizeof(previous_sampling) : 0U);
+    const auto current_patch = make_texture_patch(image);
+    if ((previous_image.flags & PROGPU_NATIVE_SCENE_IMAGE_PATCH_BATCH) != 0U) {
+        if (previous.payload.size() <
+            batch_offset + sizeof(progpu_native_scene_image_patch_batch)) {
+            return false;
+        }
+        progpu_native_scene_image_patch_batch batch{};
+        std::memcpy(
+            &batch,
+            previous.payload.data() + batch_offset,
+            sizeof(batch));
+        if (batch.patch_count == 0U ||
+            batch.patch_count >= PROGPU_NATIVE_SCENE_MAX_IMAGE_PATCHES) {
+            return false;
+        }
+        const std::size_t expected_size = batch_offset + sizeof(batch) +
+            static_cast<std::size_t>(batch.patch_count) *
+                sizeof(progpu_native_scene_image_patch);
+        if (previous.payload.size() != expected_size) {
+            return false;
+        }
+        previous.payload.resize(
+            expected_size + sizeof(progpu_native_scene_image_patch));
+        std::memcpy(
+            previous.payload.data() + expected_size,
+            &current_patch,
+            sizeof(current_patch));
+        ++batch.patch_count;
+        std::memcpy(
+            previous.payload.data() + batch_offset,
+            &batch,
+            sizeof(batch));
+    } else {
+        const auto first_patch = make_texture_patch(previous_image);
+        previous_image.flags |= PROGPU_NATIVE_SCENE_IMAGE_PATCH_BATCH;
+        const progpu_native_scene_image_patch_batch batch{
+            sizeof(progpu_native_scene_image_patch_batch), 0U, 2U, 0U};
+        std::vector<std::byte> payload(
+            batch_offset + sizeof(batch) +
+            2U * sizeof(progpu_native_scene_image_patch));
+        std::size_t offset = 0U;
+        const auto append = [&](const void* value, std::size_t size) {
+            std::memcpy(payload.data() + offset, value, size);
+            offset += size;
+        };
+        append(&previous_image, sizeof(previous_image));
+        if (cubic) {
+            append(&previous_sampling, sizeof(previous_sampling));
+        }
+        append(&batch, sizeof(batch));
+        append(&first_patch, sizeof(first_patch));
+        append(&current_patch, sizeof(current_patch));
+        previous.payload = std::move(payload);
+    }
+    previous.record.payload_size =
+        static_cast<std::uint32_t>(previous.payload.size());
+    const auto merged_bounds = union_bounds(
+        {previous.record.bounds_x,
+            previous.record.bounds_y,
+            previous.record.bounds_width,
+            previous.record.bounds_height},
+        bounds);
+    previous.record.bounds_x = merged_bounds.x;
+    previous.record.bounds_y = merged_bounds.y;
+    previous.record.bounds_width = merged_bounds.width;
+    previous.record.bounds_height = merged_bounds.height;
+    return true;
+}
 
 bool semantic_scene_builder::add_rgba8_image(
     std::uint32_t width,
@@ -182,6 +377,15 @@ bool semantic_scene_builder::draw_image(
         return implementation_->fail(scene_build_error::capacity_exceeded);
     }
     try {
+        if (implementation_->try_merge_image_draw(
+                image_resource_index,
+                image,
+                bounds,
+                state_resource_index,
+                sampling_options)) {
+            implementation_->error = scene_build_error::none;
+            return true;
+        }
         implementation_->commands.reserve(
             implementation_->commands.size() + 1U);
         implementation::command_entry command{};

--- a/src/ProGPU.Native/src/Scene/Builder/progpu_native_scene_builder_internal.hpp
+++ b/src/ProGPU.Native/src/Scene/Builder/progpu_native_scene_builder_internal.hpp
@@ -57,6 +57,14 @@ struct semantic_scene_builder::implementation final {
             (index < resources.size() && resources[index].record.kind ==
                 PROGPU_NATIVE_SCENE_RESOURCE_STATE);
     }
+
+    bool try_merge_image_draw(
+        std::uint32_t image_resource_index,
+        const progpu_native_scene_image_draw& image,
+        progpu_native_image_rect bounds,
+        std::uint32_t state_resource_index,
+        const progpu_native_scene_image_sampling_options*
+            sampling_options);
 };
 
 namespace scene_builder_detail {

--- a/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
@@ -909,6 +909,8 @@ int main() {
     require(progpu::native::tests::
         semantic_scene_builder_records_image_patch_batches());
     require(progpu::native::tests::
+        semantic_scene_builder_batches_compatible_image_draws());
+    require(progpu::native::tests::
         semantic_scene_builder_serializes_external_images_pointer_free());
     require(progpu::native::tests::
         semantic_scene_builder_updates_retained_images_transactionally());

--- a/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
@@ -76,6 +76,34 @@ void native_webgpu_scopes_share_one_process_lock() {
     second.join();
 }
 
+void native_submission_retirement_is_periodic_and_bounded() {
+    using progpu::native::webgpu::submission_retirement_action;
+    using progpu::native::webgpu::submission_retirement_tracker;
+
+    submission_retirement_tracker tracker;
+    for (std::uint64_t submission = 1U; submission < 64U; ++submission) {
+        const auto action = tracker.on_submission(submission);
+        require(action == (submission % 8U == 0U
+            ? submission_retirement_action::poll
+            : submission_retirement_action::none));
+    }
+    require(tracker.on_submission(64U) ==
+        submission_retirement_action::wait);
+    require(tracker.polled_count() == 64U);
+    require(tracker.retired_count() == 0U);
+
+    tracker.observe_latest_completion(64U);
+    require(tracker.retired_count() == 64U);
+    for (std::uint64_t submission = 65U; submission < 72U; ++submission) {
+        require(tracker.on_submission(submission) ==
+            submission_retirement_action::none);
+    }
+    require(tracker.on_submission(72U) ==
+        submission_retirement_action::poll);
+    tracker.observe_latest_completion(72U);
+    require(tracker.retired_count() == 72U);
+}
+
 void semantic_contiguous_draws_merge_without_reordering() {
     const auto vertex_stride =
         sizeof(progpu::native::vector_vertex);
@@ -853,6 +881,7 @@ void draw_state_resolution_is_cpu_only_and_bounded() {
 
 int main() {
     native_webgpu_scopes_share_one_process_lock();
+    native_submission_retirement_is_periodic_and_bounded();
     semantic_contiguous_draws_merge_without_reordering();
     effect_plan_uses_three_bounded_intermediates();
     semantic_budget_counts_effected_depth_once();

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.cpp
@@ -706,6 +706,100 @@ bool semantic_scene_builder_records_image_patch_batches() {
         invalid.last_error() == scene_build_error::invalid_argument;
 }
 
+bool semantic_scene_builder_batches_compatible_image_draws() {
+    semantic_scene_builder builder(716U, 1U);
+    std::uint32_t image_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+    if (!builder.add_external_image(64U, 32U, image_index)) {
+        return false;
+    }
+    progpu_native_scene_image_draw image{};
+    image.flags = PROGPU_NATIVE_SCENE_IMAGE_SOURCE_PREMULTIPLIED;
+    image.image_width = 64U;
+    image.image_height = 32U;
+    image.row_bytes = 256U;
+    image.sampling = PROGPU_NATIVE_IMAGE_SAMPLING_LINEAR;
+    image.source_rect = {0.0F, 0.0F, 16.0F, 16.0F};
+    image.destination_rect = {0.0F, 0.0F, 16.0F, 16.0F};
+    image.transform = semantic_scene_builder::identity_transform();
+    image.opacity = 0.75F;
+    if (!builder.draw_image(
+            image_index, image, {0.0F, 0.0F, 16.0F, 16.0F})) {
+        return false;
+    }
+    image.destination_rect.x = 16.0F;
+    if (!builder.draw_image(
+            image_index, image, {16.0F, 0.0F, 16.0F, 16.0F})) {
+        return false;
+    }
+    image.destination_rect.x = 32.0F;
+    if (!builder.draw_image(
+            image_index, image, {32.0F, 0.0F, 16.0F, 16.0F})) {
+        return false;
+    }
+
+    std::vector<std::byte> stream;
+    scene_build_metrics metrics{};
+    if (!builder.build(stream, &metrics) || metrics.command_count != 1U) {
+        return false;
+    }
+    const auto validation = scene::validate(stream.data(), stream.size());
+    if (validation.status != PROGPU_NATIVE_STATUS_SUCCESS ||
+        validation.draw_count != 1U) {
+        return false;
+    }
+    const auto command = read<progpu_native_scene_command>(
+        stream, validation.header.command_offset);
+    const auto retained_image = read<progpu_native_scene_image_draw>(
+        stream, command.payload_offset);
+    const auto batch = read<progpu_native_scene_image_patch_batch>(
+        stream, command.payload_offset + sizeof(retained_image));
+    const auto third_patch = read<progpu_native_scene_image_patch>(
+        stream,
+        command.payload_offset + sizeof(retained_image) + sizeof(batch) +
+            2U * sizeof(progpu_native_scene_image_patch));
+    if ((retained_image.flags &
+            PROGPU_NATIVE_SCENE_IMAGE_PATCH_BATCH) == 0U ||
+        batch.patch_count != 3U ||
+        third_patch.destination_rect.x != 32.0F ||
+        command.bounds_x != 0.0F || command.bounds_y != 0.0F ||
+        command.bounds_width != 48.0F || command.bounds_height != 16.0F) {
+        return false;
+    }
+
+    semantic_scene_builder boundaries(717U, 1U);
+    std::uint32_t state_index = PROGPU_NATIVE_SCENE_NO_INDEX;
+    auto state = semantic_scene_builder::identity_state();
+    if (!boundaries.add_external_image(64U, 32U, image_index) ||
+        !boundaries.add_state(state, state_index)) {
+        return false;
+    }
+    image.destination_rect.x = 0.0F;
+    if (!boundaries.draw_image(
+            image_index, image, {0.0F, 0.0F, 16.0F, 16.0F})) {
+        return false;
+    }
+    image.destination_rect.x = 16.0F;
+    if (!boundaries.draw_image(
+            image_index,
+            image,
+            {16.0F, 0.0F, 16.0F, 16.0F},
+            state_index)) {
+        return false;
+    }
+    image.sampling = PROGPU_NATIVE_IMAGE_SAMPLING_NEAREST;
+    image.destination_rect.x = 32.0F;
+    if (!boundaries.draw_image(
+            image_index,
+            image,
+            {32.0F, 0.0F, 16.0F, 16.0F},
+            state_index)) {
+        return false;
+    }
+    scene_build_metrics boundary_metrics{};
+    return boundaries.build(stream, &boundary_metrics) &&
+        boundary_metrics.command_count == 3U;
+}
+
 bool semantic_scene_builder_serializes_external_images_pointer_free() {
     semantic_scene_builder builder(713U, 4U);
     std::uint32_t image_index = PROGPU_NATIVE_SCENE_NO_INDEX;

--- a/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.hpp
+++ b/src/ProGPU.Native/tests/progpu_native_scene_builder_tests.hpp
@@ -10,6 +10,7 @@ bool semantic_scene_builder_records_native_svg_layers();
 bool semantic_scene_builder_rejects_invalid_state();
 bool semantic_scene_builder_reuses_retained_images();
 bool semantic_scene_builder_records_image_patch_batches();
+bool semantic_scene_builder_batches_compatible_image_draws();
 bool semantic_scene_builder_serializes_external_images_pointer_free();
 bool semantic_scene_builder_updates_retained_images_transactionally();
 bool semantic_scene_builder_records_styled_glyph_runs();

--- a/src/ProGPU.Scene.Native/GpuPictureNativeSceneCompiler.cs
+++ b/src/ProGPU.Scene.Native/GpuPictureNativeSceneCompiler.cs
@@ -86,7 +86,8 @@ public static partial class GpuPictureNativeSceneCompiler
         bool HasColorMatrix,
         NativeSceneImageEffect Effect,
         bool HasEffect,
-        NativeSceneImagePatch[] Patches);
+        NativeSceneImagePatch[] Patches,
+        List<NativeSceneImagePatch>? GeneratedPatches);
 
     private readonly record struct AffineColorTransform(
         Vector4 Red,
@@ -1226,7 +1227,7 @@ public static partial class GpuPictureNativeSceneCompiler
                     Unsafe.SizeOf<NativeSceneImageSamplingOptions>() +
                     Unsafe.SizeOf<NativeSceneImagePatchBatch>() + 8) +
                 externalImages.Sum(static image =>
-                    image.Patches.Length *
+                    (image.GeneratedPatches?.Count ?? image.Patches.Length) *
                         Unsafe.SizeOf<NativeSceneImagePatch>()) +
                 materials.BrushCount * Unsafe.SizeOf<NativeSceneBrush>() +
                 materials.GradientStopCount *
@@ -4591,8 +4592,7 @@ public static partial class GpuPictureNativeSceneCompiler
             sampling == NativeImageSampling.LinearMipmap
                 ? (byte)Math.Clamp((int)command.TextureMaxAnisotropy, 1, 16)
                 : (byte)1);
-        int drawIndex = externalImages.Count;
-        externalImages.Add(new(
+        var externalImage = new ExternalImageDraw(
             texture,
             chromaTexture,
             maskTexture,
@@ -4603,7 +4603,21 @@ public static partial class GpuPictureNativeSceneCompiler
             hasColorMatrix,
             nativeEffect,
             hasEffect,
-            patches));
+            patches,
+            GeneratedPatches: null);
+        if (TryMergeExternalImageDraw(
+                externalImage,
+                bounds,
+                externalImages,
+                batches,
+                operations))
+        {
+            error = NativePictureCompileError.None;
+            return true;
+        }
+
+        int drawIndex = externalImages.Count;
+        externalImages.Add(externalImage);
         batches.Add(new Batch
         {
             Kind = BatchKind.Image,
@@ -4616,6 +4630,100 @@ public static partial class GpuPictureNativeSceneCompiler
         return true;
     }
 
+    private static bool TryMergeExternalImageDraw(
+        in ExternalImageDraw current,
+        NativeImageRect currentBounds,
+        List<ExternalImageDraw> externalImages,
+        List<Batch> batches,
+        List<Operation> operations)
+    {
+        if (current.Patches.Length != 0 ||
+            current.HasColorMatrix || current.HasEffect ||
+            batches.Count == 0 || operations.Count == 0 ||
+            operations[^1].Kind != OperationKind.Draw ||
+            operations[^1].BatchIndex != batches.Count - 1 ||
+            batches[^1].Kind != BatchKind.Image)
+        {
+            return false;
+        }
+
+        Batch previousBatch = batches[^1];
+        ExternalImageDraw previous = externalImages[previousBatch.Start];
+        if ((previous.GeneratedPatches is null && previous.Patches.Length != 0) ||
+            previous.HasColorMatrix || previous.HasEffect ||
+            !ReferenceEquals(previous.Texture, current.Texture) ||
+            !ReferenceEquals(previous.ChromaTexture, current.ChromaTexture) ||
+            !ReferenceEquals(previous.MaskTexture, current.MaskTexture) ||
+            previous.HasSamplingOptions != current.HasSamplingOptions ||
+            previous.HasSamplingOptions &&
+                !previous.SamplingOptions.Equals(current.SamplingOptions) ||
+            !CanShareImagePatchBatch(previous.Draw, current.Draw))
+        {
+            return false;
+        }
+
+        List<NativeSceneImagePatch> patches;
+        if (previous.GeneratedPatches is { } generatedPatches)
+        {
+            if (generatedPatches.Count >= 65_536)
+            {
+                return false;
+            }
+            generatedPatches.Add(CreateTexturePatch(current.Draw));
+            patches = generatedPatches;
+        }
+        else
+        {
+            patches = new List<NativeSceneImagePatch>(16)
+            {
+                CreateTexturePatch(previous.Draw),
+                CreateTexturePatch(current.Draw)
+            };
+        }
+
+        NativeSceneImageDraw source = previous.Draw;
+        var batchedDraw = new NativeSceneImageDraw(
+            source.ImageWidth,
+            source.ImageHeight,
+            source.RowBytes,
+            source.Sampling,
+            source.SourceRect,
+            source.DestinationRect,
+            Matrix3x2.Identity,
+            source.Opacity,
+            source.Flags | NativeSceneImageFlags.PatchBatch,
+            checked((byte)source.MaxAnisotropy));
+        externalImages[previousBatch.Start] = previous with
+        {
+            Draw = batchedDraw,
+            Patches = [],
+            GeneratedPatches = patches
+        };
+        previousBatch.Bounds = Union(previousBatch.Bounds, currentBounds);
+        batches[^1] = previousBatch;
+        return true;
+    }
+
+    private static bool CanShareImagePatchBatch(
+        in NativeSceneImageDraw left,
+        in NativeSceneImageDraw right) =>
+        left.ImageWidth == right.ImageWidth &&
+        left.ImageHeight == right.ImageHeight &&
+        left.RowBytes == right.RowBytes &&
+        left.Sampling == right.Sampling &&
+        left.Opacity == right.Opacity &&
+        left.MaxAnisotropy == right.MaxAnisotropy &&
+        (left.Flags & ~NativeSceneImageFlags.PatchBatch) ==
+            (right.Flags & ~NativeSceneImageFlags.PatchBatch);
+
+    private static NativeSceneImagePatch CreateTexturePatch(
+        in NativeSceneImageDraw draw) =>
+        new(
+            NativeSceneImagePatchKind.Texture,
+            draw.SourceRect,
+            draw.DestinationRect,
+            draw.Transform);
+
     private static bool TryDrawExternalImage(
         ref NativeSceneStreamBuilder builder,
         ulong commandId,
@@ -4624,7 +4732,11 @@ public static partial class GpuPictureNativeSceneCompiler
         in ExternalImageDraw image)
     {
         NativeSceneImageDraw draw = image.Draw;
-        if (image.Patches.Length > 0)
+        ReadOnlySpan<NativeSceneImagePatch> patches =
+            image.GeneratedPatches is { } generatedPatches
+                ? CollectionsMarshal.AsSpan(generatedPatches)
+                : image.Patches;
+        if (!patches.IsEmpty)
         {
             NativeSceneImageSamplingOptions? sampling =
                 image.HasSamplingOptions ? image.SamplingOptions : null;
@@ -4637,7 +4749,7 @@ public static partial class GpuPictureNativeSceneCompiler
                 resourceIndex,
                 bounds,
                 in draw,
-                image.Patches,
+                patches,
                 sampling,
                 colorMatrix,
                 effect);

--- a/src/ProGPU.Scene/Compositor.IncrementalPages.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalPages.cs
@@ -24,6 +24,7 @@ public unsafe partial class Compositor
     private int _incrementalScenePageCompilations;
     private int _incrementalScenePageReusedArrays;
     private long _incrementalScenePageBytes;
+    private int _activeIncrementalScenePageDrawCallStart = -1;
     private string? _incrementalScenePageRejectReason;
     private string? _incrementalScenePageMissReason;
 
@@ -150,6 +151,7 @@ public unsafe partial class Compositor
         _incrementalScenePageReusedArrays = 0;
         _incrementalScenePageRejectReason = null;
         _incrementalScenePageMissReason = null;
+        _activeIncrementalScenePageDrawCallStart = -1;
         ResetIncrementalSceneUploadFrameMetrics();
     }
 
@@ -428,6 +430,7 @@ public unsafe partial class Compositor
             _activeClipRect,
             _activeOpacity,
             _activeBlendMode);
+        _activeIncrementalScenePageDrawCallStart = boundary.DrawCallStart;
         return true;
     }
 
@@ -437,6 +440,7 @@ public unsafe partial class Compositor
         in IncrementalScenePageBoundary boundary)
     {
         CommitPendingDrawCalls();
+        _activeIncrementalScenePageDrawCallStart = -1;
         if (_maskRenderPasses.Count != boundary.MaskRenderPassStart)
         {
             _incrementalScenePageRejectReason ??=
@@ -1115,6 +1119,13 @@ public unsafe partial class Compositor
         ref CompositorDrawCall previous = ref
             CollectionsMarshal.AsSpan(_drawCalls)[previousIndex];
         uint indexStart = current.IndexStart + indexBase;
+        if (previous.Type == DrawCallType.Texture &&
+            current.Type == DrawCallType.Texture)
+        {
+            CompositorDrawCall expanded = current.Expand(indexBase);
+            return TryMergeTextureDrawCall(ref previous, expanded);
+        }
+
         if (previous.Type != current.Type ||
             previous.Type is not (DrawCallType.Vector or DrawCallType.Text) ||
             previous.IndexStart + previous.IndexCount != indexStart ||
@@ -1137,6 +1148,12 @@ public unsafe partial class Compositor
     {
         ref CompositorDrawCall previous = ref
             CollectionsMarshal.AsSpan(_drawCalls)[previousIndex];
+        if (previous.Type == DrawCallType.Texture &&
+            current.Type == DrawCallType.Texture)
+        {
+            return TryMergeTextureDrawCall(ref previous, current);
+        }
+
         if (previous.Type != current.Type ||
             previous.Type is not (DrawCallType.Vector or DrawCallType.Text) ||
             previous.IndexStart + previous.IndexCount != current.IndexStart ||

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -13671,7 +13671,7 @@ SceneStateUploadComplete:
             return;
         }
 
-        _drawCalls.Add(new CompositorDrawCall
+        var drawCall = new CompositorDrawCall
         {
             Type = DrawCallType.Texture,
             IndexStart = (uint)indexStart,
@@ -13684,7 +13684,49 @@ SceneStateUploadComplete:
             TextureSamplingMode = cmd.TextureSamplingMode,
             TextureMaxAnisotropy = cmd.TextureMaxAnisotropy,
             TextureAlphaMode = cmd.Texture.AlphaMode
-        });
+        };
+        AppendOrMergeTextureDrawCall(drawCall);
+    }
+
+    private void AppendOrMergeTextureDrawCall(in CompositorDrawCall drawCall)
+    {
+        if (_drawCalls.Count != 0 &&
+            (_activeIncrementalScenePageDrawCallStart < 0 ||
+                _drawCalls.Count > _activeIncrementalScenePageDrawCallStart))
+        {
+            ref CompositorDrawCall previous = ref
+                CollectionsMarshal.AsSpan(_drawCalls)[_drawCalls.Count - 1];
+            if (TryMergeTextureDrawCall(ref previous, drawCall))
+            {
+                return;
+            }
+        }
+
+        _drawCalls.Add(drawCall);
+    }
+
+    private static bool TryMergeTextureDrawCall(
+        ref CompositorDrawCall previous,
+        in CompositorDrawCall current)
+    {
+        if (previous.Type != DrawCallType.Texture ||
+            current.Type != DrawCallType.Texture ||
+            previous.IndexStart + previous.IndexCount != current.IndexStart ||
+            !ReferenceEquals(previous.Texture, current.Texture) ||
+            previous.ClipRect != current.ClipRect ||
+            !ReferenceEquals(previous.MaskTexture, current.MaskTexture) ||
+            previous.MaskBindGroupOverride != current.MaskBindGroupOverride ||
+            previous.BlendMode != current.BlendMode ||
+            previous.TextureSamplingMode != current.TextureSamplingMode ||
+            previous.TextureMaxAnisotropy != current.TextureMaxAnisotropy ||
+            previous.TextureAlphaMode != current.TextureAlphaMode ||
+            previous.HasImageEffect || current.HasImageEffect)
+        {
+            return false;
+        }
+
+        previous.IndexCount += current.IndexCount;
+        return true;
     }
 
     private void AppendTextureQuad(

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -304,6 +304,9 @@ public struct CompositorMetrics
     public ulong MsaaTextureBytes;
     public ulong TrackedIntermediateTextureBytes;
     public bool SceneCacheHit;
+    public bool RenderBundleCacheHit;
+    public bool RenderBundleRecorded;
+    public int RenderBundleDrawCallCount;
     public bool GpuHitTestingEnabled;
     public string? SceneCacheMissReason;
 }
@@ -1397,6 +1400,8 @@ public unsafe partial class Compositor : IDisposable
     private GpuBuffer _gradientStopsStorageBuffer;
     private ulong _frameNumber = 0;
     private bool _compiledSceneReusable;
+    private RenderBundle* _compiledRenderBundle;
+    private int _compiledRenderBundleDrawCallCount;
     private string _compiledSceneCacheStateReason = "No compiled scene";
     private string? _currentSceneCacheMissReason;
     private Visual? _compiledSceneRoot;
@@ -2956,6 +2961,7 @@ public unsafe partial class Compositor : IDisposable
         // 2. Clear CPU collection batch lists and active brushes
         if (!reuseCompiledScene)
         {
+            ReleaseCompiledRenderBundle();
             ReleaseCompiledSceneAnalyticMaskResources();
             ReleaseCompiledSceneRetainedResources();
             _currentSolidRoundedPrimitiveCount = 0;
@@ -2991,6 +2997,7 @@ public unsafe partial class Compositor : IDisposable
         bool glyphBatchActive = false;
         CommandEncoder* encoder = null;
         int preparedExtensionDrawCallRestoreStart = -1;
+        bool renderBundleRecorded = false;
         System.Diagnostics.Stopwatch uploadSw = null!;
         System.Diagnostics.Stopwatch passSw = null!;
         try
@@ -3404,6 +3411,17 @@ DynamicBufferUploadComplete:
 
 SceneStateUploadComplete:
         RefreshAtlasBindGroupsIfNeeded();
+        if (_compiledRenderBundle == null &&
+            _compiledSceneReusable &&
+            TryCreateCompiledRenderBundle(
+                renderWidth,
+                renderHeight,
+                out var compiledRenderBundle))
+        {
+            _compiledRenderBundle = compiledRenderBundle;
+            _compiledRenderBundleDrawCallCount = _drawCalls.Count;
+            renderBundleRecorded = true;
+        }
         uploadSw.Stop();
         passSw = System.Diagnostics.Stopwatch.StartNew();
 
@@ -3470,16 +3488,30 @@ SceneStateUploadComplete:
         byte? currentVectorPipelineKind = null;
 
         var drawCallCount = _drawCalls.Count;
-        for (var drawCallIndex = 0; drawCallIndex < drawCallCount; drawCallIndex++)
+        if (_compiledRenderBundle != null)
         {
-            var dc = _drawCalls[drawCallIndex];
-            if (!ApplyDrawCallScissor(pass, dc, useRenderTargetViewport: true))
+            _context.Api.RenderPassEncoderSetScissorRect(
+                pass,
+                CurrentCanvasPixelXUInt,
+                CurrentCanvasPixelYUInt,
+                CurrentCanvasPixelWidthUInt,
+                CurrentCanvasPixelHeightUInt);
+            var bundle = _compiledRenderBundle;
+            ((IWebGpuRenderBundleApi)_context.Api)
+                .RenderPassEncoderExecuteBundles(pass, 1, &bundle);
+        }
+        else
+        {
+            for (var drawCallIndex = 0; drawCallIndex < drawCallCount; drawCallIndex++)
             {
-                continue;
-            }
+                var dc = _drawCalls[drawCallIndex];
+                if (!ApplyDrawCallScissor(pass, dc, useRenderTargetViewport: true))
+                {
+                    continue;
+                }
 
-            if (dc.Type == DrawCallType.Vector)
-            {
+                if (dc.Type == DrawCallType.Vector)
+                {
                 var hasMask = HasMask(dc);
                 var vectorPipelineKind = GetVectorPipelineKind(dc);
                 var activePipeline = GetVectorPipeline(
@@ -3688,6 +3720,7 @@ SceneStateUploadComplete:
                         pipeline.Render(this, pass, isOffscreen: false, in localDc);
                         currentType = DrawCallType.Extension;
                     }
+                }
                 }
             }
         }
@@ -3936,6 +3969,11 @@ SceneStateUploadComplete:
                 (_sceneMappedUploadRing?.AllocatedBytes ?? 0UL) +
                 (_sceneUploadStagingBuffer?.AllocatedSize ?? 0U),
             SceneCacheHit = reuseCompiledScene,
+            RenderBundleCacheHit = reuseCompiledScene &&
+                _compiledRenderBundle != null,
+            RenderBundleRecorded = renderBundleRecorded,
+            RenderBundleDrawCallCount =
+                _compiledRenderBundleDrawCallCount,
             GpuHitTestingEnabled = Options.EnableGpuHitTesting,
             SceneCacheMissReason = reuseCompiledScene ? null : _currentSceneCacheMissReason
         };
@@ -14227,6 +14265,7 @@ SceneStateUploadComplete:
 
         lock (_context.RenderLock)
         {
+            ReleaseCompiledRenderBundle();
             _wavefrontEngine?.Dispose();
             _wavefrontEngine = null;
             _wavefrontColorTexture?.Dispose();
@@ -15139,6 +15178,189 @@ SceneStateUploadComplete:
             var vertex = vertices[index];
             vertex.Position = ClampToClip(vertex.Position);
             vertices[index] = vertex;
+        }
+    }
+
+    private unsafe bool TryCreateCompiledRenderBundle(
+        uint renderWidth,
+        uint renderHeight,
+        out RenderBundle* bundle)
+    {
+        bundle = null;
+        if (!Options.EnableCompiledRenderBundles ||
+            _context.Api is not IWebGpuRenderBundleApi bundleApi ||
+            _drawCalls.Count == 0 ||
+            renderWidth == 0 ||
+            renderHeight == 0 ||
+            _maskRenderPasses.Count != 0)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < _drawCalls.Count; index++)
+        {
+            var drawCall = _drawCalls[index];
+            if (drawCall.ClipRect.HasValue ||
+                HasMask(drawCall) ||
+                drawCall.HasImageEffect ||
+                drawCall.Type is not (
+                    DrawCallType.Vector or
+                    DrawCallType.Text or
+                    DrawCallType.Texture) ||
+                (drawCall.Type == DrawCallType.Texture &&
+                    !IsTextureBindable(drawCall.Texture)))
+            {
+                return false;
+            }
+        }
+
+        var colorFormat = RenderFormat;
+        var descriptor = new RenderBundleEncoderDescriptor
+        {
+            ColorFormatCount = 1,
+            ColorFormats = &colorFormat,
+            DepthStencilFormat = TextureFormat.Undefined,
+            SampleCount = Options.PrimarySampleCount
+        };
+        var encoder = bundleApi.DeviceCreateRenderBundleEncoder(
+            _context.Device,
+            &descriptor);
+        if (encoder == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            for (int index = 0; index < _drawCalls.Count; index++)
+            {
+                var drawCall = _drawCalls[index];
+                if (drawCall.Type == DrawCallType.Vector)
+                {
+                    bundleApi.RenderBundleEncoderSetPipeline(
+                        encoder,
+                        GetVectorPipeline(
+                            drawCall,
+                            isOffscreen: false,
+                            hasMask: false));
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 0, _vectorUniformBindGroup, 0, null);
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 1, _pathAtlasBindGroup, 0, null);
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 2, _dummyMaskBindGroup, 0, null);
+                    bundleApi.RenderBundleEncoderSetVertexBuffer(
+                        encoder,
+                        0,
+                        _vectorVertexBuffer.BufferPtr,
+                        0,
+                        _vectorVertexBuffer.Size);
+                    bundleApi.RenderBundleEncoderSetIndexBuffer(
+                        encoder,
+                        _vectorIndexBuffer.BufferPtr,
+                        IndexFormat.Uint32,
+                        0,
+                        _vectorIndexBuffer.Size);
+                    bundleApi.RenderBundleEncoderDrawIndexed(
+                        encoder,
+                        drawCall.IndexCount,
+                        1,
+                        drawCall.IndexStart,
+                        0,
+                        0);
+                }
+                else if (drawCall.Type == DrawCallType.Text)
+                {
+                    bundleApi.RenderBundleEncoderSetPipeline(
+                        encoder,
+                        GetPipeline(
+                            DrawCallType.Text,
+                            drawCall.BlendMode,
+                            isOffscreen: false,
+                            hasMask: false));
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 0, _textUniformBindGroup, 0, null);
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 1, _atlasBindGroup, 0, null);
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 2, _dummyMaskBindGroup, 0, null);
+                    var textVertexOffset =
+                        (ulong)drawCall.IndexStart * GlyphInstanceStride;
+                    var textVertexSize =
+                        (ulong)drawCall.IndexCount * GlyphInstanceStride;
+                    bundleApi.RenderBundleEncoderSetVertexBuffer(
+                        encoder,
+                        0,
+                        _textVertexBuffer.BufferPtr,
+                        textVertexOffset,
+                        textVertexSize);
+                    bundleApi.RenderBundleEncoderDraw(
+                        encoder,
+                        6,
+                        drawCall.IndexCount,
+                        0,
+                        0);
+                }
+                else
+                {
+                    var texture = drawCall.Texture!;
+                    bundleApi.RenderBundleEncoderSetPipeline(
+                        encoder,
+                        GetPipeline(
+                            DrawCallType.Texture,
+                            drawCall.BlendMode,
+                            isOffscreen: false,
+                            textureAlphaMode:
+                                drawCall.TextureAlphaMode,
+                            hasMask: false));
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 0, _textureUniformBindGroup, 0, null);
+                    var cachedBindGroup =
+                        GetOrCreatePersistentTextureBindGroup(
+                            texture,
+                            isOffscreen: false,
+                            drawCall.TextureSamplingMode,
+                            drawCall.TextureMaxAnisotropy,
+                            _textureBindGroupLayout);
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder,
+                        1,
+                        (BindGroup*)cachedBindGroup.BindGroupPtr,
+                        0,
+                        null);
+                    bundleApi.RenderBundleEncoderSetBindGroup(
+                        encoder, 2, _dummyMaskBindGroup, 0, null);
+                    bundleApi.RenderBundleEncoderSetVertexBuffer(
+                        encoder,
+                        0,
+                        _textureVertexBuffer.BufferPtr,
+                        0,
+                        _textureVertexBuffer.Size);
+                    bundleApi.RenderBundleEncoderSetIndexBuffer(
+                        encoder,
+                        _textureIndexBuffer.BufferPtr,
+                        IndexFormat.Uint32,
+                        0,
+                        _textureIndexBuffer.Size);
+                    bundleApi.RenderBundleEncoderDrawIndexed(
+                        encoder,
+                        drawCall.IndexCount,
+                        1,
+                        drawCall.IndexStart,
+                        0,
+                        0);
+                }
+            }
+
+            var bundleDescriptor = new RenderBundleDescriptor();
+            bundle = bundleApi.RenderBundleEncoderFinish(
+                encoder,
+                &bundleDescriptor);
+            return bundle != null;
+        }
+        finally
+        {
+            bundleApi.RenderBundleEncoderRelease(encoder);
         }
     }
 
@@ -19340,6 +19562,20 @@ SceneStateUploadComplete:
         _analyticMaskResourcePool.AddRange(
             _compiledSceneAnalyticMaskResources);
         _compiledSceneAnalyticMaskResources.Clear();
+    }
+
+    private void ReleaseCompiledRenderBundle()
+    {
+        if (_compiledRenderBundle == null)
+        {
+            _compiledRenderBundleDrawCallCount = 0;
+            return;
+        }
+
+        ((IWebGpuRenderBundleApi)_context.Api)
+            .RenderBundleRelease(_compiledRenderBundle);
+        _compiledRenderBundle = null;
+        _compiledRenderBundleDrawCallCount = 0;
     }
 
     private void ReleaseCompiledSceneRetainedResources()

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -3769,10 +3769,6 @@ SceneStateUploadComplete:
 
         _context.Api.CommandBufferRelease(cmdBuffer);
         _context.Api.CommandEncoderRelease(encoder);
-        // Native wgpu backends reclaim completed command buffers and their
-        // transient driver resources while polling. Keep this non-blocking:
-        // frame pacing must remain queue-driven rather than waiting for the GPU.
-        _context.PollDevice(wait: false);
 
         ReturnPendingMaskTexturesToPool();
 
@@ -16977,9 +16973,6 @@ SceneStateUploadComplete:
 
         _context.Api.CommandBufferRelease(cmdBuffer);
         _context.Api.CommandEncoderRelease(encoder);
-        // Retire completed native submissions without introducing a CPU/GPU
-        // synchronization point. Browser WebGPU devices are polled by the host.
-        _context.PollDevice(wait: false);
         targetTexture.AlphaMode = GpuTextureAlphaMode.Premultiplied;
         targetTexture.MarkContentsDirty();
         long renderEndTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();

--- a/src/ProGPU.Scene/CompositorOptions.cs
+++ b/src/ProGPU.Scene/CompositorOptions.cs
@@ -41,6 +41,14 @@ public sealed record CompositorOptions
     public bool EnableCompiledSceneCache { get; init; } = true;
 
     /// <summary>
+    /// Records eligible cached scenes into a WebGPU render bundle so retained
+    /// frames replay one encoded command stream instead of re-encoding every
+    /// draw call. Providers without render-bundle support use the ordinary
+    /// render-pass path.
+    /// </summary>
+    public bool EnableCompiledRenderBundles { get; init; } = true;
+
+    /// <summary>
     /// Reuses immutable local command compilation pages when another visual in
     /// the retained tree changes. Unsupported composition scopes fail closed to
     /// ordinary compilation.

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -6,6 +6,7 @@ using ProGPU.Backend;
 using ProGPU.Scene;
 using ProGPU.Tests.Headless;
 using ProGPU.Vector;
+using Silk.NET.WebGPU;
 using Xunit;
 
 namespace ProGPU.Tests;
@@ -105,6 +106,53 @@ public sealed class LayerRenderTests
             Assert.Equal(2, window.Compositor.Metrics.IncrementalScenePageCount);
             Assert.True(
                 window.Compositor.Metrics.IncrementalScenePageReusedArrays > 0);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
+    public void IncrementalPagesMergeCompatibleRetainedTextureDraws()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableGpuHitTesting = false,
+            PrimarySampleCount = 1
+        };
+        using var window = new HeadlessWindow(64, 32, options);
+        using var texture = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Incremental texture page batch input",
+            alphaMode: GpuTextureAlphaMode.Straight);
+        texture.WritePixels<byte>([33, 211, 97, 255]);
+        var first = new OwnedTexturePageVisual(texture, new Vector2(0f, 0f));
+        var second = new OwnedTexturePageVisual(texture, new Vector2(20f, 0f));
+        window.Content = new IncrementalPageHost(first, second);
+
+        try
+        {
+            window.Render();
+            Assert.Equal(2, window.Compositor.Metrics.IncrementalScenePageCount);
+            Assert.Equal(1, window.Compositor.TextureDrawCallCount);
+
+            first.Transform = Matrix4x4.CreateTranslation(4f, 0f, 0f);
+            window.Render();
+
+            Assert.Equal(1, window.Compositor.Metrics.IncrementalScenePageHits);
+            Assert.Equal(1, window.Compositor.TextureDrawCallCount);
+            byte[] pixels = window.ReadPixels();
+            Assert.Equal(
+                new RgbaPixel(33, 211, 97, 255),
+                ReadPixel(pixels, window.Width, 8, 8));
+            Assert.Equal(
+                new RgbaPixel(33, 211, 97, 255),
+                ReadPixel(pixels, window.Width, 28, 8));
         }
         finally
         {
@@ -1234,6 +1282,22 @@ public sealed class LayerRenderTests
                 new SolidColorBrush(color),
                 null,
                 new Rect(0f, 0f, 20f, 20f));
+        }
+
+        public DrawingContext GetOrUpdateRenderCommandCache() => _commands;
+    }
+
+    private sealed class OwnedTexturePageVisual : FrameworkElement,
+        IIncrementalRenderCommandCache
+    {
+        private readonly DrawingContext _commands = new();
+
+        public OwnedTexturePageVisual(GpuTexture texture, Vector2 offset)
+        {
+            Width = 16f;
+            Height = 16f;
+            Transform = Matrix4x4.CreateTranslation(offset.X, offset.Y, 0f);
+            _commands.DrawTexture(texture, new Rect(0f, 0f, 16f, 16f));
         }
 
         public DrawingContext GetOrUpdateRenderCommandCache() => _commands;

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Numerics;
 using Microsoft.UI.Xaml;
 using ProGPU.Backend;
+using ProGPU.Backend.Dawn;
 using ProGPU.Scene;
 using ProGPU.Tests.Headless;
 using ProGPU.Vector;
@@ -13,6 +14,47 @@ namespace ProGPU.Tests;
 
 public sealed class LayerRenderTests
 {
+    [Fact]
+    public unsafe void DawnReplaysCompiledRenderBundle()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        using var dawn = DawnGpuContext.CreateMetalPresentation();
+        using var compositor = new Compositor(
+            dawn.Context,
+            TextureFormat.Rgba8Unorm,
+            CompositorOptions.Default with
+            {
+                EnableGpuHitTesting = false,
+                PrimarySampleCount = 1
+            });
+        using var target = new GpuTexture(
+            dawn.Context,
+            64,
+            64,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.RenderAttachment | TextureUsage.CopySrc,
+            "Dawn retained bundle test target");
+        var visual = new SceneCacheVisual();
+        visual.Measure(new Vector2(64f, 64f));
+        visual.Arrange(new Rect(0f, 0f, 64f, 64f));
+
+        compositor.RenderScene(visual, 64, 64, target.ViewPtr);
+
+        Assert.True(compositor.Metrics.RenderBundleRecorded);
+        Assert.False(compositor.Metrics.RenderBundleCacheHit);
+
+        compositor.RenderScene(visual, 64, 64, target.ViewPtr);
+
+        Assert.True(compositor.Metrics.SceneCacheHit);
+        Assert.False(compositor.Metrics.RenderBundleRecorded);
+        Assert.True(compositor.Metrics.RenderBundleCacheHit);
+        AssertRed(ReadPixel(target.ReadPixels(), 64, 20, 20));
+    }
+
     [Fact]
     public void UnchangedSceneReusesCompiledGpuBuffers()
     {

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -24,10 +24,17 @@ public sealed class LayerRenderTests
         {
             window.Render();
             Assert.False(window.Compositor.Metrics.SceneCacheHit);
+            Assert.True(window.Compositor.Metrics.RenderBundleRecorded);
+            Assert.False(window.Compositor.Metrics.RenderBundleCacheHit);
+            Assert.Equal(
+                window.Compositor.Metrics.DrawCallsCount,
+                window.Compositor.Metrics.RenderBundleDrawCallCount);
 
             window.Render();
 
             Assert.True(window.Compositor.Metrics.SceneCacheHit);
+            Assert.False(window.Compositor.Metrics.RenderBundleRecorded);
+            Assert.True(window.Compositor.Metrics.RenderBundleCacheHit);
             Assert.Equal(1, visual.RenderCount);
             AssertRed(ReadPixel(window.ReadPixels(), window.Width, 20, 20));
         }
@@ -35,6 +42,27 @@ public sealed class LayerRenderTests
         {
             window.Content = null;
         }
+    }
+
+    [Fact]
+    public void CompiledRenderBundleCanBeDisabledWithoutDisablingSceneCache()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableCompiledRenderBundles = false,
+            PrimarySampleCount = 1
+        };
+        using var window = new HeadlessWindow(64, 64, options);
+        window.Content = new SceneCacheVisual();
+
+        window.Render();
+        window.Render();
+
+        Assert.True(window.Compositor.Metrics.SceneCacheHit);
+        Assert.False(window.Compositor.Metrics.RenderBundleRecorded);
+        Assert.False(window.Compositor.Metrics.RenderBundleCacheHit);
+        Assert.Equal(0, window.Compositor.Metrics.RenderBundleDrawCallCount);
+        AssertRed(ReadPixel(window.ReadPixels(), window.Width, 20, 20));
     }
 
     [Fact]
@@ -722,6 +750,8 @@ public sealed class LayerRenderTests
             window.Render();
 
             Assert.False(window.Compositor.Metrics.SceneCacheHit);
+            Assert.True(window.Compositor.Metrics.RenderBundleRecorded);
+            Assert.False(window.Compositor.Metrics.RenderBundleCacheHit);
             Assert.Equal(2, visual.RenderCount);
         }
         finally

--- a/src/ProGPU.Tests/NativePictureCompilerTests.cs
+++ b/src/ProGPU.Tests/NativePictureCompilerTests.cs
@@ -1087,6 +1087,109 @@ public class NativePictureCompilerTests
     }
 
     [Fact]
+    public void CompilerBatchesConsecutiveCompatibleTexturesIntoOneNativeDraw()
+    {
+        using GpuTexture texture = CreateUnbackedTexture(16U, 8U);
+        using var picture = new GpuPicture(
+            [
+                CreateTextureCommand(texture, new Rect(0f, 0f, 8f, 8f)),
+                CreateTextureCommand(texture, new Rect(8f, 0f, 8f, 8f)),
+                CreateTextureCommand(texture, new Rect(16f, 0f, 8f, 8f))
+            ],
+            Array.Empty<Vector2>(),
+            Array.Empty<double>(),
+            Array.Empty<Line3D>(),
+            Array.Empty<float>());
+
+        Assert.True(GpuPictureNativeSceneCompiler.TryCompile(
+            picture,
+            127U,
+            1U,
+            out NativeCompiledPicture? compiled,
+            out NativePictureCompileFailure failure),
+            failure.ToString());
+        Assert.NotNull(compiled);
+        Assert.Equal(3, compiled.SourceCommandCount);
+        Assert.Equal(1, compiled.NativeCommandCount);
+        Assert.Equal(1, compiled.NativeDrawCount);
+        Assert.Equal(1, compiled.ExternalImages.Length);
+
+        NativeMethods.SceneHeader header =
+            MemoryMarshal.Read<NativeMethods.SceneHeader>(compiled.Stream);
+        NativeMethods.SceneCommand command =
+            MemoryMarshal.Read<NativeMethods.SceneCommand>(
+                compiled.Stream.Slice(checked((int)header.CommandOffset)));
+        int payloadOffset = checked((int)command.PayloadOffset);
+        NativeSceneImageDraw draw = MemoryMarshal.Read<NativeSceneImageDraw>(
+            compiled.Stream.Slice(payloadOffset));
+        Assert.Equal(NativeSceneImageFlags.PatchBatch, draw.Flags);
+        int batchOffset = payloadOffset + Unsafe.SizeOf<NativeSceneImageDraw>();
+        NativeSceneImagePatchBatch batch =
+            MemoryMarshal.Read<NativeSceneImagePatchBatch>(
+                compiled.Stream.Slice(batchOffset));
+        Assert.Equal(3U, batch.PatchCount);
+        ReadOnlySpan<NativeSceneImagePatch> patches =
+            MemoryMarshal.Cast<byte, NativeSceneImagePatch>(
+                compiled.Stream.Slice(
+                    batchOffset + Unsafe.SizeOf<NativeSceneImagePatchBatch>(),
+                    3 * Unsafe.SizeOf<NativeSceneImagePatch>()));
+        Assert.All(
+            patches.ToArray(),
+            static patch => Assert.Equal(
+                NativeSceneImagePatchKind.Texture,
+                patch.Kind));
+        Assert.Equal(0f, patches[0].DestinationRect.X);
+        Assert.Equal(8f, patches[1].DestinationRect.X);
+        Assert.Equal(16f, patches[2].DestinationRect.X);
+        Assert.Equal(new NativeImageRect(0f, 0f, 24f, 8f), command.Bounds);
+    }
+
+    [Fact]
+    public void CompilerPreservesTextureBatchStateBoundaries()
+    {
+        using GpuTexture first = CreateUnbackedTexture(16U, 8U);
+        using GpuTexture second = CreateUnbackedTexture(16U, 8U);
+        RenderCommand nearest = CreateTextureCommand(
+            first,
+            new Rect(8f, 0f, 8f, 8f));
+        nearest.TextureSamplingMode = TextureSamplingMode.Nearest;
+        using var picture = new GpuPicture(
+            [
+                CreateTextureCommand(first, new Rect(0f, 0f, 8f, 8f)),
+                nearest,
+                CreateTextureCommand(second, new Rect(16f, 0f, 8f, 8f))
+            ],
+            Array.Empty<Vector2>(),
+            Array.Empty<double>(),
+            Array.Empty<Line3D>(),
+            Array.Empty<float>());
+
+        Assert.True(GpuPictureNativeSceneCompiler.TryCompile(
+            picture,
+            128U,
+            1U,
+            out NativeCompiledPicture? compiled,
+            out NativePictureCompileFailure failure),
+            failure.ToString());
+        Assert.NotNull(compiled);
+        Assert.Equal(3, compiled.NativeDrawCount);
+        Assert.Equal(3, compiled.ExternalImages.Length);
+    }
+
+    private static RenderCommand CreateTextureCommand(
+        GpuTexture texture,
+        Rect destination) =>
+        new()
+        {
+            Type = RenderCommandType.DrawTexture,
+            Texture = texture,
+            Rect = destination,
+            SrcRect = new Rect(0f, 0f, 16f, 8f),
+            TextureSamplingMode = TextureSamplingMode.Linear,
+            Transform = Matrix4x4.Identity
+        };
+
+    [Fact]
     public void CompilerLowersAndBatchesSupportedImmutablePictureCommands()
     {
         var red = new SolidColorBrush(new Vector4(1f, 0f, 0f, 1f));

--- a/src/ProGPU.Tests/NativeRendererInteropTests.cs
+++ b/src/ProGPU.Tests/NativeRendererInteropTests.cs
@@ -34,6 +34,14 @@ public class NativeRendererInteropTests
             managedContext,
             StringComparison.Ordinal);
         Assert.Contains(
+            "wgpuQueueSubmitForIndex",
+            managedContext,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "WrappedSubmissionIndex",
+            managedContext,
+            StringComparison.Ordinal);
+        Assert.Contains(
             "poll_interval = 8U",
             nativeSynchronization,
             StringComparison.Ordinal);

--- a/src/ProGPU.Tests/NativeRendererInteropTests.cs
+++ b/src/ProGPU.Tests/NativeRendererInteropTests.cs
@@ -34,14 +34,6 @@ public class NativeRendererInteropTests
             managedContext,
             StringComparison.Ordinal);
         Assert.Contains(
-            "wgpuQueueSubmitForIndex",
-            managedContext,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "WrappedSubmissionIndex",
-            managedContext,
-            StringComparison.Ordinal);
-        Assert.Contains(
             "poll_interval = 8U",
             nativeSynchronization,
             StringComparison.Ordinal);

--- a/src/ProGPU.Tests/NativeRendererInteropTests.cs
+++ b/src/ProGPU.Tests/NativeRendererInteropTests.cs
@@ -12,6 +12,50 @@ namespace Avalonia.ProGpu.UnitTests;
 public class NativeRendererInteropTests
 {
     [Fact]
+    public void ManagedAndNativeSubmissionRetirementStayBoundedAndEquivalent()
+    {
+        string managedContext = File.ReadAllText(FindRepoFile(
+            "src", "ProGPU.Backend", "WgpuContext.cs"));
+        string managedNativeHost = File.ReadAllText(FindRepoFile(
+            "src", "ProGPU.Backend.Native", "NativeCompositor.cs"));
+        string nativeSynchronization = File.ReadAllText(FindRepoFile(
+            "src", "ProGPU.Native", "src", "Backend",
+            "progpu_native_webgpu_synchronization.hpp"));
+        string nativeEngine = File.ReadAllText(FindRepoFile(
+            "src", "ProGPU.Native", "src", "Backend",
+            "progpu_native_engine.hpp"));
+
+        Assert.Contains(
+            "QueuePollSubmissionInterval = 8",
+            managedContext,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "DefaultMaximumDeferredQueueSubmissions = 64",
+            managedContext,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "poll_interval = 8U",
+            nativeSynchronization,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "maximum_deferred_submissions = 64U",
+            nativeSynchronization,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "submission_retirement.on_submission(submission_count)",
+            nativeEngine,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "submission_retirement_action::wait",
+            nativeEngine,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "_context.PollDevice(wait: false)",
+            managedNativeHost,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PublicRectangleMatchesNativePodLayout()
     {
         Assert.Equal(32, Unsafe.SizeOf<NativeSolidRectangle>());

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -1305,6 +1305,26 @@ public sealed class SampleProjectSplitTests
         Assert.DoesNotContain("checked((int)handle.Value)", browserApi, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ManagedAndNativeRetainedScenesReplayRenderBundles()
+    {
+        var managed = Read("src", "ProGPU.Scene", "Compositor.cs");
+        var native = Read(
+            "src",
+            "ProGPU.Native",
+            "src",
+            "Scene",
+            "progpu_native_semantic_render_execution.cpp");
+
+        Assert.Contains("TryCreateCompiledRenderBundle", managed, StringComparison.Ordinal);
+        Assert.Contains("RenderPassEncoderExecuteBundles", managed, StringComparison.Ordinal);
+        Assert.Contains("ReleaseCompiledRenderBundle();", managed, StringComparison.Ordinal);
+        Assert.Contains("semantic_render_bundle_valid", native, StringComparison.Ordinal);
+        Assert.Contains("wgpuDeviceCreateRenderBundleEncoder", native, StringComparison.Ordinal);
+        Assert.Contains("wgpuRenderPassEncoderExecuteBundles", native, StringComparison.Ordinal);
+        Assert.Contains("wgpuRenderBundleRelease", native, StringComparison.Ordinal);
+    }
+
     private static FrameworkElement? FindByName(FrameworkElement element, string name)
     {
         if (element.Name == name) return element;

--- a/src/ProGPU.Tests/SampleProjectSplitTests.cs
+++ b/src/ProGPU.Tests/SampleProjectSplitTests.cs
@@ -1308,7 +1308,16 @@ public sealed class SampleProjectSplitTests
     [Fact]
     public void ManagedAndNativeRetainedScenesReplayRenderBundles()
     {
+        var api = Read("src", "ProGPU.Backend", "IWebGpuApi.cs");
         var managed = Read("src", "ProGPU.Scene", "Compositor.cs");
+        var dawn = Read(
+            "src",
+            "ProGPU.Backend.Dawn",
+            "DawnWebGpuApi.cs");
+        var browser = Read(
+            "src",
+            "ProGPU.Browser",
+            "BrowserWebGpuApi.cs");
         var native = Read(
             "src",
             "ProGPU.Native",
@@ -1316,9 +1325,14 @@ public sealed class SampleProjectSplitTests
             "Scene",
             "progpu_native_semantic_render_execution.cpp");
 
+        Assert.Contains("interface IWebGpuRenderBundleApi", api, StringComparison.Ordinal);
         Assert.Contains("TryCreateCompiledRenderBundle", managed, StringComparison.Ordinal);
         Assert.Contains("RenderPassEncoderExecuteBundles", managed, StringComparison.Ordinal);
         Assert.Contains("ReleaseCompiledRenderBundle();", managed, StringComparison.Ordinal);
+        Assert.Contains("IWebGpuRenderBundleApi", dawn, StringComparison.Ordinal);
+        Assert.Contains("DeviceCreateRenderBundleEncoder", dawn, StringComparison.Ordinal);
+        Assert.Contains("RenderPassEncoderExecuteBundles", dawn, StringComparison.Ordinal);
+        Assert.DoesNotContain("IWebGpuRenderBundleApi", browser, StringComparison.Ordinal);
         Assert.Contains("semantic_render_bundle_valid", native, StringComparison.Ordinal);
         Assert.Contains("wgpuDeviceCreateRenderBundleEncoder", native, StringComparison.Ordinal);
         Assert.Contains("wgpuRenderPassEncoderExecuteBundles", native, StringComparison.Ordinal);

--- a/src/ProGPU.Tests/TextureBlendRenderTests.cs
+++ b/src/ProGPU.Tests/TextureBlendRenderTests.cs
@@ -468,6 +468,82 @@ public sealed class TextureBlendRenderTests
         }
     }
 
+    [Fact]
+    public void ConsecutiveCompatibleTextureCommandsShareOneDrawCall()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(48, 16);
+        using var texture = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Compatible texture batch input",
+            alphaMode: GpuTextureAlphaMode.Straight);
+        texture.WritePixels<byte>([37, 149, 223, 255]);
+        window.Content = new ConsecutiveTextureVisual(texture);
+
+        try
+        {
+            window.Render();
+
+            Assert.Equal(1, window.Compositor.TextureDrawCallCount);
+            Assert.Equal(18, window.Compositor.TextureIndexCount);
+            byte[] pixels = window.ReadPixels();
+            Assert.Equal(new RgbaPixel(37, 149, 223, 255), ReadPixel(pixels, window.Width, 8, 8));
+            Assert.Equal(new RgbaPixel(37, 149, 223, 255), ReadPixel(pixels, window.Width, 24, 8));
+            Assert.Equal(new RgbaPixel(37, 149, 223, 255), ReadPixel(pixels, window.Width, 40, 8));
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
+    public void TextureBatchingPreservesSamplingTextureAndClipBoundaries()
+    {
+        var window = HeadlessWindow.Shared;
+        window.Resize(64, 16);
+        using var first = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Texture batch state input A",
+            alphaMode: GpuTextureAlphaMode.Straight);
+        using var second = new GpuTexture(
+            window.Context,
+            1,
+            1,
+            TextureFormat.Rgba8Unorm,
+            TextureUsage.TextureBinding | TextureUsage.CopyDst,
+            "Texture batch state input B",
+            alphaMode: GpuTextureAlphaMode.Straight);
+        first.WritePixels<byte>([255, 0, 0, 255]);
+        second.WritePixels<byte>([0, 255, 0, 255]);
+        window.Content = new TextureStateBoundaryVisual(first, second);
+
+        try
+        {
+            window.Render();
+
+            Assert.Equal(4, window.Compositor.TextureDrawCallCount);
+            byte[] pixels = window.ReadPixels();
+            Assert.Equal(new RgbaPixel(255, 0, 0, 255), ReadPixel(pixels, window.Width, 8, 8));
+            Assert.Equal(new RgbaPixel(255, 0, 0, 255), ReadPixel(pixels, window.Width, 24, 8));
+            Assert.Equal(new RgbaPixel(0, 255, 0, 255), ReadPixel(pixels, window.Width, 40, 8));
+            Assert.Equal(new RgbaPixel(0, 255, 0, 255), ReadPixel(pixels, window.Width, 52, 8));
+            Assert.Equal(new RgbaPixel(20, 20, 31, 255), ReadPixel(pixels, window.Width, 60, 8));
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
     private static RgbaPixel ReadPixel(byte[] pixels, uint width, int x, int y)
     {
         var index = ((y * (int)width) + x) * 4;
@@ -486,6 +562,54 @@ public sealed class TextureBlendRenderTests
     }
 
     private readonly record struct RgbaPixel(byte R, byte G, byte B, byte A);
+
+    private sealed class ConsecutiveTextureVisual : FrameworkElement
+    {
+        private readonly GpuTexture _texture;
+
+        public ConsecutiveTextureVisual(GpuTexture texture)
+        {
+            _texture = texture;
+            Width = 48f;
+            Height = 16f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawTexture(_texture, new Rect(0f, 0f, 16f, 16f));
+            context.DrawTexture(_texture, new Rect(16f, 0f, 16f, 16f));
+            context.DrawTexture(_texture, new Rect(32f, 0f, 16f, 16f));
+        }
+    }
+
+    private sealed class TextureStateBoundaryVisual : FrameworkElement
+    {
+        private readonly GpuTexture _first;
+        private readonly GpuTexture _second;
+
+        public TextureStateBoundaryVisual(GpuTexture first, GpuTexture second)
+        {
+            _first = first;
+            _second = second;
+            Width = 64f;
+            Height = 16f;
+        }
+
+        public override void OnRender(DrawingContext context)
+        {
+            context.DrawTexture(_first, new Rect(0f, 0f, 16f, 16f));
+            context.DrawTexture(
+                _first,
+                new Rect(16f, 0f, 16f, 16f),
+                default,
+                Matrix4x4.Identity,
+                TextureSamplingMode.Nearest);
+            context.DrawTexture(_second, new Rect(32f, 0f, 16f, 16f));
+            context.PushClip(new Rect(48f, 0f, 8f, 16f));
+            context.DrawTexture(_second, new Rect(48f, 0f, 16f, 16f));
+            context.PopClip();
+        }
+    }
 
     private sealed class TextureBlendVisual : FrameworkElement
     {

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -227,7 +227,7 @@ public sealed class WgpuContextTests
             BrowserWebGpuApi.QueueHandle,
             TextureFormat.Bgra8Unorm);
 
-        for (var index = 0; index < 8; index++)
+        for (var index = 0; index < 64; index++)
         {
             using (var texture = new GpuTexture(
                        context,
@@ -241,14 +241,18 @@ public sealed class WgpuContextTests
             var commandBuffer = (CommandBuffer*)1;
             context.Submit(1, &commandBuffer);
             context.CleanupPendingResources();
-            if (index < 7)
+            if (index < 63)
             {
                 Assert.Equal(0, lifetime.WaitingPollCount);
             }
+
+            Assert.Equal(
+                index < 7 ? 0 : Math.Min(7, (index + 1) / 8),
+                lifetime.NonBlockingPollCount);
         }
 
         Assert.Equal(1, lifetime.WaitingPollCount);
-        Assert.Equal(3, lifetime.NonBlockingPollCount);
+        Assert.Equal(7, lifetime.NonBlockingPollCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- bound managed and native C++ submission-retirement polling
- batch compatible consecutive texture draws in managed and native scene compilers
- replay strictly eligible cached scenes through retained WebGPU render bundles
- expose bundle replay through Silk.NET and Dawn providers
- document managed/native parity, lifetime invariants, evidence, and fallback ownership

## Correctness and lifetime

- render bundles are released before every captured resource generation
- mutable, upload-dependent, mask, and effect scenes fail closed to ordinary pass encoding
- explicit completion waits retain their strong drain boundary
- deferred releases remain bounded at 64 submissions with an eight-submission polling interval

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-restore`: 3,796 passed
- `dotnet test src/ProGPU.Tests.Headless/ProGPU.Tests.Headless.csproj -c Release --no-restore`: 240 passed
- `./eng/build-progpu-native.sh`: 39 native targets built, 9/9 CTest passed, export allowlist passed
- pure C++ Metal sample: Apple M3 Pro, retained GPU hit testing passed
- managed/native rectangle differential: byte-exact output
- real Dawn/Metal retained-bundle replay test passed