### PR TITLE
Fix Avalonia Silk.NET windowing, input, and native rendering integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -580,7 +580,10 @@ jobs:
           PROGPU_AVALONIA_PAGE_FILTER: ^(Border|Canvas|ScrollViewer|TextBlock|Viewbox)$
           PROGPU_AVALONIA_WARMUP_FRAMES: 5
           PROGPU_AVALONIA_MEASURE_FRAMES: 10
-          PROGPU_AVALONIA_SCREENSHOTS: 1
+          # Windows visual captures run in the interactive Parallels lane. A
+          # service-desktop RenderTargetBitmap readback can block indefinitely
+          # after valid D3D12/HWND telemetry on GitHub-hosted Windows runners.
+          PROGPU_AVALONIA_SCREENSHOTS: 0
           PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE: 1
           PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE: 1
           PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -473,6 +473,11 @@ jobs:
         shell: bash
         run: ./tools/prepare-avalonia-12.1.1-source.sh
 
+      - name: Build Dawn-compatible AvaloniaNative
+        if: runner.os == 'macOS'
+        shell: bash
+        run: ./tools/build-avalonia-native-dawn.sh
+
       - name: Build native-window ControlCatalog and contracts
         shell: bash
         run: |
@@ -499,11 +504,6 @@ jobs:
             --configuration Release
           dotnet build integration/AvaloniaSilkNetInputHarness/AvaloniaSilkNetInputHarness.csproj \
             --configuration Release
-
-      - name: Build Dawn-compatible AvaloniaNative
-        if: runner.os == 'macOS'
-        shell: bash
-        run: ./tools/build-avalonia-native-dawn.sh
 
       - name: Run X11 Vulkan ControlCatalog telemetry smoke
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -434,6 +434,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
 
     steps:
@@ -456,6 +457,7 @@ jobs:
             libvulkan1 \
             mesa-vulkan-drivers \
             libx11-6 \
+            libxi6 \
             libx11-xcb1 \
             libxcb1 \
             libxcb-randr0 \
@@ -495,6 +497,13 @@ jobs:
             --filter "FullyQualifiedName~DawnNativeWindowSourceTests"
           dotnet build tools/ProGPU.SampleMemoryProfiler/ProGPU.SampleMemoryProfiler.csproj \
             --configuration Release
+          dotnet build integration/AvaloniaSilkNetInputHarness/AvaloniaSilkNetInputHarness.csproj \
+            --configuration Release
+
+      - name: Build Dawn-compatible AvaloniaNative
+        if: runner.os == 'macOS'
+        shell: bash
+        run: ./tools/build-avalonia-native-dawn.sh
 
       - name: Run X11 Vulkan ControlCatalog telemetry smoke
         if: runner.os == 'Linux'
@@ -502,21 +511,126 @@ jobs:
         env:
           PROGPU_AVALONIA_SKIP_BUILD: 1
           PROGPU_AVALONIA_BACKENDS: source-progpu-native
-          PROGPU_AVALONIA_PAGE_FILTER: ^Buttons$
-          PROGPU_AVALONIA_WARMUP_FRAMES: 10
-          PROGPU_AVALONIA_MEASURE_FRAMES: 20
+          PROGPU_AVALONIA_PAGE_FILTER: ^(Border|Canvas|ScrollViewer|TextBlock|Viewbox)$
+          PROGPU_AVALONIA_WARMUP_FRAMES: 5
+          PROGPU_AVALONIA_MEASURE_FRAMES: 10
+          PROGPU_AVALONIA_SCREENSHOTS: 1
+          PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE: 1
+          PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE: 1
+          PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE: 1
+          PROGPU_AVALONIA_EFFECT_FIXTURE: 1
+          PROGPU_AVALONIA_OPACITY_MASK_FIXTURE: 1
+          PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE: 1
           LIBGL_ALWAYS_SOFTWARE: 1
         run: |
           xvfb-run -a \
             ./tools/profile-avalonia-controlcatalog.sh \
             artifacts/avalonia-native-dawn-linux
+          xvfb-run -a env \
+            PROGPU_AVALONIA_PAGE_FILTER='^AdornerLayer$' \
+            PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE=0 \
+            PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE=0 \
+            PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE=0 \
+            PROGPU_AVALONIA_EFFECT_FIXTURE=0 \
+            PROGPU_AVALONIA_OPACITY_MASK_FIXTURE=0 \
+            PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE=0 \
+            PROGPU_AVALONIA_TOPOLOGY_FIXTURE=0 \
+            PROGPU_AVALONIA_ADORNER_FIXTURE=1 \
+            ./tools/profile-avalonia-controlcatalog.sh \
+            artifacts/avalonia-native-dawn-linux-adorner
+
+      - name: Run macOS Metal ControlCatalog telemetry smoke
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          PROGPU_AVALONIA_SKIP_BUILD: 1
+          PROGPU_AVALONIA_BACKENDS: source-progpu-native
+          PROGPU_AVALONIA_PAGE_FILTER: ^(Border|Canvas|ScrollViewer|TextBlock|Viewbox)$
+          PROGPU_AVALONIA_WARMUP_FRAMES: 5
+          PROGPU_AVALONIA_MEASURE_FRAMES: 10
+          PROGPU_AVALONIA_SCREENSHOTS: 1
+          PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE: 1
+          PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE: 1
+          PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE: 1
+          PROGPU_AVALONIA_EFFECT_FIXTURE: 1
+          PROGPU_AVALONIA_OPACITY_MASK_FIXTURE: 1
+          PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE: 1
+        run: |
+          ./tools/profile-avalonia-controlcatalog.sh \
+            artifacts/avalonia-native-dawn-macos
+          env \
+            PROGPU_AVALONIA_PAGE_FILTER='^AdornerLayer$' \
+            PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE=0 \
+            PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE=0 \
+            PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE=0 \
+            PROGPU_AVALONIA_EFFECT_FIXTURE=0 \
+            PROGPU_AVALONIA_OPACITY_MASK_FIXTURE=0 \
+            PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE=0 \
+            PROGPU_AVALONIA_TOPOLOGY_FIXTURE=0 \
+            PROGPU_AVALONIA_ADORNER_FIXTURE=1 \
+            ./tools/profile-avalonia-controlcatalog.sh \
+            artifacts/avalonia-native-dawn-macos-adorner
+
+      - name: Run Win32 D3D12 ControlCatalog telemetry smoke
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          PROGPU_AVALONIA_SKIP_BUILD: 1
+          PROGPU_AVALONIA_BACKENDS: source-progpu-native
+          PROGPU_AVALONIA_PAGE_FILTER: ^(Border|Canvas|ScrollViewer|TextBlock|Viewbox)$
+          PROGPU_AVALONIA_WARMUP_FRAMES: 5
+          PROGPU_AVALONIA_MEASURE_FRAMES: 10
+          PROGPU_AVALONIA_SCREENSHOTS: 1
+          PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE: 1
+          PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE: 1
+          PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE: 1
+          PROGPU_AVALONIA_EFFECT_FIXTURE: 1
+          PROGPU_AVALONIA_OPACITY_MASK_FIXTURE: 1
+          PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE: 1
+        run: |
+          ./tools/profile-avalonia-controlcatalog.sh \
+            artifacts/avalonia-native-dawn-windows
+          env \
+            PROGPU_AVALONIA_PAGE_FILTER='^AdornerLayer$' \
+            PROGPU_AVALONIA_LAYOUT_CLIP_FIXTURE=0 \
+            PROGPU_AVALONIA_GEOMETRY_CLIP_FIXTURE=0 \
+            PROGPU_AVALONIA_BITMAP_CACHE_FIXTURE=0 \
+            PROGPU_AVALONIA_EFFECT_FIXTURE=0 \
+            PROGPU_AVALONIA_OPACITY_MASK_FIXTURE=0 \
+            PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE=0 \
+            PROGPU_AVALONIA_TOPOLOGY_FIXTURE=0 \
+            PROGPU_AVALONIA_ADORNER_FIXTURE=1 \
+            ./tools/profile-avalonia-controlcatalog.sh \
+            artifacts/avalonia-native-dawn-windows-adorner
 
       - name: Upload Linux native Dawn telemetry
         if: runner.os == 'Linux' && always()
         uses: actions/upload-artifact@v7
         with:
           name: avalonia-native-dawn-linux
-          path: artifacts/avalonia-native-dawn-linux
+          path: |
+            artifacts/avalonia-native-dawn-linux
+            artifacts/avalonia-native-dawn-linux-adorner
+          if-no-files-found: warn
+
+      - name: Upload macOS native Dawn telemetry
+        if: runner.os == 'macOS' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: avalonia-native-dawn-macos
+          path: |
+            artifacts/avalonia-native-dawn-macos
+            artifacts/avalonia-native-dawn-macos-adorner
+          if-no-files-found: warn
+
+      - name: Upload Windows native Dawn telemetry
+        if: runner.os == 'Windows' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: avalonia-native-dawn-windows
+          path: |
+            artifacts/avalonia-native-dawn-windows
+            artifacts/avalonia-native-dawn-windows-adorner
           if-no-files-found: warn
 
   build-test:

--- a/docs/progpu-avalonia-rendering-research.md
+++ b/docs/progpu-avalonia-rendering-research.md
@@ -3496,3 +3496,104 @@ strict linked iOS Release build and an iPhone 17 Pro simulator launch
 completed without Dawn validation errors. This establishes the managed/native
 ABI and simulator startup path; a physical-device IOSurface/MTLSharedEvent
 run and matched Instruments evidence remain required.
