### PR TITLE
Fix texture-backed pixel peeks and enforce GPU buffer limits

### DIFF
--- a/src/ProGPU.Backend.Dawn/DawnGpuContext.cs
+++ b/src/ProGPU.Backend.Dawn/DawnGpuContext.cs
@@ -314,6 +314,7 @@ public sealed unsafe partial class DawnGpuContext :
                 maxSamplersPerShaderStage:
                     limits.MaxSamplersPerShaderStage,
                 maxBindGroups: limits.MaxBindGroups,
+                maxBufferSize: limits.MaxBufferSize,
                 supportsTextureFormatsTier1:
                     supportsTextureFormatsTier1,
                 adapterBackendType: SW.BackendType.Metal,

--- a/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
+++ b/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
@@ -194,6 +194,7 @@ public sealed unsafe partial class DawnGpuContext
                 maxSamplersPerShaderStage:
                     limits.MaxSamplersPerShaderStage,
                 maxBindGroups: limits.MaxBindGroups,
+                maxBufferSize: limits.MaxBufferSize,
                 supportsTextureFormatsTier1:
                     supportsTextureFormatsTier1,
                 adapterBackendType:

--- a/src/ProGPU.Backend/GpuBuffer.cs
+++ b/src/ProGPU.Backend/GpuBuffer.cs
@@ -23,10 +23,14 @@ public unsafe class GpuBuffer : IDisposable
 
     public GpuBuffer(WgpuContext context, uint size, BufferUsage usage, string label = "GpuBuffer")
     {
+        ArgumentNullException.ThrowIfNull(context);
         _context = context;
         Size = size;
         Usage = usage;
-        var allocatedSize = AlignToQueueWriteSize(size);
+        var allocatedSize = ValidateAndAlignAllocationSize(
+            size,
+            context.MaxBufferSize,
+            label);
         AllocatedSize = allocatedSize;
 
         var labelPtr = SilkMarshal.StringToPtr(label);
@@ -143,9 +147,20 @@ public unsafe class GpuBuffer : IDisposable
         _partialWriteShadow = new byte[AllocatedSize];
     }
 
-    private static uint AlignToQueueWriteSize(uint size)
+    internal static uint ValidateAndAlignAllocationSize(
+        uint size,
+        ulong maxBufferSize,
+        string label)
     {
-        return (size + 3) & ~3u;
+        ulong allocatedSize = ((ulong)size + 3UL) & ~3UL;
+        ulong effectiveLimit = Math.Min(maxBufferSize, uint.MaxValue & ~3UL);
+        if (allocatedSize > effectiveLimit)
+        {
+            throw new InvalidOperationException(
+                $"GPU buffer '{label}' requests {allocatedSize} bytes, exceeding the device maximum of {effectiveLimit} bytes.");
+        }
+
+        return checked((uint)allocatedSize);
     }
 
     public void WriteSingle<T>(T value, uint offsetBytes = 0) where T : unmanaged

--- a/src/ProGPU.Backend/GpuMappedUploadBufferRing.cs
+++ b/src/ProGPU.Backend/GpuMappedUploadBufferRing.cs
@@ -60,6 +60,11 @@ public unsafe sealed class GpuMappedUploadBufferRing : IDisposable
             throw new ArgumentOutOfRangeException(nameof(slotCount));
         }
 
+        GpuBuffer.ValidateAndAlignAllocationSize(
+            capacity,
+            context.MaxBufferSize,
+            label);
+
         _context = context;
         _capacity = capacity;
         _slots = new Slot[slotCount];

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -29,6 +29,7 @@ public enum WgpuBackendKind
 
 public unsafe class WgpuContext : IDisposable
 {
+    public const ulong DefaultMaxBufferSize = 256UL * 1024UL * 1024UL;
     // Device polling can materialize internal Metal signal/transition command
     // buffers even when the renderer has no callbacks to service. Keep progress
     // bounded without injecting that work into every retained frame.
@@ -49,6 +50,7 @@ public unsafe class WgpuContext : IDisposable
     public uint MaxSampledTexturesPerShaderStage { get; private set; } = 16;
     public uint MaxSamplersPerShaderStage { get; private set; } = 16;
     public uint MaxBindGroups { get; private set; } = 4;
+    public ulong MaxBufferSize { get; private set; } = DefaultMaxBufferSize;
     public bool SupportsReadOnlyAndReadWriteStorageTextures { get; private set; }
     public bool SupportsTextureFormatsTier1 { get; private set; }
     public BackendType AdapterBackendType { get; private set; } = BackendType.Undefined;
@@ -1038,6 +1040,10 @@ public unsafe class WgpuContext : IDisposable
         MaxSampledTexturesPerShaderStage = Math.Max(16, deviceLimits.Limits.MaxSampledTexturesPerShaderStage);
         MaxSamplersPerShaderStage = Math.Max(16, deviceLimits.Limits.MaxSamplersPerShaderStage);
         MaxBindGroups = Math.Max(4, deviceLimits.Limits.MaxBindGroups);
+        if (deviceLimits.Limits.MaxBufferSize != 0)
+        {
+            MaxBufferSize = deviceLimits.Limits.MaxBufferSize;
+        }
         SupportsReadOnlyAndReadWriteStorageTextures = IsReadWriteStorageTextureSupportEnabled();
 
         // 5. Retrieve Default Queue
@@ -1375,7 +1381,8 @@ public unsafe class WgpuContext : IDisposable
         uint maxSampledTexturesPerShaderStage = 16,
         uint maxSamplersPerShaderStage = 16,
         uint maxBindGroups = 4,
-        bool supportsReadOnlyAndReadWriteStorageTextures = false)
+        bool supportsReadOnlyAndReadWriteStorageTextures = false,
+        ulong maxBufferSize = DefaultMaxBufferSize)
     {
         ArgumentNullException.ThrowIfNull(api);
         if (Api != null || Device != null || _isDisposed)
@@ -1393,6 +1400,7 @@ public unsafe class WgpuContext : IDisposable
         MaxSampledTexturesPerShaderStage = Math.Max(16, maxSampledTexturesPerShaderStage);
         MaxSamplersPerShaderStage = Math.Max(16, maxSamplersPerShaderStage);
         MaxBindGroups = Math.Max(4, maxBindGroups);
+        MaxBufferSize = NormalizeMaxBufferSize(maxBufferSize);
         SupportsReadOnlyAndReadWriteStorageTextures = supportsReadOnlyAndReadWriteStorageTextures;
         _deviceResourceDomain = new WgpuDeviceResourceDomain(Api, Device);
         _isSurfaceConfigured = true;
@@ -1443,7 +1451,8 @@ public unsafe class WgpuContext : IDisposable
         AdapterType adapterType = AdapterType.Unknown,
         string? adapterDriverDescription = null,
         uint adapterVendorId = 0,
-        uint adapterDeviceId = 0)
+        uint adapterDeviceId = 0,
+        ulong maxBufferSize = DefaultMaxBufferSize)
     {
         ArgumentNullException.ThrowIfNull(api);
         ArgumentNullException.ThrowIfNull(lifetime);
@@ -1469,6 +1478,7 @@ public unsafe class WgpuContext : IDisposable
         MaxSamplersPerShaderStage =
             Math.Max(16, maxSamplersPerShaderStage);
         MaxBindGroups = Math.Max(4, maxBindGroups);
+        MaxBufferSize = NormalizeMaxBufferSize(maxBufferSize);
         SupportsReadOnlyAndReadWriteStorageTextures =
             supportsReadOnlyAndReadWriteStorageTextures;
         SupportsTextureFormatsTier1 =
@@ -1573,6 +1583,7 @@ public unsafe class WgpuContext : IDisposable
         MaxSampledTexturesPerShaderStage = deviceOwner.MaxSampledTexturesPerShaderStage;
         MaxSamplersPerShaderStage = deviceOwner.MaxSamplersPerShaderStage;
         MaxBindGroups = deviceOwner.MaxBindGroups;
+        MaxBufferSize = deviceOwner.MaxBufferSize;
         SupportsReadOnlyAndReadWriteStorageTextures = deviceOwner.SupportsReadOnlyAndReadWriteStorageTextures;
         SupportsTextureFormatsTier1 =
             deviceOwner.SupportsTextureFormatsTier1;
@@ -1904,6 +1915,9 @@ public unsafe class WgpuContext : IDisposable
             && maxSampledTexturesPerShaderStage >= requiredTextureAndSamplerCount
             && maxSamplersPerShaderStage >= requiredTextureAndSamplerCount;
     }
