### PR TITLE
Render popup surfaces without macOS OS-drawn rounded corners

### DIFF
--- a/src/ProGPU.Backend/MacOsNativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/MacOsNativeWindowPlatform.cs
@@ -48,6 +48,15 @@ internal sealed class MacOsNativeWindowPlatform : GlfwNativeWindowPlatform
         switch (state.Decorations)
         {
             case NativeWindowDecorations.None:
+                if (state.IsPopup)
+                {
+                    // Popup surfaces (ComboBox/ContextMenu/ToolTip drop-downs) must be truly
+                    // borderless: NSWindowStyleMaskTitled forces the OS-drawn rounded window
+                    // corners even with the title bar hidden/transparent, which real WPF popups
+                    // never have. Leave styleMask cleared (NSWindowStyleMaskBorderless = 0) so
+                    // the popup renders as a plain rectangle, matching Win32 popup chrome.
+                    break;
+                }
                 style |= StyleTitled | StyleFullSizeContentView;
                 if (nativeResizable)
                 {

--- a/src/ProGPU.Backend/NativeWindowTypes.cs
+++ b/src/ProGPU.Backend/NativeWindowTypes.cs
@@ -203,7 +203,8 @@ internal readonly record struct NativeWindowState(
     NativeWindowSize MaximumSize,
     NativeWindowTheme Theme,
     NativeWindowBackdrop Backdrop,
-    NativeWindowHandle Parent)
+    NativeWindowHandle Parent,
+    bool IsPopup = false)
 {
     public static NativeWindowState Default => new(
         NativeWindowDecorations.Full,
@@ -220,5 +221,6 @@ internal readonly record struct NativeWindowState(
         MaximumSize: NativeWindowSize.Unbounded,
         Theme: NativeWindowTheme.Default,
         Backdrop: NativeWindowBackdrop.None,
-        Parent: NativeWindowHandle.Empty);
+        Parent: NativeWindowHandle.Empty,
+        IsPopup: false);
 }

--- a/src/ProGPU.Backend/SilkWindowController.cs
+++ b/src/ProGPU.Backend/SilkWindowController.cs
@@ -61,6 +61,12 @@ public sealed class SilkWindowController : IDisposable
         return Apply(ApplyChromeAndShadow);
     }
 
+    public bool SetIsPopup(bool value)
+    {
+        _state = _state with { IsPopup = value };
+        return Apply(ApplyChromeAndShadow);
+    }
+
     public bool SetCanResize(bool value)
     {
         _state = _state with { CanResize = value };


### PR DESCRIPTION
## Summary
- `MacOsNativeWindowPlatform.ApplyChrome` set `NSWindowStyleMaskTitled` for `NativeWindowDecorations.None` windows and only hid the title bar via `setTitlebarAppearsTransparent:`/`setTitleVisibility:`. macOS still draws rounded corners on any `NSWindowStyleMaskTitled` window regardless of title-bar visibility, so every popup surface (WPF `ComboBox`/`ContextMenu`/`ToolTip` drop-downs, which all render through this same "no decorations" chrome path) came out with visible rounded corners on macOS - real WPF popups are always square.
- Added a `bool IsPopup` flag to `NativeWindowState` (defaults to `false`, so existing chromeless top-level windows keep their current rounded appearance unchanged) and a `SilkWindowController.SetIsPopup(bool)` setter.
- When `IsPopup` is set, `ApplyChrome`'s `NativeWindowDecorations.None` case now leaves the style mask cleared entirely, landing on a true `NSWindowStyleMaskBorderless` window (styleMask 0) instead of a titled-but-transparent one.
- This only changes macOS chrome; other platforms are unaffected (Win32/X11 popups were already borderless).

## Test plan
- [x] `dotnet build src/ProGPU.Backend/ProGPU.Backend.csproj -c Release` succeeds.
- [x] Verified end-to-end with a minimal standalone WPF app (`ComboBox` popups) against a locally rebuilt `LibreWPF.ProGPU`/`ProGPU.Backend` package before/after the fix, using DevFlow to inspect the managed `Border`'s `CornerRadius` (already `0`, confirming the rounding was a native-OS chrome artifact, not a WPF template issue) and the popup's actual width/height/scrollbar behavior (unaffected, already matched real WPF).
- [x] Structural coverage added on the LibreWPF side (companion PR) asserting the `IsPopup` wiring end-to-end from `WpfPortableNativePopupHost` through to this file.

Companion LibreWPF-side PR: wieslawsoltes/LibreWPF#118