+
+## Retained glyph-atlas residency during incremental replay (2026-08-26)
+
+ControlCatalog geometry-clip integration exposed a retained-resource defect,
+not a clipping algorithm defect. An incremental scene page stored text
+vertices containing glyph-atlas UVs, but replaying that page did not mark the
+referenced glyph entries as used in the current atlas batch. Later page
+compilation could therefore select one of those entries as an LRU victim,
+reuse its rectangle, and then submit the earlier retained vertices with stale
+UVs. The visible result looked like arbitrary clipped or substituted text.
+
+The clean-room design was informed by these primary sources:
+
+- Skia's
+  [`GrTextBlob` vertex regenerator](https://skia.googlesource.com/skia/+/43cbd7229f83ef265b52270a1264a36d06c4f1ed/src/gpu/text/GrTextBlob.cpp)
+  compares retained subrun atlas generations and bulk-updates use tokens even
+  when texture coordinates do not need regeneration. Its
+  [`GrDrawOpAtlas`](https://skia.googlesource.com/skia/+/34c67453a5d032b2f5416564a8c80aa5dca05c9f/src/gpu/GrDrawOpAtlas.h)
+  explicitly requires clients to set a last-use token to prevent eviction.
+  SkParagraph separately caches reusable shaped paragraph results in
+  [`ParagraphCache`](https://skia.googlesource.com/skia/+/5d8f55bfa851a55fa7e111b9a4f1fd063509eca5/modules/skparagraph/src/ParagraphCache.cpp).
+- DirectWrite/Direct2D retain glyph positions in reusable text layouts while
+  drawing device-specific glyph runs, as documented in
+  [Text Rendering with Direct2D and DirectWrite](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-and-directwrite).
+  Direct2D's
+  [resource domains](https://learn.microsoft.com/en-us/windows/win32/direct2d/resources-and-resource-domains)
+  require device-dependent resources to be recreated when their render target
+  is lost. This supports keeping CPU shaping/layout identity independent from
+  validation of GPU atlas residency.
+- WebRender's
+  [`gpu_cache` contract](https://searchfox.org/firefox-main/source/gfx/wr/webrender/src/gpu_cache.rs)
+  requires every resource needed by a frame to be requested before its address
+  is consumed, and its
+  [profiler](https://github.com/servo/webrender/blob/main/webrender/src/profiler.rs)
+  separately measures glyph resolution, texture-cache updates, pressure, and
+  eviction. The relevant concept is current-frame demand, not preserving a UV
+  merely because a display item remains retained.
+- Vello's resource design requires the atlas to contain every resource needed
+  by the encoded viewport and protects pending draw resources from eviction;
+  glyphs follow the same rule in its
+  [image-resource design](https://github.com/linebender/vello/issues/176).
+  Its [glyph-caching roadmap](https://github.com/linebender/vello/blob/main/doc/roadmap_2023.md)
+  keeps glyph-run identity in the scene and resolves cached atlas resources
+  before submission.
+- HarfBuzz's
+  [`hb_shape`](https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-shape.cc)
+  turns a Unicode buffer into glyph IDs and positions, while its documented
+  [shape-plan cache](https://github.com/harfbuzz/harfbuzz/blob/main/docs/usermanual-opentype-features.xml)
+  caches shaping decisions. It does not own raster-atlas residency. ProGPU's
+  shaped glyph runs therefore remain reusable CPU results.
+
+Adopted: a retained page carries an opaque set of the exact `GlyphKey` values
+used to produce its atlas-backed vertices. Replay first verifies that every
+key still maps to a non-fallback resident entry and then marks all entries as
+used for the current batch before any later page can allocate. If any entry is
+missing, the page/picture is discarded and compiled again; stale UVs are never
+submitted. The same capture and replay contract is used by incremental scene
+pages and retained composition pictures.
+
+Adapted: ProGPU keeps fine-grained key residency rather than invalidating every
+retained text page after any atlas eviction. This preserves unaffected pages
+while providing the same safety as Skia's generation/use-token combination.
+The existing key already includes font identity, glyph index, raster size, and
+subpixel phase, so DPI/subpixel quality and font fallback semantics are not
+weakened. Color bitmap entries participate when they use atlas storage; vector
+CFF/color fallbacks retain their existing path-resource contracts.
+
+Rejected: permanently pinning every glyph referenced by any retained page,
+clearing the atlas on every page hit, trusting coordinates without identity,
+or reshaping text during replay. Those choices respectively create unbounded
+residency, destroy reuse, permit recycled rectangles, or conflate reusable CPU
+layout with GPU resource validation.
+
+Capture is `O(G)` time for `G` glyph uses since the page boundary and `O(U)`
+retained storage for `U` distinct keys. Replay is two `O(U)` passes: the first
+is transactional validation and the second updates LRU state. Stable replay
+performs no rasterization, upload, or managed allocation after the batch-use
+journal reaches capacity. Startup remains lazy, visibility culling and worker
+preparation are unchanged, GPU draw batching is unchanged, and existing atlas
+generation/device-loss invalidation remains authoritative. No shader, C ABI,
+or native resource layout changed.
+
+Two focused regressions use a deliberately 96-pixel atlas. One verifies that
+a replayed entry cannot be selected during later LRU churn; the other renders
+an incremental label, mutates a sibling page until the atlas evicts entries,
+and requires the retained label pixels to remain byte-identical. Both pass in
+Release. Linux native-Dawn ControlCatalog runs then completed Border, Canvas,
+ScrollViewer, TextBlock, Viewbox, and AdornerLayer with 1024x800 logical,
+2048x1600 physical output, no retained-scene full synchronization during the
+fixture mutations, and visually correct screenshots. Windows native
+Dawn/D3D12 completed Canvas and the text-heavy TextBox at the same 2x physical
+resolution. macOS native Dawn/Metal completed the same five representative
+pages plus AdornerLayer at 1024x800 logical and 2048x1600 physical output; all
+typed clip, drawing-option, and adorner synchronization gates passed, and the
+TextBlock, Canvas, and moved-adorner screenshots were visually correct.
+
+The managed/native applicability audit found no equivalent defect in the C++
+renderer. Its immutable native scene owns a complete positioned-glyph atlas
+and grows/replaces that scene resource as a unit; it has neither the managed
+LRU slot reuse nor Avalonia incremental-page replay that formed this bug. The
+native renderer therefore requires no one-sided approximation or wire change.

--- a/docs/progpu-avalonia-silknet-platform-audit.md
+++ b/docs/progpu-avalonia-silknet-platform-audit.md
@@ -71,6 +71,47 @@ macOS uses Meta/Command and Command+Left/Right line navigation, Windows adds
 Shift+F10 for context menus, and other desktop platforms use Control plus a
 Super meta-key label.
 
+### Complete routed input bridge
+
+Silk.NET's high-level keyboard callback omitted GLFW repeat events and exposed
+text as UTF-16 `char` values, which cannot represent supplementary Unicode
+scalars. The host now chains the native GLFW key, character, and cursor-enter
+callbacks after Silk.NET has installed its input context. The native modifier
+bitmask is used while a key callback is active, repeats are emitted as
+additional Avalonia key-down events, GLFW Unicode scalar values are converted
+without truncation, and key symbols come from `glfwGetKeyName`. Pointer exit is
+raised from GLFW's authoritative cursor-enter callback. Left, right, middle,
+X1, and X2 buttons and both wheel axes retain their O(1), allocation-free
+routing path. This follows GLFW's public
+[input contract](https://www.glfw.org/docs/3.4/input_guide.html); the previous
+poll-only modifier and BMP-only character assumptions were rejected.
+
+Windows touch uses the documented
+[`WM_TOUCH`](https://learn.microsoft.com/en-us/windows/win32/wintouch/wm-touchdown)
+contact packet and hundredths-of-a-pixel coordinate contract. The Win32
+adapter registers each GLFW HWND, closes every acquired touch handle, converts
+screen contacts to client coordinates, and emits stable Avalonia touch IDs.
+Compatibility mouse messages carrying Microsoft's touch signature are
+suppressed only while their native message is dispatched, preventing one
+finger from producing both touch and mouse routed events.
+
+Linux/X11 touch selects XI2.2 touch begin/update/end events on GLFW's existing
+display connection. A process-local pump removes only matching generic touch
+cookies before GLFW drains the shared Xlib queue, dispatches them to their
+owning X11 window, and suppresses XI2 pointer-emulation mouse events for the
+same poll. The design follows the X.Org
+[XI2 protocol](https://www.x.org/releases/current/doc/inputproto/XI2proto.txt)
+and adds no competing display connection or background thread.
+
+macOS desktop hardware exposes indirect trackpad gestures rather than
+touchscreen contacts. The backend adds the public AppKit responder methods
+[`magnify(with:)`](https://developer.apple.com/documentation/appkit/nsresponder/magnify(with:)),
+[`rotate(with:)`](https://developer.apple.com/documentation/appkit/nsresponder/rotate(with:)),
+and [`swipe(with:)`](https://developer.apple.com/documentation/appkit/nsresponder/swipe(with:))
+to GLFW's process-local content-view class when absent and routes their deltas
+as Avalonia magnify, rotate, and swipe events. Handler lookup is bounded and
+the unmanaged entry points allocate no delegate per gesture.
+
 ## Initialization comparison
 
 The comparison used the official 12.1.1 and 11.3.20 implementations for
@@ -194,10 +235,10 @@ not provide are not advertised:
 - embeddable top levels;
 - native drag sources and drop protocols;
 - platform storage pickers and launcher integration;
-- IME composition/preedit integration;
+- IME composition/preedit integration, which GLFW does not expose;
 - native menus, tray icons, mounted-volume notifications, accessibility
   bridges, and operating-system shutdown/session events;
-- touch and pen input.
+- pen-specific pressure, tilt, barrel-button, and eraser input.
 
 Avalonia supplies its documented no-op storage and launcher fallbacks when
 those optional features are absent. Embedding throws `NotSupportedException`,
@@ -224,10 +265,12 @@ completed with zero warnings and zero errors.
 ## Validation evidence
 
 - The shared Silk.NET contract suite passes in Release against both exact
-  lanes: 91 tests on Avalonia 12.1.1 and 78 tests on Avalonia 11.3.20. The new
+  lanes: 115 tests on Avalonia 12.1.1 and 102 tests on Avalonia 11.3.20. The new
   coverage includes Windows logical/native client-size conversion, one-to-one
   Windows framebuffer sizing, scaled frame insets and constraints, scaled
-  Windows pointer input, and unchanged Linux screen-coordinate layout/input.
+  Windows pointer input, unchanged Linux screen-coordinate layout/input,
+  UTF-32 text, GLFW modifier mapping, touch phases, X11 ABI layout, macOS
+  gesture mapping, and Windows promoted-mouse suppression.
 - Both windowing projects build in Release, and the focused backend windowing
   presenter suite passes 17 tests.
 - Package validation produced both
@@ -239,27 +282,54 @@ completed with zero warnings and zero errors.
 - A package-backed Release smoke run on macOS rendered the Charting sample
   through `ProGPU/Silk.NET + embedded ProGPU`, presented non-transparent output
   through the same-device WebGPU texture path at 2x DPI, and exited normally.
-- A self-contained Windows ARM64 package and a framework-dependent ARM64
-  package were launched in the running Parallels Windows 11 session. The first
-  run exposed and then verified removal of a pre-initialization framebuffer
-  query in the new constraint path. The corrected build proceeds past that
-  windowing boundary; the VM's subsequent `wgpu_native.dll` failure occurs in
-  the existing renderer bootstrap before `window.Initialize()` returns, so it
-  is recorded separately and is not attributed to the DPI/windowing change.
+- A self-contained Windows ARM64 harness ran in the logged-in Parallels
+  Windows 11 session at 200% display scaling. Live routed telemetry passed
+  keyboard down/up, complete text, Control+Shift+K command routing, pointer
+  movement, two-axis-capable wheel routing, and left/right/middle/X1/X2
+  buttons. The window reported a 720x480 logical client, 1440x960 physical
+  rectangle, and `RenderScaling=2`. A custom-title-bar drag moved the native
+  rectangle, and one edge drag produced four client-size notifications and
+  three matching Avalonia layout-size observations before release, proving
+  layout continued inside the modal resize loop.
+- The same Windows VM rendered the ControlCatalog Canvas and text-heavy
+  TextBox pages through Avalonia Win32 plus native Dawn/D3D12 at 1024x800
+  logical and 2048x1600 physical pixels. The older Silk.NET 2.23
+  `wgpu_native.dll` presentation lane loses D3D12 resources under the
+  Parallels display adapter during the larger catalog workload. Native
+  Win32/Dawn succeeds on the same scene/text workload, while the Skia-rendered
+  Silk.NET harness completes all windowing and input checks; this isolates the
+  remaining VM-specific failure from the corrected Silk.NET window/input
+  boundary rather than hiding it as a DPI or layout failure.
+- An Ubuntu X11 VM passed live keyboard, text, pointer, wheel, shortcut, and
+  all five mouse-button telemetry. XI2 touch ABI and conversion are covered by
+  focused contracts because the VM has no injectable physical multitouch
+  device. The rebuilt macOS app passed live keyboard, text, pointer movement,
+  and Command+Shift+K telemetry; AppKit gesture entry points are covered by
+  native mapping contracts because desktop automation cannot synthesize a
+  hardware trackpad gesture at GLFW's responder boundary.
+- Native Avalonia windowing with Dawn/Metal on macOS passed Border, Canvas,
+  ScrollViewer, TextBlock, Viewbox, and AdornerLayer at 1024x800 logical and
+  2048x1600 physical output. Typed clip, inherited drawing-option, and adorner
+  synchronization gates all passed without a measured full-scene fallback;
+  representative screenshots were visually correct.
 
 ## Managed/native applicability
 
 The DPI conversion, modal resize pulse, custom title-bar ordering,
 platform-settings, dispatcher, screen, window, input, and clipboard work
-belongs to the managed Avalonia/Silk.NET host. Neither the managed ProGPU scene
-renderer nor the native C++ renderer implements those operating-system
-services, so there is no paired renderer change. The same managed and native
-renderer binaries consume the corrected framebuffer dimensions; scene,
-shader, resource-identity, device-loss, upload, and presentation contracts are
-unchanged. The bitmap-encoder update is also specific to Avalonia 12's managed
-`IBitmapImpl` contract; the native C++ renderer does not expose or consume that
-interface. No managed/native differential fixture or canonical shader needs
-to move for these host-only fixes.
+belongs to the managed Avalonia/Silk.NET host. Neither renderer implements
+those operating-system services, so there is no paired renderer change. The
+bitmap-encoder update is likewise specific to Avalonia 12's managed
+`IBitmapImpl` contract.
+
+The retained glyph-residency correction found during ControlCatalog
+integration is specific to the managed compositor's LRU glyph atlas plus
+incremental-page/picture replay. The native C++ renderer builds an immutable
+scene-owned positioned-glyph atlas, grows that atlas instead of recycling an
+LRU slot behind retained UVs, and has no equivalent Avalonia incremental-page
+cache. Its applicability audit therefore found no matching defect or native
+code change. Both implementations retain the same shaping, glyph identity,
+DPI, and output contracts; no C ABI record or canonical shader changed.
 
 No third-party implementation source was copied into ProGPU. The Avalonia and
 GLFW sources were used to identify public contracts and observable platform

--- a/docs/progpu-avalonia-silknet-platform-audit.md
+++ b/docs/progpu-avalonia-silknet-platform-audit.md
@@ -21,20 +21,24 @@ framebuffer allocation. It also sent logical resize requests directly to the
 native pixel-sized window. This produced oversized layout, incorrect pointer
 coordinates, constraints, and frame insets at non-100% Windows display scales.
 
-The corrected boundary now converts exactly once in each direction: native
-client pixels and pointer coordinates are divided by `DesktopScaling` when
-entering Avalonia, while logical client sizes and constraints are multiplied
-when entering GLFW. Desktop positions remain physical `PixelPoint` values,
-and the actual GLFW framebuffer remains authoritative. Each conversion is
-bounded `O(1)` arithmetic with no retained allocation or renderer-boundary
-crossing.
+The corrected Windows boundary now converts exactly once in each direction:
+native client pixels and pointer coordinates are divided by `DesktopScaling`
+when entering Avalonia, while logical client sizes and constraints are
+multiplied when entering GLFW. These conversions are deliberately gated to
+Win32. GLFW already reports logical screen coordinates for macOS and scaled
+X11/Wayland desktops, so applying the Win32 conversion there would scale
+layout, input, and constraints twice. Desktop positions remain physical
+`PixelPoint` values, and the actual GLFW framebuffer remains authoritative.
+Each conversion is bounded `O(1)` arithmetic with no retained allocation or
+renderer-boundary crossing.
 
 Windows enters a modal operating-system sizing loop between
 [`WM_ENTERSIZEMOVE`](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-entersizemove)
 and `WM_EXITSIZEMOVE`. That loop prevents the normal outer GLFW render cadence
-from advancing. The Win32 adapter now tracks the modal interval and the resize
-callback synchronously pulses Avalonia layout and presentation only while that
-interval is active. Normal frame scheduling is unchanged.
+from advancing. The Win32 adapter now keeps its window procedure installed for
+both extended-client and ordinary system-chrome windows, tracks the modal
+interval, and synchronously pulses Avalonia layout and presentation only while
+that interval is active. Normal frame scheduling is unchanged.
 
 Custom title-bar dragging previously sent `WM_NCLBUTTONDOWN` synchronously
 with an empty coordinate. The corrected path releases Avalonia pointer capture,
@@ -115,10 +119,11 @@ contract cannot be established by compilation alone.
 - `DesktopScaling` follows the native backend coordinate contract: it is 1 on
   macOS while `RenderScaling` may be 2 or greater; Win32/X11 desktop scaling
   follows the render scale. Avalonia client dimensions, input points, frame
-  insets, and constraints are logical; GLFW client dimensions and pointer
-  coordinates are native. Desktop positions remain physical pixels. Deferred
-  window sizes are converted only after the native window and its scaling are
-  known.
+  insets, and constraints are logical. GLFW client dimensions and pointer
+  coordinates require physical-to-logical conversion only on Win32; macOS and
+  scaled X11/Wayland already expose screen-coordinate units. Desktop positions
+  remain physical pixels. Deferred window sizes are converted only after the
+  native window and its scaling are known.
 - Framebuffer storage uses physical framebuffer pixels. `FrameSize` is unknown
   until native frame insets are available and then includes those insets rather
   than incorrectly returning the client size.
@@ -134,10 +139,11 @@ contract cannot be established by compilation alone.
   allocation-free tracker correlates the expected native size with the next
   callback, preserving application, layout, and DPI reasons without allowing
   a later unrelated user resize to inherit stale state.
-- Win32 modal move/resize state is tracked from the native message stream.
-  Each interactive size notification performs one immediate layout/render
-  pulse so content follows the window edge; steady-state and programmatic
-  resize scheduling retain the normal event-loop path.
+- Win32 modal move/resize state is tracked from the native message stream for
+  both managed custom chrome and ordinary system chrome. Each interactive size
+  notification performs one immediate layout/render pulse so content follows
+  the window edge; steady-state and programmatic resize scheduling retain the
+  normal event-loop path.
 - Managed title-bar moves release pointer capture and are deferred until the
   routed press has unwound. The native non-client message carries the actual
   signed screen coordinate, including negative multi-monitor coordinates.
@@ -219,9 +225,9 @@ completed with zero warnings and zero errors.
 
 - The shared Silk.NET contract suite passes in Release against both exact
   lanes: 91 tests on Avalonia 12.1.1 and 78 tests on Avalonia 11.3.20. The new
-  coverage includes logical/native client-size conversion, one-to-one Windows
-  framebuffer sizing, scaled frame insets and constraints, and scaled pointer
-  input.
+  coverage includes Windows logical/native client-size conversion, one-to-one
+  Windows framebuffer sizing, scaled frame insets and constraints, scaled
+  Windows pointer input, and unchanged Linux screen-coordinate layout/input.
 - Both windowing projects build in Release, and the focused backend windowing
   presenter suite passes 17 tests.
 - Package validation produced both

--- a/docs/progpu-avalonia-silknet-platform-audit.md
+++ b/docs/progpu-avalonia-silknet-platform-audit.md
@@ -1,6 +1,6 @@
 # Avalonia Silk.NET platform contract audit
 
-Audit date: 2026-08-24
+Audit date: 2026-08-25
 
 Supported Avalonia lanes:
 
@@ -10,6 +10,49 @@ Supported Avalonia lanes:
   the latest stable 11.x release at audit time.
 
 ## Incident and root cause
+
+### Windows DPI, interactive resize, and custom title bar
+
+On Windows, GLFW reports both the client size and framebuffer size in physical
+pixels while its content scale describes the conversion from Avalonia logical
+units to those pixels. The Silk.NET host previously exposed the native client
+size as logical units and then multiplied it by the display scale again for
+framebuffer allocation. It also sent logical resize requests directly to the
+native pixel-sized window. This produced oversized layout, incorrect pointer
+coordinates, constraints, and frame insets at non-100% Windows display scales.
+
+The corrected boundary now converts exactly once in each direction: native
+client pixels and pointer coordinates are divided by `DesktopScaling` when
+entering Avalonia, while logical client sizes and constraints are multiplied
+when entering GLFW. Desktop positions remain physical `PixelPoint` values,
+and the actual GLFW framebuffer remains authoritative. Each conversion is
+bounded `O(1)` arithmetic with no retained allocation or renderer-boundary
+crossing.
+
+Windows enters a modal operating-system sizing loop between
+[`WM_ENTERSIZEMOVE`](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-entersizemove)
+and `WM_EXITSIZEMOVE`. That loop prevents the normal outer GLFW render cadence
+from advancing. The Win32 adapter now tracks the modal interval and the resize
+callback synchronously pulses Avalonia layout and presentation only while that
+interval is active. Normal frame scheduling is unchanged.
+
+Custom title-bar dragging previously sent `WM_NCLBUTTONDOWN` synchronously
+with an empty coordinate. The corrected path releases Avalonia pointer capture,
+lets the routed press unwind through a send-priority dispatcher post, and sends
+the signed screen pointer packed in `lParam`, as required by the official
+[`WM_NCLBUTTONDOWN`](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-nclbuttondown)
+contract. This matches the ordering used by Avalonia's official
+[`WindowImpl.BeginMoveDrag`](https://github.com/AvaloniaUI/Avalonia/blob/12.1.1/src/Windows/Avalonia.Win32/WindowImpl.cs)
+without copying its implementation.
+
+GLFW's official [window guide](https://www.glfw.org/docs/3.4/window_guide.html)
+was used as the coordinate-space authority. Its distinction between content
+scale, screen coordinates, and framebuffer pixels was adopted. The prior
+derived framebuffer enlargement and synchronous zero-coordinate title-bar
+message were rejected because they conflict with the public platform
+contracts.
+
+### Platform settings
 
 `DataGridColumnHeader.ProcessSort` asks
 `KeyboardHelper.GetPlatformCtrlOrCmdKeyModifier` for the target platform's
@@ -71,8 +114,11 @@ contract cannot be established by compilation alone.
 
 - `DesktopScaling` follows the native backend coordinate contract: it is 1 on
   macOS while `RenderScaling` may be 2 or greater; Win32/X11 desktop scaling
-  follows the render scale. Deferred window positions are converted only after
-  the native window and its scaling are known.
+  follows the render scale. Avalonia client dimensions, input points, frame
+  insets, and constraints are logical; GLFW client dimensions and pointer
+  coordinates are native. Desktop positions remain physical pixels. Deferred
+  window sizes are converted only after the native window and its scaling are
+  known.
 - Framebuffer storage uses physical framebuffer pixels. `FrameSize` is unknown
   until native frame insets are available and then includes those insets rather
   than incorrectly returning the client size.
@@ -88,6 +134,13 @@ contract cannot be established by compilation alone.
   allocation-free tracker correlates the expected native size with the next
   callback, preserving application, layout, and DPI reasons without allowing
   a later unrelated user resize to inherit stale state.
+- Win32 modal move/resize state is tracked from the native message stream.
+  Each interactive size notification performs one immediate layout/render
+  pulse so content follows the window edge; steady-state and programmatic
+  resize scheduling retain the normal event-loop path.
+- Managed title-bar moves release pointer capture and are deferred until the
+  routed press has unwound. The native non-client message carries the actual
+  signed screen coordinate, including negative multi-monitor coordinates.
 - An unspecified Avalonia 12 frame theme now resolves through registered
   platform settings, as Avalonia.Native and Win32 do. Native backend defaults
   remain correct for direct controller users: Cocoa clears the explicit
@@ -164,8 +217,11 @@ completed with zero warnings and zero errors.
 
 ## Validation evidence
 
-- The shared Silk.NET contract suite passes in Debug and Release against both
-  exact lanes: 85 tests on Avalonia 12.1.1 and 72 tests on Avalonia 11.3.20.
+- The shared Silk.NET contract suite passes in Release against both exact
+  lanes: 91 tests on Avalonia 12.1.1 and 78 tests on Avalonia 11.3.20. The new
+  coverage includes logical/native client-size conversion, one-to-one Windows
+  framebuffer sizing, scaled frame insets and constraints, and scaled pointer
+  input.
 - Both windowing projects build in Release, and the focused backend windowing
   presenter suite passes 17 tests.
 - Package validation produced both
@@ -177,18 +233,27 @@ completed with zero warnings and zero errors.
 - A package-backed Release smoke run on macOS rendered the Charting sample
   through `ProGPU/Silk.NET + embedded ProGPU`, presented non-transparent output
   through the same-device WebGPU texture path at 2x DPI, and exited normally.
+- A self-contained Windows ARM64 package and a framework-dependent ARM64
+  package were launched in the running Parallels Windows 11 session. The first
+  run exposed and then verified removal of a pre-initialization framebuffer
+  query in the new constraint path. The corrected build proceeds past that
+  windowing boundary; the VM's subsequent `wgpu_native.dll` failure occurs in
+  the existing renderer bootstrap before `window.Initialize()` returns, so it
+  is recorded separately and is not attributed to the DPI/windowing change.
 
 ## Managed/native applicability
 
-The platform-settings, dispatcher, screen, window, input, and clipboard work
+The DPI conversion, modal resize pulse, custom title-bar ordering,
+platform-settings, dispatcher, screen, window, input, and clipboard work
 belongs to the managed Avalonia/Silk.NET host. Neither the managed ProGPU scene
 renderer nor the native C++ renderer implements those operating-system
-services, so there is no paired renderer change. The bitmap-encoder update is
-also specific to Avalonia 12's managed `IBitmapImpl` contract; the native C++
-renderer does not expose or consume that interface. Shared scene, shader,
-resource-identity, device-loss, upload, and presentation contracts are
-unchanged, so no managed/native differential fixture or canonical shader needs
-to move for this fix.
+services, so there is no paired renderer change. The same managed and native
+renderer binaries consume the corrected framebuffer dimensions; scene,
+shader, resource-identity, device-loss, upload, and presentation contracts are
+unchanged. The bitmap-encoder update is also specific to Avalonia 12's managed
+`IBitmapImpl` contract; the native C++ renderer does not expose or consume that
+interface. No managed/native differential fixture or canonical shader needs
+to move for these host-only fixes.
 
 No third-party implementation source was copied into ProGPU. The Avalonia and
 GLFW sources were used to identify public contracts and observable platform

--- a/eng/avalonia/12.1.1/progpu.patch
+++ b/eng/avalonia/12.1.1/progpu.patch
@@ -1411,20 +1411,33 @@ index 4a49edd..81914bd 100644
      <ProjectReference Include="..\Avalonia.FreeDesktop.AtSpi\Avalonia.FreeDesktop.AtSpi.csproj" />
      <Compile Include="..\Shared\RawEventGrouping.cs" />
 diff --git a/src/Avalonia.X11/X11Window.cs b/src/Avalonia.X11/X11Window.cs
-index 1ed6124..d0660ff 100644
+index 1ed6124..9e5d9e2 100644
 --- a/src/Avalonia.X11/X11Window.cs
 +++ b/src/Avalonia.X11/X11Window.cs
-@@ -141,7 +141,12 @@ public X11Window(AvaloniaX11Platform platform, IWindowImpl? popupParent, bool ov
+@@ -108,7 +108,15 @@ public X11Window(AvaloniaX11Platform platform, IWindowImpl? popupParent, bool ov
+             _touch = new TouchDevice();
+             _keyboard = platform.KeyboardDevice;
+ 
+-            var glfeature = AvaloniaLocator.Current.GetService<IPlatformGraphics>();
++            bool requiresOpaqueSurface =
++                AvaloniaLocator.Current.GetService<IPlatformRenderInterface>()
++                    is IPlatformRenderInterfaceNativeSurfaceFeature
++                    {
++                        RequiresOpaqueSurface: true
++                    };
++            var glfeature = requiresOpaqueSurface
++                ? null
++                : AvaloniaLocator.Current.GetService<IPlatformGraphics>();
+             XSetWindowAttributes attr = new XSetWindowAttributes();
+             var valueMask = default(SetWindowValuemask);
+ 
+@@ -141,7 +149,8 @@ public X11Window(AvaloniaX11Platform platform, IWindowImpl? popupParent, bool ov
              {
                  visualInfo = X11EglHelper.GetVisualInfo(_x11, egl.Display);
              }
 -            else if (glfeature == null)
 +            else if (glfeature == null &&
-+                     AvaloniaLocator.Current.GetService<IPlatformRenderInterface>()
-+                         is not IPlatformRenderInterfaceNativeSurfaceFeature
-+                         {
-+                             RequiresOpaqueSurface: true
-+                         })
++                     !requiresOpaqueSurface)
                  visualInfo = _x11.TransparentVisualInfo;
  
              var visual = IntPtr.Zero;

--- a/integration/AvaloniaControlCatalogHarness/ControlCatalogTelemetrySession.cs
+++ b/integration/AvaloniaControlCatalogHarness/ControlCatalogTelemetrySession.cs
@@ -246,6 +246,7 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
 #if PROGPU_AVALONIA_BACKEND
             _measurementActive = true;
 #endif
+            _fixture?.ActivateMeasurementMutations();
             _previousAnimationTimestamp = timestamp;
             _measurementStartTimestamp = Stopwatch.GetTimestamp();
             ControlCatalogBenchmarkEventSource.Log.MeasurementStarted(
@@ -280,7 +281,6 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
 
     private void PrepareMeasurement()
     {
-        _fixture?.ActivateMeasurementMutations();
         CollectRetainedMemory();
         _allocatedBytesStart =
             GC.GetTotalAllocatedBytes(precise: true);
@@ -669,16 +669,16 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
             return;
         }
 
+        // RenderTargetBitmap.Render records in the visual's logical coordinate
+        // space. Keep deterministic catalog captures at one pixel per logical
+        // unit; the live-surface telemetry independently validates the native
+        // physical framebuffer size and render scaling.
         int width = Math.Max(
             1,
-            checked((int)Math.Ceiling(
-                _window.Bounds.Width *
-                _window.RenderScaling)));
+            checked((int)Math.Ceiling(_window.Bounds.Width)));
         int height = Math.Max(
             1,
-            checked((int)Math.Ceiling(
-                _window.Bounds.Height *
-                _window.RenderScaling)));
+            checked((int)Math.Ceiling(_window.Bounds.Height)));
         string path = Path.GetFullPath(_screenshotPath);
         string? directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory))
@@ -688,11 +688,9 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
 
         using var bitmap = new RenderTargetBitmap(
             new PixelSize(width, height),
-            new Vector(
-                96d * _window.RenderScaling,
-                96d * _window.RenderScaling));
+            new Vector(96d, 96d));
         bitmap.Render(_window);
-        bitmap.Save(path);
+        bitmap.Save(path, PngBitmapEncoderOptions.Default);
     }
 
     private void SignalDiagnosticHold()
@@ -905,6 +903,7 @@ internal sealed class BenchmarkVisualFixture
     private readonly Visual _target;
     private readonly Panel? _panel;
     private readonly bool _customVisual;
+    private readonly bool _geometryClip;
     private readonly bool _drawingOptions;
     private readonly bool _topology;
     private readonly bool _adorner;
@@ -925,6 +924,7 @@ internal sealed class BenchmarkVisualFixture
         Panel? panel,
         BenchmarkPulseControl? pulse,
         bool customVisual,
+        bool geometryClip,
         bool drawingOptions,
         bool topology,
         bool adorner,
@@ -939,6 +939,7 @@ internal sealed class BenchmarkVisualFixture
         _panel = panel;
         _pulse = pulse;
         _customVisual = customVisual;
+        _geometryClip = geometryClip;
         _drawingOptions = drawingOptions;
         _topology = topology;
         _adorner = adorner;
@@ -1125,6 +1126,7 @@ internal sealed class BenchmarkVisualFixture
             panel,
             pulse,
             customVisual,
+            geometryClip,
             drawingOptions,
             topology,
             adorner,
@@ -1216,6 +1218,18 @@ internal sealed class BenchmarkVisualFixture
 
     public void ActivateMeasurementMutations()
     {
+        if (_geometryClip)
+        {
+            _target.Clip = new RectangleGeometry(
+                new Rect(
+                    1.25,
+                    1.25,
+                    Math.Max(1, _target.Bounds.Width - 2.5),
+                    Math.Max(1, _target.Bounds.Height - 2.5)));
+            Console.Error.WriteLine(
+                "[ControlCatalog] typed retained geometry-clip channel fixture attached");
+        }
+
         if (_drawingOptions)
         {
             RenderOptions.SetBitmapInterpolationMode(

--- a/integration/AvaloniaControlCatalogHarness/SilkNetInputTelemetrySession.cs
+++ b/integration/AvaloniaControlCatalogHarness/SilkNetInputTelemetrySession.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace ProGpu.Avalonia.Integration;
+
+/// <summary>
+/// Records real routed input delivered by the Silk.NET windowing backend.
+/// The harness is intentionally driven by external OS/VM automation rather
+/// than by raising Avalonia events in-process.
+/// </summary>
+internal sealed class SilkNetInputTelemetrySession : IDisposable
+{
+    private const string OutputVariable =
+        "PROGPU_AVALONIA_INPUT_OUTPUT";
+    private const string ExpectedVariable =
+        "PROGPU_AVALONIA_INPUT_EXPECT";
+    private const string TimeoutVariable =
+        "PROGPU_AVALONIA_INPUT_TIMEOUT_SECONDS";
+
+    private readonly string _outputPath;
+    private readonly HashSet<string> _expected;
+    private readonly Dictionary<string, int> _observed =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly IDisposable _windowOpenedSubscription;
+    private readonly DispatcherTimer _timer;
+    private readonly DateTime _deadline;
+    private Window? _window;
+    private PixelPoint _initialPosition;
+    private Size _lastLayoutSize;
+    private bool _hasInitialPosition;
+    private bool _hasLayoutSize;
+    private bool _attached;
+    private bool _completed;
+
+    private SilkNetInputTelemetrySession(
+        string outputPath,
+        HashSet<string> expected,
+        int timeoutSeconds)
+    {
+        _outputPath = outputPath;
+        _expected = expected;
+        _deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        _windowOpenedSubscription =
+            Window.WindowOpenedEvent.AddClassHandler<Window>(
+                OnWindowOpened);
+        _timer = new DispatcherTimer(
+            TimeSpan.FromMilliseconds(250),
+            DispatcherPriority.Background,
+            OnTimerTick);
+    }
+
+    internal static SilkNetInputTelemetrySession? TryStart(
+        bool nativeWindowing)
+    {
+        string? outputPath =
+            Environment.GetEnvironmentVariable(OutputVariable);
+        if (string.IsNullOrWhiteSpace(outputPath))
+            return null;
+        if (nativeWindowing)
+        {
+            throw new InvalidOperationException(
+                "Silk.NET input telemetry requires Silk.NET windowing.");
+        }
+
+        string expectedText =
+            Environment.GetEnvironmentVariable(ExpectedVariable) ??
+            "keyboard,text,pointer,wheel,shortcut";
+        HashSet<string> expected = expectedText
+            .Split(',', StringSplitOptions.RemoveEmptyEntries |
+                StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        int timeout = int.TryParse(
+                Environment.GetEnvironmentVariable(TimeoutVariable),
+                out int value) && value > 0
+            ? value
+            : 30;
+        return new SilkNetInputTelemetrySession(
+            Path.GetFullPath(outputPath),
+            expected,
+            timeout);
+    }
+
+    internal void Attach()
+    {
+        if (_attached)
+        {
+            throw new InvalidOperationException(
+                "Silk.NET input telemetry was attached twice.");
+        }
+
+        _attached = true;
+        _timer.Start();
+    }
+
+    public void Dispose()
+    {
+        _timer.Stop();
+        _windowOpenedSubscription.Dispose();
+    }
+
+    private void OnWindowOpened(
+        Window window,
+        RoutedEventArgs args)
+    {
+        _ = args;
+        if (!_attached || _window is not null)
+            return;
+
+        _window = window;
+        _initialPosition = window.Position;
+        _hasInitialPosition = true;
+        window.PositionChanged += OnPositionChanged;
+        window.PropertyChanged += OnWindowPropertyChanged;
+        window.LayoutUpdated += OnLayoutUpdated;
+        window.AddHandler(
+            InputElement.KeyDownEvent,
+            OnKeyDown,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.KeyUpEvent,
+            OnKeyUp,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.TextInputEvent,
+            OnTextInput,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerMovedEvent,
+            OnPointerMoved,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerPressedEvent,
+            OnPointerPressed,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerReleasedEvent,
+            OnPointerReleased,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerWheelChangedEvent,
+            OnPointerWheel,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerTouchPadGestureMagnifyEvent,
+            OnMagnify,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerTouchPadGestureRotateEvent,
+            OnRotate,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+        window.AddHandler(
+            InputElement.PointerTouchPadGestureSwipeEvent,
+            OnSwipe,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+            handledEventsToo: true);
+
+        KeyModifiers commandModifier = OperatingSystem.IsMacOS()
+            ? KeyModifiers.Meta
+            : KeyModifiers.Control;
+        window.KeyBindings.Add(
+            new KeyBinding
+            {
+                Gesture = new KeyGesture(
+                    Key.K,
+                    commandModifier | KeyModifiers.Shift),
+                Command = new CallbackCommand(
+                    () => Record("shortcut"))
+            });
+        Dispatcher.UIThread.Post(
+            () => window.GetVisualDescendants()
+                .OfType<TextBox>()
+                .FirstOrDefault()?
+                .Focus(),
+            DispatcherPriority.Input);
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        Record("key-down");
+        RecordKeyboardIfComplete();
+    }
+
+    private void OnKeyUp(object? sender, KeyEventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        Record("key-up");
+        RecordKeyboardIfComplete();
+    }
+
+    private void OnTextInput(object? sender, TextInputEventArgs args)
+    {
+        _ = sender;
+        if (!string.IsNullOrEmpty(args.Text))
+            Record("text");
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        Record("pointer-move");
+        RecordPointerIfComplete();
+    }
+
+    private void OnPointerPressed(
+        object? sender,
+        PointerPressedEventArgs args)
+    {
+        _ = sender;
+        Record("pointer-press");
+        RecordPointerButton(
+            args.GetCurrentPoint(_window)
+                .Properties.PointerUpdateKind);
+        if (args.Pointer.Type == PointerType.Touch)
+            Record("touch-press");
+        RecordPointerIfComplete();
+    }
+
+    private void OnPointerReleased(
+        object? sender,
+        PointerReleasedEventArgs args)
+    {
+        _ = sender;
+        Record("pointer-release");
+        RecordPointerButton(
+            args.GetCurrentPoint(_window)
+                .Properties.PointerUpdateKind);
+        if (args.Pointer.Type == PointerType.Touch)
+        {
+            Record("touch-release");
+            if (Has("touch-press"))
+                Record("touch");
+        }
+        RecordPointerIfComplete();
+    }
+
+    private void OnPointerWheel(
+        object? sender,
+        PointerWheelEventArgs args)
+    {
+        _ = sender;
+        if (args.Delta.X != 0 || args.Delta.Y != 0)
+            Record("wheel");
+    }
+
+    private void OnMagnify(object? sender, PointerDeltaEventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        Record("magnify");
+    }
+
+    private void OnRotate(object? sender, PointerDeltaEventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        Record("rotate");
+    }
+
+    private void OnSwipe(object? sender, PointerDeltaEventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        Record("swipe");
+    }
+
+    private void OnPositionChanged(object? sender, PixelPointEventArgs args)
+    {
+        _ = sender;
+        if (_hasInitialPosition &&
+            (Math.Abs(args.Point.X - _initialPosition.X) >= 100 ||
+             Math.Abs(args.Point.Y - _initialPosition.Y) >= 100))
+        {
+            Record("move");
+        }
+    }
+
+    private void OnWindowPropertyChanged(
+        object? sender,
+        AvaloniaPropertyChangedEventArgs args)
+    {
+        _ = sender;
+        if (args.Property == TopLevel.ClientSizeProperty)
+        {
+            Record("resize-sample");
+            RecordResizeIfComplete();
+        }
+    }
+
+    private void OnLayoutUpdated(object? sender, EventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        if (_window is null)
+            return;
+
+        Size size = _window.ClientSize;
+        if (!_hasLayoutSize)
+        {
+            _lastLayoutSize = size;
+            _hasLayoutSize = true;
+            return;
+        }
+
+        if (size == _lastLayoutSize)
+            return;
+
+        _lastLayoutSize = size;
+        Record("layout-resize");
+        RecordResizeIfComplete();
+    }
+
+    private void RecordResizeIfComplete()
+    {
+        // A final-only resize notification is insufficient here. Requiring
+        // multiple matching client-size and layout observations proves that
+        // Avalonia continued arranging while the native size loop was active.
+        if (Count("resize-sample") >= 3 && Count("layout-resize") >= 3)
+            Record("resize");
+    }
+
+    private void RecordPointerButton(PointerUpdateKind kind)
+    {
+        string? name = kind switch
+        {
+            PointerUpdateKind.LeftButtonPressed or
+            PointerUpdateKind.LeftButtonReleased => "mouse-left",
+            PointerUpdateKind.RightButtonPressed or
+            PointerUpdateKind.RightButtonReleased => "mouse-right",
+            PointerUpdateKind.MiddleButtonPressed or
+            PointerUpdateKind.MiddleButtonReleased => "mouse-middle",
+            PointerUpdateKind.XButton1Pressed or
+            PointerUpdateKind.XButton1Released => "mouse-x1",
+            PointerUpdateKind.XButton2Pressed or
+            PointerUpdateKind.XButton2Released => "mouse-x2",
+            _ => null
+        };
+        if (name is not null)
+            Record(name);
+    }
+
+    private void RecordKeyboardIfComplete()
+    {
+        if (Has("key-down") && Has("key-up"))
+            Record("keyboard");
+    }
+
+    private void RecordPointerIfComplete()
+    {
+        if (Has("pointer-move") &&
+            Has("pointer-press") &&
+            Has("pointer-release"))
+        {
+            Record("pointer");
+        }
+    }
+
+    private void Record(string name)
+    {
+        _observed.TryGetValue(name, out int count);
+        _observed[name] = count + 1;
+        if (!_completed && _expected.All(Has))
+            Complete(passed: true, error: null);
+    }
+
+    private bool Has(string name) =>
+        _observed.TryGetValue(name, out int count) && count > 0;
+
+    private int Count(string name) =>
+        _observed.TryGetValue(name, out int count) ? count : 0;
+
+    private void OnTimerTick(object? sender, EventArgs args)
+    {
+        _ = sender;
+        _ = args;
+        if (!_completed && DateTime.UtcNow >= _deadline)
+            Complete(passed: false, error: "Input telemetry timed out.");
+    }
+
+    private void Complete(bool passed, string? error)
+    {
+        if (_completed)
+            return;
+        _completed = true;
+        _timer.Stop();
+        string? directory = Path.GetDirectoryName(_outputPath);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+        using FileStream output = File.Create(_outputPath);
+        using var writer = new Utf8JsonWriter(
+            output,
+            new JsonWriterOptions { Indented = true });
+        writer.WriteStartObject();
+        writer.WriteBoolean("Passed", passed);
+        writer.WriteStartArray("Expected");
+        foreach (string name in _expected.Order())
+            writer.WriteStringValue(name);
+        writer.WriteEndArray();
+        writer.WriteStartObject("Observed");
+        foreach ((string name, int count) in _observed.OrderBy(x => x.Key))
+            writer.WriteNumber(name, count);
+        writer.WriteEndObject();
+        if (_window is not null)
+        {
+            writer.WriteStartObject("Window");
+            writer.WriteNumber("PositionX", _window.Position.X);
+            writer.WriteNumber("PositionY", _window.Position.Y);
+            writer.WriteNumber("ClientWidth", _window.ClientSize.Width);
+            writer.WriteNumber("ClientHeight", _window.ClientSize.Height);
+            writer.WriteNumber("RenderScaling", _window.RenderScaling);
+            writer.WriteEndObject();
+        }
+        if (error is not null)
+            writer.WriteString("Error", error);
+        writer.WriteEndObject();
+        writer.Flush();
+        Environment.Exit(passed ? 0 : 12);
+    }
+
+    private sealed class CallbackCommand(Action action) : ICommand
+    {
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public bool CanExecute(object? parameter)
+        {
+            _ = parameter;
+            return true;
+        }
+
+        public void Execute(object? parameter)
+        {
+            _ = parameter;
+            action();
+        }
+    }
+}

--- a/integration/AvaloniaSilkNetInputHarness/AvaloniaSilkNetInputHarness.csproj
+++ b/integration/AvaloniaSilkNetInputHarness/AvaloniaSilkNetInputHarness.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AvaloniaControlCatalogHarness\SilkNetInputTelemetrySession.cs"
+             Link="SilkNetInputTelemetrySession.cs" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.HarfBuzz" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <ProjectReference Include="..\..\src\ProGPU.Avalonia.SilkNet\ProGPU.Avalonia.SilkNet.csproj" />
+  </ItemGroup>
+</Project>

--- a/integration/AvaloniaSilkNetInputHarness/InputApplication.cs
+++ b/integration/AvaloniaSilkNetInputHarness/InputApplication.cs
@@ -1,0 +1,24 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Themes.Fluent;
+
+namespace AvaloniaSilkNetInputHarness;
+
+internal sealed class InputApplication : Application
+{
+    public override void Initialize()
+    {
+        Styles.Add(new FluentTheme());
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is
+            IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new InputWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/integration/AvaloniaSilkNetInputHarness/InputWindow.cs
+++ b/integration/AvaloniaSilkNetInputHarness/InputWindow.cs
@@ -1,0 +1,91 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace AvaloniaSilkNetInputHarness;
+
+internal sealed class InputWindow : Window
+{
+    internal InputWindow()
+    {
+        Title = "ProGPU Avalonia Silk.NET input validation";
+        Width = 720;
+        Height = 480;
+        MinWidth = 420;
+        MinHeight = 280;
+        ExtendClientAreaToDecorationsHint = true;
+        ExtendClientAreaTitleBarHeightHint = 44;
+
+        var titleBar = new Border
+        {
+            Height = 44,
+            Background = new SolidColorBrush(Color.FromRgb(38, 42, 50)),
+            Padding = new Thickness(16, 0),
+            Child = new TextBlock
+            {
+                Text = "Silk.NET input validation",
+                Foreground = Brushes.White,
+                VerticalAlignment = VerticalAlignment.Center
+            }
+        };
+        titleBar.PointerPressed += OnTitleBarPointerPressed;
+
+        var editor = new TextBox
+        {
+            Name = "InputEditor",
+            PlaceholderText = "Type here",
+            Width = 360,
+            HorizontalAlignment = HorizontalAlignment.Left
+        };
+
+        var content = new StackPanel
+        {
+            Margin = new Thickness(28),
+            Spacing = 16,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = "Mouse, touch, keyboard, shortcuts, and gestures",
+                    FontSize = 22
+                },
+                editor,
+                new Border
+                {
+                    Height = 220,
+                    Background = new SolidColorBrush(
+                        Color.FromRgb(224, 232, 244)),
+                    CornerRadius = new CornerRadius(12),
+                    Child = new TextBlock
+                    {
+                        Text = "Pointer target",
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center
+                    }
+                }
+            }
+        };
+
+        Content = new Grid
+        {
+            RowDefinitions = new RowDefinitions("44,*"),
+            Children =
+            {
+                titleBar,
+                content
+            }
+        };
+        Grid.SetRow(content, 1);
+    }
+
+    private void OnTitleBarPointerPressed(
+        object? sender,
+        PointerPressedEventArgs args)
+    {
+        _ = sender;
+        if (args.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(args);
+    }
+}

--- a/integration/AvaloniaSilkNetInputHarness/Program.cs
+++ b/integration/AvaloniaSilkNetInputHarness/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using Avalonia;
+using ProGpu.Avalonia.Integration;
+
+namespace AvaloniaSilkNetInputHarness;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        using SilkNetInputTelemetrySession? telemetry =
+            SilkNetInputTelemetrySession.TryStart(
+                nativeWindowing: false);
+        AppBuilder builder = BuildAvaloniaApp();
+        builder.AfterSetup(_ => telemetry?.Attach());
+        return builder.StartWithClassicDesktopLifetime(args);
+    }
+
+    internal static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<InputApplication>()
+            .UseSilkNet()
+            .UseSkia()
+            .UseHarfBuzz()
+            .WithInterFont();
+}

--- a/integration/AvaloniaSilkNetInputHarness/windows-inject-input.ps1
+++ b/integration/AvaloniaSilkNetInputHarness/windows-inject-input.ps1
@@ -1,0 +1,189 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("TitleBarDrag", "Resize", "XButtons")]
+    [string] $Action
+)
+
+$ErrorActionPreference = "Stop"
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class ProGpuWindowsInput
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Rect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetWindowRect(IntPtr window, out Rect rect);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetDpiForWindow(IntPtr window);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetCursorPos(int x, int y);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetForegroundWindow(IntPtr window);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetProcessDpiAwarenessContext(IntPtr context);
+
+    [DllImport("user32.dll")]
+    public static extern void mouse_event(
+        uint flags,
+        uint dx,
+        uint dy,
+        uint data,
+        UIntPtr extraInfo);
+
+    public const uint LeftDown = 0x0002;
+    public const uint LeftUp = 0x0004;
+    public const uint XDown = 0x0080;
+    public const uint XUp = 0x0100;
+}
+"@
+
+# Match the target's per-monitor-v2 coordinate space before reading its
+# physical window rectangle or injecting absolute pointer coordinates.
+[void] [ProGpuWindowsInput]::SetProcessDpiAwarenessContext([IntPtr] (-4))
+
+function Get-TargetProcess {
+    $process = Get-Process -Name "AvaloniaSilkNetInputHarness" `
+        -ErrorAction SilentlyContinue |
+        Where-Object { $_.MainWindowHandle -ne 0 } |
+        Sort-Object StartTime -Descending |
+        Select-Object -First 1
+    if ($null -eq $process) {
+        throw "AvaloniaSilkNetInputHarness has no visible top-level window."
+    }
+
+    return $process
+}
+
+function Get-WindowRect([IntPtr] $window) {
+    $rect = New-Object ProGpuWindowsInput+Rect
+    if (-not [ProGpuWindowsInput]::GetWindowRect($window, [ref] $rect)) {
+        throw "GetWindowRect failed."
+    }
+
+    return $rect
+}
+
+function Send-MouseButton([uint32] $down, [uint32] $up, [uint32] $data) {
+    [ProGpuWindowsInput]::mouse_event($down, 0, 0, $data, [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 40
+    [ProGpuWindowsInput]::mouse_event($up, 0, 0, $data, [UIntPtr]::Zero)
+}
+
+$target = Get-TargetProcess
+$window = [IntPtr] $target.MainWindowHandle
+[void] [ProGpuWindowsInput]::SetForegroundWindow($window)
+Start-Sleep -Milliseconds 100
+$before = Get-WindowRect $window
+
+switch ($Action) {
+    "TitleBarDrag" {
+        $dpi = [ProGpuWindowsInput]::GetDpiForWindow($window)
+        $x = $before.Left + [int] (($before.Right - $before.Left) / 2)
+        $y = $before.Top + [int] (22 * $dpi / 96)
+        [void] [ProGpuWindowsInput]::SetCursorPos($x, $y)
+        [ProGpuWindowsInput]::mouse_event(
+            [ProGpuWindowsInput]::LeftDown,
+            0,
+            0,
+            0,
+            [UIntPtr]::Zero)
+        for ($step = 1; $step -le 20; $step++) {
+            [void] [ProGpuWindowsInput]::SetCursorPos(
+                $x + (15 * $step),
+                $y + (8 * $step))
+            Start-Sleep -Milliseconds 20
+        }
+        [ProGpuWindowsInput]::mouse_event(
+            [ProGpuWindowsInput]::LeftUp,
+            0,
+            0,
+            0,
+            [UIntPtr]::Zero)
+    }
+    "Resize" {
+        $x = $before.Right - 3
+        $y = $before.Bottom - 3
+        [void] [ProGpuWindowsInput]::SetCursorPos($x, $y)
+        [ProGpuWindowsInput]::mouse_event(
+            [ProGpuWindowsInput]::LeftDown,
+            0,
+            0,
+            0,
+            [UIntPtr]::Zero)
+        for ($step = 1; $step -le 20; $step++) {
+            [void] [ProGpuWindowsInput]::SetCursorPos(
+                $x + (20 * $step),
+                $y + (12 * $step))
+            Start-Sleep -Milliseconds 25
+        }
+        [ProGpuWindowsInput]::mouse_event(
+            [ProGpuWindowsInput]::LeftUp,
+            0,
+            0,
+            0,
+            [UIntPtr]::Zero)
+    }
+    "XButtons" {
+        $x = $before.Left + [int] (($before.Right - $before.Left) / 2)
+        $y = $before.Top + [int] (($before.Bottom - $before.Top) / 2)
+        [void] [ProGpuWindowsInput]::SetCursorPos($x, $y)
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::XDown) `
+            ([ProGpuWindowsInput]::XUp) `
+            1
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::XDown) `
+            ([ProGpuWindowsInput]::XUp) `
+            2
+    }
+}
+
+Start-Sleep -Milliseconds 200
+$after = $null
+try {
+    $after = Get-WindowRect $window
+}
+catch {
+    # The telemetry harness exits immediately after all expected events are
+    # observed, so a successful injection can legitimately close the target.
+}
+$afterResult = if ($null -eq $after) {
+    $null
+}
+else {
+    [ordered]@{
+        Left = $after.Left
+        Top = $after.Top
+        Width = $after.Right - $after.Left
+        Height = $after.Bottom - $after.Top
+    }
+}
+[ordered]@{
+    Action = $Action
+    Before = [ordered]@{
+        Left = $before.Left
+        Top = $before.Top
+        Width = $before.Right - $before.Left
+        Height = $before.Bottom - $before.Top
+    }
+    After = $afterResult
+    TargetExited = $null -eq $after
+} | ConvertTo-Json -Depth 3

--- a/integration/AvaloniaSourceControlCatalog/AvaloniaSourceControlCatalog.csproj
+++ b/integration/AvaloniaSourceControlCatalog/AvaloniaSourceControlCatalog.csproj
@@ -17,6 +17,8 @@
              Link="ControlCatalogTelemetrySession.cs" />
     <Compile Include="..\AvaloniaControlCatalogHarness\ControlCatalogRuntimeTitle.cs"
              Link="ControlCatalogRuntimeTitle.cs" />
+    <Compile Include="..\AvaloniaControlCatalogHarness\SilkNetInputTelemetrySession.cs"
+             Link="SilkNetInputTelemetrySession.cs" />
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\packages\Avalonia\Avalonia.csproj" />
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\samples\ControlCatalog\ControlCatalog.csproj"
                       AdditionalProperties="AvaloniaSingleProject=false;UseSkiaSharpShim=true;ProGpuSourceRoot=$(ProGpuSourceRoot);ProGpuAvaloniaSourceRoot=$(ProGpuAvaloniaSourceRoot)" />

--- a/integration/AvaloniaSourceControlCatalog/Program.cs
+++ b/integration/AvaloniaSourceControlCatalog/Program.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Logging;
 using Avalonia.ProGpu;
 using ControlCatalog;
+using ProGpu.Avalonia.Integration;
 
 namespace ControlCatalog.Desktop
 {
@@ -43,6 +44,9 @@ namespace ControlCatalog.Desktop
                     : "ProGPU.SourceBuilt.SilkNet",
                 App.InitialPage,
                 useHarfBuzz ? "HarfBuzz" : "ProGPU");
+            using var inputTelemetry =
+                SilkNetInputTelemetrySession.TryStart(
+                    useNativeWindowing);
             AppBuilder builder = BuildAvaloniaApp(
                 useHarfBuzz,
                 requireNativeCompositionScene: !allowCompositionFallback,
@@ -50,7 +54,11 @@ namespace ControlCatalog.Desktop
                 requireDawnMetalPresentation:
                     useNativeWindowing &&
                     !allowDawnPresentationFallback);
-            builder.AfterSetup(_ => benchmark?.Attach());
+            builder.AfterSetup(_ =>
+            {
+                benchmark?.Attach();
+                inputTelemetry?.Attach();
+            });
             return builder.StartWithClassicDesktopLifetime(args);
         }
 

--- a/integration/ProGpuAvaloniaPackageSmoke/WindowChromeSmokeCoordinator.cs
+++ b/integration/ProGpuAvaloniaPackageSmoke/WindowChromeSmokeCoordinator.cs
@@ -22,6 +22,7 @@ internal sealed class WindowChromeSmokeCoordinator
     private readonly string? _outputPath;
     private readonly int _targetFrames;
     private readonly bool _requireRetainedCompositor;
+    private readonly bool _manualInteraction;
     private readonly SmokeWindow _owner;
     private SmokeWindow? _owned;
     private int _frameCount;
@@ -40,6 +41,8 @@ internal sealed class WindowChromeSmokeCoordinator
             "PROGPU_PACKAGE_SMOKE_FRAMES");
         _requireRetainedCompositor = ReadBoolean(
             "PROGPU_PACKAGE_SMOKE_REQUIRE_RETAINED");
+        _manualInteraction = ReadBoolean(
+            "PROGPU_PACKAGE_SMOKE_MANUAL");
         _owner = new SmokeWindow(standalone: false)
         {
             Title =
@@ -82,6 +85,9 @@ internal sealed class WindowChromeSmokeCoordinator
     {
         _ = sender;
         _ = e;
+        if (_manualInteraction)
+            return;
+
         Dispatcher.UIThread.Post(
             ValidateOwnerAndOpenChild,
             DispatcherPriority.Background);
@@ -337,6 +343,24 @@ internal sealed class WindowChromeSmokeCoordinator
         writer.WriteNumber(
             "ExtendedTopMargin",
             owner?.ExtendedMargins.Top ?? 0);
+        writer.WriteNumber(
+            "DesktopScaling",
+            owner?.DesktopScaling ?? 0);
+        writer.WriteNumber(
+            "RenderScaling",
+            owner?.RenderScaling ?? 0);
+        writer.WriteNumber(
+            "LogicalClientWidth",
+            owner?.ClientSize.Width ?? 0);
+        writer.WriteNumber(
+            "LogicalClientHeight",
+            owner?.ClientSize.Height ?? 0);
+        writer.WriteNumber(
+            "FramebufferWidth",
+            owner?.FramebufferPixelSize.Width ?? 0);
+        writer.WriteNumber(
+            "FramebufferHeight",
+            owner?.FramebufferPixelSize.Height ?? 0);
         writer.WriteString(
             "TransparencyLevel",
             owner?.TransparencyLevel.ToString() ??

--- a/integration/README.md
+++ b/integration/README.md
@@ -8,7 +8,7 @@ backend.
 Run all commands from the repository root:
 
 ```bash
-cd /Users/wieslawsoltes/GitHub/ProGPU-clean-preview27
+cd /path/to/ProGPU
 ```
 
 The source-host scripts prepare the pinned Avalonia 12.1.1 checkout
@@ -282,6 +282,57 @@ initialization failures.
 | `--native-windowing` | off | Use Avalonia Native, Win32, or X11 instead of Silk.NET/GLFW |
 | `--allow-composition-fallback` | off | Permit flattened rendering when retained composition is unavailable |
 | `--allow-dawn-presentation-fallback` | off | Permit non-Dawn presentation if strict native Dawn startup fails |
+
+## Silk.NET windowing and input harness
+
+`AvaloniaSilkNetInputHarness` uses the production Silk.NET/GLFW windowing
+backend with Avalonia's Skia renderer. Keeping rendering independent makes
+native window, DPI, resize, custom-titlebar, and routed-input validation useful
+even on a VM whose WebGPU driver cannot run the larger ControlCatalog workload.
+The harness exits with code 0 as soon as every expected category is observed,
+or code 12 on timeout:
+
+```bash
+PROGPU_AVALONIA_INPUT_OUTPUT=/tmp/progpu-input.json \
+PROGPU_AVALONIA_INPUT_EXPECT='keyboard,text,pointer,wheel,shortcut,mouse-left,mouse-right,mouse-middle,mouse-x1,mouse-x2' \
+PROGPU_AVALONIA_INPUT_TIMEOUT_SECONDS=120 \
+dotnet run \
+  --project integration/AvaloniaSilkNetInputHarness/AvaloniaSilkNetInputHarness.csproj \
+  --configuration Release
+```
+
+Supported expected categories are `keyboard`, `text`, `pointer`, `wheel`,
+`shortcut`, `mouse-left`, `mouse-right`, `mouse-middle`, `mouse-x1`,
+`mouse-x2`, `touch`, `magnify`, `rotate`, `swipe`, `move`, and `resize`.
+`resize` requires at least three native client-size notifications and three
+matching Avalonia layout-size changes, so a final-only resize callback cannot
+pass. `move` requires a 100-pixel native position delta from the initial
+placement. The JSON also records the final logical client, native position,
+and Avalonia render scaling.
+
+For an interactive Windows VM, publish for its RID and run the process in the
+logged-in desktop session. The companion injector drives X1/X2 buttons, the
+custom title bar, and a gradual resize using the target's per-monitor-v2
+physical coordinate space:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File integration\AvaloniaSilkNetInputHarness\windows-inject-input.ps1 `
+  -Action XButtons
+
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File integration\AvaloniaSilkNetInputHarness\windows-inject-input.ps1 `
+  -Action TitleBarDrag
+
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File integration\AvaloniaSilkNetInputHarness\windows-inject-input.ps1 `
+  -Action Resize
+```
+
+Physical touch and trackpad gestures must be supplied by capable hardware (or
+a platform-specific trusted device injector). Focused contracts cover Win32
+`WM_TOUCH`, XI2.2 layouts/phases, promoted-mouse suppression, and AppKit
+gesture mapping when such hardware is unavailable in CI.
 
 ## Original Skia ControlCatalog
 

--- a/src/ProGPU.Avalonia.Rendering/ImmutableProGpuBitmap.cs
+++ b/src/ProGPU.Avalonia.Rendering/ImmutableProGpuBitmap.cs
@@ -237,7 +237,11 @@ internal sealed class ImmutableBitmap :
                 stream.Write(encoded);
                 return;
 #else
-                using Image<Rgba32> decoded = Image.Load<Rgba32>(encoded);
+                Rgba32[] decodedPixels = AvaloniaEncodedImage.Decode(encoded);
+                using Image<Rgba32> decoded = Image.LoadPixelData(
+                    decodedPixels,
+                    PixelSize.Width,
+                    PixelSize.Height);
                 AvaloniaBitmapEncoding.Save(decoded, stream, options);
                 return;
 #endif

--- a/src/ProGPU.Avalonia.SilkNet/MacOsGestureInputSource.cs
+++ b/src/ProGPU.Avalonia.SilkNet/MacOsGestureInputSource.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Silk.NET.Windowing;
+
+namespace Avalonia.SilkNet;
+
+internal enum MacOsGestureKind
+{
+    Magnify,
+    Rotate,
+    Swipe
+}
+
+internal readonly record struct MacOsGestureEvent(
+    MacOsGestureKind Kind,
+    double DeltaX,
+    double DeltaY);
+
+/// <summary>
+/// Adds the three public NSResponder gesture methods that GLFW's content view
+/// does not implement. Methods remain installed on the process-local GLFW
+/// view class and dispatch only while a source is registered for the view.
+/// </summary>
+internal sealed unsafe class MacOsGestureInputSource : IDisposable
+{
+    private const string ObjCLibrary = "/usr/lib/libobjc.A.dylib";
+    private static readonly object Gate = new();
+    private static readonly Dictionary<nint, Action<MacOsGestureEvent>>
+        Handlers = [];
+    private static readonly HashSet<nint> InstalledClasses = [];
+    private static nint s_magnificationSelector;
+    private static nint s_rotationSelector;
+    private static nint s_deltaXSelector;
+    private static nint s_deltaYSelector;
+
+    private readonly nint _view;
+    private bool _disposed;
+
+    private MacOsGestureInputSource(
+        nint view,
+        Action<MacOsGestureEvent> handler)
+    {
+        _view = view;
+        Handlers[view] = handler;
+    }
+
+    internal static MacOsGestureInputSource? TryCreate(
+        IWindow window,
+        Action<MacOsGestureEvent> handler)
+    {
+        if (!OperatingSystem.IsMacOS() ||
+            window.Native?.Cocoa is not { } nsWindow ||
+            nsWindow == 0)
+        {
+            return null;
+        }
+
+        nint contentView = SendObject(
+            nsWindow,
+            sel_registerName("contentView"));
+        nint viewClass = object_getClass(contentView);
+        if (contentView == 0 || viewClass == 0)
+            return null;
+
+        lock (Gate)
+        {
+            s_magnificationSelector =
+                sel_registerName("magnification");
+            s_rotationSelector = sel_registerName("rotation");
+            s_deltaXSelector = sel_registerName("deltaX");
+            s_deltaYSelector = sel_registerName("deltaY");
+            if (!InstalledClasses.Contains(viewClass) &&
+                !InstallGestureMethods(viewClass))
+            {
+                return null;
+            }
+
+            InstalledClasses.Add(viewClass);
+            return new MacOsGestureInputSource(
+                contentView,
+                handler);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        lock (Gate)
+            Handlers.Remove(_view);
+    }
+
+    private static bool InstallGestureMethods(nint viewClass)
+    {
+        const string signature = "v@:@";
+        return EnsureMethod(
+                viewClass,
+                sel_registerName("magnifyWithEvent:"),
+                (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)
+                    &OnMagnify,
+                signature) &&
+            EnsureMethod(
+                viewClass,
+                sel_registerName("rotateWithEvent:"),
+                (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)
+                    &OnRotate,
+                signature) &&
+            EnsureMethod(
+                viewClass,
+                sel_registerName("swipeWithEvent:"),
+                (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)
+                    &OnSwipe,
+                signature);
+    }
+
+    private static bool EnsureMethod(
+        nint viewClass,
+        nint selector,
+        nint implementation,
+        string signature)
+    {
+        if (class_addMethod(
+                viewClass,
+                selector,
+                implementation,
+                signature))
+        {
+            return true;
+        }
+
+        nint method = class_getInstanceMethod(viewClass, selector);
+        return method != 0 &&
+            method_getImplementation(method) == implementation;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnMagnify(
+        nint view,
+        nint selector,
+        nint nsevent)
+    {
+        _ = selector;
+        double delta = SendDouble(
+            nsevent,
+            s_magnificationSelector);
+        Dispatch(
+            view,
+            new MacOsGestureEvent(
+                MacOsGestureKind.Magnify,
+                delta,
+                delta));
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnRotate(
+        nint view,
+        nint selector,
+        nint nsevent)
+    {
+        _ = selector;
+        double delta = SendDouble(nsevent, s_rotationSelector);
+        Dispatch(
+            view,
+            new MacOsGestureEvent(
+                MacOsGestureKind.Rotate,
+                delta,
+                delta));
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnSwipe(
+        nint view,
+        nint selector,
+        nint nsevent)
+    {
+        _ = selector;
+        Dispatch(
+            view,
+            new MacOsGestureEvent(
+                MacOsGestureKind.Swipe,
+                SendDouble(nsevent, s_deltaXSelector),
+                SendDouble(nsevent, s_deltaYSelector)));
+    }
+
+    private static void Dispatch(
+        nint view,
+        MacOsGestureEvent gesture)
+    {
+        Action<MacOsGestureEvent>? handler;
+        lock (Gate)
+            Handlers.TryGetValue(view, out handler);
+        handler?.Invoke(gesture);
+    }
+
+    [DllImport(ObjCLibrary)]
+    private static extern nint sel_registerName(string name);
+
+    [DllImport(ObjCLibrary)]
+    private static extern nint object_getClass(nint value);
+
+    [DllImport(ObjCLibrary)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    private static extern bool class_addMethod(
+        nint type,
+        nint selector,
+        nint implementation,
+        string signature);
+
+    [DllImport(ObjCLibrary)]
+    private static extern nint class_getInstanceMethod(
+        nint type,
+        nint selector);
+
+    [DllImport(ObjCLibrary)]
+    private static extern nint method_getImplementation(nint method);
+
+    [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+    private static extern nint SendObject(
+        nint receiver,
+        nint selector);
+
+    [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+    private static extern double SendDouble(
+        nint receiver,
+        nint selector);
+}

--- a/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
+++ b/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
@@ -5,9 +5,14 @@ using System.Numerics;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using ProGPU.Backend;
+using Silk.NET.GLFW;
 using Silk.NET.Input;
 using Silk.NET.Windowing;
 using AvaloniaKey = Avalonia.Input.Key;
+using GlfwInputAction = Silk.NET.GLFW.InputAction;
+using GlfwKey = Silk.NET.GLFW.Keys;
+using GlfwKeyModifiers = Silk.NET.GLFW.KeyModifiers;
+using GlfwWindowHandle = Silk.NET.GLFW.WindowHandle;
 using SilkInputDevice = Silk.NET.Input.IInputDevice;
 using SilkKey = Silk.NET.Input.Key;
 using SilkMouseButton = Silk.NET.Input.MouseButton;
@@ -21,19 +26,34 @@ namespace Avalonia.SilkNet;
 /// Pointer and key events use O(1) work and allocate only when text input
 /// requires a managed string.
 /// </remarks>
-internal sealed class SilkNetInputRouter : IDisposable
+internal sealed unsafe class SilkNetInputRouter : IDisposable
 {
     private readonly WindowImpl _owner;
     private readonly SilkNetClipboard _clipboard;
     private readonly MouseDevice _mouseDevice = new();
+    private readonly TouchDevice _touchDevice = new();
     private readonly IKeyboardDevice _keyboardDevice;
     private readonly List<IKeyboard> _keyboards = [];
     private readonly List<IMouse> _mice = [];
+    private readonly HashSet<uint> _emulatedTouchIds = [];
+    private readonly Glfw _glfw = Glfw.GetApi();
     private IInputContext? _context;
     private IInputRoot? _inputRoot;
+    private X11TouchInputSource? _x11Touch;
+    private MacOsGestureInputSource? _macOsGestures;
+    private GlfwWindowHandle* _glfwWindow;
+    private GlfwCallbacks.KeyCallback? _keyCallback;
+    private GlfwCallbacks.KeyCallback? _previousKeyCallback;
+    private GlfwCallbacks.CharCallback? _charCallback;
+    private GlfwCallbacks.CharCallback? _previousCharCallback;
+    private GlfwCallbacks.CursorEnterCallback? _cursorEnterCallback;
+    private GlfwCallbacks.CursorEnterCallback? _previousCursorEnterCallback;
     private RawInputModifiers _pointerButtons;
+    private RawInputModifiers _glfwKeyModifiers;
     private Vector2 _lastPointerPosition;
     private bool _pointerInside;
+    private bool _insideGlfwKeyCallback;
+    private bool _suppressPromotedMouseForPoll;
 
     internal SilkNetInputRouter(
         WindowImpl owner,
@@ -60,6 +80,14 @@ internal sealed class SilkNetInputRouter : IDisposable
             AttachKeyboard(keyboard);
         foreach (IMouse mouse in _context.Mice)
             AttachMouse(mouse);
+        AttachGlfwCallbacks(window);
+        _owner.SetNativeTouchHandler(OnNativeTouch);
+        _x11Touch = X11TouchInputSource.TryCreate(
+            window,
+            OnNativeTouch);
+        _macOsGestures = MacOsGestureInputSource.TryCreate(
+            window,
+            OnMacOsGesture);
     }
 
     internal void ApplyCursor(SilkNetCursorImpl? cursor)
@@ -87,6 +115,11 @@ internal sealed class SilkNetInputRouter : IDisposable
             RawPointerEventType.LeaveWindow);
     }
 
+    internal void PollSupplementalEvents() => _x11Touch?.Poll();
+
+    internal void CompleteSupplementalEventPoll() =>
+        _suppressPromotedMouseForPoll = false;
+
     internal static bool ShouldEmitPointerLeave(
         bool wasInside,
         bool isHovered) =>
@@ -100,12 +133,19 @@ internal sealed class SilkNetInputRouter : IDisposable
             return;
 
         context.ConnectionChanged -= OnConnectionChanged;
+        _owner.SetNativeTouchHandler(null);
+        _x11Touch?.Dispose();
+        _x11Touch = null;
+        _macOsGestures?.Dispose();
+        _macOsGestures = null;
+        DetachGlfwCallbacks();
         while (_keyboards.Count > 0)
             DetachKeyboard(_keyboards[^1]);
         while (_mice.Count > 0)
             DetachMouse(_mice[^1]);
         context.Dispose();
         _mouseDevice.Dispose();
+        _touchDevice.Dispose();
     }
 
     private void OnConnectionChanged(
@@ -136,7 +176,6 @@ internal sealed class SilkNetInputRouter : IDisposable
         _keyboards.Add(keyboard);
         keyboard.KeyDown += OnKeyDown;
         keyboard.KeyUp += OnKeyUp;
-        keyboard.KeyChar += OnKeyChar;
         _clipboard.AttachKeyboard(keyboard);
     }
 
@@ -146,7 +185,6 @@ internal sealed class SilkNetInputRouter : IDisposable
             return;
         keyboard.KeyDown -= OnKeyDown;
         keyboard.KeyUp -= OnKeyUp;
-        keyboard.KeyChar -= OnKeyChar;
         _clipboard.DetachKeyboard(keyboard);
     }
 
@@ -178,6 +216,7 @@ internal sealed class SilkNetInputRouter : IDisposable
         EmitKey(
             keyboard,
             key,
+            scanCode,
             RawKeyEventType.KeyDown);
 
     private void OnKeyUp(
@@ -187,11 +226,13 @@ internal sealed class SilkNetInputRouter : IDisposable
         EmitKey(
             keyboard,
             key,
+            scanCode,
             RawKeyEventType.KeyUp);
 
     private void EmitKey(
         IKeyboard keyboard,
         SilkKey key,
+        int scanCode,
         RawKeyEventType eventType)
     {
         IInputRoot? root = _inputRoot;
@@ -209,12 +250,10 @@ internal sealed class SilkNetInputRouter : IDisposable
                 mapped.Key,
                 ReadModifiers(keyboard),
                 mapped.PhysicalKey,
-                keySymbol: null));
+                ResolveKeySymbol(key, scanCode)));
     }
 
-    private void OnKeyChar(
-        IKeyboard keyboard,
-        char character)
+    private void EmitText(string text)
     {
         IInputRoot? root = _inputRoot;
         if (root is null || !_owner.TryAcceptInput())
@@ -225,13 +264,236 @@ internal sealed class SilkNetInputRouter : IDisposable
                 _keyboardDevice,
                 Timestamp(),
                 root,
-                character.ToString()));
+                text));
     }
+
+    private void AttachGlfwCallbacks(IWindow window)
+    {
+        nint handle = window.Native?.Glfw ?? window.Handle;
+        if (handle == 0)
+            return;
+
+        _glfwWindow = (GlfwWindowHandle*)handle;
+        _keyCallback = OnGlfwKey;
+        _charCallback = OnGlfwChar;
+        _cursorEnterCallback = OnGlfwCursorEnter;
+        _previousKeyCallback =
+            _glfw.SetKeyCallback(_glfwWindow, _keyCallback);
+        _previousCharCallback =
+            _glfw.SetCharCallback(_glfwWindow, _charCallback);
+        _previousCursorEnterCallback =
+            _glfw.SetCursorEnterCallback(
+                _glfwWindow,
+                _cursorEnterCallback);
+    }
+
+    private void DetachGlfwCallbacks()
+    {
+        GlfwWindowHandle* window = _glfwWindow;
+        _glfwWindow = null;
+        if (window is null)
+            return;
+
+        _glfw.SetKeyCallback(
+            window,
+            _previousKeyCallback!);
+        _glfw.SetCharCallback(
+            window,
+            _previousCharCallback!);
+        _glfw.SetCursorEnterCallback(
+            window,
+            _previousCursorEnterCallback!);
+        _keyCallback = null;
+        _previousKeyCallback = null;
+        _charCallback = null;
+        _previousCharCallback = null;
+        _cursorEnterCallback = null;
+        _previousCursorEnterCallback = null;
+    }
+
+    private void OnGlfwKey(
+        GlfwWindowHandle* window,
+        GlfwKey key,
+        int scanCode,
+        GlfwInputAction action,
+        GlfwKeyModifiers modifiers)
+    {
+        bool previousInsideCallback = _insideGlfwKeyCallback;
+        RawInputModifiers previousModifiers = _glfwKeyModifiers;
+        _insideGlfwKeyCallback = true;
+        _glfwKeyModifiers = MapGlfwModifiers(modifiers);
+        try
+        {
+            _previousKeyCallback?.Invoke(
+                window,
+                key,
+                scanCode,
+                action,
+                modifiers);
+            if (action != GlfwInputAction.Repeat ||
+                _keyboards.Count == 0)
+            {
+                return;
+            }
+
+            EmitKey(
+                _keyboards[0],
+                (SilkKey)(int)key,
+                scanCode,
+                RawKeyEventType.KeyDown);
+        }
+        finally
+        {
+            _insideGlfwKeyCallback = previousInsideCallback;
+            _glfwKeyModifiers = previousModifiers;
+        }
+    }
+
+    private void OnGlfwChar(
+        GlfwWindowHandle* window,
+        uint codePoint)
+    {
+        _previousCharCallback?.Invoke(window, codePoint);
+        string? text = ConvertUnicodeScalar(codePoint);
+        if (text is not null)
+            EmitText(text);
+    }
+
+    private void OnGlfwCursorEnter(
+        GlfwWindowHandle* window,
+        bool entered)
+    {
+        _previousCursorEnterCallback?.Invoke(window, entered);
+        if (entered)
+        {
+            _pointerInside = true;
+            return;
+        }
+
+        if (!_pointerInside)
+            return;
+        _pointerInside = false;
+        EmitPointer(
+            _lastPointerPosition,
+            RawPointerEventType.LeaveWindow);
+    }
+
+    private string? ResolveKeySymbol(
+        SilkKey key,
+        int scanCode)
+    {
+        string? symbol =
+            _glfw.GetKeyName((int)key, scanCode);
+        return string.IsNullOrEmpty(symbol)
+            ? null
+            : symbol;
+    }
+
+    internal static string? ConvertUnicodeScalar(uint codePoint)
+    {
+        if (codePoint > 0x10ffff ||
+            codePoint is >= 0xd800 and <= 0xdfff)
+        {
+            return null;
+        }
+
+        return char.ConvertFromUtf32((int)codePoint);
+    }
+
+    private void OnNativeTouch(NativeTouchEvent touch)
+    {
+        IInputRoot? root = _inputRoot;
+        if (root is null || !_owner.TryAcceptInput())
+            return;
+
+        Point position = ToLogicalPoint(
+            new Vector2((float)touch.X, (float)touch.Y),
+            _owner.NativeCoordinateScaling);
+        var point = new RawPointerPoint
+        {
+            Position = position,
+            ContactRect = new Rect(
+                position.X - touch.ContactWidth /
+                    _owner.NativeCoordinateScaling / 2d,
+                position.Y - touch.ContactHeight /
+                    _owner.NativeCoordinateScaling / 2d,
+                touch.ContactWidth /
+                    _owner.NativeCoordinateScaling,
+                touch.ContactHeight /
+                    _owner.NativeCoordinateScaling)
+        };
+        RawInputModifiers modifiers =
+            _keyboards.Count > 0
+                ? ReadModifiers(_keyboards[0])
+                : RawInputModifiers.None;
+        if (touch.IsPointerEmulation &&
+            touch.Phase == NativeTouchPhase.Begin)
+        {
+            _emulatedTouchIds.Add(touch.Id);
+        }
+        if (touch.IsPointerEmulation)
+            _suppressPromotedMouseForPoll = true;
+
+        _owner.EmitInput(
+            new RawTouchEventArgs(
+                _touchDevice,
+                touch.Timestamp,
+                root,
+                MapTouchPhase(touch.Phase),
+                point,
+                modifiers,
+                touch.Id));
+        if (touch.Phase is NativeTouchPhase.End or NativeTouchPhase.Cancel)
+            _emulatedTouchIds.Remove(touch.Id);
+    }
+
+    internal static RawPointerEventType MapTouchPhase(
+        NativeTouchPhase phase) => phase switch
+        {
+            NativeTouchPhase.Begin => RawPointerEventType.TouchBegin,
+            NativeTouchPhase.Update => RawPointerEventType.TouchUpdate,
+            NativeTouchPhase.End => RawPointerEventType.TouchEnd,
+            _ => RawPointerEventType.TouchCancel
+        };
+
+    private void OnMacOsGesture(MacOsGestureEvent gesture)
+    {
+        IInputRoot? root = _inputRoot;
+        if (root is null || !_owner.TryAcceptInput())
+            return;
+
+        RawInputModifiers modifiers =
+            _keyboards.Count > 0
+                ? ReadModifiers(_keyboards[0])
+                : RawInputModifiers.None;
+        Point position = ToLogicalPoint(
+            _lastPointerPosition,
+            _owner.NativeCoordinateScaling);
+        _owner.EmitInput(
+            new RawPointerGestureEventArgs(
+                _mouseDevice,
+                Timestamp(),
+                root,
+                MapMacOsGesture(gesture.Kind),
+                position,
+                new Vector(gesture.DeltaX, gesture.DeltaY),
+                modifiers));
+    }
+
+    internal static RawPointerEventType MapMacOsGesture(
+        MacOsGestureKind kind) => kind switch
+        {
+            MacOsGestureKind.Magnify => RawPointerEventType.Magnify,
+            MacOsGestureKind.Rotate => RawPointerEventType.Rotate,
+            _ => RawPointerEventType.Swipe
+        };
 
     private void OnMouseDown(
         IMouse mouse,
         SilkMouseButton button)
     {
+        if (ShouldSuppressPromotedMouse())
+            return;
         _pointerInside = true;
         _lastPointerPosition = mouse.Position;
         RawPointerEventType? eventType =
@@ -248,6 +510,8 @@ internal sealed class SilkNetInputRouter : IDisposable
         IMouse mouse,
         SilkMouseButton button)
     {
+        if (ShouldSuppressPromotedMouse())
+            return;
         _pointerInside = true;
         _lastPointerPosition = mouse.Position;
         _owner.UpdateNativeDrag(
@@ -268,6 +532,8 @@ internal sealed class SilkNetInputRouter : IDisposable
         IMouse mouse,
         Vector2 position)
     {
+        if (ShouldSuppressPromotedMouse())
+            return;
         _pointerInside = true;
         _lastPointerPosition = position;
         _owner.UpdateNativeDrag(
@@ -281,6 +547,8 @@ internal sealed class SilkNetInputRouter : IDisposable
         IMouse mouse,
         ScrollWheel wheel)
     {
+        if (ShouldSuppressPromotedMouse())
+            return;
         _pointerInside = true;
         _lastPointerPosition = mouse.Position;
         IInputRoot? root = _inputRoot;
@@ -315,6 +583,11 @@ internal sealed class SilkNetInputRouter : IDisposable
                 ReadModifiers() | _pointerButtons));
     }
 
+    private bool ShouldSuppressPromotedMouse() =>
+        _owner.IsProcessingPromotedTouchMouse ||
+        _suppressPromotedMouseForPoll ||
+        _emulatedTouchIds.Count > 0;
+
     private RawInputModifiers ReadModifiers()
     {
         IKeyboard? keyboard =
@@ -324,9 +597,12 @@ internal sealed class SilkNetInputRouter : IDisposable
             : ReadModifiers(keyboard);
     }
 
-    private static RawInputModifiers ReadModifiers(
+    private RawInputModifiers ReadModifiers(
         IKeyboard keyboard)
     {
+        if (_insideGlfwKeyCallback)
+            return _glfwKeyModifiers;
+
         RawInputModifiers result = RawInputModifiers.None;
         if (keyboard.IsKeyPressed(SilkKey.AltLeft) ||
             keyboard.IsKeyPressed(SilkKey.AltRight))
@@ -339,6 +615,21 @@ internal sealed class SilkNetInputRouter : IDisposable
             result |= RawInputModifiers.Shift;
         if (keyboard.IsKeyPressed(SilkKey.SuperLeft) ||
             keyboard.IsKeyPressed(SilkKey.SuperRight))
+            result |= RawInputModifiers.Meta;
+        return result;
+    }
+
+    internal static RawInputModifiers MapGlfwModifiers(
+        GlfwKeyModifiers modifiers)
+    {
+        RawInputModifiers result = RawInputModifiers.None;
+        if ((modifiers & GlfwKeyModifiers.Alt) != 0)
+            result |= RawInputModifiers.Alt;
+        if ((modifiers & GlfwKeyModifiers.Control) != 0)
+            result |= RawInputModifiers.Control;
+        if ((modifiers & GlfwKeyModifiers.Shift) != 0)
+            result |= RawInputModifiers.Shift;
+        if ((modifiers & GlfwKeyModifiers.Super) != 0)
             result |= RawInputModifiers.Meta;
         return result;
     }

--- a/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
+++ b/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
@@ -388,8 +388,22 @@ internal sealed class SilkNetInputRouter : IDisposable
             _ => RawInputModifiers.None
         };
 
-    private static Point ToPoint(Vector2 point) =>
-        new(point.X, point.Y);
+    private Point ToPoint(Vector2 point) =>
+        ToLogicalPoint(
+            point,
+            _owner.DesktopScaling);
+
+    internal static Point ToLogicalPoint(
+        Vector2 point,
+        double desktopScaling)
+    {
+        double scaling =
+            DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling);
+        return new Point(
+            point.X / scaling,
+            point.Y / scaling);
+    }
 
     private static ulong Timestamp() =>
         (ulong)(Stopwatch.GetTimestamp() *

--- a/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
+++ b/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
@@ -391,7 +391,7 @@ internal sealed class SilkNetInputRouter : IDisposable
     private Point ToPoint(Vector2 point) =>
         ToLogicalPoint(
             point,
-            _owner.DesktopScaling);
+            _owner.NativeCoordinateScaling);
 
     internal static Point ToLogicalPoint(
         Vector2 point,

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
@@ -162,6 +162,11 @@ public sealed class WindowImpl :
             OperatingSystem.IsMacOS(),
             RenderScaling);
 
+    internal double NativeCoordinateScaling =>
+        SilkNetDisplayMetrics.ResolveNativeCoordinateScaling(
+            OperatingSystem.IsWindows(),
+            DesktopScaling);
+
     public IPlatformHandle? Handle
     {
         get
@@ -199,7 +204,7 @@ public sealed class WindowImpl :
                 : SilkNetDisplayMetrics.ResolveLogicalClientSize(
                     window.Size.X,
                     window.Size.Y,
-                    DesktopScaling);
+                    NativeCoordinateScaling);
         }
     }
 
@@ -253,7 +258,7 @@ public sealed class WindowImpl :
                 window.FramebufferSize.X,
                 window.FramebufferSize.Y,
                 RenderScaling,
-                DesktopScaling);
+                NativeCoordinateScaling);
         }
     }
 
@@ -292,7 +297,7 @@ public sealed class WindowImpl :
             _windowController is { IsAttached: true } controller
                 ? controller.FrameInsets
                 : null,
-            DesktopScaling);
+            NativeCoordinateScaling);
 
     public PixelPoint Position
     {
@@ -367,7 +372,7 @@ public sealed class WindowImpl :
             double titleBarHeight = _titleBarHeight >= 0d
                 ? _titleBarHeight
                 : controller.ExtendedTitleBarHeight /
-                  DesktopScaling;
+                  NativeCoordinateScaling;
             return new Thickness(
                 0,
                 titleBarHeight,
@@ -424,7 +429,7 @@ public sealed class WindowImpl :
             point.Y);
         Vector2D<int> result =
             window?.PointToClient(source) ?? source;
-        double scaling = DesktopScaling;
+        double scaling = NativeCoordinateScaling;
         return new Point(
             result.X / scaling,
             result.Y / scaling);
@@ -432,7 +437,7 @@ public sealed class WindowImpl :
 
     public PixelPoint PointToScreen(Point point)
     {
-        double scaling = DesktopScaling;
+        double scaling = NativeCoordinateScaling;
         Vector2D<int> source = new(
             checked((int)Math.Round(point.X * scaling)),
             checked((int)Math.Round(point.Y * scaling)));
@@ -691,7 +696,7 @@ public sealed class WindowImpl :
             PixelSize pixels =
                 SilkNetDisplayMetrics.ResolveNativeClientSize(
                     constrained,
-                    DesktopScaling);
+                    NativeCoordinateScaling);
             var nativeSize = new Vector2D<int>(
                 pixels.Width,
                 pixels.Height);
@@ -1059,7 +1064,7 @@ public sealed class WindowImpl :
             SilkNetDisplayMetrics.ResolveLogicalClientSize(
                 size.X,
                 size.Y,
-                DesktopScaling);
+                NativeCoordinateScaling);
         Resized?.Invoke(
             _desiredSize,
             _resizeReasons.Resolve(size));
@@ -1262,7 +1267,7 @@ public sealed class WindowImpl :
             return;
 
         double scaling = _window?.IsInitialized == true
-            ? DesktopScaling
+            ? NativeCoordinateScaling
             : 1d;
         controller.SetSizeConstraints(
             SilkNetWindowChrome.ToMinimumSize(

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
@@ -15,6 +15,7 @@ using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Platform.Surfaces;
 #endif
 using Avalonia.Rendering.Composition;
+using Avalonia.Threading;
 using ProGPU.Backend;
 using Silk.NET.Core;
 using Silk.NET.Maths;
@@ -195,9 +196,10 @@ public sealed class WindowImpl :
             IWindow? window = _window;
             return window is null
                 ? _desiredSize
-                : new Size(
-                    Math.Max(0, window.Size.X),
-                    Math.Max(0, window.Size.Y));
+                : SilkNetDisplayMetrics.ResolveLogicalClientSize(
+                    window.Size.X,
+                    window.Size.Y,
+                    DesktopScaling);
         }
     }
 
@@ -250,7 +252,8 @@ public sealed class WindowImpl :
                 window.Size.Y,
                 window.FramebufferSize.X,
                 window.FramebufferSize.Y,
-                RenderScaling);
+                RenderScaling,
+                DesktopScaling);
         }
     }
 
@@ -288,7 +291,8 @@ public sealed class WindowImpl :
             ClientSize,
             _windowController is { IsAttached: true } controller
                 ? controller.FrameInsets
-                : null);
+                : null,
+            DesktopScaling);
 
     public PixelPoint Position
     {
@@ -297,12 +301,9 @@ public sealed class WindowImpl :
             IWindow? window = _window;
             if (window is null)
                 return _desiredPosition ?? default;
-            double scaling = DesktopScaling;
             return new PixelPoint(
-                checked((int)Math.Round(
-                    window.Position.X * scaling)),
-                checked((int)Math.Round(
-                    window.Position.Y * scaling)));
+                window.Position.X,
+                window.Position.Y);
         }
     }
 
@@ -363,9 +364,13 @@ public sealed class WindowImpl :
                 return default;
             }
 
+            double titleBarHeight = _titleBarHeight >= 0d
+                ? _titleBarHeight
+                : controller.ExtendedTitleBarHeight /
+                  DesktopScaling;
             return new Thickness(
                 0,
-                controller.ExtendedTitleBarHeight,
+                titleBarHeight,
                 0,
                 0);
         }
@@ -414,26 +419,28 @@ public sealed class WindowImpl :
     public Point PointToClient(PixelPoint point)
     {
         IWindow? window = _window;
-        double scaling = DesktopScaling;
         Vector2D<int> source = new(
-            checked((int)Math.Round(point.X / scaling)),
-            checked((int)Math.Round(point.Y / scaling)));
+            point.X,
+            point.Y);
         Vector2D<int> result =
             window?.PointToClient(source) ?? source;
-        return new Point(result.X, result.Y);
+        double scaling = DesktopScaling;
+        return new Point(
+            result.X / scaling,
+            result.Y / scaling);
     }
 
     public PixelPoint PointToScreen(Point point)
     {
+        double scaling = DesktopScaling;
         Vector2D<int> source = new(
-            checked((int)Math.Round(point.X)),
-            checked((int)Math.Round(point.Y)));
+            checked((int)Math.Round(point.X * scaling)),
+            checked((int)Math.Round(point.Y * scaling)));
         Vector2D<int> result =
             _window?.PointToScreen(source) ?? source;
-        double scaling = DesktopScaling;
         return new PixelPoint(
-            checked((int)Math.Round(result.X * scaling)),
-            checked((int)Math.Round(result.Y * scaling)));
+            result.X,
+            result.Y);
     }
 
     public void SetCursor(ICursorImpl? cursor)
@@ -633,9 +640,15 @@ public sealed class WindowImpl :
     public void BeginMoveDrag(PointerPressedEventArgs e)
     {
         ArgumentNullException.ThrowIfNull(e);
-        if (_input is not null)
-            _windowController?.BeginMove(
-                _input.CurrentNativePointer);
+        if (_input is null || !e.Pointer.IsPrimary)
+            return;
+
+        e.Pointer.Capture(null);
+        NativeWindowPoint pointer =
+            _input.CurrentNativePointer;
+        Dispatcher.UIThread.Post(
+            () => _windowController?.BeginMove(pointer),
+            DispatcherPriority.Send);
     }
 
     public void BeginResizeDrag(
@@ -675,15 +688,13 @@ public sealed class WindowImpl :
         _desiredSize = constrained;
         if (_window is not null)
         {
+            PixelSize pixels =
+                SilkNetDisplayMetrics.ResolveNativeClientSize(
+                    constrained,
+                    DesktopScaling);
             var nativeSize = new Vector2D<int>(
-                Math.Max(
-                    1,
-                    checked((int)Math.Round(
-                        constrained.Width))),
-                Math.Max(
-                    1,
-                    checked((int)Math.Round(
-                        constrained.Height))));
+                pixels.Width,
+                pixels.Height);
             if (_window.Size != nativeSize)
             {
                 _resizeReasons.Begin(nativeSize, reason);
@@ -697,10 +708,9 @@ public sealed class WindowImpl :
         _desiredPosition = point;
         if (_window is null)
             return;
-        double scaling = DesktopScaling;
         _window.Position = new Vector2D<int>(
-            checked((int)Math.Round(point.X / scaling)),
-            checked((int)Math.Round(point.Y / scaling)));
+            point.X,
+            point.Y);
     }
 
     public void SetMinMaxSize(Size minSize, Size maxSize)
@@ -713,9 +723,7 @@ public sealed class WindowImpl :
             maxSize.Height > 0
                 ? maxSize.Height
                 : double.PositiveInfinity);
-        _windowController?.SetSizeConstraints(
-            SilkNetWindowChrome.ToMinimumSize(_minSize),
-            SilkNetWindowChrome.ToMaximumSize(_maxSize));
+        ApplyNativeSizeConstraints();
     }
 
     public void SetExtendClientAreaToDecorationsHint(
@@ -930,6 +938,7 @@ public sealed class WindowImpl :
         if (_window is not null)
             return _window;
 
+        Size requestedLogicalSize = _desiredSize;
         Vector2D<int> size = new(
             Math.Max(
                 1,
@@ -978,6 +987,9 @@ public sealed class WindowImpl :
         window.Initialize();
         _resizeReasons.Cancel();
         NotifyScalingChanged();
+        Resize(
+            requestedLogicalSize,
+            WindowResizeReason.Layout);
         if (_desiredPosition is { } desired)
             Move(desired);
         _platform.EventLoop.Register(this);
@@ -1042,13 +1054,18 @@ public sealed class WindowImpl :
 
     private void OnResize(Vector2D<int> size)
     {
-        _desiredSize = new Size(
-            Math.Max(0, size.X),
-            Math.Max(0, size.Y));
+        NotifyScalingChanged();
+        _desiredSize =
+            SilkNetDisplayMetrics.ResolveLogicalClientSize(
+                size.X,
+                size.Y,
+                DesktopScaling);
         Resized?.Invoke(
             _desiredSize,
             _resizeReasons.Resolve(size));
         QueuePaint();
+        if (_windowController?.IsInteractiveMoveResize == true)
+            OnRender(0d);
     }
 
     private void OnFramebufferResize(Vector2D<int> size)
@@ -1088,6 +1105,7 @@ public sealed class WindowImpl :
 
         _reportedScaling = scaling;
         _screens.Invalidate();
+        ApplyNativeSizeConstraints();
         ScalingChanged?.Invoke(scaling);
     }
 
@@ -1222,9 +1240,7 @@ public sealed class WindowImpl :
         controller.SetTopMost(_topmost);
         controller.SetEnabled(_enabled);
         controller.SetShowInTaskbar(_showInTaskbar);
-        controller.SetSizeConstraints(
-            SilkNetWindowChrome.ToMinimumSize(_minSize),
-            SilkNetWindowChrome.ToMaximumSize(_maxSize));
+        ApplyNativeSizeConstraints();
 #if AVALONIA11
         controller.SetChromeHints(
             SilkNetWindowChrome.MapChromeHints(
@@ -1236,6 +1252,25 @@ public sealed class WindowImpl :
         controller.SetTheme(_theme);
         controller.SetBackdrop(_backdrop);
         controller.SetWindowShadow(_addShadow);
+    }
+
+    private void ApplyNativeSizeConstraints()
+    {
+        SilkWindowController? controller =
+            _windowController;
+        if (controller is null)
+            return;
+
+        double scaling = _window?.IsInitialized == true
+            ? DesktopScaling
+            : 1d;
+        controller.SetSizeConstraints(
+            SilkNetWindowChrome.ToMinimumSize(
+                _minSize,
+                scaling),
+            SilkNetWindowChrome.ToMaximumSize(
+                _maxSize,
+                scaling));
     }
 
     private void ApplyNativeParent()

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
@@ -900,6 +900,9 @@ public sealed class WindowImpl :
         return false;
     }
 
+    internal bool IsProcessingPromotedTouchMouse =>
+        _windowController?.IsProcessingPromotedTouchMouse ?? false;
+
     internal NativeWindowPoint ToNativeScreenPoint(
         float clientX,
         float clientY)
@@ -923,8 +926,26 @@ public sealed class WindowImpl :
     internal void EndNativeDrag() =>
         _windowController?.EndDrag();
 
-    void ISilkNetLoopParticipant.PollNativeEvents() =>
-        _window?.DoEvents();
+    internal void SetNativeTouchHandler(
+        Action<NativeTouchEvent>? handler)
+    {
+        if (_windowController is not null)
+            _windowController.TouchHandler = handler;
+    }
+
+    void ISilkNetLoopParticipant.PollNativeEvents()
+    {
+        SilkNetInputRouter? input = _input;
+        input?.PollSupplementalEvents();
+        try
+        {
+            _window?.DoEvents();
+        }
+        finally
+        {
+            input?.CompleteSupplementalEventPoll();
+        }
+    }
 
     void ISilkNetLoopParticipant.UpdateNativeWindow()
     {

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDisplayMetrics.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDisplayMetrics.cs
@@ -20,18 +20,50 @@ internal static class SilkNetDisplayMetrics
 
     internal static Size? ResolveFrameSize(
         Size clientSize,
-        NativeWindowFrameInsets? frameInsets)
+        NativeWindowFrameInsets? frameInsets,
+        double desktopScaling = 1d)
     {
         if (frameInsets is not { } insets)
             return null;
 
+        double scale =
+            DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling);
+
         return new Size(
             Math.Max(
                 0,
-                clientSize.Width + insets.Left + insets.Right),
+                clientSize.Width +
+                (insets.Left + insets.Right) / scale),
             Math.Max(
                 0,
-                clientSize.Height + insets.Top + insets.Bottom));
+                clientSize.Height +
+                (insets.Top + insets.Bottom) / scale));
+    }
+
+    internal static Size ResolveLogicalClientSize(
+        int nativeWidth,
+        int nativeHeight,
+        double desktopScaling)
+    {
+        double scale =
+            DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling);
+        return new Size(
+            Math.Max(0, nativeWidth) / scale,
+            Math.Max(0, nativeHeight) / scale);
+    }
+
+    internal static PixelSize ResolveNativeClientSize(
+        Size logicalSize,
+        double desktopScaling)
+    {
+        double scale =
+            DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling);
+        return new PixelSize(
+            ScaleLength(logicalSize.Width, scale),
+            ScaleLength(logicalSize.Height, scale));
     }
 
     internal static double ResolveRenderScaling(
@@ -80,12 +112,19 @@ internal static class SilkNetDisplayMetrics
         int windowHeight,
         int framebufferWidth,
         int framebufferHeight,
-        double renderScaling)
+        double renderScaling,
+        double desktopScaling = 1d)
     {
-        double scale =
+        double renderScale =
             DisplayScaleResolver.NormalizeDisplayScale(renderScaling);
-        int scaledWidth = ScaleLength(windowWidth, scale);
-        int scaledHeight = ScaleLength(windowHeight, scale);
+        double desktopScale =
+            DisplayScaleResolver.NormalizeDisplayScale(desktopScaling);
+        int scaledWidth = ScaleLength(
+            windowWidth / desktopScale,
+            renderScale);
+        int scaledHeight = ScaleLength(
+            windowHeight / desktopScale,
+            renderScale);
         return new PixelSize(
             Math.Max(
                 Math.Max(1, framebufferWidth),
@@ -95,7 +134,7 @@ internal static class SilkNetDisplayMetrics
                 scaledHeight));
     }
 
-    private static int ScaleLength(int value, double scale) =>
+    private static int ScaleLength(double value, double scale) =>
         Math.Max(
             1,
             checked((int)Math.Ceiling(Math.Max(0, value) * scale)));

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDisplayMetrics.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDisplayMetrics.cs
@@ -18,6 +18,14 @@ internal static class SilkNetDisplayMetrics
             : DisplayScaleResolver.NormalizeDisplayScale(
                 renderScaling);
 
+    internal static double ResolveNativeCoordinateScaling(
+        bool isWindows,
+        double desktopScaling) =>
+        isWindows
+            ? DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling)
+            : 1d;
+
     internal static Size? ResolveFrameSize(
         Size clientSize,
         NativeWindowFrameInsets? frameInsets,

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetWindowChrome.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetWindowChrome.cs
@@ -125,16 +125,18 @@ internal static class SilkNetWindowChrome
         };
 
     internal static NativeWindowSize ToMinimumSize(
-        Size size) =>
+        Size size,
+        double desktopScaling = 1d) =>
         new(
-            NormalizeMinimum(size.Width),
-            NormalizeMinimum(size.Height));
+            NormalizeMinimum(size.Width, desktopScaling),
+            NormalizeMinimum(size.Height, desktopScaling));
 
     internal static NativeWindowSize ToMaximumSize(
-        Size size) =>
+        Size size,
+        double desktopScaling = 1d) =>
         new(
-            NormalizeMaximum(size.Width),
-            NormalizeMaximum(size.Height));
+            NormalizeMaximum(size.Width, desktopScaling),
+            NormalizeMaximum(size.Height, desktopScaling));
 
 #if !AVALONIA11
     internal static PlatformAllowedWindowActions
@@ -186,23 +188,33 @@ internal static class SilkNetWindowChrome
     }
 #endif
 
-    private static int NormalizeMinimum(double value)
+    private static int NormalizeMinimum(
+        double value,
+        double desktopScaling)
     {
         if (!double.IsFinite(value) || value <= 0)
             return 0;
+        double scale =
+            DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling);
         return checked(
             (int)Math.Min(
                 int.MaxValue,
-                Math.Ceiling(value)));
+                Math.Ceiling(value * scale)));
     }
 
-    private static int NormalizeMaximum(double value)
+    private static int NormalizeMaximum(
+        double value,
+        double desktopScaling)
     {
         if (!double.IsFinite(value) || value <= 0)
             return int.MaxValue;
+        double scale =
+            DisplayScaleResolver.NormalizeDisplayScale(
+                desktopScaling);
         return checked(
             (int)Math.Min(
                 int.MaxValue,
-                Math.Floor(value)));
+                Math.Floor(value * scale)));
     }
 }

--- a/src/ProGPU.Avalonia.SilkNet/X11TouchInputSource.cs
+++ b/src/ProGPU.Avalonia.SilkNet/X11TouchInputSource.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using ProGPU.Backend;
+using Silk.NET.Windowing;
+
+namespace Avalonia.SilkNet;
+
+/// <summary>
+/// Selects XI2 touch events on GLFW's X11 connection and removes only those
+/// events before GLFW drains the shared Xlib queue.
+/// </summary>
+internal sealed unsafe class X11TouchInputSource : IDisposable
+{
+    private const string X11Library = "libX11.so.6";
+    private const string XiLibrary = "libXi.so.6";
+    private const int GenericEvent = 35;
+    private const int XiAllMasterDevices = 1;
+    private const int XiTouchBegin = 18;
+    private const int XiTouchUpdate = 19;
+    private const int XiTouchEnd = 20;
+    private const int XiTouchEmulatingPointer = 1 << 17;
+    private static readonly object Gate = new();
+    private static readonly Dictionary<nint, Pump> Pumps = [];
+    private static readonly XEventPredicate TouchPredicate = IsTouchEvent;
+
+    private readonly Pump _pump;
+    private readonly nuint _window;
+    private bool _disposed;
+
+    private X11TouchInputSource(
+        Pump pump,
+        nuint window)
+    {
+        _pump = pump;
+        _window = window;
+    }
+
+    internal static X11TouchInputSource? TryCreate(
+        IWindow window,
+        Action<NativeTouchEvent> handler)
+    {
+        if (!OperatingSystem.IsLinux() ||
+            window.Native?.X11 is not { } x11 ||
+            x11.Display == 0 ||
+            x11.Window == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            lock (Gate)
+            {
+                if (!Pumps.TryGetValue(x11.Display, out Pump? pump))
+                {
+                    pump = Pump.TryCreate(x11.Display);
+                    if (pump is null)
+                        return null;
+                    Pumps.Add(x11.Display, pump);
+                }
+
+                if (!pump.Register(x11.Window, handler))
+                {
+                    if (pump.Count == 0)
+                        Pumps.Remove(x11.Display);
+                    return null;
+                }
+
+                return new X11TouchInputSource(pump, x11.Window);
+            }
+        }
+        catch (DllNotFoundException)
+        {
+            return null;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    internal void Poll() => _pump.Poll();
+
+    internal static int NativeEventSize => sizeof(XEvent);
+    internal static int NativeCookieSize =>
+        sizeof(XGenericEventCookie);
+    internal static int NativeDeviceEventSize =>
+        sizeof(XiDeviceEvent);
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        lock (Gate)
+        {
+            _pump.Unregister(_window);
+            if (_pump.Count == 0)
+                Pumps.Remove(_pump.Display);
+        }
+    }
+
+    private static int IsTouchEvent(
+        nint display,
+        XEvent* xevent,
+        nint extensionArgument)
+    {
+        _ = display;
+        ref XGenericEventCookie cookie = ref xevent->Cookie;
+        return cookie.Type == GenericEvent &&
+            cookie.Extension == (int)extensionArgument &&
+            cookie.EventType is >= XiTouchBegin and <= XiTouchEnd
+                ? 1
+                : 0;
+    }
+
+    private sealed class Pump
+    {
+        private readonly int _extension;
+        private readonly Dictionary<nuint, Action<NativeTouchEvent>>
+            _handlers = [];
+
+        private Pump(nint display, int extension)
+        {
+            Display = display;
+            _extension = extension;
+        }
+
+        internal nint Display { get; }
+        internal int Count => _handlers.Count;
+
+        internal static Pump? TryCreate(nint display)
+        {
+            if (XQueryExtension(
+                    display,
+                    "XInputExtension",
+                    out int extension,
+                    out _,
+                    out _) == 0)
+            {
+                return null;
+            }
+
+            int major = 2;
+            int minor = 2;
+            return XIQueryVersion(display, ref major, ref minor) == 0 &&
+                (major > 2 || major == 2 && minor >= 2)
+                    ? new Pump(display, extension)
+                    : null;
+        }
+
+        internal bool Register(
+            nuint window,
+            Action<NativeTouchEvent> handler)
+        {
+            byte* eventMask = stackalloc byte[3];
+            eventMask[0] = 0;
+            eventMask[1] = 0;
+            eventMask[2] = 0;
+            SetMask(eventMask, XiTouchBegin);
+            SetMask(eventMask, XiTouchUpdate);
+            SetMask(eventMask, XiTouchEnd);
+            var mask = new XiEventMask
+            {
+                DeviceId = XiAllMasterDevices,
+                MaskLength = 3,
+                Mask = eventMask
+            };
+            if (XISelectEvents(Display, window, &mask, 1) != 0)
+                return false;
+            _ = XFlush(Display);
+            _handlers[window] = handler;
+            return true;
+        }
+
+        internal void Unregister(nuint window)
+        {
+            _handlers.Remove(window);
+            var mask = new XiEventMask
+            {
+                DeviceId = XiAllMasterDevices,
+                MaskLength = 0,
+                Mask = null
+            };
+            _ = XISelectEvents(Display, window, &mask, 1);
+            _ = XFlush(Display);
+        }
+
+        internal void Poll()
+        {
+            while (true)
+            {
+                XEvent xevent = default;
+                if (XCheckIfEvent(
+                        Display,
+                        &xevent,
+                        TouchPredicate,
+                        _extension) == 0)
+                {
+                    return;
+                }
+
+                XGenericEventCookie* cookie = &xevent.Cookie;
+                if (XGetEventData(Display, cookie) == 0)
+                    continue;
+                try
+                {
+                    Dispatch(*(XiDeviceEvent*)cookie->Data);
+                }
+                finally
+                {
+                    XFreeEventData(Display, cookie);
+                }
+            }
+        }
+
+        private void Dispatch(in XiDeviceEvent touch)
+        {
+            if (!_handlers.TryGetValue(
+                    touch.Event,
+                    out Action<NativeTouchEvent>? handler))
+            {
+                return;
+            }
+
+            NativeTouchPhase phase = touch.EventType switch
+            {
+                XiTouchBegin => NativeTouchPhase.Begin,
+                XiTouchUpdate => NativeTouchPhase.Update,
+                _ => NativeTouchPhase.End
+            };
+            handler(new NativeTouchEvent(
+                unchecked((uint)touch.Detail),
+                phase,
+                touch.EventX,
+                touch.EventY,
+                0d,
+                0d,
+                unchecked((uint)touch.Time),
+                (touch.Flags & XiTouchEmulatingPointer) != 0));
+        }
+
+        private static void SetMask(byte* mask, int eventType) =>
+            mask[eventType >> 3] |=
+                (byte)(1 << (eventType & 7));
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int XEventPredicate(
+        nint display,
+        XEvent* xevent,
+        nint argument);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XiEventMask
+    {
+        public int DeviceId;
+        public int MaskLength;
+        public byte* Mask;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XiButtonState
+    {
+        public int MaskLength;
+        public byte* Mask;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XiValuatorState
+    {
+        public int MaskLength;
+        public byte* Mask;
+        public double* Values;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XiModifierState
+    {
+        public int Base;
+        public int Latched;
+        public int Locked;
+        public int Effective;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XiDeviceEvent
+    {
+        public int Type;
+        public nuint Serial;
+        public int SendEvent;
+        public nint Display;
+        public int Extension;
+        public int EventType;
+        public nuint Time;
+        public int DeviceId;
+        public int SourceId;
+        public int Detail;
+        public nuint Root;
+        public nuint Event;
+        public nuint Child;
+        public double RootX;
+        public double RootY;
+        public double EventX;
+        public double EventY;
+        public int Flags;
+        public XiButtonState Buttons;
+        public XiValuatorState Valuators;
+        public XiModifierState Modifiers;
+        public XiModifierState Group;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XGenericEventCookie
+    {
+        public int Type;
+        public nuint Serial;
+        public int SendEvent;
+        public nint Display;
+        public int Extension;
+        public int EventType;
+        public uint CookieId;
+        public nint Data;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 192)]
+    private struct XEvent
+    {
+        [FieldOffset(0)]
+        public XGenericEventCookie Cookie;
+    }
+
+    [DllImport(X11Library)]
+    private static extern int XQueryExtension(
+        nint display,
+        string name,
+        out int majorOpcode,
+        out int firstEvent,
+        out int firstError);
+
+    [DllImport(X11Library)]
+    private static extern int XCheckIfEvent(
+        nint display,
+        XEvent* xevent,
+        XEventPredicate predicate,
+        nint argument);
+
+    [DllImport(X11Library)]
+    private static extern int XGetEventData(
+        nint display,
+        XGenericEventCookie* cookie);
+
+    [DllImport(X11Library)]
+    private static extern void XFreeEventData(
+        nint display,
+        XGenericEventCookie* cookie);
+
+    [DllImport(X11Library)]
+    private static extern int XFlush(nint display);
+
+    [DllImport(XiLibrary)]
+    private static extern int XIQueryVersion(
+        nint display,
+        ref int major,
+        ref int minor);
+
+    [DllImport(XiLibrary)]
+    private static extern int XISelectEvents(
+        nint display,
+        nuint window,
+        XiEventMask* masks,
+        int maskCount);
+}

--- a/src/ProGPU.Backend.Dawn/DawnGpuContext.cs
+++ b/src/ProGPU.Backend.Dawn/DawnGpuContext.cs
@@ -23,11 +23,23 @@ public sealed unsafe partial class DawnGpuContext :
     IProGpuExternalTextureImporter
 {
     private const string NativeLibraryName = "webgpu_dawn";
+    private const string LinuxNativeLibraryName = "webgpu_dawn.so";
     private const string IosFrameworkLibrary =
         "@rpath/webgpu_dawn.framework/webgpu_dawn";
     private static readonly object NativeLibrarySync = new();
     private static nint s_iosNativeLibrary;
     private static bool s_iosResolversInstalled;
+
+    static DawnGpuContext()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            InstallLinuxNativeLibraryResolver(
+                typeof(WebGPU_FFI).Assembly);
+            InstallLinuxNativeLibraryResolver(
+                typeof(DawnGpuContext).Assembly);
+        }
+    }
 
     /// <summary>
     /// Reports whether the exact WebGPUSharp/Dawn native ABI can be resolved
@@ -40,14 +52,57 @@ public sealed unsafe partial class DawnGpuContext :
             return EnsureIosNativeLibrary();
         }
 
+        string libraryName = OperatingSystem.IsLinux()
+            ? LinuxNativeLibraryName
+            : NativeLibraryName;
         if (!NativeLibrary.TryLoad(
-                NativeLibraryName,
+                libraryName,
+                typeof(DawnGpuContext).Assembly,
+                searchPath: null,
                 out nint library))
         {
             return false;
         }
         NativeLibrary.Free(library);
         return true;
+    }
+
+    private static void InstallLinuxNativeLibraryResolver(
+        System.Reflection.Assembly assembly)
+    {
+        try
+        {
+            NativeLibrary.SetDllImportResolver(
+                assembly,
+                ResolveLinuxDawnImport);
+        }
+        catch (InvalidOperationException)
+        {
+            // The host already owns this assembly's resolver. Its resolver is
+            // given the first opportunity to satisfy the Dawn import.
+        }
+    }
+
+    private static nint ResolveLinuxDawnImport(
+        string libraryName,
+        System.Reflection.Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        if (!string.Equals(
+                libraryName,
+                NativeLibraryName,
+                StringComparison.Ordinal))
+        {
+            return 0;
+        }
+
+        return NativeLibrary.TryLoad(
+                LinuxNativeLibraryName,
+                assembly,
+                searchPath,
+                out nint library)
+            ? library
+            : 0;
     }
 
     private static bool EnsureIosNativeLibrary()

--- a/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
+++ b/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
@@ -462,7 +462,8 @@ public sealed unsafe partial class DawnGpuContext
                 return W.CompositeAlphaMode.Opaque;
             }
             throw new NotSupportedException(
-                "The Dawn Vulkan surface does not expose the required opaque alpha mode.");
+                "The Dawn Vulkan surface does not expose the required opaque " +
+                $"alpha mode. Advertised modes: {string.Join(", ", modes)}.");
         }
         if (modes.Contains(W.CompositeAlphaMode.Premultiplied))
         {

--- a/src/ProGPU.Backend/GlfwNativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/GlfwNativeWindowPlatform.cs
@@ -42,6 +42,7 @@ internal unsafe class GlfwNativeWindowPlatform : INativeWindowPlatform
     public virtual bool SupportsManagedMove => Handle.Kind is not NativeWindowKind.Wayland;
     public virtual bool SupportsManagedResize => true;
     public virtual bool SupportsSystemChromeExtension => false;
+    public virtual bool IsInteractiveMoveResize => false;
 
     public virtual bool ApplyChrome(in NativeWindowState state)
     {

--- a/src/ProGPU.Backend/GlfwNativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/GlfwNativeWindowPlatform.cs
@@ -43,6 +43,8 @@ internal unsafe class GlfwNativeWindowPlatform : INativeWindowPlatform
     public virtual bool SupportsManagedResize => true;
     public virtual bool SupportsSystemChromeExtension => false;
     public virtual bool IsInteractiveMoveResize => false;
+    public virtual bool IsProcessingPromotedTouchMouse => false;
+    public virtual Action<NativeTouchEvent>? TouchHandler { get; set; }
 
     public virtual bool ApplyChrome(in NativeWindowState state)
     {

--- a/src/ProGPU.Backend/INativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/INativeWindowPlatform.cs
@@ -13,6 +13,7 @@ internal interface INativeWindowPlatform : IDisposable
     bool SupportsManagedMove { get; }
     bool SupportsManagedResize { get; }
     bool SupportsSystemChromeExtension { get; }
+    bool IsInteractiveMoveResize { get; }
 
     bool ApplyChrome(in NativeWindowState state);
     bool SetTopMost(bool value);

--- a/src/ProGPU.Backend/INativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/INativeWindowPlatform.cs
@@ -14,6 +14,8 @@ internal interface INativeWindowPlatform : IDisposable
     bool SupportsManagedResize { get; }
     bool SupportsSystemChromeExtension { get; }
     bool IsInteractiveMoveResize { get; }
+    bool IsProcessingPromotedTouchMouse { get; }
+    Action<NativeTouchEvent>? TouchHandler { get; set; }
 
     bool ApplyChrome(in NativeWindowState state);
     bool SetTopMost(bool value);

--- a/src/ProGPU.Backend/NativeWindowTypes.cs
+++ b/src/ProGPU.Backend/NativeWindowTypes.cs
@@ -100,6 +100,24 @@ public readonly record struct NativeWindowHandle(
 
 public readonly record struct NativeWindowPoint(int X, int Y);
 
+public enum NativeTouchPhase
+{
+    Begin,
+    Update,
+    End,
+    Cancel
+}
+
+public readonly record struct NativeTouchEvent(
+    uint Id,
+    NativeTouchPhase Phase,
+    double X,
+    double Y,
+    double ContactWidth,
+    double ContactHeight,
+    uint Timestamp,
+    bool IsPointerEmulation = false);
+
 public readonly record struct NativeWindowSize(int Width, int Height)
 {
     public static NativeWindowSize Unbounded => new(int.MaxValue, int.MaxValue);

--- a/src/ProGPU.Backend/ProGPU.Backend.csproj
+++ b/src/ProGPU.Backend/ProGPU.Backend.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Silk.NET.GLFW" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="ProGPU.Avalonia.SilkNet.ContractTests, PublicKey=$(ProGPUPublicKey)" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="buildTransitive/ProGPU.Backend.targets"
           Pack="true"
           PackagePath="buildTransitive/ProGPU.Backend.targets" />

--- a/src/ProGPU.Backend/SilkWindowController.cs
+++ b/src/ProGPU.Backend/SilkWindowController.cs
@@ -43,6 +43,8 @@ public sealed class SilkWindowController : IDisposable
     public NativeWindowBackdrop Backdrop => _state.Backdrop;
     public NativeWindowTheme Theme => _state.Theme;
     public NativeWindowHandle Parent => _state.Parent;
+    public bool IsInteractiveMoveResize =>
+        _platform?.IsInteractiveMoveResize ?? false;
 
     public bool Attach()
     {

--- a/src/ProGPU.Backend/SilkWindowController.cs
+++ b/src/ProGPU.Backend/SilkWindowController.cs
@@ -45,6 +45,18 @@ public sealed class SilkWindowController : IDisposable
     public NativeWindowHandle Parent => _state.Parent;
     public bool IsInteractiveMoveResize =>
         _platform?.IsInteractiveMoveResize ?? false;
+    public bool IsProcessingPromotedTouchMouse =>
+        _platform?.IsProcessingPromotedTouchMouse ?? false;
+
+    public Action<NativeTouchEvent>? TouchHandler
+    {
+        get => _platform?.TouchHandler;
+        set
+        {
+            if (_platform is not null)
+                _platform.TouchHandler = value;
+        }
+    }
 
     public bool Attach()
     {

--- a/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
@@ -116,7 +116,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
         }
 
         SetWindowLongPtr(_hwnd, GwlStyle, (nint)style);
-        EnsureWindowProcedure(_extended);
+        EnsureWindowProcedure(true);
         RefreshFrame();
         SetBackdrop(_backdrop);
         return true;
@@ -160,7 +160,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     public override bool SetClientAreaExtension(bool enabled, double titleBarHeight)
     {
         _extended = enabled;
-        EnsureWindowProcedure(enabled);
+        EnsureWindowProcedure(true);
         var margins = enabled
             ? new Margins { Left = -1, Right = -1, Top = -1, Bottom = -1 }
             : default;

--- a/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
@@ -29,6 +29,9 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private const uint WmNcCalcSize = 0x0083;
     private const uint WmNcHitTest = 0x0084;
     private const uint WmNcLButtonDown = 0x00A1;
+    private const uint WmTouch = 0x0240;
+    private const uint WmMouseFirst = 0x0200;
+    private const uint WmMouseLast = 0x020e;
     private const uint WmEnterSizeMove = 0x0231;
     private const uint WmExitSizeMove = 0x0232;
     private const int HtClient = 1;
@@ -48,6 +51,14 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private const int AccentDisabled = 0;
     private const int AccentEnableBlurBehind = 3;
     private const int AccentEnableAcrylicBlurBehind = 4;
+    private const uint TouchEventMove = 0x0001;
+    private const uint TouchEventDown = 0x0002;
+    private const uint TouchEventUp = 0x0004;
+    private const uint TouchMaskContactArea = 0x0004;
+    private const int MaximumTouchContacts = 256;
+    private const nuint MouseEventFromTouchSignature = 0xff515700;
+    private const nuint MouseEventFromTouchMask = 0xffffff00;
+    private const nuint MouseEventTouchFlag = 0x80;
 
     private readonly nint _hwnd;
     private readonly WndProc _wndProc;
@@ -55,6 +66,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private bool _extended;
     private bool _canResize = true;
     private bool _isInteractiveMoveResize;
+    private bool _isProcessingPromotedTouchMouse;
     private NativeWindowBackdrop _backdrop;
 
     public Win32NativeWindowPlatform(IWindow window, nint hwnd)
@@ -82,6 +94,8 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     public override bool SupportsSystemChromeExtension => true;
     public override bool IsInteractiveMoveResize =>
         _isInteractiveMoveResize;
+    public override bool IsProcessingPromotedTouchMouse =>
+        _isProcessingPromotedTouchMouse;
 
     public override bool ApplyChrome(in NativeWindowState state)
     {
@@ -117,6 +131,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
 
         SetWindowLongPtr(_hwnd, GwlStyle, (nint)style);
         EnsureWindowProcedure(true);
+        _ = RegisterTouchWindow(_hwnd, 0);
         RefreshFrame();
         SetBackdrop(_backdrop);
         return true;
@@ -287,6 +302,9 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
         else if (message == WmExitSizeMove)
             _isInteractiveMoveResize = false;
 
+        if (message == WmTouch && TryDispatchTouch(wParam, lParam))
+            return 0;
+
         if (_extended && message == WmNcCalcSize)
         {
             return 0;
@@ -301,9 +319,134 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
             }
         }
 
-        return _previousWndProc != 0
-            ? CallWindowProc(_previousWndProc, hwnd, message, wParam, lParam)
-            : DefWindowProc(hwnd, message, wParam, lParam);
+        bool promotedTouchMouse =
+            IsPromotedTouchMouseMessage(
+                message,
+                GetMessageExtraInfo());
+        bool previousPromotedTouchMouse =
+            _isProcessingPromotedTouchMouse;
+        _isProcessingPromotedTouchMouse =
+            previousPromotedTouchMouse || promotedTouchMouse;
+        try
+        {
+            return _previousWndProc != 0
+                ? CallWindowProc(
+                    _previousWndProc,
+                    hwnd,
+                    message,
+                    wParam,
+                    lParam)
+                : DefWindowProc(hwnd, message, wParam, lParam);
+        }
+        finally
+        {
+            _isProcessingPromotedTouchMouse =
+                previousPromotedTouchMouse;
+        }
+    }
+
+    internal static bool IsPromotedTouchMouseMessage(
+        uint message,
+        nint extraInfo)
+    {
+        if (message is < WmMouseFirst or > WmMouseLast)
+            return false;
+
+        nuint value = unchecked((nuint)extraInfo);
+        return (value & MouseEventFromTouchMask) ==
+                MouseEventFromTouchSignature &&
+            (value & MouseEventTouchFlag) != 0;
+    }
+
+    private unsafe bool TryDispatchTouch(nint wParam, nint lParam)
+    {
+        int count = unchecked((ushort)(nuint)wParam);
+        if (count <= 0)
+            return false;
+        if (count > MaximumTouchContacts)
+        {
+            _ = CloseTouchInputHandle(lParam);
+            return true;
+        }
+
+        var touches = stackalloc TouchInput[count];
+        bool acquired = GetTouchInputInfo(
+            lParam,
+            (uint)count,
+            touches,
+            Marshal.SizeOf<TouchInput>());
+        if (!acquired)
+        {
+            _ = CloseTouchInputHandle(lParam);
+            return true;
+        }
+
+        try
+        {
+            Action<NativeTouchEvent>? handler = TouchHandler;
+            if (handler is null)
+                return true;
+
+            for (int index = 0; index < count; index++)
+            {
+                ref TouchInput touch = ref touches[index];
+                if (!TryMapTouchPhase(touch.Flags, out NativeTouchPhase phase))
+                    continue;
+
+                var point = new Point
+                {
+                    X = checked((int)Math.Round(touch.X / 100d)),
+                    Y = checked((int)Math.Round(touch.Y / 100d))
+                };
+                if (!ScreenToClient(_hwnd, ref point))
+                    continue;
+
+                double width = (touch.Mask & TouchMaskContactArea) != 0
+                    ? touch.ContactWidth / 100d
+                    : 0d;
+                double height = (touch.Mask & TouchMaskContactArea) != 0
+                    ? touch.ContactHeight / 100d
+                    : 0d;
+                handler(new NativeTouchEvent(
+                    touch.Id,
+                    phase,
+                    point.X,
+                    point.Y,
+                    width,
+                    height,
+                    touch.Timestamp));
+            }
+
+            return true;
+        }
+        finally
+        {
+            _ = CloseTouchInputHandle(lParam);
+        }
+    }
+
+    internal static bool TryMapTouchPhase(
+        uint flags,
+        out NativeTouchPhase phase)
+    {
+        if ((flags & TouchEventDown) != 0)
+        {
+            phase = NativeTouchPhase.Begin;
+            return true;
+        }
+        if ((flags & TouchEventUp) != 0)
+        {
+            phase = NativeTouchPhase.End;
+            return true;
+        }
+        if ((flags & TouchEventMove) != 0)
+        {
+            phase = NativeTouchPhase.Update;
+            return true;
+        }
+
+        phase = default;
+        return false;
     }
 
     private int HitTestResizeBorder(nint lParam)
@@ -430,6 +573,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
 
     public override void Dispose()
     {
+        _ = UnregisterTouchWindow(_hwnd);
         EnsureWindowProcedure(false);
         base.Dispose();
     }
@@ -463,6 +607,21 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     {
         public int X;
         public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct TouchInput
+    {
+        public int X;
+        public int Y;
+        public nint Source;
+        public uint Id;
+        public uint Flags;
+        public uint Mask;
+        public uint Timestamp;
+        public nuint ExtraInfo;
+        public uint ContactWidth;
+        public uint ContactHeight;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -513,6 +672,22 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private static extern bool EnableWindow(nint hwnd, bool enabled);
     [DllImport("user32.dll")]
     private static extern bool ReleaseCapture();
+    [DllImport("user32.dll")]
+    private static extern bool RegisterTouchWindow(nint hwnd, uint flags);
+    [DllImport("user32.dll")]
+    private static extern bool UnregisterTouchWindow(nint hwnd);
+    [DllImport("user32.dll")]
+    private static extern unsafe bool GetTouchInputInfo(
+        nint touchInputHandle,
+        uint inputCount,
+        TouchInput* inputs,
+        int touchInputSize);
+    [DllImport("user32.dll")]
+    private static extern bool CloseTouchInputHandle(nint touchInputHandle);
+    [DllImport("user32.dll")]
+    private static extern bool ScreenToClient(nint hwnd, ref Point point);
+    [DllImport("user32.dll")]
+    private static extern nint GetMessageExtraInfo();
     [DllImport("user32.dll", EntryPoint = "SendMessageW")]
     private static extern nint SendMessage(nint hwnd, uint message, nint wParam, nint lParam);
     [DllImport("user32.dll", EntryPoint = "CallWindowProcW")]

--- a/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
@@ -29,6 +29,8 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private const uint WmNcCalcSize = 0x0083;
     private const uint WmNcHitTest = 0x0084;
     private const uint WmNcLButtonDown = 0x00A1;
+    private const uint WmEnterSizeMove = 0x0231;
+    private const uint WmExitSizeMove = 0x0232;
     private const int HtClient = 1;
     private const int HtCaption = 2;
     private const int HtLeft = 10;
@@ -52,6 +54,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private nint _previousWndProc;
     private bool _extended;
     private bool _canResize = true;
+    private bool _isInteractiveMoveResize;
     private NativeWindowBackdrop _backdrop;
 
     public Win32NativeWindowPlatform(IWindow window, nint hwnd)
@@ -77,6 +80,8 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     public override bool SupportsManagedMove => true;
     public override bool SupportsManagedResize => true;
     public override bool SupportsSystemChromeExtension => true;
+    public override bool IsInteractiveMoveResize =>
+        _isInteractiveMoveResize;
 
     public override bool ApplyChrome(in NativeWindowState state)
     {
@@ -251,7 +256,11 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     public override bool TryBeginMove(NativeWindowPoint pointer)
     {
         ReleaseCapture();
-        SendMessage(_hwnd, WmNcLButtonDown, HtCaption, 0);
+        SendMessage(
+            _hwnd,
+            WmNcLButtonDown,
+            HtCaption,
+            PackScreenPoint(pointer));
         return true;
     }
 
@@ -263,12 +272,21 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
         }
 
         ReleaseCapture();
-        SendMessage(_hwnd, WmNcLButtonDown, MapHitTest(edge), 0);
+        SendMessage(
+            _hwnd,
+            WmNcLButtonDown,
+            MapHitTest(edge),
+            PackScreenPoint(pointer));
         return true;
     }
 
     private nint WindowProcedure(nint hwnd, uint message, nint wParam, nint lParam)
     {
+        if (message == WmEnterSizeMove)
+            _isInteractiveMoveResize = true;
+        else if (message == WmExitSizeMove)
+            _isInteractiveMoveResize = false;
+
         if (_extended && message == WmNcCalcSize)
         {
             return 0;
@@ -401,6 +419,14 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
         NativeResizeEdge.BottomLeft => HtBottomLeft,
         _ => HtBottomRight
     };
+
+    private static nint PackScreenPoint(
+        NativeWindowPoint pointer)
+    {
+        uint x = unchecked((ushort)(short)pointer.X);
+        uint y = unchecked((ushort)(short)pointer.Y);
+        return unchecked((nint)(x | (y << 16)));
+    }
 
     public override void Dispose()
     {

--- a/src/ProGPU.Scene/Compositor.IncrementalPages.cs
+++ b/src/ProGPU.Scene/Compositor.IncrementalPages.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ProGPU.Backend;
+using ProGPU.Text;
 using ProGPU.Vector;
 
 namespace ProGPU.Scene;
@@ -33,6 +34,7 @@ public unsafe partial class Compositor
         int VectorIndexStart,
         int TextVertexStart,
         int TextStyleStart,
+        int GlyphResidencyStart,
         int TextureVertexStart,
         int TextureIndexStart,
         int DrawCallStart,
@@ -80,6 +82,7 @@ public unsafe partial class Compositor
         internal required IncrementalScenePageDrawCall[] DrawCalls { get; init; }
         internal required GpuBrush[] Brushes { get; init; }
         internal required GpuTextStyle[] TextStyles { get; init; }
+        internal required GlyphAtlas.ResidencySet GlyphResidency { get; init; }
         internal required int LegacyTextVertexCount { get; init; }
         internal required int SolidRoundedPrimitiveCount { get; init; }
         internal required long ByteSize { get; init; }
@@ -273,6 +276,14 @@ public unsafe partial class Compositor
             return false;
         }
 
+        if (!_atlas.TryMarkRetainedGlyphReplay(page.GlyphResidency))
+        {
+            RemoveIncrementalScenePages(node);
+            _incrementalScenePageMissReason ??= "Glyph atlas residency changed";
+            _incrementalScenePageMisses++;
+            return false;
+        }
+
         CommitPendingDrawCalls();
         AppendIncrementalScenePage(page);
         _pathAtlas.MarkRetainedPathReplay();
@@ -419,6 +430,7 @@ public unsafe partial class Compositor
             _vectorIndicesList.Count,
             _textVerticesList.Count,
             _activeTextStyles.Count,
+            _atlas.BatchUsageCount,
             _textureVerticesList.Count,
             _textureIndicesList.Count,
             _drawCalls.Count,
@@ -700,6 +712,10 @@ public unsafe partial class Compositor
             CollectionsMarshal.AsSpan(_activeTextStyles)
                 .Slice(boundary.TextStyleStart, textStyleCount),
             reusablePage?.TextStyles);
+        GlyphAtlas.ResidencySet glyphResidency =
+            _atlas.CaptureBatchResidency(
+                boundary.GlyphResidencyStart,
+                reusablePage?.GlyphResidency);
 
         for (int index = 0; index < vectorIndices.Length; index++)
         {
@@ -737,7 +753,8 @@ public unsafe partial class Compositor
             (long)drawCalls.Length *
                 Unsafe.SizeOf<IncrementalScenePageDrawCall>() +
             (long)brushes.Length * Marshal.SizeOf<GpuBrush>() +
-            (long)textStyles.Length * Marshal.SizeOf<GpuTextStyle>();
+            (long)textStyles.Length * Marshal.SizeOf<GpuTextStyle>() +
+            glyphResidency.ByteSize;
 
         return new IncrementalScenePage
         {
@@ -749,6 +766,7 @@ public unsafe partial class Compositor
             DrawCalls = drawCalls,
             Brushes = brushes,
             TextStyles = textStyles,
+            GlyphResidency = glyphResidency,
             LegacyTextVertexCount =
                 CountLegacyTextVertices(textVertices),
             SolidRoundedPrimitiveCount =

--- a/src/ProGPU.Scene/Compositor.RetainedPictures.cs
+++ b/src/ProGPU.Scene/Compositor.RetainedPictures.cs
@@ -124,6 +124,15 @@ public unsafe partial class Compositor
             return false;
         }
 
+        if (!_atlas.TryMarkRetainedGlyphReplay(page.GlyphResidency))
+        {
+            RemoveRetainedCompositionPicture(lookup);
+            observation =
+                _retainedPictureObservations.GetOrCreateValue(picture);
+            _retainedCompositionPictureMisses++;
+            return false;
+        }
+
         CommitPendingDrawCalls();
         AppendIncrementalScenePage(page);
         _pathAtlas.MarkRetainedPathReplay();
@@ -149,6 +158,7 @@ public unsafe partial class Compositor
             _vectorIndicesList.Count,
             _textVerticesList.Count,
             _activeTextStyles.Count,
+            _atlas.BatchUsageCount,
             _textureVerticesList.Count,
             _textureIndicesList.Count,
             _drawCalls.Count,

--- a/src/ProGPU.Tests/LayerRenderTests.cs
+++ b/src/ProGPU.Tests/LayerRenderTests.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Microsoft.UI.Xaml;
 using ProGPU.Backend;
 using ProGPU.Backend.Dawn;
+using ProGPU.Fonts.Inter;
 using ProGPU.Scene;
 using ProGPU.Tests.Headless;
 using ProGPU.Vector;
@@ -494,6 +495,71 @@ public sealed class LayerRenderTests
             metrics = window.Compositor.Metrics;
             Assert.Equal(0, metrics.IncrementalSceneUploadBytes);
             Assert.Equal(0, metrics.SceneUploadCopyCount);
+        }
+        finally
+        {
+            window.Content = null;
+        }
+    }
+
+    [Fact]
+    public void IncrementalTextPageReplayRetainsGlyphsDuringLaterAtlasChurn()
+    {
+        var options = CompositorOptions.Default with
+        {
+            EnableCompiledSceneCache = false,
+            EnableGpuHitTesting = false,
+            PrimarySampleCount = 1,
+            GlyphAtlasSize = 96,
+            InitialGlyphAtlasSize = 96
+        };
+        using var window = new HeadlessWindow(512, 256, options);
+        var retainedLabel = new OwnedTextPageVisual(
+            "A",
+            new Vector2(8f, 48f));
+        var atlasChurn = new OwnedTextPageVisual(
+            "BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()",
+            new Vector2(64f, 48f),
+            lineLength: 12);
+        var host = new IncrementalPageHost(retainedLabel, atlasChurn)
+        {
+            Width = 512f,
+            Height = 256f,
+            GeometryClip = PrimitivePathGeometry.CreateRectangle(
+                0f,
+                0f,
+                512f,
+                256f)
+        };
+        window.Content = host;
+
+        try
+        {
+            window.Render();
+            byte[] firstLabel = CopyPixelRegion(
+                window.ReadPixels(),
+                window.Width,
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64);
+
+            atlasChurn.SetText(
+                "abcdefghijklmnopqrstuvwxyz[]{}<>?/\\|`~:;,_+-=",
+                lineLength: 12);
+            window.Render();
+
+            Assert.Equal(1, window.Compositor.Metrics.IncrementalScenePageHits);
+            Assert.True(window.Compositor.Metrics.GlyphLastBatchNewGlyphCount > 0);
+            Assert.Equal(
+                firstLabel,
+                CopyPixelRegion(
+                    window.ReadPixels(),
+                    window.Width,
+                    x: 0,
+                    y: 0,
+                    width: 64,
+                    height: 64));
         }
         finally
         {
@@ -1069,6 +1135,29 @@ public sealed class LayerRenderTests
             pixels[index + 3]);
     }
 
+    private static byte[] CopyPixelRegion(
+        byte[] pixels,
+        uint sourceWidth,
+        int x,
+        int y,
+        int width,
+        int height)
+    {
+        var result = new byte[checked(width * height * 4)];
+        int sourceStride = checked((int)sourceWidth * 4);
+        int destinationStride = checked(width * 4);
+        for (int row = 0; row < height; row++)
+        {
+            Array.Copy(
+                pixels,
+                checked((y + row) * sourceStride + x * 4),
+                result,
+                row * destinationStride,
+                destinationStride);
+        }
+        return result;
+    }
+
     private static void AssertRed(RgbaPixel pixel)
     {
         Assert.True(pixel.R >= 220, $"Expected cached layer to render red, found {pixel}.");
@@ -1370,6 +1459,56 @@ public sealed class LayerRenderTests
             Height = 16f;
             Transform = Matrix4x4.CreateTranslation(offset.X, offset.Y, 0f);
             _commands.DrawTexture(texture, new Rect(0f, 0f, 16f, 16f));
+        }
+
+        public DrawingContext GetOrUpdateRenderCommandCache() => _commands;
+    }
+
+    private sealed class OwnedTextPageVisual : FrameworkElement,
+        IIncrementalRenderCommandCache
+    {
+        private readonly DrawingContext _commands = new();
+        private readonly float _textY;
+
+        public OwnedTextPageVisual(
+            string text,
+            Vector2 offset,
+            int lineLength = int.MaxValue)
+        {
+            Width = 448f;
+            Height = 256f;
+            _textY = offset.Y;
+            Transform = Matrix4x4.CreateTranslation(
+                offset.X,
+                0f,
+                0f);
+            RecordText(text, lineLength);
+        }
+
+        public void SetText(string text, int lineLength)
+        {
+            _commands.Clear();
+            RecordText(text, lineLength);
+            Invalidate();
+        }
+
+        private void RecordText(string text, int lineLength)
+        {
+            var brush = new SolidColorBrush(Vector4.One);
+            int start = 0;
+            int line = 0;
+            while (start < text.Length)
+            {
+                int count = Math.Min(lineLength, text.Length - start);
+                _commands.DrawText(
+                    text.Substring(start, count),
+                    InterFontFamily.Regular,
+                    36f,
+                    brush,
+                    new Vector2(0f, _textY + line * 40f));
+                start += count;
+                line++;
+            }
         }
 
         public DrawingContext GetOrUpdateRenderCommandCache() => _commands;

--- a/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
+++ b/src/ProGPU.Tests/SamplePerformanceRegressionTests.cs
@@ -740,6 +740,86 @@ public sealed class SamplePerformanceRegressionTests
     }
 
     [Fact]
+    public void RetainedGlyphResidencyProtectsReplayedAtlasEntriesFromLruReuse()
+    {
+        var font = LoadTestFont();
+        using var atlas = new GlyphAtlas(
+            HeadlessWindow.Shared.Context,
+            atlasSize: 96);
+        ushort firstGlyph = font.GetGlyphIndex('A');
+        GlyphAtlas.ResidencySet residency;
+        GlyphInfo first;
+        ushort missingGlyph = 0;
+        int residentGlyphs = 0;
+
+        atlas.BeginBatch();
+        try
+        {
+            int residencyStart = atlas.BatchUsageCount;
+            first = atlas.GetOrCreateGlyphByIndex(
+                font,
+                firstGlyph,
+                36f,
+                preferGlyphAtlas: true);
+            residency = atlas.CaptureBatchResidency(residencyStart);
+
+            for (char character = 'B'; character <= '~'; character++)
+            {
+                ushort glyph = font.GetGlyphIndex(character);
+                GlyphInfo info = atlas.GetOrCreateGlyphByIndex(
+                    font,
+                    glyph,
+                    36f,
+                    preferGlyphAtlas: true);
+                if (info.Width == 0)
+                {
+                    missingGlyph = glyph;
+                    break;
+                }
+
+                residentGlyphs++;
+            }
+        }
+        finally
+        {
+            atlas.EndBatch();
+        }
+
+        Assert.True(first.Width > 0);
+        Assert.Equal(1, residency.Count);
+        Assert.True(residentGlyphs > 0);
+        Assert.NotEqual((ushort)0, missingGlyph);
+
+        atlas.BeginBatch();
+        try
+        {
+            Assert.True(atlas.TryMarkRetainedGlyphReplay(residency));
+            GlyphInfo replacement = atlas.GetOrCreateGlyphByIndex(
+                font,
+                missingGlyph,
+                36f,
+                preferGlyphAtlas: true);
+            GlyphInfo replayed = atlas.GetOrCreateGlyphByIndex(
+                font,
+                firstGlyph,
+                36f,
+                preferGlyphAtlas: true);
+
+            Assert.True(replacement.Width > 0);
+            Assert.Equal(first.X, replayed.X);
+            Assert.Equal(first.Y, replayed.Y);
+            Assert.Equal(first.Width, replayed.Width);
+            Assert.Equal(first.Height, replayed.Height);
+        }
+        finally
+        {
+            atlas.EndBatch();
+        }
+
+        Assert.True(atlas.EvictionCount > 0);
+    }
+
+    [Fact]
     public void SampleEffectGpuResourcesAreCreatedOnlyByEffectPages()
     {
         var controller = File.ReadAllText(FindRepoFile(

--- a/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
+++ b/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
@@ -121,6 +121,10 @@ public sealed class WindowsDpiAwarenessTests
             win32,
             StringComparison.Ordinal);
         Assert.Contains(
+            "EnsureWindowProcedure(true);",
+            win32,
+            StringComparison.Ordinal);
+        Assert.Contains(
             "PackScreenPoint(pointer)",
             win32,
             StringComparison.Ordinal);

--- a/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
+++ b/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
@@ -75,6 +75,62 @@ public sealed class WindowsDpiAwarenessTests
     }
 
     [Fact]
+    public void AvaloniaSilkWindowingPreservesWindowsInteractiveContracts()
+    {
+        string window = File.ReadAllText(
+            FindRepoFile(
+                "src",
+                "ProGPU.Avalonia.SilkNet",
+                "SilkNetDesktopWindow.cs"));
+        string win32 = File.ReadAllText(
+            FindRepoFile(
+                "src",
+                "ProGPU.Backend",
+                "Win32NativeWindowPlatform.cs"));
+
+        Assert.Contains(
+            "ResolveLogicalClientSize(",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "result.X / scaling",
+            window,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "point.X / scaling",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "IsInteractiveMoveResize == true",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Dispatcher.UIThread.Post(",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "_window?.IsInitialized == true",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "OnRender(0d);",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "WmEnterSizeMove",
+            win32,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "PackScreenPoint(pointer)",
+            win32,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "SendMessage(_hwnd, WmNcLButtonDown, HtCaption, 0)",
+            win32,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FeatureRenderSurfacesUseResolvedWindowDpiScale()
     {
         string shaderToy = File.ReadAllText(FindRepoFile("src", "ProGPU.Samples", "Controls", "ShaderToyControl.cs"));

--- a/src/ProGPU.Text/GlyphAtlas.cs
+++ b/src/ProGPU.Text/GlyphAtlas.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Silk.NET.WebGPU;
 using ProGPU.Backend;
@@ -64,7 +65,30 @@ public unsafe class GlyphAtlas : IDisposable
     private uint _nextShelfY = 2;
     private uint _nextColorShelfY = 2;
 
-    private readonly record struct GlyphKey(TtfFont Font, ushort GlyphIndex, float Size, byte SubpixelX);
+    internal readonly record struct GlyphKey(
+        TtfFont Font,
+        ushort GlyphIndex,
+        float Size,
+        byte SubpixelX);
+
+    /// <summary>
+    /// Opaque set of glyph-atlas entries referenced by retained compositor data.
+    /// The atlas owns the key representation so consumers cannot manufacture a
+    /// residency claim from texture coordinates that may have been recycled.
+    /// </summary>
+    public sealed class ResidencySet
+    {
+        internal ResidencySet()
+        {
+        }
+
+        internal GlyphKey[] Keys = Array.Empty<GlyphKey>();
+
+        public int Count { get; internal set; }
+
+        public long ByteSize =>
+            (long)Keys.Length * Unsafe.SizeOf<GlyphKey>();
+    }
 
     private struct CachedGlyph
     {
@@ -74,6 +98,8 @@ public unsafe class GlyphAtlas : IDisposable
     }
 
     private readonly Dictionary<GlyphKey, CachedGlyph> _glyphs = new();
+    private readonly List<GlyphKey> _batchGlyphUsages = new();
+    private readonly HashSet<GlyphKey> _glyphResidencyScratch = new();
     private sealed class FontGpuData
     {
         public Dictionary<ushort, uint> RecordSlots { get; } = new();
@@ -132,6 +158,7 @@ public unsafe class GlyphAtlas : IDisposable
         TrimGpuOutlineCache();
         _frameNumber++;
         _currentBatchNewGlyphCount = 0;
+        _batchGlyphUsages.Clear();
 
         CreateBatchEncoder();
     }
@@ -378,6 +405,81 @@ public unsafe class GlyphAtlas : IDisposable
     public ulong RasterComputePassCount { get; private set; }
 
     public int LastBatchNewGlyphCount { get; private set; }
+
+    /// <summary>
+    /// Current-frame glyph-use cursor for a retained compilation boundary.
+    /// </summary>
+    public int BatchUsageCount => _batchGlyphUsages.Count;
+
+    /// <summary>
+    /// Captures the distinct atlas entries used since <paramref name="startIndex"/>.
+    /// The returned opaque set may be reused by a retained compositor page.
+    /// </summary>
+    public ResidencySet CaptureBatchResidency(
+        int startIndex,
+        ResidencySet? reusable = null)
+    {
+        if ((uint)startIndex > (uint)_batchGlyphUsages.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startIndex));
+        }
+
+        _glyphResidencyScratch.Clear();
+        for (int index = startIndex; index < _batchGlyphUsages.Count; index++)
+        {
+            _glyphResidencyScratch.Add(_batchGlyphUsages[index]);
+        }
+
+        ResidencySet result = reusable ?? new ResidencySet();
+        int count = _glyphResidencyScratch.Count;
+        if (result.Keys.Length != count)
+        {
+            result.Keys = count == 0
+                ? Array.Empty<GlyphKey>()
+                : new GlyphKey[count];
+        }
+
+        _glyphResidencyScratch.CopyTo(result.Keys);
+        result.Count = count;
+        return result;
+    }
+
+    /// <summary>
+    /// Protects the atlas entries referenced by retained vertices from eviction
+    /// for the remainder of the current frame. Returns false if any entry is no
+    /// longer resident, so the caller can recompile instead of sampling a reused
+    /// atlas region.
+    /// </summary>
+    public bool TryMarkRetainedGlyphReplay(ResidencySet residency)
+    {
+        ArgumentNullException.ThrowIfNull(residency);
+
+        for (int index = 0; index < residency.Count; index++)
+        {
+            GlyphKey key = residency.Keys[index];
+            if (!_glyphs.TryGetValue(key, out CachedGlyph cached) ||
+                cached.IsCapacityFallback ||
+                cached.Info.AtlasRegionWidth == 0 ||
+                cached.Info.AtlasRegionHeight == 0)
+            {
+                return false;
+            }
+        }
+
+        for (int index = 0; index < residency.Count; index++)
+        {
+            GlyphKey key = residency.Keys[index];
+            CachedGlyph cached = _glyphs[key];
+            if (cached.LastUsedFrame != _frameNumber)
+            {
+                cached.LastUsedFrame = _frameNumber;
+                _glyphs[key] = cached;
+            }
+            _batchGlyphUsages.Add(key);
+        }
+
+        return true;
+    }
 
     public ulong Generation { get; private set; }
 
@@ -675,6 +777,7 @@ public unsafe class GlyphAtlas : IDisposable
                     cached.LastUsedFrame = _frameNumber;
                     _glyphs[key] = cached;
                 }
+                RecordBatchGlyphUsage(key, cached.Info);
                 return cached.Info;
             }
 
@@ -686,6 +789,7 @@ public unsafe class GlyphAtlas : IDisposable
             if (TryCreateColorBitmapGlyph(font, glyphIdx, size, preferGlyphAtlas, out info))
             {
                 CacheGlyph(key, info);
+                RecordBatchGlyphUsage(key, info);
                 return info;
             }
             // Color vector glyphs are emitted as paths by the compositor.
@@ -1013,7 +1117,18 @@ public unsafe class GlyphAtlas : IDisposable
             CacheGlyph(key, info);
         }
 
+        RecordBatchGlyphUsage(key, info);
         return info;
+    }
+
+    private void RecordBatchGlyphUsage(in GlyphKey key, in GlyphInfo info)
+    {
+        if (_batchDepth > 0 &&
+            info.AtlasRegionWidth > 0 &&
+            info.AtlasRegionHeight > 0)
+        {
+            _batchGlyphUsages.Add(key);
+        }
     }
 
     private void CacheGlyph(GlyphKey key, GlyphInfo info, bool isCapacityFallback = false)

--- a/tests/ProGPU.Avalonia.ContractTests/AvaloniaEncodedImageContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/AvaloniaEncodedImageContractTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Buffers.Binary;
 using System.IO;
+using Avalonia.Media.Imaging;
 using Avalonia.ProGpu;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
@@ -29,6 +31,22 @@ public sealed class AvaloniaEncodedImageContractTests
 
         Assert.Throws<InvalidDataException>(
             () => AvaloniaEncodedImage.Identify(icon));
+    }
+
+    [Fact]
+    public void ImmutableIconBitmapCanBeSavedAsPng()
+    {
+        using var source = new MemoryStream(CreateTwoPixelIcon());
+        using var bitmap = new ImmutableBitmap(source);
+        using var encoded = new MemoryStream();
+
+        bitmap.Save(encoded, PngBitmapEncoderOptions.Default);
+
+        using Image<Rgba32> image = Image.Load<Rgba32>(encoded.ToArray());
+        Assert.Equal(2, image.Width);
+        Assert.Equal(1, image.Height);
+        Assert.Equal(new Rgba32(255, 0, 0, 255), image[0, 0]);
+        Assert.Equal(new Rgba32(0, 255, 0, 0), image[1, 0]);
     }
 
     [Fact]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/DisplayMetricsContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/DisplayMetricsContractTests.cs
@@ -38,6 +38,45 @@ public sealed class DisplayMetricsContractTests
     }
 
     [Fact]
+    public void FrameInsetsAreConvertedFromWindowsPixelsToLogicalUnits()
+    {
+        Size? frame = SilkNetDisplayMetrics.ResolveFrameSize(
+            new Size(800, 600),
+            new NativeWindowFrameInsets(12, 45, 12, 12),
+            desktopScaling: 1.5d);
+
+        Assert.Equal(new Size(816, 638), frame);
+    }
+
+    [Theory]
+    [InlineData(1200, 900, 1.5d, 800d, 600d)]
+    [InlineData(800, 600, 1d, 800d, 600d)]
+    public void NativeClientPixelsConvertToAvaloniaLogicalUnits(
+        int nativeWidth,
+        int nativeHeight,
+        double desktopScaling,
+        double expectedWidth,
+        double expectedHeight)
+    {
+        Assert.Equal(
+            new Size(expectedWidth, expectedHeight),
+            SilkNetDisplayMetrics.ResolveLogicalClientSize(
+                nativeWidth,
+                nativeHeight,
+                desktopScaling));
+    }
+
+    [Fact]
+    public void AvaloniaLogicalSizeConvertsToWindowsClientPixels()
+    {
+        Assert.Equal(
+            new PixelSize(1200, 900),
+            SilkNetDisplayMetrics.ResolveNativeClientSize(
+                new Size(800, 600),
+                desktopScaling: 1.5d));
+    }
+
+    [Fact]
     public void NativeScaleRepairsOneToOneSilkFramebufferReports()
     {
         double scaling = SilkNetDisplayMetrics.ResolveRenderScaling(
@@ -64,7 +103,7 @@ public sealed class DisplayMetricsContractTests
     }
 
     [Fact]
-    public void PhysicalTargetNeverUsesFewerPixelsThanNativeBackingScale()
+    public void RetinaTargetUsesLogicalSizeTimesRenderScale()
     {
         PixelSize size =
             SilkNetDisplayMetrics.ResolveFramebufferPixelSize(
@@ -75,6 +114,21 @@ public sealed class DisplayMetricsContractTests
                 renderScaling: 2d);
 
         Assert.Equal(new PixelSize(2048, 1600), size);
+    }
+
+    [Fact]
+    public void WindowsOneToOneFramebufferIsNotScaledTwice()
+    {
+        PixelSize size =
+            SilkNetDisplayMetrics.ResolveFramebufferPixelSize(
+                windowWidth: 1536,
+                windowHeight: 1200,
+                framebufferWidth: 1536,
+                framebufferHeight: 1200,
+                renderScaling: 1.5d,
+                desktopScaling: 1.5d);
+
+        Assert.Equal(new PixelSize(1536, 1200), size);
     }
 
     [Fact]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/DisplayMetricsContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/DisplayMetricsContractTests.cs
@@ -23,6 +23,22 @@ public sealed class DisplayMetricsContractTests
                 renderScaling));
     }
 
+    [Theory]
+    [InlineData(true, 1.5d, 1.5d)]
+    [InlineData(false, 1.5d, 1d)]
+    [InlineData(true, 0d, 1d)]
+    public void OnlyWindowsUsesPhysicalClientAndPointerCoordinates(
+        bool isWindows,
+        double desktopScaling,
+        double expected)
+    {
+        Assert.Equal(
+            expected,
+            SilkNetDisplayMetrics.ResolveNativeCoordinateScaling(
+                isWindows,
+                desktopScaling));
+    }
+
     [Fact]
     public void FrameSizeIncludesNativeChromeInsets()
     {

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
@@ -20,6 +20,21 @@ public sealed class InputAndCursorContractTests
                 desktopScaling: 1.5d));
     }
 
+    [Fact]
+    public void LinuxPointerScreenCoordinatesRemainLogical()
+    {
+        double coordinateScaling =
+            SilkNetDisplayMetrics.ResolveNativeCoordinateScaling(
+                isWindows: false,
+                desktopScaling: 1.5d);
+
+        Assert.Equal(
+            new Point(300, 150),
+            SilkNetInputRouter.ToLogicalPoint(
+                new Vector2(300, 150),
+                coordinateScaling));
+    }
+
     [Theory]
     [InlineData(true, false, true)]
     [InlineData(true, true, false)]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
@@ -1,9 +1,12 @@
 using Avalonia;
 using Avalonia.Input;
+using Avalonia.Input.Raw;
 using Avalonia.SilkNet;
 using System.Numerics;
+using GlfwKeyModifiers = Silk.NET.GLFW.KeyModifiers;
 using SilkKey = Silk.NET.Input.Key;
 using SilkStandardCursor = Silk.NET.Input.StandardCursor;
+using ProGPU.Backend;
 using Xunit;
 
 namespace ProGPU.Avalonia.SilkNet.ContractTests;
@@ -33,6 +36,109 @@ public sealed class InputAndCursorContractTests
             SilkNetInputRouter.ToLogicalPoint(
                 new Vector2(300, 150),
                 coordinateScaling));
+    }
+
+    [Theory]
+    [InlineData(0x41u, "A")]
+    [InlineData(0x00e9u, "é")]
+    [InlineData(0x1f642u, "🙂")]
+    public void GlfwUnicodeScalarsPreserveCompleteTextInput(
+        uint codePoint,
+        string expected)
+    {
+        Assert.Equal(
+            expected,
+            SilkNetInputRouter.ConvertUnicodeScalar(codePoint));
+    }
+
+    [Theory]
+    [InlineData(0xd800u)]
+    [InlineData(0x110000u)]
+    public void InvalidUnicodeScalarsAreIgnored(uint codePoint)
+    {
+        Assert.Null(
+            SilkNetInputRouter.ConvertUnicodeScalar(codePoint));
+    }
+
+    [Theory]
+    [InlineData(NativeTouchPhase.Begin, RawPointerEventType.TouchBegin)]
+    [InlineData(NativeTouchPhase.Update, RawPointerEventType.TouchUpdate)]
+    [InlineData(NativeTouchPhase.End, RawPointerEventType.TouchEnd)]
+    [InlineData(NativeTouchPhase.Cancel, RawPointerEventType.TouchCancel)]
+    public void NativeTouchPhasesMapToAvaloniaPointerContracts(
+        NativeTouchPhase phase,
+        RawPointerEventType expected)
+    {
+        Assert.Equal(expected, SilkNetInputRouter.MapTouchPhase(phase));
+    }
+
+    [Fact]
+    public void GlfwCallbackModifiersMapToAvaloniaShortcutModifiers()
+    {
+        Assert.Equal(
+            RawInputModifiers.Control |
+            RawInputModifiers.Shift |
+            RawInputModifiers.Alt |
+            RawInputModifiers.Meta,
+            SilkNetInputRouter.MapGlfwModifiers(
+                GlfwKeyModifiers.Control |
+                GlfwKeyModifiers.Shift |
+                GlfwKeyModifiers.Alt |
+                GlfwKeyModifiers.Super));
+    }
+
+    [Theory]
+    [InlineData(0x0200u)]
+    [InlineData(0x0201u)]
+    [InlineData(0x0202u)]
+    [InlineData(0x020au)]
+    [InlineData(0x020eu)]
+    public void Win32PromotedTouchMouseMessagesAreRecognized(
+        uint message)
+    {
+        Assert.True(
+            Win32NativeWindowPlatform.IsPromotedTouchMouseMessage(
+                message,
+                unchecked((nint)0xff515780u)));
+        Assert.False(
+            Win32NativeWindowPlatform.IsPromotedTouchMouseMessage(
+                message,
+                unchecked((nint)0xff515700u)));
+        Assert.False(
+            Win32NativeWindowPlatform.IsPromotedTouchMouseMessage(
+                message,
+                0));
+    }
+
+    [Fact]
+    public void Win32TouchSignatureDoesNotSuppressNonMouseMessages()
+    {
+        Assert.False(
+            Win32NativeWindowPlatform.IsPromotedTouchMouseMessage(
+                0x0240u,
+                unchecked((nint)0xff515780u)));
+    }
+
+    [Theory]
+    [InlineData(0, RawPointerEventType.Magnify)]
+    [InlineData(1, RawPointerEventType.Rotate)]
+    [InlineData(2, RawPointerEventType.Swipe)]
+    public void MacTrackpadGesturesMapToAvaloniaPointerContracts(
+        int kind,
+        RawPointerEventType expected)
+    {
+        Assert.Equal(
+            expected,
+            SilkNetInputRouter.MapMacOsGesture(
+                (MacOsGestureKind)kind));
+    }
+
+    [Fact]
+    public void X11TouchInteropMatches64BitXlibLayouts()
+    {
+        Assert.Equal(192, X11TouchInputSource.NativeEventSize);
+        Assert.Equal(56, X11TouchInputSource.NativeCookieSize);
+        Assert.Equal(200, X11TouchInputSource.NativeDeviceEventSize);
     }
 
     [Theory]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Input;
 using Avalonia.SilkNet;
+using System.Numerics;
 using SilkKey = Silk.NET.Input.Key;
 using SilkStandardCursor = Silk.NET.Input.StandardCursor;
 using Xunit;
@@ -8,6 +10,16 @@ namespace ProGPU.Avalonia.SilkNet.ContractTests;
 
 public sealed class InputAndCursorContractTests
 {
+    [Fact]
+    public void WindowsPointerPixelsConvertToAvaloniaLogicalCoordinates()
+    {
+        Assert.Equal(
+            new Point(200, 100),
+            SilkNetInputRouter.ToLogicalPoint(
+                new Vector2(300, 150),
+                desktopScaling: 1.5d));
+    }
+
     [Theory]
     [InlineData(true, false, true)]
     [InlineData(true, true, false)]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/WindowChromeContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/WindowChromeContractTests.cs
@@ -257,5 +257,16 @@ public sealed class WindowChromeContractTests
                 new Size(
                     double.PositiveInfinity,
                     double.NaN)));
+
+        Assert.Equal(
+            new NativeWindowSize(16, 31),
+            SilkNetWindowChrome.ToMinimumSize(
+                new Size(10.1, 20.01),
+                desktopScaling: 1.5d));
+        Assert.Equal(
+            new NativeWindowSize(149, 299),
+            SilkNetWindowChrome.ToMaximumSize(
+                new Size(99.9, 199.8),
+                desktopScaling: 1.5d));
     }
 }

