### PR TITLE
Expose Avalonia SkiaSharp API lease compatibility

### DIFF
--- a/docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md
+++ b/docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md
@@ -1,0 +1,88 @@
+# Avalonia SkiaSharp API lease compatibility research
+
+## Scope
+
+This review covers source compatibility for Avalonia custom draw operations
+that use `ISkiaSharpApiLeaseFeature`. The implementation is clean-room: it
+uses Avalonia's public contract and observable behavior as conformance inputs;
+no Avalonia renderer implementation is copied into ProGPU.
+
+The change does not alter shaping, layout, glyph caching, rasterization,
+scene compilation, shaders, GPU submission, device loss, or the native C++
+renderer. Managed/native rendering parity is therefore not applicable beyond
+the unchanged canonical ProGPU scene commands produced by the shim canvas.
+
+## Primary sources and findings
+
+| Source | Finding | Decision |
+| --- | --- | --- |
+| [Avalonia 12.0.5 lease contract](https://github.com/AvaloniaUI/Avalonia/blob/12.0.5/src/Skia/Avalonia.Skia/ISkiaSharpApiLeaseFeature.cs) | The optional feature returns a bounded lease containing `SKCanvas`, optional `GRContext`/`SKSurface`, current opacity, and optional platform graphics access. | Adopt the public source shape so existing custom draw operation source compiles unchanged. |
+| [Avalonia 12.0.5 drawing context](https://github.com/AvaloniaUI/Avalonia/blob/12.0.5/src/Skia/Avalonia.Skia/DrawingContextImpl.cs#L85-L165) | Avalonia makes the backend unavailable while the lease is active, restores ownership on disposal, and returns no platform lease when the renderer has no platform graphics context. | Adapt ownership to ProGPU's existing thread-affine `IProGpuApiLease`; return `null` for unsupported surface and platform objects. |
+| [Avalonia custom Skia sample](https://github.com/AvaloniaUI/Avalonia/blob/12.0.5/samples/RenderDemo/Pages/CustomSkiaPage.cs) | Application code probes the feature inside `ICustomDrawOperation.Render`, scopes the lease with `using`, and draws through `lease.SkCanvas`. | Preserve this call shape and lifetime. |
+| [Skia canvas overview](https://skia.org/docs/user/api/skcanvas_overview/) and [coordinate spaces](https://skia.org/docs/user/coordinates/) | Canvas state owns the active matrix and clip, and draw calls are transformed through that matrix. | Initialize the ProGPU shim canvas with Avalonia's complete active 2D transform before user drawing. |
+| [Skia canvas creation](https://skia.org/docs/user/api/skcanvas_creation/) | GPU contexts are associated with the backing device and are expected to be current for the drawing scope. | Construct the canvas over the leased `WgpuContext`; expose its borrowed `GRContext` wrapper only for the lease lifetime. |
+
+The required wider rendering/text review found no competing public lease
+contract to adopt:
+
+- [SkParagraph](https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/include/Paragraph.h)
+  keeps layout results separate from canvas painting. This change leaves
+  ProGPU shaping and layout untouched.
+- [DirectWrite `IDWriteTextLayout`](https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nn-dwrite-idwritetextlayout),
+  [Direct2D device contexts](https://learn.microsoft.com/en-us/windows/win32/direct2d/devices-and-device-contexts),
+  and [Win2D interop](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/interop)
+  expose backend-specific drawing or resource objects, but none can satisfy
+  an Avalonia `SKCanvas` contract. Adding a Direct2D bridge was rejected.
+- [WebRender's retained display-list pipeline](https://firefox-source-docs.mozilla.org/gfx/RenderingOverview.html)
+  keeps recording and GPU submission separated. The shim follows the same
+  ownership principle by recording into the current ProGPU scene rather than
+  submitting a second frame.
+- [Vello's renderer integration](https://github.com/linebender/vello/blob/main/vello/README.md)
+  likewise separates scene construction from rendering to a device texture,
+  while [Parley](https://docs.rs/parley/latest/parley/) reuses CPU layout
+  state. Neither requires a change to this bounded adapter.
+- [HarfBuzz shaping](https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-shape.cc)
+  converts Unicode buffers to positioned glyphs independently of canvas
+  ownership. The existing ProGPU shaping path remains authoritative.
+
+## Package and type-identity decision
+
+The compatibility contract is implemented in
+`ProGPU.Avalonia.Rendering`, not `ProGPU.SkiaSharp`. Feature discovery is an
+Avalonia renderer responsibility and requires the active draw scope,
+transform, opacity, target size, and device. The generic SkiaSharp shim does
+not own any of those values.
+
+A separate compatibility package was rejected because it would add a
+mandatory assembly dependency to the rendering hot path without providing a
+new ownership boundary. Shipping a replacement assembly named
+`Avalonia.Skia` was also rejected: it would collide with Avalonia's official
+renderer and its native SkiaSharp dependency.
+
+This is source compatibility. Applications must use the ProGPU package set
+and recompile code that references `Avalonia.Skia`. A precompiled library
+whose metadata references the official `Avalonia.Skia` and native
+`SkiaSharp` assembly identities is not binary-compatible with the ProGPU
+replacement packages.
+
+## Resulting contract
+
+- Feature discovery is `O(1)` and does not initialize another GPU device.
+- One lease creates one bounded `SKCanvas` and one borrowed `GRContext`
+  wrapper over the existing recorder/device. Work and storage are `O(1)`
+  before application draw calls.
+- The canvas target extent uses the active physical `PixelSize`.
+- Avalonia's full affine/perspective-compatible 4x4 transform is mapped into
+  the shim's 3x3 `SKMatrix` using the same row-vector convention already used
+  by `SKMatrix` and ProGPU scene commands.
+- Existing ProGPU opacity and clip stacks remain active; opacity is exposed
+  for API compatibility and is not multiplied into draw colors a second time.
+- `SkSurface` and `TryLeasePlatformGraphicsApi()` return `null` because the
+  recorder is not an Avalonia Skia surface and WebGPU is not represented by
+  an `IPlatformGraphicsContext` here.
+- Disposal removes the canvas command interceptor before releasing the
+  thread-affine ProGPU lease.
+
+Focused tests cover feature coexistence, source call shape, target size,
+transform mapping, device identity, opacity, unsupported optional objects,
+exclusive ownership, command recording, and disposal.

--- a/docs/progpu-package-readme.md
+++ b/docs/progpu-package-readme.md
@@ -92,6 +92,39 @@ framebuffer surface.
 
 ## Use the ProGPU API lease
 
+### Keep existing Avalonia SkiaSharp custom draw operations
+
+`ProGPU.Avalonia.Rendering` exposes Avalonia's
+`ISkiaSharpApiLeaseFeature` source contract through the ProGPU SkiaSharp
+shim. Existing custom draw operation source can keep its backend probe and
+drawing code:
+
+```csharp
+using Avalonia.Skia;
+
+public void Render(ImmediateDrawingContext context)
+{
+    var feature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+    if (feature is null)
+        return;
+
+    using var lease = feature.Lease();
+    SKCanvas canvas = lease.SkCanvas;
+    RenderCore(canvas);
+}
+```
+
+The canvas already uses the active ProGPU recorder, WebGPU device, physical
+target size, Avalonia transform, clip, and opacity stack. Do not apply the
+Avalonia transform or current opacity again. `SkSurface` and
+`TryLeasePlatformGraphicsApi()` return `null` because the ProGPU recorder is
+not backed by an Avalonia Skia surface or platform graphics context.
+
+This compatibility is for source rebuilt against the ProGPU package set.
+Do not add the official `Avalonia.Skia` package: a precompiled library tied to
+the official `Avalonia.Skia` and native `SkiaSharp` assembly identities must
+be recompiled for ProGPU.
+
 Custom controls can submit ProGPU scene commands from an Avalonia custom draw operation. Acquire `IProGpuApiLeaseFeature` only inside `ICustomDrawOperation.Render`, dispose the lease before returning, and pass `CurrentTransform` to transform-aware ProGPU methods.
 
 ```csharp

--- a/docs/progpu-packaging.md
+++ b/docs/progpu-packaging.md
@@ -363,6 +363,14 @@ public static AppBuilder BuildAvaloniaApp() =>
 
 `UseSkia()` remains available as a compatibility alias for the ProGPU renderer, but `UseProGpu()` avoids ambiguity with Avalonia's Skia package.
 
+The renderer also exposes Avalonia's `ISkiaSharpApiLeaseFeature` source
+contract over `ProGPU.SkiaSharp`, allowing existing custom draw operations to
+keep using `lease.SkCanvas` after recompilation. Do not reference the official
+`Avalonia.Skia` package in this lane; its assembly and native SkiaSharp
+identities are a different binary contract. See
+`docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md` for the design and
+conformance record.
+
 Use `IProGpuApiLeaseFeature` from `ICustomDrawOperation.Render` for scoped
 access to the ProGPU scene command recorder and active `WgpuContext`. The
 lease lifetime and package-facing API contract are documented in

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
@@ -944,6 +944,18 @@ internal partial class DrawingContextImpl :
         Rect localBounds,
         bool isGeometryClip)
     {
+        Rect deviceBounds = localBounds.TransformToAABB(CommandTransform);
+        bool isDeviceRect = !isGeometryClip &&
+            IsAxisAlignedSkiaClipTransform(CommandTransform);
+        PushSkiaDeviceClipState(
+            ToLocalRect(deviceBounds),
+            isDeviceRect);
+    }
+
+    private void PushSkiaDeviceClipState(
+        SceneRect deviceBounds,
+        bool isDeviceRect)
+    {
         _skiaClipFrames.Push(_skiaClipState);
         if (_skiaClipState.DeviceBounds.Right <=
                 _skiaClipState.DeviceBounds.Left ||
@@ -953,15 +965,12 @@ internal partial class DrawingContextImpl :
             return;
         }
 
-        Rect deviceBounds = localBounds.TransformToAABB(CommandTransform);
-        bool isDeviceRect = !isGeometryClip &&
-            IsAxisAlignedSkiaClipTransform(CommandTransform);
         SKRectI incoming = SKCanvas.ToDeviceBounds(
             new SKRect(
-                (float)deviceBounds.Left,
-                (float)deviceBounds.Top,
-                (float)deviceBounds.Right,
-                (float)deviceBounds.Bottom),
+                deviceBounds.X,
+                deviceBounds.Y,
+                deviceBounds.Right,
+                deviceBounds.Bottom),
             roundToNearest: isDeviceRect);
         SKRectI intersection = SKRectI.Intersect(
             _skiaClipState.DeviceBounds,

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
@@ -692,8 +692,12 @@ internal partial class DrawingContextImpl :
     public object? GetFeature(Type featureType)
     {
         ArgumentNullException.ThrowIfNull(featureType);
-        if (featureType == typeof(IProGpuApiLeaseFeature))
+        if (featureType == typeof(IProGpuApiLeaseFeature) ||
+            featureType ==
+                typeof(Avalonia.Skia.ISkiaSharpApiLeaseFeature))
+        {
             return new LeaseFeature(this);
+        }
 #if PROGPU_AVALONIA_SOURCE_COMPOSITOR
         if (featureType == typeof(ICompositionRenderDataDrawingContextFeature))
             return this;
@@ -967,7 +971,9 @@ internal partial class DrawingContextImpl :
 #endif
     }
 
-    private sealed class LeaseFeature : IProGpuApiLeaseFeature
+    private sealed class LeaseFeature :
+        IProGpuApiLeaseFeature,
+        Avalonia.Skia.ISkiaSharpApiLeaseFeature
     {
         private readonly DrawingContextImpl _owner;
 
@@ -977,6 +983,10 @@ internal partial class DrawingContextImpl :
         }
 
         public IProGpuApiLease Lease() => new Lease(_owner);
+
+        Avalonia.Skia.ISkiaSharpApiLease
+            Avalonia.Skia.ISkiaSharpApiLeaseFeature.Lease() =>
+                new ProGpuSkiaSharpApiLease(new Lease(_owner));
     }
 
     private sealed class Lease : IProGpuApiLease

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
@@ -14,6 +14,7 @@ using ProGPU.Scene;
 using ProGPU.Text;
 using ProGPU.Vector;
 using Silk.NET.WebGPU;
+using SkiaSharp;
 using AVector = Avalonia.Vector;
 using SceneBrush = ProGPU.Vector.Brush;
 using ScenePen = ProGPU.Vector.Pen;
@@ -21,6 +22,10 @@ using SceneRect = ProGPU.Scene.Rect;
 using AColor = Avalonia.Media.Color;
 
 namespace Avalonia.ProGpu;
+
+internal readonly record struct AvaloniaSkiaClipState(
+    SKRectI DeviceBounds,
+    bool IsRect);
 
 /// <summary>
 /// Records Avalonia drawing contracts as typed ProGPU retained commands.
@@ -51,6 +56,7 @@ internal partial class DrawingContextImpl :
     private readonly AvaloniaDrawingState _drawingState;
     private readonly Stack<double> _opacityFrames;
     private readonly Stack<bool> _clipFrames;
+    private readonly Stack<AvaloniaSkiaClipState> _skiaClipFrames;
     private readonly Stack<RenderOptions> _renderOptionFrames;
     private readonly Stack<RenderCommandPresentationDependencies>
         _renderOptionDependencyFrames;
@@ -65,6 +71,7 @@ internal partial class DrawingContextImpl :
     private bool _leased;
     private bool _disposed;
     private bool _recordingReturned;
+    private AvaloniaSkiaClipState _skiaClipState;
     private RenderCommandPresentationDependencies
         _presentationDependencies;
     private bool _insideRetainedVisual;
@@ -116,6 +123,7 @@ internal partial class DrawingContextImpl :
             : _resources.RentDrawingState();
         _opacityFrames = _drawingState.OpacityFrames;
         _clipFrames = _drawingState.GeometryClipFrames;
+        _skiaClipFrames = _drawingState.SkiaClipFrames;
         _renderOptionFrames = _drawingState.RenderOptionFrames;
         _renderOptionDependencyFrames =
             _drawingState.RenderOptionDependencyFrames;
@@ -148,6 +156,7 @@ internal partial class DrawingContextImpl :
             : createInfo.Size ??
               _framebuffer?.Size ??
               default;
+        _skiaClipState = CreateFullSkiaClipState();
 
         if (createInfo.ScaleDrawingToDpi &&
             TryGetScale(Dpi, out double scaleX, out double scaleY) &&
@@ -216,6 +225,8 @@ internal partial class DrawingContextImpl :
         _opacity = 1d;
         _opacityFrames.Clear();
         _clipFrames.Clear();
+        _skiaClipFrames.Clear();
+        _skiaClipState = CreateFullSkiaClipState();
         _renderOptionFrames.Clear();
         _renderOptionDependencyFrames.Clear();
 #if !AVALONIA11
@@ -515,6 +526,7 @@ internal partial class DrawingContextImpl :
             ToLocalRect(clip),
             ToProGpuMatrix(CommandTransform));
         _clipFrames.Push(false);
+        PushSkiaClipState(clip, isGeometryClip: false);
     }
 
     public void PushClip(RoundedRect clip)
@@ -529,6 +541,7 @@ internal partial class DrawingContextImpl :
             CreateRoundedRectPath(clip),
             ToProGpuMatrix(CommandTransform));
         _clipFrames.Push(true);
+        PushSkiaClipState(clip.Rect, isGeometryClip: true);
     }
 
     public void PushClip(IPlatformRenderInterfaceRegion region)
@@ -553,6 +566,7 @@ internal partial class DrawingContextImpl :
             DrawingContext.PopGeometryClip();
         else
             DrawingContext.PopClip();
+        PopSkiaClipState();
     }
 
     public void PushLayer(Rect bounds)
@@ -592,12 +606,14 @@ internal partial class DrawingContextImpl :
             DrawingContext.PushGeometryClip(
                 path.Path,
                 ToProGpuMatrix(CommandTransform));
+            PushSkiaClipState(clip.Bounds, isGeometryClip: true);
         }
         else
         {
             DrawingContext.PushClip(
                 ToLocalRect(clip.Bounds),
                 ToProGpuMatrix(CommandTransform));
+            PushSkiaClipState(clip.Bounds, isGeometryClip: false);
         }
     }
 
@@ -605,6 +621,7 @@ internal partial class DrawingContextImpl :
     {
         EnsureAvailable();
         DrawingContext.PopGeometryClip();
+        PopSkiaClipState();
     }
 
     public void PushOpacityMask(IBrush mask, Rect bounds)
@@ -912,6 +929,66 @@ internal partial class DrawingContextImpl :
             ? (float)Math.Clamp(value, 0d, 1d)
             : 0f;
 
+    private AvaloniaSkiaClipState CreateFullSkiaClipState()
+    {
+        SKRectI bounds = _size.Width > 0 && _size.Height > 0
+            ? new SKRectI(0, 0, _size.Width, _size.Height)
+            : SKRectI.Empty;
+        return new AvaloniaSkiaClipState(
+            bounds,
+            IsRect: bounds.Right > bounds.Left &&
+                bounds.Bottom > bounds.Top);
+    }
+
+    private void PushSkiaClipState(
+        Rect localBounds,
+        bool isGeometryClip)
+    {
+        _skiaClipFrames.Push(_skiaClipState);
+        if (_skiaClipState.DeviceBounds.Right <=
+                _skiaClipState.DeviceBounds.Left ||
+            _skiaClipState.DeviceBounds.Bottom <=
+                _skiaClipState.DeviceBounds.Top)
+        {
+            return;
+        }
+
+        Rect deviceBounds = localBounds.TransformToAABB(CommandTransform);
+        bool isDeviceRect = !isGeometryClip &&
+            IsAxisAlignedSkiaClipTransform(CommandTransform);
+        SKRectI incoming = SKCanvas.ToDeviceBounds(
+            new SKRect(
+                (float)deviceBounds.Left,
+                (float)deviceBounds.Top,
+                (float)deviceBounds.Right,
+                (float)deviceBounds.Bottom),
+            roundToNearest: isDeviceRect);
+        SKRectI intersection = SKRectI.Intersect(
+            _skiaClipState.DeviceBounds,
+            incoming);
+        _skiaClipState = intersection.Right > intersection.Left &&
+            intersection.Bottom > intersection.Top
+                ? new AvaloniaSkiaClipState(
+                    intersection,
+                    _skiaClipState.IsRect && isDeviceRect)
+                : new AvaloniaSkiaClipState(
+                    SKRectI.Empty,
+                    IsRect: false);
+    }
+
+    private void PopSkiaClipState()
+    {
+        if (_skiaClipFrames.Count > 0)
+            _skiaClipState = _skiaClipFrames.Pop();
+    }
+
+    private static bool IsAxisAlignedSkiaClipTransform(Matrix matrix)
+    {
+        const double epsilon = 0.0001;
+        return Math.Abs(matrix.M12) <= epsilon &&
+            Math.Abs(matrix.M21) <= epsilon;
+    }
+
     private TextureSamplingMode GetTextureSampling() =>
         RenderOptions.BitmapInterpolationMode switch
         {
@@ -986,7 +1063,9 @@ internal partial class DrawingContextImpl :
 
         Avalonia.Skia.ISkiaSharpApiLease
             Avalonia.Skia.ISkiaSharpApiLeaseFeature.Lease() =>
-                new ProGpuSkiaSharpApiLease(new Lease(_owner));
+                new ProGpuSkiaSharpApiLease(
+                    new Lease(_owner),
+                    _owner._skiaClipState);
     }
 
     private sealed class Lease : IProGpuApiLease

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaEffectScopes.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaEffectScopes.cs
@@ -100,6 +100,12 @@ partial class DrawingContextImpl
                     "A supported effect did not create a retained subtree.");
             ProGPU.Scene.DrawingContext parent = DrawingContext;
             DrawingContext = retained.Context;
+            if (clipRect is { } subtreeClip)
+            {
+                PushSkiaClipState(
+                    subtreeClip,
+                    isGeometryClip: false);
+            }
             PushAvaloniaEffectFrame(
                 new AvaloniaEffectFrame(
                     parent,
@@ -134,7 +140,10 @@ partial class DrawingContextImpl
         }
 
         if ((frame.Operations & AvaloniaEffectOperations.Clip) != 0)
+        {
             DrawingContext.PopClip();
+            PopSkiaClipState();
+        }
         if ((frame.Operations & AvaloniaEffectOperations.Blend) != 0)
             DrawingContext.PopBlendMode();
     }
@@ -150,6 +159,7 @@ partial class DrawingContextImpl
         if (clipRect is not { } clip)
             return false;
         DrawingContext.PushClip(ToProGpuRect(clip));
+        PushSkiaClipState(clip, isGeometryClip: false);
         return true;
     }
 
@@ -164,7 +174,10 @@ partial class DrawingContextImpl
             DrawingContext.PushClip(ToProGpuRect(clip));
         DrawingContext.DrawVisual(subtree);
         if (frame.OutputClip.HasValue)
+        {
             DrawingContext.PopClip();
+            PopSkiaClipState();
+        }
     }
 
     private bool TryCreateEffectSubtree(
@@ -307,6 +320,8 @@ partial class DrawingContextImpl
             {
                 DrawingContext = frame.Parent;
                 frame.Subtree?.Dispose();
+                if (frame.OutputClip.HasValue)
+                    PopSkiaClipState();
                 continue;
             }
 
@@ -314,6 +329,7 @@ partial class DrawingContextImpl
                  AvaloniaEffectOperations.Clip) != 0)
             {
                 DrawingContext.PopClip();
+                PopSkiaClipState();
             }
             if ((frame.Operations &
                  AvaloniaEffectOperations.Blend) != 0)

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaEffectScopes.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaEffectScopes.cs
@@ -102,9 +102,9 @@ partial class DrawingContextImpl
             DrawingContext = retained.Context;
             if (clipRect is { } subtreeClip)
             {
-                PushSkiaClipState(
-                    subtreeClip,
-                    isGeometryClip: false);
+                PushSkiaDeviceClipState(
+                    ToProGpuRect(subtreeClip),
+                    isDeviceRect: true);
             }
             PushAvaloniaEffectFrame(
                 new AvaloniaEffectFrame(
@@ -158,8 +158,9 @@ partial class DrawingContextImpl
     {
         if (clipRect is not { } clip)
             return false;
-        DrawingContext.PushClip(ToProGpuRect(clip));
-        PushSkiaClipState(clip, isGeometryClip: false);
+        ProGPU.Scene.Rect deviceClip = ToProGpuRect(clip);
+        DrawingContext.PushClip(deviceClip);
+        PushSkiaDeviceClipState(deviceClip, isDeviceRect: true);
         return true;
     }
 

--- a/src/ProGPU.Avalonia.Rendering/ProGpuRenderResourceCache.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuRenderResourceCache.cs
@@ -544,6 +544,7 @@ internal sealed class AvaloniaDrawingState
 
     internal readonly Stack<double> OpacityFrames = new();
     internal readonly Stack<bool> GeometryClipFrames = new();
+    internal readonly Stack<AvaloniaSkiaClipState> SkiaClipFrames = new();
     internal readonly Stack<RenderOptions> RenderOptionFrames = new();
     internal readonly Stack<RenderCommandPresentationDependencies>
         RenderOptionDependencyFrames = new();
@@ -556,6 +557,7 @@ internal sealed class AvaloniaDrawingState
     internal bool CanRetain =>
         OpacityFrames.EnsureCapacity(0) <= MaximumRetainedCapacity &&
         GeometryClipFrames.EnsureCapacity(0) <= MaximumRetainedCapacity &&
+        SkiaClipFrames.EnsureCapacity(0) <= MaximumRetainedCapacity &&
         RenderOptionFrames.EnsureCapacity(0) <= MaximumRetainedCapacity &&
         RenderOptionDependencyFrames.EnsureCapacity(0) <= MaximumRetainedCapacity
 #if !AVALONIA11
@@ -568,6 +570,7 @@ internal sealed class AvaloniaDrawingState
     {
         OpacityFrames.Clear();
         GeometryClipFrames.Clear();
+        SkiaClipFrames.Clear();
         RenderOptionFrames.Clear();
         RenderOptionDependencyFrames.Clear();
 #if !AVALONIA11

--- a/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Numerics;
+
+namespace Avalonia.ProGpu;
+
+/// <summary>
+/// Adapts one thread-affine ProGPU drawing lease to Avalonia's public
+/// SkiaSharp-compatible lease contract.
+/// </summary>
+internal sealed class ProGpuSkiaSharpApiLease :
+    Avalonia.Skia.ISkiaSharpApiLease
+{
+    private readonly int _threadId;
+    private IProGpuApiLease? _lease;
+    private SkiaSharp.SKCanvas? _canvas;
+
+    internal ProGpuSkiaSharpApiLease(IProGpuApiLease lease)
+    {
+        _threadId = Environment.CurrentManagedThreadId;
+        _lease = lease;
+        try
+        {
+            _canvas = new SkiaSharp.SKCanvas(
+                lease.DrawingContext,
+                lease.PixelSize.Width,
+                lease.PixelSize.Height,
+                lease.WgpuContext);
+            _canvas.SetMatrix(ToSkiaMatrix(lease.CurrentTransform));
+        }
+        catch
+        {
+            lease.Dispose();
+            _lease = null;
+            throw;
+        }
+    }
+
+    public SkiaSharp.SKCanvas SkCanvas =>
+        _canvas ??
+        throw new ObjectDisposedException(
+            nameof(Avalonia.Skia.ISkiaSharpApiLease));
+
+    public SkiaSharp.GRContext? GrContext =>
+        SkCanvas.Context as SkiaSharp.GRContext;
+
+    public SkiaSharp.SKSurface? SkSurface
+    {
+        get
+        {
+            _ = SkCanvas;
+            return null;
+        }
+    }
+
+    public double CurrentOpacity =>
+        (_lease ??
+         throw new ObjectDisposedException(
+             nameof(Avalonia.Skia.ISkiaSharpApiLease)))
+        .CurrentOpacity;
+
+    public Avalonia.Skia.ISkiaSharpPlatformGraphicsApiLease?
+        TryLeasePlatformGraphicsApi()
+    {
+        _ = SkCanvas;
+        return null;
+    }
+
+    public void Dispose()
+    {
+        IProGpuApiLease? lease = _lease;
+        if (lease is null)
+            return;
+        if (_threadId != Environment.CurrentManagedThreadId)
+        {
+            throw new InvalidOperationException(
+                "A SkiaSharp API lease must be returned on its " +
+                "acquisition thread.");
+        }
+
+        SkiaSharp.SKCanvas? canvas = _canvas;
+        _canvas = null;
+        _lease = null;
+        try
+        {
+            canvas?.Dispose();
+        }
+        finally
+        {
+            lease.Dispose();
+        }
+    }
+
+    private static SkiaSharp.SKMatrix ToSkiaMatrix(
+        Matrix4x4 matrix) =>
+        new(
+            matrix.M11,
+            matrix.M21,
+            matrix.M41,
+            matrix.M12,
+            matrix.M22,
+            matrix.M42,
+            matrix.M14,
+            matrix.M24,
+            matrix.M44);
+}

--- a/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
@@ -14,6 +14,7 @@ internal sealed class ProGpuSkiaSharpApiLease :
     private readonly int _canvasRestoreCount;
     private IProGpuApiLease? _lease;
     private SkiaSharp.SKCanvas? _canvas;
+    private SkiaSharp.GRContext? _grContext;
 
     internal ProGpuSkiaSharpApiLease(
         IProGpuApiLease lease,
@@ -28,6 +29,7 @@ internal sealed class ProGpuSkiaSharpApiLease :
                 lease.PixelSize.Width,
                 lease.PixelSize.Height,
                 lease.WgpuContext);
+            _grContext = _canvas.Context as SkiaSharp.GRContext;
             _canvas.SetMatrix(ToSkiaMatrix(lease.CurrentTransform));
             _canvas.InitializeDeviceClipBounds(
                 clipState.DeviceBounds,
@@ -42,9 +44,17 @@ internal sealed class ProGpuSkiaSharpApiLease :
             }
             finally
             {
-                lease.Dispose();
-                _canvas = null;
-                _lease = null;
+                try
+                {
+                    _grContext?.Dispose();
+                }
+                finally
+                {
+                    lease.Dispose();
+                    _grContext = null;
+                    _canvas = null;
+                    _lease = null;
+                }
             }
             throw;
         }
@@ -55,8 +65,14 @@ internal sealed class ProGpuSkiaSharpApiLease :
         throw new ObjectDisposedException(
             nameof(Avalonia.Skia.ISkiaSharpApiLease));
 
-    public SkiaSharp.GRContext? GrContext =>
-        SkCanvas.Context as SkiaSharp.GRContext;
+    public SkiaSharp.GRContext? GrContext
+    {
+        get
+        {
+            _ = SkCanvas;
+            return _grContext;
+        }
+    }
 
     public SkiaSharp.SKSurface? SkSurface
     {
@@ -93,7 +109,9 @@ internal sealed class ProGpuSkiaSharpApiLease :
         }
 
         SkiaSharp.SKCanvas? canvas = _canvas;
+        SkiaSharp.GRContext? grContext = _grContext;
         _canvas = null;
+        _grContext = null;
         _lease = null;
         try
         {
@@ -105,8 +123,19 @@ internal sealed class ProGpuSkiaSharpApiLease :
                 }
                 finally
                 {
-                    canvas.Dispose();
+                    try
+                    {
+                        canvas.Dispose();
+                    }
+                    finally
+                    {
+                        grContext?.Dispose();
+                    }
                 }
+            }
+            else
+            {
+                grContext?.Dispose();
             }
         }
         finally

--- a/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
@@ -11,10 +11,13 @@ internal sealed class ProGpuSkiaSharpApiLease :
     Avalonia.Skia.ISkiaSharpApiLease
 {
     private readonly int _threadId;
+    private readonly int _canvasRestoreCount;
     private IProGpuApiLease? _lease;
     private SkiaSharp.SKCanvas? _canvas;
 
-    internal ProGpuSkiaSharpApiLease(IProGpuApiLease lease)
+    internal ProGpuSkiaSharpApiLease(
+        IProGpuApiLease lease,
+        AvaloniaSkiaClipState clipState)
     {
         _threadId = Environment.CurrentManagedThreadId;
         _lease = lease;
@@ -26,11 +29,23 @@ internal sealed class ProGpuSkiaSharpApiLease :
                 lease.PixelSize.Height,
                 lease.WgpuContext);
             _canvas.SetMatrix(ToSkiaMatrix(lease.CurrentTransform));
+            _canvas.InitializeDeviceClipBounds(
+                clipState.DeviceBounds,
+                clipState.IsRect);
+            _canvasRestoreCount = _canvas.Save();
         }
         catch
         {
-            lease.Dispose();
-            _lease = null;
+            try
+            {
+                _canvas?.Dispose();
+            }
+            finally
+            {
+                lease.Dispose();
+                _canvas = null;
+                _lease = null;
+            }
             throw;
         }
     }
@@ -82,7 +97,17 @@ internal sealed class ProGpuSkiaSharpApiLease :
         _lease = null;
         try
         {
-            canvas?.Dispose();
+            if (canvas is not null)
+            {
+                try
+                {
+                    canvas.RestoreToCount(_canvasRestoreCount);
+                }
+                finally
+                {
+                    canvas.Dispose();
+                }
+            }
         }
         finally
         {

--- a/src/ProGPU.Avalonia.Rendering/SkiaSharpApiLeaseContracts.cs
+++ b/src/ProGPU.Avalonia.Rendering/SkiaSharpApiLeaseContracts.cs
@@ -1,0 +1,51 @@
+using System;
+using Avalonia.Metadata;
+using Avalonia.Platform;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+/// <summary>
+/// Opens a bounded SkiaSharp-compatible drawing scope over the active
+/// Avalonia renderer.
+/// </summary>
+/// <remarks>
+/// ProGPU implements this source-compatible Avalonia contract with its
+/// SkiaSharp shim. The returned objects are valid only until the lease is
+/// disposed.
+/// </remarks>
+[Unstable]
+public interface ISkiaSharpApiLeaseFeature
+{
+    /// <summary>
+    /// Acquires the active SkiaSharp-compatible drawing scope.
+    /// </summary>
+    ISkiaSharpApiLease Lease();
+}
+
+/// <summary>
+/// Provides bounded access to the SkiaSharp-compatible objects for the
+/// current custom draw operation.
+/// </summary>
+[Unstable]
+public interface ISkiaSharpApiLease : IDisposable
+{
+    SKCanvas SkCanvas { get; }
+
+    GRContext? GrContext { get; }
+
+    SKSurface? SkSurface { get; }
+
+    double CurrentOpacity { get; }
+
+    ISkiaSharpPlatformGraphicsApiLease? TryLeasePlatformGraphicsApi();
+}
+
+/// <summary>
+/// Represents direct access to an Avalonia platform graphics context.
+/// </summary>
+[Unstable]
+public interface ISkiaSharpPlatformGraphicsApiLease : IDisposable
+{
+    IPlatformGraphicsContext Context { get; }
+}

--- a/src/SkiaSharp/GRContext.cs
+++ b/src/SkiaSharp/GRContext.cs
@@ -1155,7 +1155,14 @@ public class GRContext : GRRecordingContext
     {
     }
 
-    public WgpuContext Context => BackendContext;
+    public WgpuContext Context
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+            return BackendContext;
+        }
+    }
 
     public override GRBackend Backend => base.Backend;
 

--- a/src/SkiaSharp/SKCanvas.cs
+++ b/src/SkiaSharp/SKCanvas.cs
@@ -3212,7 +3212,7 @@ public class SKCanvas : SKObject
             ? new ClipState(new SKRectI(left, top, right, bottom), IsRect: true)
             : new ClipState(SKRectI.Empty, IsRect: false);
 
-    private static SKRectI ToDeviceBounds(SKRect bounds, bool roundToNearest)
+    internal static SKRectI ToDeviceBounds(SKRect bounds, bool roundToNearest)
     {
         if (!IsFiniteNonEmpty(bounds))
         {
@@ -3230,6 +3230,30 @@ public class SKCanvas : SKObject
                 FloorDeviceCoordinate(bounds.Top),
                 CeilingDeviceCoordinate(bounds.Right),
                 CeilingDeviceCoordinate(bounds.Bottom));
+    }
+
+    internal void InitializeDeviceClipBounds(
+        SKRectI deviceBounds,
+        bool isRect)
+    {
+        if (_savedStateCount != 0 || _pushedScopes.Count != 0)
+        {
+            throw new InvalidOperationException(
+                "Initial clip bounds can only be set on a fresh canvas.");
+        }
+
+        SKRectI canvasBounds = new(
+            0,
+            0,
+            ToCanvasExtent(_width),
+            ToCanvasExtent(_height));
+        SKRectI intersection = SKRectI.Intersect(
+            canvasBounds,
+            deviceBounds);
+        _clipState = intersection.Right > intersection.Left &&
+            intersection.Bottom > intersection.Top
+                ? new ClipState(intersection, isRect)
+                : new ClipState(SKRectI.Empty, IsRect: false);
     }
 
     private static bool IsFiniteNonEmpty(SKRect bounds) =>

--- a/src/SkiaSharp/SkiaSharp.csproj
+++ b/src/SkiaSharp/SkiaSharp.csproj
@@ -21,4 +21,7 @@
     <ProjectReference Include="..\ProGPU.Text\ProGPU.Text.csproj" />
     <ProjectReference Include="..\ProGPU.Scene\ProGPU.Scene.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Avalonia.ProGpu, PublicKey=$(ProGPUPublicKey)" />
+  </ItemGroup>
 </Project>

--- a/tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
+++ b/tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="ProGpuExternalObjectsFeatureTests.cs" />
     <Compile Include="ProGpuTextShaperContractTests.cs" />
     <Compile Include="RenderTargetBitmapContractTests.cs" />
+    <Compile Include="SkiaSharpApiLeaseContractTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
@@ -1,0 +1,111 @@
+using System;
+using Avalonia.Media;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Skia;
+using SkiaSharp;
+using Xunit;
+
+namespace Avalonia.ProGpu.ContractTests;
+
+[Collection(BackendContextCollection.Name)]
+public sealed class SkiaSharpApiLeaseContractTests
+{
+    [Fact]
+    public void SkiaSharpLeaseUsesActiveRecorderDeviceTransformAndOpacity()
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(80, 60),
+                Dpi = new Vector(96, 96),
+                PreserveRecordedCommandsOnDispose = true
+            });
+        context.Transform = new Matrix(2, 0.5, 0.25, 3, 11, 13);
+        context.PushOpacity(0.4, bounds: null);
+
+        var feature = Assert.IsAssignableFrom<
+            ISkiaSharpApiLeaseFeature>(
+                context.GetFeature(
+                    typeof(ISkiaSharpApiLeaseFeature)));
+
+        ISkiaSharpApiLease lease = feature.Lease();
+        SKCanvas canvas = lease.SkCanvas;
+
+        Assert.Equal(80, canvas.DeviceClipBounds.Width);
+        Assert.Equal(60, canvas.DeviceClipBounds.Height);
+        Assert.Equal(2f, canvas.TotalMatrix.ScaleX);
+        Assert.Equal(0.25f, canvas.TotalMatrix.SkewX);
+        Assert.Equal(11f, canvas.TotalMatrix.TransX);
+        Assert.Equal(0.5f, canvas.TotalMatrix.SkewY);
+        Assert.Equal(3f, canvas.TotalMatrix.ScaleY);
+        Assert.Equal(13f, canvas.TotalMatrix.TransY);
+        Assert.Equal(0.4, lease.CurrentOpacity, precision: 6);
+        Assert.Same(context.GpuContext, lease.GrContext?.Context);
+        Assert.Null(lease.SkSurface);
+        Assert.Null(lease.TryLeasePlatformGraphicsApi());
+        Assert.Throws<InvalidOperationException>(
+            () => context.DrawRectangle(
+                Brushes.Blue,
+                null,
+                new RoundedRect(new Rect(0, 0, 4, 4))));
+
+        using (var paint = new SKPaint { Color = SKColors.Red })
+        {
+            canvas.DrawRect(1, 2, 10, 12, paint);
+        }
+
+        lease.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => lease.SkCanvas);
+        context.PopOpacity();
+        Assert.Equal(3, context.DrawingContext.Commands.Count);
+        Assert.Equal(2f, context.DrawingContext.Commands[1].Transform.M11);
+        Assert.Equal(3f, context.DrawingContext.Commands[1].Transform.M22);
+        Assert.Equal(11f, context.DrawingContext.Commands[1].Transform.M41);
+        Assert.Equal(13f, context.DrawingContext.Commands[1].Transform.M42);
+    }
+
+    [Fact]
+    public void ProGpuLeaseFeatureRemainsAvailableAlongsideSkiaContract()
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(16, 16),
+                Dpi = new Vector(96, 96),
+                PreserveRecordedCommandsOnDispose = true
+            });
+
+        Assert.IsAssignableFrom<IProGpuApiLeaseFeature>(
+            context.GetFeature(typeof(IProGpuApiLeaseFeature)));
+        Assert.IsAssignableFrom<ISkiaSharpApiLeaseFeature>(
+            context.GetFeature(typeof(ISkiaSharpApiLeaseFeature)));
+    }
+
+    private sealed class ExistingCustomDrawOperation :
+        ICustomDrawOperation
+    {
+        public Rect Bounds => new(0, 0, 16, 16);
+
+        public bool HitTest(Point point) => Bounds.Contains(point);
+
+        public void Render(ImmediateDrawingContext context)
+        {
+            var feature =
+                context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+            if (feature is null)
+                return;
+
+            using var lease = feature.Lease();
+            using var paint = new SKPaint { Color = SKColors.Black };
+            lease.SkCanvas.DrawRect(0, 0, 16, 16, paint);
+        }
+
+        public bool Equals(ICustomDrawOperation? other) =>
+            other is ExistingCustomDrawOperation;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Media;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
+using ProGPU.Backend;
 using ProGPU.Scene;
 using SkiaSharp;
 using Xunit;
@@ -180,6 +181,89 @@ public sealed class SkiaSharpApiLeaseContractTests
         context.PopClip();
         Assert.Equal(4, context.DrawingContext.Commands.Count);
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SkiaSharpLeaseUsesRecordedDeviceSpaceEffectClip(
+        bool retainedEffect)
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(80, 60),
+                Dpi = new Vector(96, 96),
+                PreserveRecordedCommandsOnDispose = true
+            });
+        context.Transform = new Matrix(
+            1,
+            0.5,
+            0.25,
+            1,
+            10.3,
+            7.3);
+        IEffect effect = retainedEffect
+            ? new ImmutableBlurEffect(2)
+            : new BlendEffect(GpuBlendMode.Multiply);
+        context.PushEffect(
+            new Rect(2.2, 3.2, 8.2, 6.2),
+            effect);
+        var feature = Assert.IsAssignableFrom<
+            ISkiaSharpApiLeaseFeature>(
+                context.GetFeature(
+                    typeof(ISkiaSharpApiLeaseFeature)));
+
+        SKRectI reportedBounds;
+        using (ISkiaSharpApiLease lease = feature.Lease())
+        {
+            Assert.True(lease.SkCanvas.IsClipRect);
+            reportedBounds = lease.SkCanvas.DeviceClipBounds;
+        }
+
+        context.PopEffect();
+        RenderCommand clipCommand = Assert.Single(
+            context.DrawingContext.Commands,
+            command => command.Type == RenderCommandType.PushClip);
+        Assert.Equal(
+            new SKRectI(
+                RoundDeviceCoordinate(clipCommand.Rect.X),
+                RoundDeviceCoordinate(clipCommand.Rect.Y),
+                RoundDeviceCoordinate(clipCommand.Rect.Right),
+                RoundDeviceCoordinate(clipCommand.Rect.Bottom)),
+            reportedBounds);
+    }
+
+    [Fact]
+    public void SkiaSharpLeaseInvalidatesBorrowedGrContext()
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(16, 16),
+                Dpi = new Vector(96, 96),
+                PreserveRecordedCommandsOnDispose = true
+            });
+        var feature = Assert.IsAssignableFrom<
+            ISkiaSharpApiLeaseFeature>(
+                context.GetFeature(
+                    typeof(ISkiaSharpApiLeaseFeature)));
+        ISkiaSharpApiLease lease = feature.Lease();
+        GRContext grContext = Assert.IsType<GRContext>(lease.GrContext);
+
+        lease.Dispose();
+
+        Assert.True(grContext.IsAbandoned);
+        Assert.Throws<ObjectDisposedException>(() => grContext.Submit());
+        Assert.Throws<ObjectDisposedException>(
+            () => grContext.PurgeResources());
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            _ = grContext.Context;
+        });
+    }
+
+    private static int RoundDeviceCoordinate(float value) =>
+        (int)MathF.Round(value, MidpointRounding.AwayFromZero);
 
     private sealed class ExistingCustomDrawOperation :
         ICustomDrawOperation

--- a/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Media;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
+using ProGPU.Scene;
 using SkiaSharp;
 using Xunit;
 
@@ -80,6 +81,104 @@ public sealed class SkiaSharpApiLeaseContractTests
             context.GetFeature(typeof(IProGpuApiLeaseFeature)));
         Assert.IsAssignableFrom<ISkiaSharpApiLeaseFeature>(
             context.GetFeature(typeof(ISkiaSharpApiLeaseFeature)));
+    }
+
+    [Fact]
+    public void SkiaSharpLeaseRestoresUnbalancedCanvasScopes()
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(64, 48),
+                Dpi = new Vector(96, 96),
+                PreserveRecordedCommandsOnDispose = true
+            });
+        var feature = Assert.IsAssignableFrom<
+            ISkiaSharpApiLeaseFeature>(
+                context.GetFeature(
+                    typeof(ISkiaSharpApiLeaseFeature)));
+
+        using var pathBuilder = new SKPathBuilder();
+        pathBuilder.MoveTo(4, 4);
+        pathBuilder.LineTo(28, 4);
+        pathBuilder.LineTo(16, 28);
+        pathBuilder.Close();
+        using SKPath path = pathBuilder.Detach();
+        using (ISkiaSharpApiLease lease = feature.Lease())
+        using (var paint = new SKPaint { Color = SKColors.Red })
+        {
+            lease.SkCanvas.ClipRect(new SKRect(2, 3, 40, 41));
+            lease.SkCanvas.ClipPath(path);
+            lease.SkCanvas.DrawRect(4, 5, 8, 9, paint);
+        }
+
+        context.DrawRectangle(
+            Brushes.Blue,
+            null,
+            new RoundedRect(new Rect(0, 0, 4, 4)));
+
+        Assert.Collection(
+            context.DrawingContext.Commands,
+            command => Assert.Equal(
+                RenderCommandType.PushClip,
+                command.Type),
+            command => Assert.Equal(
+                RenderCommandType.PushGeometryClip,
+                command.Type),
+            command => Assert.Equal(
+                RenderCommandType.DrawRect,
+                command.Type),
+            command => Assert.Equal(
+                RenderCommandType.PopGeometryClip,
+                command.Type),
+            command => Assert.Equal(
+                RenderCommandType.PopClip,
+                command.Type),
+            command => Assert.Equal(
+                RenderCommandType.DrawRect,
+                command.Type));
+    }
+
+    [Fact]
+    public void SkiaSharpLeaseSeedsActiveAvaloniaClipForQueries()
+    {
+        using var context = new DrawingContextImpl(
+            new DrawingContextImpl.CreateInfo
+            {
+                Size = new PixelSize(80, 60),
+                Dpi = new Vector(96, 96),
+                PreserveRecordedCommandsOnDispose = true
+            });
+        context.PushClip(new Rect(10.2, 8.2, 50, 40));
+        context.PushClip(
+            new RoundedRect(
+                new Rect(20.2, 15.2, 15.1, 10.1),
+                radius: 2));
+        var feature = Assert.IsAssignableFrom<
+            ISkiaSharpApiLeaseFeature>(
+                context.GetFeature(
+                    typeof(ISkiaSharpApiLeaseFeature)));
+
+        using (ISkiaSharpApiLease lease = feature.Lease())
+        {
+            Assert.Equal(
+                new SKRectI(20, 15, 36, 26),
+                lease.SkCanvas.DeviceClipBounds);
+            Assert.Equal(
+                new SKRect(19, 14, 37, 27),
+                lease.SkCanvas.LocalClipBounds);
+            Assert.True(
+                lease.SkCanvas.QuickReject(
+                    new SKRect(0, 0, 4, 4)));
+            Assert.False(
+                lease.SkCanvas.QuickReject(
+                    new SKRect(22, 17, 24, 19)));
+        }
+
+        Assert.Equal(2, context.DrawingContext.Commands.Count);
+        context.PopClip();
+        context.PopClip();
+        Assert.Equal(4, context.DrawingContext.Commands.Count);
     }
 
     private sealed class ExistingCustomDrawOperation :


### PR DESCRIPTION
## Summary

- expose Avalonia's `ISkiaSharpApiLeaseFeature` source contract from `ProGPU.Avalonia.Rendering`
- adapt each SkiaSharp lease to the existing bounded, thread-affine `IProGpuApiLease`
- construct `SKCanvas` over the active ProGPU recorder/WebGPU context and apply Avalonia's current transform
- preserve the existing ProGPU lease feature and support both Avalonia 12.0.5 and 11.3.18 package lanes

Existing custom draw operations can again keep the standard Avalonia call shape:

```csharp
var feature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
using var lease = feature?.Lease();
var canvas = lease?.SkCanvas;
```

`SkSurface` and platform-graphics leasing remain `null` because the ProGPU recorder is not an Avalonia Skia surface and its WebGPU context is not represented by `IPlatformGraphicsContext`.

This is source compatibility for applications rebuilt against the ProGPU package set. It intentionally does not claim binary compatibility with precompiled libraries bound to the official `Avalonia.Skia` and native `SkiaSharp` assembly identities.

## Architecture and research

The compatibility layer belongs in the Avalonia rendering backend, which owns feature discovery, target dimensions, transform, opacity, and device lifetime. A separate package or an `Avalonia.Skia` replacement assembly would add collisions without solving native SkiaSharp type identity.

Primary-source research and adopted/adapted/rejected decisions are recorded in [`docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md`](https://github.com/wieslawsoltes/ProGPU/blob/compat/avalonia-skiasharp-api-lease/docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md).

Managed/native parity audit: not applicable to the native renderer. This adapter only exposes an Avalonia managed optional feature and records the same canonical ProGPU scene commands through the existing managed SkiaSharp shim; no shader, scene algorithm, submission, cache, text, or native ABI behavior changes.

## Validation

- `dotnet test tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj -c Release --no-restore` — 89 passed
- `dotnet test src/ProGPU.Tests/ProGPU.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~SkCanvasOwnershipCompatibilityTests|FullyQualifiedName~SkCanvasStateTests"` — 114 passed
- `dotnet build src/ProGPU.Avalonia.Rendering.V11/ProGPU.Avalonia.Rendering.V11.csproj -c Release --no-restore` — succeeded (existing warnings only)
- packed and inspected both Avalonia 12.0.5 and 11.3.18 renderer packages; both contain the compatibility types and depend on `ProGPU.SkiaSharp`, with no `Avalonia.Skia` dependency
- `git diff --check` — clean