+
+    private static ulong NormalizeMaxBufferSize(ulong maxBufferSize) =>
+        maxBufferSize == 0 ? DefaultMaxBufferSize : maxBufferSize;
 
     private static RequiredLimits CreateRequiredLimits(SupportedLimits adapterLimits)
     {

--- a/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
+++ b/src/ProGPU.Browser/BrowserAssets/progpu-browser.js
@@ -2838,6 +2838,7 @@ async function initializeGpu(request, canvas, executionMode, diagnostics) {
     supportsSharedArrayBuffer: typeof SharedArrayBuffer !== 'undefined',
     supportsOffscreenCanvas: typeof OffscreenCanvas !== 'undefined',
     supportsBgra8UnormStorage: supportsBgraStorage,
+    maxBufferSize: state.device.limits.maxBufferSize,
     features: [...state.adapter.features],
     diagnostics
   };

--- a/src/ProGPU.Browser/BrowserGpuContext.cs
+++ b/src/ProGPU.Browser/BrowserGpuContext.cs
@@ -35,7 +35,9 @@ public unsafe sealed class BrowserGpuContext : IDisposable
             BrowserWebGpuApi.QueueHandle,
             BrowserWebGpuApi.SurfaceHandle,
             ParseTextureFormat(capabilities.CanvasFormat),
-            supportsReadOnlyAndReadWriteStorageTextures: capabilities.ActiveProfile == BrowserGpuProfile.Full);
+            supportsReadOnlyAndReadWriteStorageTextures:
+                capabilities.ActiveProfile == BrowserGpuProfile.Full,
+            maxBufferSize: capabilities.MaxBufferSize);
         return new BrowserGpuContext(api, context);
     }
 

--- a/src/ProGPU.Browser/BrowserGpuTypes.cs
+++ b/src/ProGPU.Browser/BrowserGpuTypes.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using ProGPU.Backend;
 
 namespace ProGPU.Browser;
 
@@ -44,6 +45,8 @@ public sealed record BrowserGpuCapabilities
     public bool SupportsSharedArrayBuffer { get; init; }
     public bool SupportsOffscreenCanvas { get; init; }
     public bool SupportsBgra8UnormStorage { get; init; }
+    public ulong MaxBufferSize { get; init; } =
+        WgpuContext.DefaultMaxBufferSize;
     public string[] Features { get; init; } = [];
     public string[] Diagnostics { get; init; } = [];
 }

--- a/src/ProGPU.Native/CMakeLists.txt
+++ b/src/ProGPU.Native/CMakeLists.txt
@@ -1321,6 +1321,7 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
         tests/progpu_native_semantic_layer_mask_tests.hpp
         src/Backend/progpu_native_draw_state.cpp
         src/Backend/progpu_native_draw_state.hpp
+        src/Backend/progpu_native_buffer_capacity.hpp
         src/Backend/progpu_native_effect_plan.cpp
         src/Backend/progpu_native_effect_plan.hpp
         src/Backend/progpu_native_geometry_analytic.hpp

--- a/src/ProGPU.Native/src/Backend/progpu_native_advanced_blend_execution.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_advanced_blend_execution.cpp
@@ -129,11 +129,14 @@ bool ensure_uniform_buffer(
                 engine.semantic_advanced_blend_uniform_buffer_size)) {
         return true;
     }