--- a/tools/build-avalonia-native-dawn.sh
+++ b/tools/build-avalonia-native-dawn.sh
@@ -8,6 +8,7 @@ project="$avalonia_root/native/Avalonia.Native/src/OSX/Avalonia.Native.OSX.xcode
 generated_header="$avalonia_root/native/Avalonia.Native/inc/avalonia-native.h"
 header_generator="$avalonia_root/native/Avalonia.Native/generate-headers.sh"
 destination="${1:-$repo_root/integration/AvaloniaSourceControlCatalog/bin/Release/net10.0/runtimes/osx/native/libAvaloniaNative.dylib}"
+canonical_product="$avalonia_root/Build/Products/Release/libAvalonia.Native.OSX.dylib"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "The Avalonia Native Dawn presentation lane requires macOS." >&2
@@ -65,6 +66,9 @@ if [[ ! -f "$product" ]]; then
 fi
 
 cp "$product" "$destination"
+mkdir -p "$(dirname "$canonical_product")"
+cp "$product" "$canonical_product"
 codesign --force --sign - "$destination"
+codesign --force --sign - "$canonical_product"
 
 echo "[AvaloniaNativeDawn] installed=$destination architecture=$(uname -m)"

--- a/tools/build-avalonia-native-dawn.sh
+++ b/tools/build-avalonia-native-dawn.sh
@@ -22,7 +22,7 @@ if [[ ! -f "$source_file" || ! -d "$project" ]]; then
   echo "The exact Avalonia source tree is missing. Run tools/prepare-avalonia-12.1.1-source.sh first." >&2
   exit 3
 fi
-if ! rg -q '_layer\.framebufferOnly[[:space:]]*=[[:space:]]*false;' "$source_file"; then
+if ! grep -Eq '_layer\.framebufferOnly[[:space:]]*=[[:space:]]*false;' "$source_file"; then
   echo "The Avalonia CAMetalLayer is not configured for Dawn-importable IOSurfaces." >&2
   exit 4
 fi


### PR DESCRIPTION
## Summary

- fix Windows DPI conversion, physical framebuffer sizing, live modal resize layout, and custom-title-bar dragging in the Avalonia Silk.NET host
- complete routed input for GLFW repeats, UTF-32 text, key symbols/modifiers, pointer leave, five mouse buttons, two-axis wheel, Win32 touch, X11 XI2.2 touch, and macOS trackpad gestures
- add a dedicated Silk.NET input/window harness plus Windows physical-coordinate injection and cross-version contracts
- validate ProGPU rendering under Avalonia Win32, Avalonia.Native/macOS, and X11 windowing; expand ControlCatalog clip/cache/effect/adorner telemetry gates across all three CI hosts and visual screenshot gates on interactive macOS, Linux, and Windows VM desktops
- fix the integration defects found by that matrix: retained glyph-atlas residency during incremental replay, Linux Dawn resolution and opaque X11 visuals, ICO re-encoding, deterministic fixture timing, and macOS AvaloniaNative staging