-    std::uint64_t capacity = std::max<std::uint64_t>(
-        advanced_uniform_alignment,
-        engine.semantic_advanced_blend_uniform_buffer_size);
-    while (capacity < required) {
-        capacity *= 2U;
+    std::uint64_t capacity = 0U;
+    if (!progpu::native::try_calculate_buffer_capacity(
+            engine.semantic_advanced_blend_uniform_buffer_size,
+            required,
+            advanced_uniform_alignment,
+            engine.max_buffer_size,
+            capacity)) {
+        return false;
     }
     WGPUBufferDescriptor descriptor{};
     descriptor.label = webgpu::string_view(

--- a/src/ProGPU.Native/src/Backend/progpu_native_buffer_capacity.hpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_buffer_capacity.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace progpu::native {
+
+inline constexpr std::uint64_t portable_max_buffer_size =
+    256ULL * 1024ULL * 1024ULL;
+
+inline bool try_calculate_buffer_capacity(
+    std::uint64_t current,
+    std::uint64_t required,
+    std::uint64_t initial,
+    std::uint64_t maximum,
+    std::uint64_t& capacity) noexcept {
+    if (maximum == 0U || required > maximum || current > maximum) {
+        return false;
+    }
+
+    capacity = std::max(
+        std::min(std::max<std::uint64_t>(initial, 1U), maximum),
+        current);
+    while (capacity < required) {
+        capacity = capacity > maximum / 2U
+            ? maximum
+            : capacity * 2U;
+    }
+    return true;
+}
+
+} // namespace progpu::native

--- a/src/ProGPU.Native/src/Backend/progpu_native_effect_execution.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_effect_execution.cpp
@@ -683,14 +683,14 @@ bool ensure_semantic_effect_uniform_buffer(
         required_bytes <= engine.semantic_effect_uniform_buffer_size) {
         return true;
     }
-    std::uint64_t capacity = std::max<std::uint64_t>(
-        semantic_effect_uniform_alignment,
-        engine.semantic_effect_uniform_buffer_size);
-    while (capacity < required_bytes) {
-        if (capacity > std::numeric_limits<std::uint64_t>::max() / 2U) {
-            return false;
-        }
-        capacity *= 2U;
+    std::uint64_t capacity = 0U;
+    if (!progpu::native::try_calculate_buffer_capacity(
+            engine.semantic_effect_uniform_buffer_size,
+            required_bytes,
+            semantic_effect_uniform_alignment,
+            engine.max_buffer_size,
+            capacity)) {
+        return false;
     }
     WGPUBufferDescriptor descriptor{};
     descriptor.label = ::progpu::native::webgpu::string_view(

--- a/src/ProGPU.Native/src/Backend/progpu_native_engine.hpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_engine.hpp
@@ -3,6 +3,7 @@
 // Internal engine ownership is compiled only after the selected WebGPU C
 // header and ProGPU dispatch compatibility layer have declared WGPU handles.
 #include "progpu_native.h"
+#include "progpu_native_buffer_capacity.hpp"
 #include "progpu_native_geometry_base.hpp"
 #include "progpu_native_geometry_spline.hpp"
 #include "progpu_native_gpu_records.hpp"
@@ -45,6 +46,8 @@ struct progpu_native_engine {
     WGPUInstance instance = nullptr;
     WGPUDevice device = nullptr;
     WGPUQueue queue = nullptr;
+    std::uint64_t max_buffer_size =
+        progpu::native::portable_max_buffer_size;
     WGPUTextureFormat target_format = WGPUTextureFormat_Undefined;
     WGPUShaderModule shader = nullptr;
     WGPURenderPipeline pipeline = nullptr;
@@ -1272,32 +1275,23 @@ struct progpu_native_engine {
         std::uint64_t required_vertex_bytes,
         std::uint64_t required_index_bytes) noexcept {
         auto& page = semantic_analytic_cache;
-        const auto required_capacity = [](std::uint64_t current,
-                                          std::uint64_t required,
-                                          std::uint64_t& capacity) noexcept {
-            capacity = std::max<std::uint64_t>(256U, current);
-            while (capacity < required) {
-                if (capacity >
-                    std::numeric_limits<std::uint64_t>::max() / 2U) {
-                    return false;
-                }
-                capacity *= 2U;
-            }
-            return true;
-        };
         const bool grow_vertex = page.vertex_buffer == nullptr ||
             required_vertex_bytes > page.vertex_buffer_size;
         const bool grow_index = page.index_buffer == nullptr ||
             required_index_bytes > page.index_buffer_size;
         std::uint64_t vertex_capacity = page.vertex_buffer_size;
         std::uint64_t index_capacity = page.index_buffer_size;
-        if ((grow_vertex && !required_capacity(
+        if ((grow_vertex && !progpu::native::try_calculate_buffer_capacity(
                 page.vertex_buffer_size,
                 required_vertex_bytes,
+                256U,
+                max_buffer_size,
                 vertex_capacity)) ||
-            (grow_index && !required_capacity(
+            (grow_index && !progpu::native::try_calculate_buffer_capacity(
                 page.index_buffer_size,
                 required_index_bytes,
+                256U,
+                max_buffer_size,
                 index_capacity))) {
             return false;
         }
@@ -1784,14 +1778,14 @@ struct progpu_native_engine {
             return true;
         }
 
-        std::uint64_t new_size = std::max(
-            initial_vertex_buffer_size,
-            vertex_buffer_size);
-        while (new_size < required_size) {
-            if (new_size > std::numeric_limits<std::uint64_t>::max() / 2U) {
-                return false;
-            }
-            new_size *= 2U;
+        std::uint64_t new_size = 0U;
+        if (!progpu::native::try_calculate_buffer_capacity(
+                vertex_buffer_size,
+                required_size,
+                initial_vertex_buffer_size,
+                max_buffer_size,
+                new_size)) {
+            return false;
         }
 
         WGPUBufferDescriptor descriptor{};
@@ -1818,14 +1812,14 @@ struct progpu_native_engine {
             return true;
         }
 
-        std::uint64_t new_size = std::max(
-            initial_index_buffer_size,
-            index_buffer_size);
-        while (new_size < required_size) {
-            if (new_size > std::numeric_limits<std::uint64_t>::max() / 2U) {
-                return false;
-            }
-            new_size *= 2U;
+        std::uint64_t new_size = 0U;
+        if (!progpu::native::try_calculate_buffer_capacity(
+                index_buffer_size,
+                required_size,
+                initial_index_buffer_size,
+                max_buffer_size,
+                new_size)) {
+            return false;
         }
 
         WGPUBufferDescriptor descriptor{};
@@ -1852,14 +1846,14 @@ struct progpu_native_engine {
             path_vertex_buffer != nullptr) {
             return true;
         }
-        std::uint64_t new_size = std::max(
-            initial_vertex_buffer_size,
-            path_vertex_buffer_size);
-        while (new_size < required_size) {
-            if (new_size > std::numeric_limits<std::uint64_t>::max() / 2U) {
-                return false;
-            }
-            new_size *= 2U;
+        std::uint64_t new_size = 0U;
+        if (!progpu::native::try_calculate_buffer_capacity(
+                path_vertex_buffer_size,
+                required_size,
+                initial_vertex_buffer_size,
+                max_buffer_size,
+                new_size)) {
+            return false;
         }
         WGPUBufferDescriptor descriptor{};
         descriptor.label = progpu::native::webgpu::string_view(
@@ -1885,14 +1879,14 @@ struct progpu_native_engine {
             path_index_buffer != nullptr) {
             return true;
         }
-        std::uint64_t new_size = std::max(
-            initial_index_buffer_size,
-            path_index_buffer_size);
-        while (new_size < required_size) {
-            if (new_size > std::numeric_limits<std::uint64_t>::max() / 2U) {
-                return false;
-            }
-            new_size *= 2U;
+        std::uint64_t new_size = 0U;
+        if (!progpu::native::try_calculate_buffer_capacity(
+                path_index_buffer_size,
+                required_size,
+                initial_index_buffer_size,
+                max_buffer_size,
+                new_size)) {
+            return false;
         }
         WGPUBufferDescriptor descriptor{};
         descriptor.label = progpu::native::webgpu::string_view(
@@ -1918,14 +1912,14 @@ struct progpu_native_engine {
             text_vertex_buffer != nullptr) {
             return true;
         }
-        std::uint64_t new_size = std::max(
-            initial_vertex_buffer_size,
-            text_vertex_buffer_size);
-        while (new_size < required_size) {
-            if (new_size > std::numeric_limits<std::uint64_t>::max() / 2U) {
-                return false;
-            }
-            new_size *= 2U;
+        std::uint64_t new_size = 0U;
+        if (!progpu::native::try_calculate_buffer_capacity(
+                text_vertex_buffer_size,
+                required_size,
+                initial_vertex_buffer_size,
+                max_buffer_size,
+                new_size)) {
+            return false;
         }
         WGPUBufferDescriptor descriptor{};
         descriptor.label = progpu::native::webgpu::string_view("ProGPU native positioned glyph instances");

--- a/src/ProGPU.Native/src/Backend/progpu_native_glyph_execution.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_glyph_execution.cpp
@@ -509,6 +509,9 @@ progpu_native_status render_glyphs(
             WGPUBufferDescriptor descriptor{};
             descriptor.label = progpu::native::webgpu::string_view(label);
             descriptor.size = std::max<std::uint64_t>(size, 4U);
+            if (descriptor.size > engine->max_buffer_size) {
+                return nullptr;
+            }
             descriptor.usage = usage;
             return wgpuDeviceCreateBuffer(engine->device, &descriptor);
         };

--- a/src/ProGPU.Native/src/Backend/progpu_native_layer_resource_execution.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_layer_resource_execution.cpp
@@ -609,13 +609,14 @@ bool ensure_semantic_layer_vertex_buffer(
             required_bytes <= engine.semantic_layer_vertex_buffer_size)) {
         return true;
     }
-    std::uint64_t capacity = std::max<std::uint64_t>(256U,
-        engine.semantic_layer_vertex_buffer_size);
-    while (capacity < required_bytes) {
-        if (capacity > std::numeric_limits<std::uint64_t>::max() / 2U) {
-            return false;
-        }
-        capacity *= 2U;
+    std::uint64_t capacity = 0U;
+    if (!progpu::native::try_calculate_buffer_capacity(
+            engine.semantic_layer_vertex_buffer_size,
+            required_bytes,
+            256U,
+            engine.max_buffer_size,
+            capacity)) {
+        return false;
     }
     WGPUBufferDescriptor descriptor{};
     descriptor.label = ::progpu::native::webgpu::string_view(

--- a/src/ProGPU.Native/src/Backend/progpu_native_path_execution.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_path_execution.cpp
@@ -545,6 +545,9 @@ progpu_native_status render_paths(
         WGPUBufferDescriptor descriptor{};
         descriptor.label = progpu::native::webgpu::string_view(label);
         descriptor.size = std::max<std::uint64_t>(size, 4U);
+        if (descriptor.size > engine->max_buffer_size) {
+            return nullptr;
+        }
         descriptor.usage = usage;
         return wgpuDeviceCreateBuffer(engine->device, &descriptor);
     };

--- a/src/ProGPU.Native/src/Backend/progpu_native_path_text_resources.cpp
+++ b/src/ProGPU.Native/src/Backend/progpu_native_path_text_resources.cpp
@@ -421,14 +421,14 @@ bool ensure_text_style_buffer(
         required_size <= engine.text_style_buffer_size) {
         return true;
     }
-    std::uint64_t capacity = std::max<std::uint64_t>(
-        32U,
-        engine.text_style_buffer_size);
-    while (capacity < required_size) {
-        if (capacity > std::numeric_limits<std::uint64_t>::max() / 2U) {
-            return false;
-        }
-        capacity *= 2U;
+    std::uint64_t capacity = 0U;
+    if (!progpu::native::try_calculate_buffer_capacity(
+            engine.text_style_buffer_size,
+            required_size,
+            32U,
+            engine.max_buffer_size,
+            capacity)) {
+        return false;
     }
     WGPUBufferDescriptor descriptor{};
     descriptor.label = progpu::native::webgpu::string_view(

--- a/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
+++ b/src/ProGPU.Native/tests/progpu_native_internal_tests.cpp
@@ -1,4 +1,5 @@
 #include "progpu_native_draw_state.hpp"
+#include "progpu_native_buffer_capacity.hpp"
 #include "progpu_native_effect_plan.hpp"
 #include "progpu_native_geometry_analytic.hpp"
 #include "progpu_native_geometry_dash.hpp"
@@ -102,6 +103,21 @@ void native_submission_retirement_is_periodic_and_bounded() {
         submission_retirement_action::poll);
     tracker.observe_latest_completion(72U);
     require(tracker.retired_count() == 72U);
+}
+
+void native_buffer_growth_respects_the_portable_device_limit() {
+    using progpu::native::try_calculate_buffer_capacity;
+    constexpr std::uint64_t maximum = 256U;
+    std::uint64_t capacity = 0U;
+
+    require(try_calculate_buffer_capacity(64U, 129U, 16U, maximum, capacity));
+    require(capacity == 256U);
+    require(try_calculate_buffer_capacity(0U, 1U, 0U, maximum, capacity));
+    require(capacity == 1U);
+    require(!try_calculate_buffer_capacity(
+        64U, maximum + 1U, 16U, maximum, capacity));
+    require(!try_calculate_buffer_capacity(
+        maximum + 1U, maximum, 16U, maximum, capacity));
 }
 
 void semantic_contiguous_draws_merge_without_reordering() {
@@ -882,6 +898,7 @@ void draw_state_resolution_is_cpu_only_and_bounded() {
 int main() {
     native_webgpu_scopes_share_one_process_lock();
     native_submission_retirement_is_periodic_and_bounded();
+    native_buffer_growth_respects_the_portable_device_limit();
     semantic_contiguous_draws_merge_without_reordering();
     effect_plan_uses_three_bounded_intermediates();
     semantic_budget_counts_effected_depth_once();

--- a/src/ProGPU.Scene/Compositor.IncrementalUploads.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalUploads.cs
@@ -11,6 +11,7 @@ public unsafe partial class Compositor
 {
     private const int IncrementalUploadPageBytes = 4096;
     private const int InitialSceneUploadArenaBytes = 4096;
+    private const uint MaximumSceneUploadBatchBytes = 64U * 1024U * 1024U;
 
     private readonly record struct PendingSceneBufferUpload(
         GpuBuffer Destination,
@@ -195,18 +196,65 @@ public unsafe partial class Compositor
                 "Batched scene uploads require 4-byte aligned offsets and sizes.");
         }
 
-        int sourceOffset = AlignToFour(_pendingSceneUploadByteCount);
-        int requiredSize = checked(sourceOffset + data.Length);
-        EnsurePendingSceneUploadCapacity(requiredSize);
-        data.CopyTo(
-            _pendingSceneUploadBytes!.AsSpan(sourceOffset, data.Length));
-        _pendingSceneUploadByteCount = requiredSize;
-        _pendingSceneBufferUploads.Add(
-            new PendingSceneBufferUpload(
-                destination,
-                destinationOffset,
-                checked((uint)sourceOffset),
-                checked((uint)data.Length)));
+        int batchCapacity = checked((int)GetSceneUploadBatchCapacity(
+            _context.MaxBufferSize));
+        int consumed = 0;
+        while (consumed < data.Length)
+        {
+            int sourceOffset = AlignToFour(_pendingSceneUploadByteCount);
+            int available = batchCapacity - sourceOffset;
+            if (available == 0)
+            {
+                FlushPendingSceneUploadsToQueue();
+                continue;
+            }
+
+            int chunkSize = Math.Min(data.Length - consumed, available) & ~3;
+            if (chunkSize == 0)
+            {
+                FlushPendingSceneUploadsToQueue();
+                continue;
+            }
+
+            int requiredSize = checked(sourceOffset + chunkSize);
+            EnsurePendingSceneUploadCapacity(requiredSize, batchCapacity);
+            data.Slice(consumed, chunkSize).CopyTo(
+                _pendingSceneUploadBytes!.AsSpan(sourceOffset, chunkSize));
+            _pendingSceneUploadByteCount = requiredSize;
+            _pendingSceneBufferUploads.Add(
+                new PendingSceneBufferUpload(
+                    destination,
+                    checked(destinationOffset + (uint)consumed),
+                    checked((uint)sourceOffset),
+                    checked((uint)chunkSize)));
+            consumed += chunkSize;
+        }
+    }
+
+    private void FlushPendingSceneUploadsToQueue()
+    {
+        if (_pendingSceneBufferUploads.Count == 0)
+        {
+            return;
+        }
+
+        for (int index = 0;
+             index < _pendingSceneBufferUploads.Count;
+             index++)
+        {
+            PendingSceneBufferUpload upload =
+                _pendingSceneBufferUploads[index];
+            upload.Destination.WriteAlignedBytes(
+                _pendingSceneUploadBytes.AsSpan(
+                    checked((int)upload.SourceOffset),
+                    checked((int)upload.Size)),
+                upload.DestinationOffset);
+        }
+
+        _sceneUploadBatchCount++;
+        _sceneUploadCopyCount += _pendingSceneBufferUploads.Count;
+        _pendingSceneBufferUploads.Clear();
+        _pendingSceneUploadByteCount = 0;
     }
 
     private void EncodePendingSceneUploads(CommandEncoder* encoder)
@@ -268,7 +316,9 @@ public unsafe partial class Compositor
         _sceneMappedUploadRing?.RecallAfterSubmit();
     }
 
-    private void EnsurePendingSceneUploadCapacity(int requiredSize)
+    private void EnsurePendingSceneUploadCapacity(
+        int requiredSize,
+        int maximumCapacity)
     {
         if (_pendingSceneUploadBytes != null &&
             _pendingSceneUploadBytes.Length >= requiredSize)
@@ -276,10 +326,14 @@ public unsafe partial class Compositor
             return;
         }
 
-        int capacity = InitialSceneUploadArenaBytes;
+        int capacity = Math.Min(
+            InitialSceneUploadArenaBytes,
+            maximumCapacity);
         while (capacity < requiredSize)
         {
-            capacity = checked(capacity * 2);
+            capacity = capacity > maximumCapacity / 2
+                ? maximumCapacity
+                : checked(capacity * 2);
         }
 
         byte[] replacement = ArrayPool<byte>.Shared.Rent(capacity);
@@ -302,11 +356,10 @@ public unsafe partial class Compositor
             return;
         }
 
-        uint capacity = InitialSceneUploadArenaBytes;
-        while (capacity < requiredSize)
-        {
-            capacity = checked(capacity * 2);
-        }
+        uint capacity = CalculateSceneUploadBufferCapacity(
+            _sceneUploadStagingBuffer?.Size ?? 0U,
+            requiredSize,
+            GetSceneUploadBatchCapacity(_context.MaxBufferSize));
 
         var replacement = new GpuBuffer(
             _context,
@@ -325,19 +378,58 @@ public unsafe partial class Compositor
             return;
         }
 
-        uint capacity = InitialSceneUploadArenaBytes;
-        while (capacity < requiredSize)
-        {
-            capacity = checked(capacity * 2);
-        }
-
-        _sceneMappedUploadRing?.Dispose();
-        _sceneMappedUploadRing = new GpuMappedUploadBufferRing(
+        uint capacity = CalculateSceneUploadBufferCapacity(
+            _sceneMappedUploadRing?.Capacity ?? 0U,
+            requiredSize,
+            GetSceneUploadBatchCapacity(_context.MaxBufferSize));
+        var replacement = new GpuMappedUploadBufferRing(
             _context,
             capacity,
             slotCount: 2);
+        _sceneMappedUploadRing?.Dispose();
+        _sceneMappedUploadRing = replacement;
         _sceneUploadStagingBuffer?.Dispose();
         _sceneUploadStagingBuffer = null;
+    }
+
+    internal static uint GetSceneUploadBatchCapacity(ulong maxBufferSize)
+    {
+        ulong capacity = Math.Min(
+            maxBufferSize,
+            MaximumSceneUploadBatchBytes);
+        capacity = Math.Min(capacity, int.MaxValue & ~3UL);
+        capacity &= ~3UL;
+        if (capacity < 4UL)
+        {
+            throw new InvalidOperationException(
+                $"The WebGPU device maximum buffer size of {maxBufferSize} bytes cannot hold an aligned scene upload.");
+        }
+
+        return checked((uint)capacity);
+    }
+
+    internal static uint CalculateSceneUploadBufferCapacity(
+        uint currentSize,
+        uint requiredSize,
+        uint maximumCapacity)
+    {
+        if (requiredSize > maximumCapacity)
+        {
+            throw new InvalidOperationException(
+                $"Scene upload requires {requiredSize} bytes, exceeding the bounded batch capacity of {maximumCapacity} bytes.");
+        }
+
+        uint capacity = Math.Max(
+            currentSize,
+            Math.Min((uint)InitialSceneUploadArenaBytes, maximumCapacity));
+        while (capacity < requiredSize)
+        {
+            capacity = capacity > maximumCapacity / 2U
+                ? maximumCapacity
+                : checked(capacity * 2U);
+        }
+
+        return capacity;
     }
 
     private static int AlignToFour(int value) =>

--- a/src/ProGPU.Scene/Compositor.cs
+++ b/src/ProGPU.Scene/Compositor.cs
@@ -3304,7 +3304,10 @@ SceneCompilationComplete:
 
         if (_vectorVerticesList.Count > 0)
         {
-            EnsureBufferSize(ref _vectorVertexBuffer, (uint)_vectorVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>(), BufferUsage.Vertex);
+            EnsureBufferSize(
+                ref _vectorVertexBuffer,
+                checked((ulong)_vectorVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>()),
+                BufferUsage.Vertex);
             UploadIncrementalSceneBuffer(
                 _vectorVertexBuffer,
                 CollectionsMarshal.AsSpan(_vectorVerticesList),
@@ -3312,7 +3315,10 @@ SceneCompilationComplete:
         }
         if (_vectorIndicesList.Count > 0)
         {
-            EnsureBufferSize(ref _vectorIndexBuffer, (uint)_vectorIndicesList.Count * 4, BufferUsage.Index);
+            EnsureBufferSize(
+                ref _vectorIndexBuffer,
+                checked((ulong)_vectorIndicesList.Count * 4UL),
+                BufferUsage.Index);
             UploadIncrementalSceneBuffer(
                 _vectorIndexBuffer,
                 CollectionsMarshal.AsSpan(_vectorIndicesList),
@@ -3321,7 +3327,10 @@ SceneCompilationComplete:
 
         if (_textVerticesList.Count > 0)
         {
-            EnsureBufferSize(ref _textVertexBuffer, (uint)_textVerticesList.Count * (uint)Marshal.SizeOf<GlyphInstance>(), BufferUsage.Vertex);
+            EnsureBufferSize(
+                ref _textVertexBuffer,
+                checked((ulong)_textVerticesList.Count * (uint)Marshal.SizeOf<GlyphInstance>()),
+                BufferUsage.Vertex);
             UploadIncrementalSceneBuffer(
                 _textVertexBuffer,
                 CollectionsMarshal.AsSpan(_textVerticesList),
@@ -3330,7 +3339,10 @@ SceneCompilationComplete:
 
         if (_textureVerticesList.Count > 0)
         {
-            EnsureBufferSize(ref _textureVertexBuffer, (uint)_textureVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>(), BufferUsage.Vertex);
+            EnsureBufferSize(
+                ref _textureVertexBuffer,
+                checked((ulong)_textureVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>()),
+                BufferUsage.Vertex);
             UploadIncrementalSceneBuffer(
                 _textureVertexBuffer,
                 CollectionsMarshal.AsSpan(_textureVerticesList),
@@ -3338,7 +3350,10 @@ SceneCompilationComplete:
         }
         if (_textureIndicesList.Count > 0)
         {
-            EnsureBufferSize(ref _textureIndexBuffer, (uint)_textureIndicesList.Count * 4, BufferUsage.Index);
+            EnsureBufferSize(
+                ref _textureIndexBuffer,
+                checked((ulong)_textureIndicesList.Count * 4UL),
+                BufferUsage.Index);
             UploadIncrementalSceneBuffer(
                 _textureIndexBuffer,
                 CollectionsMarshal.AsSpan(_textureIndicesList),
@@ -14098,21 +14113,21 @@ SceneStateUploadComplete:
         bool vectorStateResized = EnsureBufferSize(
             ref _brushesStorageBuffer,
             checked(
-                (uint)Math.Max(1, _activeBrushes.Count) *
+                (ulong)Math.Max(1, _activeBrushes.Count) *
                 (uint)Marshal.SizeOf<GpuBrush>()),
             BufferUsage.Storage,
             "Compositor Brushes Resize Storage Buffer");
         vectorStateResized |= EnsureBufferSize(
             ref _gradientStopsStorageBuffer,
             checked(
-                (uint)Math.Max(1, _activeGradientStops.Count) *
+                (ulong)Math.Max(1, _activeGradientStops.Count) *
                 (uint)Marshal.SizeOf<GpuGradientStop>()),
             BufferUsage.Storage,
             "Compositor Gradient Stops Resize Storage Buffer");
         bool textStateResized = EnsureBufferSize(
             ref _textStylesStorageBuffer,
             checked(
-                (uint)Math.Max(1, _activeTextStyles.Count) *
+                (ulong)Math.Max(1, _activeTextStyles.Count) *
                 (uint)Marshal.SizeOf<GpuTextStyle>()),
             BufferUsage.Storage,
             "Compositor Text Styles Resize Storage Buffer");
@@ -14142,23 +14157,49 @@ SceneStateUploadComplete:
 
     private bool EnsureBufferSize(
         ref GpuBuffer buffer,
-        uint requiredSize,
+        ulong requiredSize,
         BufferUsage usage,
         string? label = null)
     {
-        if (buffer.Size >= requiredSize) return false;
+        if ((ulong)buffer.Size >= requiredSize) return false;
 
-        uint newSize = Math.Max(buffer.Size * 2, requiredSize);
         string resolvedLabel = label ??
             (usage == BufferUsage.Vertex
                 ? "Vector/Text Resize Vertex Buffer"
                 : "Vector/Text Resize Index Buffer");
+        uint newSize = CalculateBufferGrowth(
+            buffer.Size,
+            requiredSize,
+            _context.MaxBufferSize,
+            resolvedLabel);
         var replacement =
             new GpuBuffer(_context, newSize, usage | BufferUsage.CopyDst, resolvedLabel);
         GpuBuffer previous = buffer;
         buffer = replacement;
         previous.Dispose();
         return true;
+    }
+
+    internal static uint CalculateBufferGrowth(
+        uint currentSize,
+        ulong requiredSize,
+        ulong maxBufferSize,
+        string label)
+    {
+        ulong effectiveLimit = Math.Min(
+            maxBufferSize,
+            uint.MaxValue & ~3UL);
+        if (requiredSize > effectiveLimit)
+        {
+            throw new InvalidOperationException(
+                $"GPU buffer '{label}' requires {requiredSize} bytes, exceeding the device maximum of {effectiveLimit} bytes.");
+        }
+
+        ulong doubled = currentSize > effectiveLimit / 2UL
+            ? effectiveLimit
+            : (ulong)currentSize * 2UL;
+        ulong capacity = Math.Max(requiredSize, doubled);
+        return checked((uint)Math.Min(capacity, effectiveLimit));
     }
 
     private CommandEncoder* CreateCommandEncoder(ReadOnlySpan<byte> label)
@@ -16728,7 +16769,10 @@ SceneStateUploadComplete:
         // Upload CPU batches to dynamic GPU buffers
         if (_vectorVerticesList.Count > 0)
         {
-            EnsureBufferSize(ref _vectorVertexBuffer, (uint)_vectorVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>(), BufferUsage.Vertex);
+            EnsureBufferSize(
+                ref _vectorVertexBuffer,
+                checked((ulong)_vectorVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>()),
+                BufferUsage.Vertex);
             UploadIncrementalSceneBuffer(
                 _vectorVertexBuffer,
                 CollectionsMarshal.AsSpan(_vectorVerticesList),
@@ -16736,7 +16780,10 @@ SceneStateUploadComplete:
         }
         if (_vectorIndicesList.Count > 0)
         {
-            EnsureBufferSize(ref _vectorIndexBuffer, (uint)_vectorIndicesList.Count * 4, BufferUsage.Index);
+            EnsureBufferSize(
+                ref _vectorIndexBuffer,
+                checked((ulong)_vectorIndicesList.Count * 4UL),
+                BufferUsage.Index);
             UploadIncrementalSceneBuffer(
                 _vectorIndexBuffer,
                 CollectionsMarshal.AsSpan(_vectorIndicesList),
@@ -16745,7 +16792,10 @@ SceneStateUploadComplete:
 
         if (_textVerticesList.Count > 0)
         {
-            EnsureBufferSize(ref _textVertexBuffer, (uint)_textVerticesList.Count * (uint)Marshal.SizeOf<GlyphInstance>(), BufferUsage.Vertex);
+            EnsureBufferSize(
+                ref _textVertexBuffer,
+                checked((ulong)_textVerticesList.Count * (uint)Marshal.SizeOf<GlyphInstance>()),
+                BufferUsage.Vertex);
             UploadIncrementalSceneBuffer(
                 _textVertexBuffer,
                 CollectionsMarshal.AsSpan(_textVerticesList),
@@ -16754,7 +16804,10 @@ SceneStateUploadComplete:
 
         if (_textureVerticesList.Count > 0)
         {
-            EnsureBufferSize(ref _textureVertexBuffer, (uint)_textureVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>(), BufferUsage.Vertex);
+            EnsureBufferSize(
+                ref _textureVertexBuffer,
+                checked((ulong)_textureVerticesList.Count * (uint)Marshal.SizeOf<VectorVertex>()),
+                BufferUsage.Vertex);
             UploadIncrementalSceneBuffer(
                 _textureVertexBuffer,
                 CollectionsMarshal.AsSpan(_textureVerticesList),
@@ -16762,7 +16815,10 @@ SceneStateUploadComplete:
         }
         if (_textureIndicesList.Count > 0)
         {
-            EnsureBufferSize(ref _textureIndexBuffer, (uint)_textureIndicesList.Count * 4, BufferUsage.Index);
+            EnsureBufferSize(
+                ref _textureIndexBuffer,
+                checked((ulong)_textureIndicesList.Count * 4UL),
+                BufferUsage.Index);
             UploadIncrementalSceneBuffer(
                 _textureIndexBuffer,
                 CollectionsMarshal.AsSpan(_textureIndicesList),

--- a/src/ProGPU.Tests/GpuBufferLimitTests.cs
+++ b/src/ProGPU.Tests/GpuBufferLimitTests.cs
@@ -1,0 +1,149 @@
+using ProGPU.Backend;
+using ProGPU.Browser;
+using ProGPU.Scene;
+using Silk.NET.WebGPU;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public unsafe sealed class GpuBufferLimitTests
+{
+    [Fact]
+    public void ExternalContextRetainsTheReportedBufferLimit()
+    {
+        using var api = new BrowserWebGpuApi(_ => { });
+        using var context = new WgpuContext();
+        context.InitializeExternal(
+            api,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm,
+            maxBufferSize: 1024);
+
+        Assert.Equal(1024UL, context.MaxBufferSize);
+    }
+
+    [Fact]
+    public void OversizedBufferIsRejectedBeforeWebGpuCreation()
+    {
+        var packets = new List<byte[]>();
+        using var api = new BrowserWebGpuApi(
+            packet => packets.Add(packet.WrittenSpan.ToArray()));
+        using var context = new WgpuContext();
+        context.InitializeExternal(
+            api,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm,
+            maxBufferSize: 64);
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            new GpuBuffer(
+                context,
+                68,
+                BufferUsage.Vertex,
+                "Limit regression buffer"));
+        Assert.Contains("68 bytes", error.Message, StringComparison.Ordinal);
+        Assert.Contains("64 bytes", error.Message, StringComparison.Ordinal);
+
+        api.QueueSubmit(BrowserWebGpuApi.QueueHandle, 0, null);
+        Assert.DoesNotContain(
+            packets.SelectMany(ReadOpcodes),
+            opcode => opcode == BrowserGpuOpcode.CreateBuffer);
+    }
+
+    [Fact]
+    public void OversizedMappedRingIsRejectedBeforeMappingAnInvalidBuffer()
+    {
+        var packets = new List<byte[]>();
+        using var api = new BrowserWebGpuApi(
+            packet => packets.Add(packet.WrittenSpan.ToArray()));
+        using var context = new WgpuContext();
+        context.InitializeExternalNativeDevice(
+            api,
+            new NoOpExternalDeviceLifetime(),
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm,
+            maxBufferSize: 64);
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            new GpuMappedUploadBufferRing(
+                context,
+                68,
+                slotCount: 2));
+        Assert.Contains("68 bytes", error.Message, StringComparison.Ordinal);
+        Assert.Contains("64 bytes", error.Message, StringComparison.Ordinal);
+
+        api.QueueSubmit(BrowserWebGpuApi.QueueHandle, 0, null);
+        Assert.DoesNotContain(
+            packets.SelectMany(ReadOpcodes),
+            opcode => opcode == BrowserGpuOpcode.CreateBuffer);
+    }
+
+    [Fact]
+    public void GeometryGrowthClampsToTheDeviceLimitAndRejectsOverflow()
+    {
+        Assert.Equal(
+            256U,
+            Compositor.CalculateBufferGrowth(
+                160,
+                220,
+                256,
+                "geometry"));
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            Compositor.CalculateBufferGrowth(
+                160,
+                257,
+                256,
+                "geometry"));
+        Assert.Contains("257 bytes", error.Message, StringComparison.Ordinal);
+        Assert.Contains("256 bytes", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SceneUploadBatchesStayBoundedBelowTheDeviceLimit()
+    {
+        Assert.Equal(
+            64U * 1024U * 1024U,
+            Compositor.GetSceneUploadBatchCapacity(256UL * 1024UL * 1024UL));
+        Assert.Equal(4096U, Compositor.GetSceneUploadBatchCapacity(4096));
+        Assert.Equal(
+            4096U,
+            Compositor.CalculateSceneUploadBufferCapacity(
+                1024,
+                3000,
+                4096));
+        Assert.Throws<InvalidOperationException>(() =>
+            Compositor.CalculateSceneUploadBufferCapacity(
+                1024,
+                4097,
+                4096));
+    }
+
+    private static BrowserGpuOpcode[] ReadOpcodes(byte[] packet)
+    {
+        var result = new List<BrowserGpuOpcode>();
+        var reader = new BrowserGpuPacketReader(packet);
+        while (reader.TryRead(out var command))
+        {
+            result.Add(command.Opcode);
+        }
+        return result.ToArray();
+    }
+
+    private sealed class NoOpExternalDeviceLifetime
+        : IWebGpuExternalDeviceLifetime
+    {
+        public void Poll(bool wait)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/ProGPU.Tests/SkImageApiParityTests.cs
+++ b/src/ProGPU.Tests/SkImageApiParityTests.cs
@@ -178,6 +178,45 @@ public sealed class SkImageApiParityTests
     }
 
     [Fact]
+    public void TextureBackedPeekPixelsDoesNotReadBackOrMutateDestination()
+    {
+        using var surface = SKSurface.Create(
+            new SKImageInfo(2, 1, SKColorType.Rgba8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.Red);
+        using var image = surface.Snapshot();
+        var sentinelInfo = new SKImageInfo(
+            1,
+            1,
+            SKColorType.Bgra8888,
+            SKAlphaType.Opaque);
+        IntPtr sentinelPixels = Marshal.AllocHGlobal(4);
+        try
+        {
+            using var destination = new SKPixmap(
+                sentinelInfo,
+                sentinelPixels,
+                sentinelInfo.RowBytes);
+
+            Assert.True(image.IsTextureBacked);
+            Assert.False(image.PeekPixels(destination));
+            Assert.Equal(sentinelInfo, destination.Info);
+            Assert.Equal(sentinelPixels, destination.GetPixels());
+            Assert.Equal(sentinelInfo.RowBytes, destination.RowBytes);
+            Assert.Null(image.PeekPixels());
+
+            using var raster = image.ToRasterImage();
+            Assert.Null(image.PeekPixels());
+            using var rasterPixels = raster.PeekPixels();
+            Assert.NotNull(rasterPixels);
+            Assert.Equal(SKColors.Red, rasterPixels.GetPixelColor(0, 0));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(sentinelPixels);
+        }
+    }
+
+    [Fact]
     public unsafe void TextureBackedSubsetReadPixelsUsesViewRelativeCoordinates()
     {
         using var surface = SKSurface.Create(

--- a/src/SkiaSharp/SKImage.Compatibility.cs
+++ b/src/SkiaSharp/SKImage.Compatibility.cs
@@ -142,15 +142,13 @@ public partial class SKImage
     public bool PeekPixels(SKPixmap pixmap)
     {
         ArgumentNullException.ThrowIfNull(pixmap);
-        var optionalState = Volatile.Read(ref _optionalState);
-        if (IsTextureBacked && optionalState?.RasterPixels is null)
+        if (IsTextureBacked)
         {
-            pixmap.Reset();
             return false;
         }
 
         EnsureRasterPixels();
-        optionalState = EnsureOptionalState();
+        var optionalState = EnsureOptionalState();
         var info = Info;
         pixmap.Reset(
             info,


### PR DESCRIPTION
## Summary

- make `SKImage.PeekPixels` match Skia: texture-backed images never trigger readback, failed peeks leave the destination pixmap unchanged, and explicit raster images remain peekable
- propagate `maxBufferSize` through Silk, Dawn, browser, and shared-device contexts; reject oversized and alignment-overflowing buffers before `DeviceCreateBuffer`
- clamp geometric growth to the device limit, cap scene upload batches at 64 MiB (or the smaller device limit), and flush/chunk larger aggregate uploads without creating an oversized mapped ring
- apply the same bounded growth contract to the native C++ renderer using the portable WebGPU 256 MiB limit, with explicit allocation failure instead of invalid WebGPU descriptors

## Reproduced failures

The managed renderer could geometrically grow a vector/text buffer beyond the reported device maximum. The incremental uploader then aggregated the frame into an even larger persistently mapped ring. WebGPU produced validation errors, after which native mapped-range access could abort the process. The fix validates every ordinary `GpuBuffer` and mapped-ring allocation before the native call and prevents aggregate upload capacity from growing without a bound.

## Clean-room research record

Only public contracts, architecture, and observable failure behavior informed this implementation; no third-party implementation text or structure was copied.

- [Google Skia `SkImage` contract](https://github.com/google/skia/blob/main/include/core/SkImage.h), [`SkImage` implementation](https://github.com/google/skia/blob/main/src/image/SkImage.cpp), [raster image specialization](https://github.com/google/skia/blob/main/src/image/SkImage_Raster.cpp): `peekPixels` exposes directly addressable pixels only, does not perform readback, and leaves the destination unchanged on failure. Adopted that public behavior; explicit rasterization remains the readback operation.
- [WebGPU specification](https://www.w3.org/TR/webgpu/#dom-supported-limits-maxbuffersize): buffer creation is validated against `maxBufferSize`. Adopted the device limit as an authoritative pre-allocation boundary.
- [Direct2D maximum bitmap capability](https://learn.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1rendertarget-getmaximumbitmapsize), [Win2D maximum bitmap size](https://microsoft.github.io/Win2D/WinUI2/html/P_Microsoft_Graphics_Canvas_CanvasDevice_MaximumBitmapSizeInPixels.htm), and [Win2D effect tiling](https://microsoft.github.io/Win2D/WinUI2/html/P_Microsoft_Graphics_Canvas_CanvasDrawingSession_EffectTileSize.htm): expose device limits and tile large temporary work. Adapted this as capability propagation plus bounded upload batches.
- [WebRender configuration](https://searchfox.org/mozilla-central/source/gfx/webrender_bindings/src/bindings.rs) uses an internal texture-size ceiling specifically to force tiling. This supports keeping internal temporary resources below hardware maxima.
- [Vello robust dynamic-memory design](https://github.com/linebender/vello/issues/366) and [bounded allocation/spatial-subdivision design](https://github.com/linebender/vello/issues/175): considered retries and spatial subdivision. Adopted fixed-size chunking for uploads; rejected silent geometry subdivision here because it would alter draw ordering and requires a separate renderer design.
- [SkParagraph retained layout states](https://github.com/google/skia/blob/main/modules/skparagraph/src/ParagraphImpl.h), [DirectWrite retained text layout](https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritetextlayout-draw), and [Parley layout architecture](https://github.com/linebender/parley): confirmed that reusable CPU shaping/layout remains separate from renderer upload policy. No shaping or layout contract changed.
- [HarfBuzz bounded buffer growth](https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-buffer.cc): rejects configured maxima, integer overflow, and allocation failure. Adopted the failure-before-use principle for ProGPU-owned buffer capacity calculation.

## Managed/native applicability

The managed renderer owns the mapped upload ring, so batching and ring chunking are managed-specific. Both managed and native renderers own growing vector/path/text/material buffers, so both now reject capacity beyond their WebGPU boundary before allocation. The native C ABI does not currently transport device limits; it conservatively uses the WebGPU portable 256 MiB maximum per buffer rather than risking an invalid descriptor.

## Validation

- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-build` — 3,802 passed
- focused pixel-peek, buffer-limit, browser-context, and incremental-upload tests — 50 passed
- `progpu_native_internal_tests` with Apple Clang C++20 — passed
- affected managed projects built in Release with zero warnings
- `git diff --check` and branch clean-room attribution audit — passed

This is a correctness and process-safety fix; it makes no performance-improvement claim. The steady-state retained path below the batch cap is unchanged.