## Primary sources and clean-room record

- GLFW window and input contracts: https://www.glfw.org/docs/3.4/window_guide.html and https://www.glfw.org/docs/3.4/input_guide.html
- Win32 modal sizing, native caption drag, and touch: https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-entersizemove, https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-nclbuttondown, and https://learn.microsoft.com/en-us/windows/win32/wintouch/wm-touchdown
- XInput 2.2 touch protocol: https://www.x.org/releases/current/doc/inputproto/XI2proto.txt
- AppKit gesture responder contracts: https://developer.apple.com/documentation/appkit/nsresponder/magnify(with:), https://developer.apple.com/documentation/appkit/nsresponder/rotate(with:), and https://developer.apple.com/documentation/appkit/nsresponder/swipe(with:)
- retained glyph residency research: Skia `GrTextBlob`/`GrDrawOpAtlas`, Direct2D resource domains, WebRender `gpu_cache`, Vello resource design, and HarfBuzz shaping/shape-plan contracts; direct links and adopted/adapted/rejected decisions are recorded in `docs/progpu-avalonia-rendering-research.md`

The implementation is original ProGPU code. External sources informed public contracts, architecture, and observable behavior only.

## Validation

- Avalonia Silk.NET Release contracts: 115 passed on Avalonia 12.1.1 and 102 passed on Avalonia 11.3.20
- Avalonia ProGPU rendering contracts: 99 passed
- retained rendering and atlas regressions: 84 passed, including two focused 96-pixel-atlas replay/churn tests
- macOS native Dawn/Metal: Border, Canvas, ScrollViewer, TextBlock, Viewbox, and AdornerLayer passed at 1024x800 logical / 2048x1600 physical with typed clip, drawing-option, and adorner gates and visually inspected screenshots
- Windows 11 ARM64 Parallels at 200%: live keyboard/text/shortcut/pointer/wheel/five-button input passed; custom title-bar drag passed the 100-pixel native-position gate; gradual edge resize produced four native size and three matching layout observations; native Win32/Dawn rendered the exact Border clip/cache/effect fixture at 1024x800 logical / 2048x1600 physical with zero retained fallback/full-sync regressions and a visually inspected screenshot
- Ubuntu X11 VM: live keyboard/text/shortcut/pointer/wheel/five-button input passed; native Dawn/Vulkan passed the representative page and adorner matrix at 2x with visually inspected screenshots
- GitHub Windows service-desktop CI retains the D3D12/HWND presentation, retained-scene, clip/cache/effect, DPI, and frame-distribution assertions but omits RenderTargetBitmap PNG readback; that service-desktop readback does not complete within the job bound, while the same capture passes on the interactive Parallels desktop
- physical multitouch and trackpad gesture synthesis is unavailable in the VMs; native ABI/phase/suppression/mapping contracts cover those paths, while the live hardware boundaries are documented explicitly

## Managed/native applicability

Windowing and routed input changes belong only to the managed Avalonia/Silk.NET host. The retained glyph defect belongs to the managed compositor LRU atlas and incremental page/picture replay. The native C++ renderer uses an immutable scene-owned positioned-glyph atlas, grows/replaces it as a unit, and has no equivalent incremental-page replay or slot-reuse defect. No native code, C ABI record, or canonical shader change is applicable. The paired-file audit and rationale are documented in `docs/progpu-avalonia-silknet-platform-audit.md` and `docs/progpu-avalonia-rendering-research.md`.
