### PR TITLE
Fix Avalonia windowing, input, and SkiaSharp rendering performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -606,6 +606,27 @@ jobs:
             ./tools/profile-avalonia-controlcatalog.sh \
             artifacts/avalonia-native-dawn-windows-adorner
 
+      - name: Run WebGPU device-loss recovery ControlCatalog smoke
+        shell: bash
+        env:
+          PROGPU_AVALONIA_SKIP_BUILD: 1
+          PROGPU_AVALONIA_BACKENDS: source-progpu,source-progpu-native
+          PROGPU_AVALONIA_PAGE_FILTER: ^Border$
+          PROGPU_AVALONIA_WARMUP_FRAMES: 5
+          PROGPU_AVALONIA_MEASURE_FRAMES: 10
+          PROGPU_AVALONIA_SCREENSHOTS: 0
+          PROGPU_AVALONIA_FORCE_DEVICE_LOSS: 1
+          LIBGL_ALWAYS_SOFTWARE: 1
+        run: |
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            xvfb-run -a \
+              ./tools/profile-avalonia-controlcatalog.sh \
+              artifacts/avalonia-device-loss-recovery
+          else
+            ./tools/profile-avalonia-controlcatalog.sh \
+              artifacts/avalonia-device-loss-recovery
+          fi
+
       - name: Upload Linux native Dawn telemetry
         if: runner.os == 'Linux' && always()
         uses: actions/upload-artifact@v7

--- a/docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md
+++ b/docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md
@@ -45,6 +45,49 @@ contract to adopt:
   converts Unicode buffers to positioned glyphs independently of canvas
   ownership. The existing ProGPU shaping path remains authoritative.
 
+## 2026-08-26 animated custom-draw checkpoint
+
+The ControlCatalog integration gate now overlays 96 clipped SkiaSharp cells on
+the Canvas page. Each cell records rectangle, circle, quadratic/cubic path,
+transform, clip, and save/restore operations, and the fixture invalidates on
+every benchmark pulse. It therefore exercises the public Avalonia lease shape
+with a changing custom visual instead of measuring only construction.
+
+The initial profile found that the wide general `RenderCommand` scratch array
+was repeatedly rented, copied to exact size, and returned while the custom
+visual changed. The clean-room correction keeps one reusable high-water
+recording buffer, compacts analytic circles and ordinary canvas state into
+typed retained commands, and reuses one feature object for the drawing-context
+lifetime. Recording remains `O(C)` for `C` commands; stable storage is bounded
+by the largest observed command count and replay remains `O(C)`. No GPU work,
+shader, text shaping, native ABI, or output-quality contract changed.
+
+Three fresh 60-warmup/300-frame Release processes before the command-storage
+correction allocated 238.09--307.73 KiB/frame. The final exact candidate,
+repeated with 120 warmup and 600 measured frames, allocated 16.02--18.97
+KiB/frame: a 14.9x--16.1x reduction relative to the best/worst paired bounds.
+Both rendered 282 draws per frame through `SilkNetWebGpuSurface`. Frame-time
+distributions were affected by desktop scheduler load, so no throughput
+improvement is claimed.
+
+Matched 12-second final-binary Xcode Allocations/VM Tracker, Time Profiler, and
+Metal System Trace captures were then run against Preview.60 plus only the
+benchmark/type-identity fixture and against the candidate. Persistent native
+heap plus anonymous VM was 204,308,320 versus 206,048,400 bytes (+0.85%, within
+the one-run launch/driver spread). Metal reported 336/360 submissions and
+1,054/1,103 completions, no compiler spills, potential hangs, hang risks, or
+command-buffer errors in either capture. Drawable-wait totals were 74.319 ms
+before and 6.790 ms after, but the single instrumented runs support only the
+absence-of-regression/error gate, not a latency claim. The compact summaries,
+manifests, and target logs were retained; raw traces, exports, and task-owned
+Xcode scratch were deleted after successful summarization.
+
+Managed/native parity is not applicable to this checkpoint. The optimized
+storage is the managed Avalonia retained-recording adapter; both paths still
+consume the same expanded ProGPU commands. The native C++ renderer has no
+Avalonia `ICustomDrawOperation`, SkiaSharp lease, or managed command-array
+ownership, and no corresponding implementation defect was found.
+
 ## Package and type-identity decision
 
 The compatibility contract is implemented in

--- a/docs/progpu-avalonia-rendering-research.md
+++ b/docs/progpu-avalonia-rendering-research.md
@@ -1291,8 +1291,10 @@ boundaries:
 - a monotonic device-loss generation invalidates every existing
   `WgpuContext`; a replacement context starts on the new generation;
 - normal `Destroyed` callbacks are ownership completion, not device loss;
-- lost contexts are excluded from active-context/surface lookup and
-  multi-window device sharing;
+- lost contexts are excluded from healthy-context selection and multi-window
+  device sharing; exact surface lookup can still identify a lost owner so the
+  transition is reported as not-ready instead of silently selecting an
+  unrelated standalone device;
 - `SkiaContext.IsLost` is updated lock-free, allowing Avalonia's renderer
   manager to dispose and recreate the backend without platform graphics;
 - the Silk.NET window creates a replacement device and surface before its
@@ -1325,6 +1327,111 @@ The macOS qualification passed: the shared IOSurface advanced its Metal
 timeline from 4 to 5, Dawn delivered the forced native loss callback with the
 diagnostic message, the existing `WgpuContext` became lost, and a newly
 created Dawn context reported initialized and healthy.
+
+### Device-domain and remote-session surface recovery
+
+The Windows RDP failure gate extends the typed recovery contract to native
+presentation creation and acquisition. Dawn may lose the D3D12 device while
+`Surface.Configure` is creating the DXGI swap chain (including remote-session
+transitions where swap-chain access is temporarily unavailable). A successful
+API return is therefore not sufficient evidence that the surface remained
+configured: the spontaneous device-loss callback is authoritative.
+
+Primary-source comparison:
+
+- the [WebGPU device contract](https://www.w3.org/TR/webgpu/#devices) makes
+  loss terminal for one device and every object created by that device, while
+  recommending creation of a new device for transient causes;
+- [Dawn's surface implementation](https://dawn.googlesource.com/dawn/+/refs/heads/main/src/dawn/native/Surface.cpp)
+  associates configuration with the current device and rejects unconfiguring
+  a surface that was never successfully configured;
+- Avalonia's
+  [`PlatformRenderInterfaceContextManager`](https://github.com/AvaloniaUI/Avalonia/blob/main/src/Avalonia.Base/Rendering/PlatformRenderInterfaceContextManager.cs)
+  discards a lost backend context, while its composition target discards a
+  render target that reports `Corrupted`; ProGPU adopts those public state
+  transitions rather than duplicating Avalonia's backend implementation;
+- [Win2D device-loss guidance](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/handling-device-lost)
+  and the [Direct2D render-target contract](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-quickstart)
+  recreate device-owned resources and replay drawing after the new target is
+  available; DXGI also documents remote/session-disconnect status separately
+  from ordinary success and retry states;
+- [Skia's `GrDirectContext`](https://skia.googlesource.com/skia/+/refs/heads/main/include/gpu/GrDirectContext.h)
+  abandons device-owned buffers and textures after backend loss so later
+  destruction cannot issue unsafe backend calls;
+- WebRender's
+  [GPU process manager](https://searchfox.org/mozilla-central/source/gfx/ipc/GPUProcessManager.cpp)
+  destroys compositor sessions and notifies device-reset listeners before
+  rebuilding or falling back;
+- Vello's
+  [winit integration](https://github.com/linebender/vello/blob/main/examples/with_winit/src/lib.rs)
+  treats outdated/suboptimal and timeout surface acquisition as retryable and
+  requests another redraw. ProGPU adopts that surface/device distinction but
+  replaces Vello's terminal panic with Avalonia corruption recovery;
+- [HarfBuzz shaped buffers](https://harfbuzz.github.io/shaping-and-shape-plans.html)
+  and [Parley layouts](https://docs.rs/parley/latest/parley/struct.Layout.html)
+  are CPU glyph/layout results. They are intentionally retained across device
+  replacement; reshaping text is not part of GPU recovery.
+
+The resulting implementation is original ProGPU code. Each exact native
+callback marks one shared device-domain state in O(1) time and wakes the host;
+it no longer poisons independent WebGPU devices through the compatibility
+process-wide signal. The render thread performs recovery: lost contexts are
+excluded from lookup and sharing, all device-owned compositor/layer/bitmap
+resources report corruption or are disposed, and a new device plus surface is
+created before retained CPU commands are replayed. Surface timeout is skipped;
+outdated/lost surface state invalidates capabilities and reconfigures; explicit
+device loss rebuilds the whole domain. Teardown skips `Unconfigure` after loss,
+preventing Dawn's secondary "Surface is not configured" validation error.
+
+Two additional failure modes were found during physical VM qualification.
+First, Avalonia disposes a lost backend context before the composition target
+releases its old render target. Releasing the Dawn device immediately left the
+still-configured Vulkan/Xlib surface pointing into a destroyed device and
+crashed in Dawn's fenced deleter. Dawn contexts now use explicit O(1) lifetime
+leases: the backend releases owner intent immediately, while each presentation
+surface or Metal target keeps the native device alive until it has released
+its surface and slots. This changes teardown ownership only; steady frames add
+no crossing or allocation.
+
+Second, wgpu-native on the Windows Parallels adapter reported terminal device
+failure through an uncaptured validation error before its device-loss callback
+became observable. Continuing to `wgpuQueueSubmit` then caused a non-unwinding
+native panic with `Parent device is lost`. The exact callback userdata now
+identifies the affected device domain for both device-loss and uncaptured-error
+callbacks. Internal/unknown errors and explicit lost-device/resource-creation
+messages mark that domain terminal, and queue submission rejects it before the
+native call. A failed frame is dropped without presentation; the next frame
+uses Avalonia's ordinary context replacement. A four-byte storage-buffer
+qualification write at device initialization catches adapters that accept
+device creation but fail their first device-owned resource, before expensive
+retained pipeline creation. The qualification is O(1), allocation-free on the
+managed heap after callback setup, and occurs once per new device rather than
+per frame. This is consistent with wgpu's documented
+[DX12 compiler and backend selection](https://github.com/gfx-rs/wgpu#environment-variables)
+contract; it does not change shader source, shader complexity, or retained
+replay semantics.
+
+Normal frames add one lock-free loss-state read and no allocation, upload,
+P/Invoke, or additional managed/native crossing. Recovery is bounded by one
+device/surface recreation and the existing O(C + G) retained-scene replay for
+C commands and G glyphs. The managed and native renderer applicability audit
+found no shader, scene-format, or C ABI change: both compositor
+implementations consume the same lost `WgpuContext` boundary and rebuild their
+device resources; the Dawn native-presentation adapter additionally owns the
+surface-state classification and safe teardown described above.
+
+Physical qualification used the same source-built Border ControlCatalog at
+1024x800 logical size: macOS and Windows rendered at 2048x1600 physical size,
+while the Linux VM's 1x Silk.NET surface rendered at 1024x800 and its 2x native
+X11 surface at 2048x1600. macOS Silk.NET/Metal recovered in one frame and
+native Dawn/Metal in two; Linux Parallels and Windows Parallels recovered in
+one frame for both the Silk.NET and native Dawn lanes. The
+Windows run additionally reproduced the real uncaptured-error/parent-loss path
+without the former native abort. Every final screenshot retained the circular
+image clip, border geometry, text, and 2x layout dimensions. The isolated
+native Dawn diagnostic callback also recreated successfully on macOS. CI now
+runs deterministic forced-loss smoke lanes for both source Silk.NET and native
+Dawn presentation on macOS, Windows, and Linux.
 
 ## Typed multi-window disposal-order validation
 

--- a/docs/progpu-avalonia-silknet-platform-audit.md
+++ b/docs/progpu-avalonia-silknet-platform-audit.md
@@ -1,6 +1,6 @@
 # Avalonia Silk.NET platform contract audit
 
-Audit date: 2026-08-25
+Audit date: 2026-08-26
 
 Supported Avalonia lanes:
 
@@ -40,14 +40,17 @@ both extended-client and ordinary system-chrome windows, tracks the modal
 interval, and synchronously pulses Avalonia layout and presentation only while
 that interval is active. Normal frame scheduling is unchanged.
 
-Custom title-bar dragging previously sent `WM_NCLBUTTONDOWN` synchronously
-with an empty coordinate. The corrected path releases Avalonia pointer capture,
-lets the routed press unwind through a send-priority dispatcher post, and sends
-the signed screen pointer packed in `lParam`, as required by the official
-[`WM_NCLBUTTONDOWN`](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-nclbuttondown)
-contract. This matches the ordering used by Avalonia's official
-[`WindowImpl.BeginMoveDrag`](https://github.com/AvaloniaUI/Avalonia/blob/12.1.1/src/Windows/Avalonia.Win32/WindowImpl.cs)
-without copying its implementation.
+Custom title-bar dragging previously depended on application pointer handlers
+and a synchronous `WM_NCLBUTTONDOWN` transition. That path was unreliable once
+GLFW had advanced the originating event. The windowing backend now resolves
+Avalonia 12's public `WindowDecorationsElementRole` at the raw pointer boundary,
+releases native capture, and posts the documented
+[`WM_SYSCOMMAND`](https://learn.microsoft.com/en-us/windows/win32/menurc/wm-syscommand)
+`SC_MOVE` or `SC_SIZE` request. The raw press is consumed only when a move or
+resize actually starts, so ordinary title-bar controls marked `User` or
+`DecorationsElement` retain client input. macOS and X11 use ProGPU's bounded
+pointer-delta fallback because GLFW does not preserve a usable AppKit event and
+an accepted X11 moveresize message does not prove the compositor honored it.
 
 GLFW's official [window guide](https://www.glfw.org/docs/3.4/window_guide.html)
 was used as the coordinate-space authority. Its distinction between content
@@ -95,13 +98,14 @@ Compatibility mouse messages carrying Microsoft's touch signature are
 suppressed only while their native message is dispatched, preventing one
 finger from producing both touch and mouse routed events.
 
-Linux/X11 touch selects XI2.2 touch begin/update/end events on GLFW's existing
-display connection. A process-local pump removes only matching generic touch
-cookies before GLFW drains the shared Xlib queue, dispatches them to their
-owning X11 window, and suppresses XI2 pointer-emulation mouse events for the
-same poll. The design follows the X.Org
+Linux/X11 touch selects XI2.2 touch begin/update/end events on a dedicated Xlib
+client connection. XI version negotiation is per client; GLFW had already
+negotiated XI2.0 on its connection, which prevented a later XI2.2 touch
+selection from succeeding there. The UI-thread pump drains only the dedicated
+connection, dispatches cookies to their owning X11 window, and suppresses XI2
+pointer-emulation mouse events for the same poll. The design follows the X.Org
 [XI2 protocol](https://www.x.org/releases/current/doc/inputproto/XI2proto.txt)
-and adds no competing display connection or background thread.
+and adds no background thread or access to GLFW's event queue.
 
 macOS desktop hardware exposes indirect trackpad gestures rather than
 touchscreen contacts. The backend adds the public AppKit responder methods
@@ -165,6 +169,13 @@ contract cannot be established by compilation alone.
   scaled X11/Wayland already expose screen-coordinate units. Desktop positions
   remain physical pixels. Deferred window sizes are converted only after the
   native window and its scaling are known.
+- A manual position assigned before `Show` is retained independently of native
+  creation and is supplied in the initial Silk.NET options. Avalonia's later
+  center-screen and center-owner calculations continue through `Move`; native
+  move callbacks update the retained physical position instead of reading a
+  stale platform value back into Avalonia. This covers manual, centered, and
+  subsequent programmatic placement without treating screen coordinates as
+  logical client units.
 - Framebuffer storage uses physical framebuffer pixels. `FrameSize` is unknown
   until native frame insets are available and then includes those insets rather
   than incorrectly returning the client size.
@@ -185,9 +196,11 @@ contract cannot be established by compilation alone.
   notification performs one immediate layout/render pulse so content follows
   the window edge; steady-state and programmatic resize scheduling retain the
   normal event-loop path.
-- Managed title-bar moves release pointer capture and are deferred until the
-  routed press has unwound. The native non-client message carries the actual
-  signed screen coordinate, including negative multi-monitor coordinates.
+- Drawn title bars and resize grips are resolved from Avalonia's decoration
+  role contract before the raw press is routed. Windows enters its native
+  system move/size loop through a posted system command; Cocoa and X11 use one
+  deterministic managed drag state with physical screen deltas. A failed drag
+  start does not swallow client input.
 - An unspecified Avalonia 12 frame theme now resolves through registered
   platform settings, as Avalonia.Native and Win32 do. Native backend defaults
   remain correct for direct controller users: Cocoa clears the explicit
@@ -264,13 +277,13 @@ completed with zero warnings and zero errors.
 
 ## Validation evidence
 
-- The shared Silk.NET contract suite passes in Release against both exact
-  lanes: 115 tests on Avalonia 12.1.1 and 102 tests on Avalonia 11.3.20. The new
+- The Avalonia 12.1.1 Silk.NET contract suite passes 129 tests in Release. The
   coverage includes Windows logical/native client-size conversion, one-to-one
-  Windows framebuffer sizing, scaled frame insets and constraints, scaled
-  Windows pointer input, unchanged Linux screen-coordinate layout/input,
-  UTF-32 text, GLFW modifier mapping, touch phases, X11 ABI layout, macOS
-  gesture mapping, and Windows promoted-mouse suppression.
+  framebuffer sizing, scaled frame insets and constraints, callback-authority
+  for macOS pointer coordinates, UTF-32 text, GLFW modifiers and repeat,
+  decoration-role mapping, touch phases, X11 ABI layout, macOS gesture mapping,
+  and Windows promoted-mouse suppression. The separate pinned Avalonia 11 lane
+  remains compile- and package-gated by its existing compatibility suite.
 - Both windowing projects build in Release, and the focused backend windowing
   presenter suite passes 17 tests.
 - Package validation produced both
@@ -282,15 +295,17 @@ completed with zero warnings and zero errors.
 - A package-backed Release smoke run on macOS rendered the Charting sample
   through `ProGPU/Silk.NET + embedded ProGPU`, presented non-transparent output
   through the same-device WebGPU texture path at 2x DPI, and exited normally.
-- A self-contained Windows ARM64 harness ran in the logged-in Parallels
+- A Windows ARM64 harness ran in the logged-in Parallels
   Windows 11 session at 200% display scaling. Live routed telemetry passed
   keyboard down/up, complete text, Control+Shift+K command routing, pointer
   movement, two-axis-capable wheel routing, and left/right/middle/X1/X2
-  buttons. The window reported a 720x480 logical client, 1440x960 physical
-  rectangle, and `RenderScaling=2`. A custom-title-bar drag moved the native
-  rectangle, and one edge drag produced four client-size notifications and
-  three matching Avalonia layout-size observations before release, proving
-  layout continued inside the modal resize loop.
+  buttons. Windows' synthetic pointer API also delivered a real routed touch
+  begin/update/end sequence without a promoted duplicate mouse event. The
+  window reported a 720x480 logical client, 1440x960 physical framebuffer, and
+  `RenderScaling=2`. A decoration-role title-bar drag moved the native
+  rectangle, and live resize produced matching client-size and Avalonia layout
+  observations before release. Manual initial placement was exactly 180,140
+  physical screen pixels while the surface transitioned from scale 1 to 2.
 - The same Windows VM rendered the ControlCatalog Canvas and text-heavy
   TextBox pages through Avalonia Win32 plus native Dawn/D3D12 at 1024x800
   logical and 2048x1600 physical pixels. The older Silk.NET 2.23
@@ -301,17 +316,27 @@ completed with zero warnings and zero errors.
   remaining VM-specific failure from the corrected Silk.NET window/input
   boundary rather than hiding it as a DPI or layout failure.
 - An Ubuntu X11 VM passed live keyboard, text, pointer, wheel, shortcut, and
-  all five mouse-button telemetry. XI2 touch ABI and conversion are covered by
-  focused contracts because the VM has no injectable physical multitouch
-  device. The rebuilt macOS app passed live keyboard, text, pointer movement,
-  and Command+Shift+K telemetry; AppKit gesture entry points are covered by
-  native mapping contracts because desktop automation cannot synthesize a
-  hardware trackpad gesture at GLFW's responder boundary.
+  all five mouse-button telemetry. A virtual direct-touch device injected
+  through Linux `uinput` produced real XI2.2 begin/update/end events and passed
+  the routed Avalonia touch gate. Title-bar drag, live resize/layout, and manual
+  180,140 placement also passed. The rebuilt macOS app passed keyboard, text,
+  pointer movement, wheel, buttons, Command+Shift+K, title-bar drag, live
+  resize/layout, and exact manual placement at Retina scale 2. AppKit magnify,
+  rotate, and swipe entry points remain native mapping contracts because
+  desktop automation cannot synthesize a hardware trackpad gesture at GLFW's
+  responder boundary.
 - Native Avalonia windowing with Dawn/Metal on macOS passed Border, Canvas,
   ScrollViewer, TextBlock, Viewbox, and AdornerLayer at 1024x800 logical and
   2048x1600 physical output. Typed clip, inherited drawing-option, and adorner
   synchronization gates all passed without a measured full-scene fallback;
   representative screenshots were visually correct.
+- The same Border, Canvas, ScrollViewer, TextBlock, and Viewbox gate passed with
+  Avalonia Win32/Dawn D3D12 and Avalonia X11/Dawn Vulkan. Linux TextBlock
+  exposed a genuine bitmap-only color-emoji culling defect and a too-small
+  managed color-atlas limit. Bitmap strike metrics now contribute glyph-run ink
+  bounds, and the Avalonia renderer grows its color atlas from 64 to at most
+  1024 pixels. The final Noto Color Emoji family sequence rendered without
+  clipping or retained-composition fallback.
 
 ## Managed/native applicability
 
@@ -330,6 +355,13 @@ LRU slot behind retained UVs, and has no equivalent Avalonia incremental-page
 cache. Its applicability audit therefore found no matching defect or native
 code change. Both implementations retain the same shaping, glyph identity,
 DPI, and output contracts; no C ABI record or canonical shader changed.
+
+The bitmap-only color-glyph bounds and Avalonia color-atlas sizing corrections
+are also managed integration concerns. The native C++ color atlas already
+grows dynamically up to its 4096-pixel cap and does not use Avalonia's
+`IGlyphRunImpl.Bounds` for culling. Its applicability audit therefore found no
+paired defect. Both renderers keep the same strike selection, baseline,
+device-scale, and color-glyph image contracts.
 
 No third-party implementation source was copied into ProGPU. The Avalonia and
 GLFW sources were used to identify public contracts and observable platform

--- a/integration/AvaloniaControlCatalogHarness/ControlCatalogTelemetrySession.cs
+++ b/integration/AvaloniaControlCatalogHarness/ControlCatalogTelemetrySession.cs
@@ -49,6 +49,8 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
         "PROGPU_AVALONIA_BENCHMARK_DIAGNOSTIC_HOLD_SECONDS";
     private const string ReadyVariable =
         "PROGPU_AVALONIA_BENCHMARK_DIAGNOSTIC_READY";
+    private const string ForceDeviceLossVariable =
+        "PROGPU_AVALONIA_FORCE_DEVICE_LOSS";
 
     private readonly string _backend;
     private readonly string _page;
@@ -61,6 +63,7 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
     private readonly int _run;
     private readonly int _holdSeconds;
     private readonly bool _useSilkFrameSource;
+    private readonly bool _forceDeviceLoss;
     private readonly double[] _frameTimes;
 #if PROGPU_AVALONIA_BACKEND
     private readonly double[] _compileTimes;
@@ -99,6 +102,10 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
     private int _sceneCacheHits;
     private CompositorMetrics _measurementStartMetrics;
     private CompositorMetrics _lastMetrics;
+    private WgpuContext? _lostContext;
+    private int _deviceLossRecoveryFrames;
+    private bool _waitingForDeviceRecovery;
+    private bool _deviceLossRecovered;
 #endif
 
     private ControlCatalogTelemetrySession(
@@ -125,6 +132,11 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
         _holdSeconds = holdSeconds;
         _useSilkFrameSource = backend.Contains(
             "SilkNet",
+            StringComparison.Ordinal);
+        _forceDeviceLoss = string.Equals(
+            Environment.GetEnvironmentVariable(
+                ForceDeviceLossVariable),
+            "1",
             StringComparison.Ordinal);
         _frameTimes = new double[measureFrames];
 #if PROGPU_AVALONIA_BACKEND
@@ -231,12 +243,48 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
             return;
         }
 
+#if PROGPU_AVALONIA_BACKEND
+        if (_waitingForDeviceRecovery)
+        {
+            _deviceLossRecoveryFrames++;
+            _deviceLossRecovered =
+                WgpuContext.ActiveContexts.Any(
+                    candidate =>
+                        !ReferenceEquals(candidate, _lostContext) &&
+                        candidate.BackendKind ==
+                            _lostContext!.BackendKind &&
+                        candidate.IsInitialized &&
+                        !candidate.IsDeviceLost);
+            if (_deviceLossRecovered)
+            {
+                _waitingForDeviceRecovery = false;
+                _previousAnimationTimestamp = default;
+                PrepareMeasurement();
+            }
+            else if (_deviceLossRecoveryFrames >= 600)
+            {
+                throw new InvalidOperationException(
+                    "ControlCatalog did not recreate a healthy WebGPU context within 600 frames after device loss.");
+            }
+            RequestNextFrame();
+            return;
+        }
+#endif
+
         if (_warmupCompleted < _warmupFrames)
         {
             _warmupCompleted++;
             _previousAnimationTimestamp = timestamp;
             if (_warmupCompleted == _warmupFrames)
             {
+#if PROGPU_AVALONIA_BACKEND
+                if (_forceDeviceLoss)
+                {
+                    InjectDeviceLoss();
+                    RequestNextFrame();
+                    return;
+                }
+#endif
                 PrepareMeasurement();
             }
             RequestNextFrame();
@@ -311,6 +359,27 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
     }
 
 #if PROGPU_AVALONIA_BACKEND
+    private void InjectDeviceLoss()
+    {
+        WgpuBackendKind expectedBackend = _useSilkFrameSource
+            ? WgpuBackendKind.SilkNative
+            : WgpuBackendKind.DawnNative;
+        _lostContext = WgpuContext.ActiveContexts.FirstOrDefault(
+            candidate =>
+                candidate.BackendKind == expectedBackend &&
+                candidate.IsInitialized &&
+                !candidate.IsDeviceLost) ??
+            throw new InvalidOperationException(
+                $"ControlCatalog could not find an active {expectedBackend} context for device-loss injection.");
+        _waitingForDeviceRecovery = true;
+        _deviceLossRecoveryFrames = 0;
+        _lostContext.ReportDeviceLost(
+            Silk.NET.WebGPU.DeviceLostReason.Unknown,
+            "ControlCatalog synthetic device-loss integration gate");
+        Console.Error.WriteLine(
+            $"[ControlCatalog] injected device loss for {expectedBackend}");
+    }
+
     private void OnProGpuFrameRendered(CompositorMetrics metrics)
     {
         _lastMetrics = metrics;
@@ -401,6 +470,17 @@ internal sealed class ControlCatalogTelemetrySession : IDisposable
             writer.WriteNumber("Run", _run);
             writer.WriteNumber("WarmupFrames", _warmupFrames);
             writer.WriteNumber("MeasuredFrames", _measuredFrames);
+#if PROGPU_AVALONIA_BACKEND
+            writer.WriteBoolean(
+                "DeviceLossInjected",
+                _lostContext is not null);
+            writer.WriteBoolean(
+                "DeviceLossRecovered",
+                _deviceLossRecovered);
+            writer.WriteNumber(
+                "DeviceLossRecoveryFrames",
+                _deviceLossRecoveryFrames);
+#endif
             writer.WriteNumber("ElapsedSeconds", elapsedSeconds);
             writer.WriteNumber(
                 "FramesPerSecond",

--- a/integration/AvaloniaControlCatalogHarness/ControlCatalogTelemetrySession.cs
+++ b/integration/AvaloniaControlCatalogHarness/ControlCatalogTelemetrySession.cs
@@ -13,8 +13,11 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Skia;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using SkiaSharp;
 #if PROGPU_AVALONIA_BACKEND
 using Avalonia.ProGpu;
 using Avalonia.SilkNet;
@@ -899,6 +902,8 @@ internal sealed class BenchmarkVisualFixture
         "PROGPU_AVALONIA_BENCHMARK_TOPOLOGY_CHANNEL";
     private const string AdornerVariable =
         "PROGPU_AVALONIA_BENCHMARK_ADORNER_CHANNEL";
+    private const string SkiaSharpCustomDrawVariable =
+        "PROGPU_AVALONIA_BENCHMARK_SKIASHARP_CUSTOM_DRAW";
 
     private readonly Visual _target;
     private readonly Panel? _panel;
@@ -908,6 +913,7 @@ internal sealed class BenchmarkVisualFixture
     private readonly bool _topology;
     private readonly bool _adorner;
     private readonly BenchmarkPulseControl? _pulse;
+    private readonly BenchmarkSkiaSharpControl? _skiaSharpControl;
     private readonly Panel? _topologyFirstParent;
     private readonly Panel? _topologySecondParent;
     private Visual? _adornerFirstTarget;
@@ -933,7 +939,8 @@ internal sealed class BenchmarkVisualFixture
         Border? topologyChild,
         Border? adornerVisual,
         Visual? adornerFirstTarget,
-        Visual? adornerSecondTarget)
+        Visual? adornerSecondTarget,
+        BenchmarkSkiaSharpControl? skiaSharpControl)
     {
         _target = target;
         _panel = panel;
@@ -949,6 +956,7 @@ internal sealed class BenchmarkVisualFixture
         _adornerVisual = adornerVisual;
         _adornerFirstTarget = adornerFirstTarget;
         _adornerSecondTarget = adornerSecondTarget;
+        _skiaSharpControl = skiaSharpControl;
     }
 
     public static BenchmarkVisualFixture? Create(Window window)
@@ -978,6 +986,8 @@ internal sealed class BenchmarkVisualFixture
         bool drawingOptions = ReadEnabled(DrawingOptionsVariable);
         bool topology = ReadEnabled(TopologyVariable);
         bool adorner = ReadEnabled(AdornerVariable);
+        bool skiaSharpCustomDraw =
+            ReadEnabled(SkiaSharpCustomDrawVariable);
         Visual target = window.Content as Visual ?? window;
         if (layoutClip)
         {
@@ -1087,6 +1097,22 @@ internal sealed class BenchmarkVisualFixture
             panel.Children.Add(pulse);
         }
 
+        BenchmarkSkiaSharpControl? skiaSharpControl = null;
+        if (skiaSharpCustomDraw && panel is not null)
+        {
+            skiaSharpControl = new BenchmarkSkiaSharpControl
+            {
+                Width = 320,
+                Height = 240,
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Bottom,
+                IsHitTestVisible = false
+            };
+            panel.Children.Add(skiaSharpControl);
+            Console.Error.WriteLine(
+                "[ControlCatalog] deterministic SkiaSharp custom-draw fixture attached");
+        }
+
         Panel? topologyFirstParent = null;
         Panel? topologySecondParent = null;
         Border? topologyChild = null;
@@ -1135,7 +1161,8 @@ internal sealed class BenchmarkVisualFixture
             topologyChild,
             adornerVisual,
             adornerFirstTarget,
-            adornerSecondTarget);
+            adornerSecondTarget,
+            skiaSharpControl);
     }
 
     private static bool TrySelectCustomVisualTab(Visual root)
@@ -1181,6 +1208,7 @@ internal sealed class BenchmarkVisualFixture
 
         _pulsePhase = !_pulsePhase;
         _pulse.SetPhase(_pulsePhase);
+        _skiaSharpControl?.SetPhase(_pulsePhase);
     }
 
     private void TryPrepareAdornerFixture()
@@ -1381,6 +1409,95 @@ internal sealed class BenchmarkPulseControl : Control
         context.FillRectangle(
             _phase ? _firstBrush : _secondBrush,
             new Rect(Bounds.Size));
+    }
+}
+
+internal sealed class BenchmarkSkiaSharpControl : Control
+{
+    private bool _phase;
+
+    internal void SetPhase(bool phase)
+    {
+        _phase = phase;
+        InvalidateVisual();
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        context.Custom(
+            new BenchmarkSkiaSharpDrawOperation(
+                new Rect(Bounds.Size),
+                _phase));
+    }
+
+    private sealed class BenchmarkSkiaSharpDrawOperation :
+        ICustomDrawOperation
+    {
+        private readonly bool _phase;
+
+        internal BenchmarkSkiaSharpDrawOperation(
+            Rect bounds,
+            bool phase)
+        {
+            Bounds = bounds;
+            _phase = phase;
+        }
+
+        public Rect Bounds { get; }
+
+        public bool HitTest(Point point) => false;
+
+        public bool Equals(ICustomDrawOperation? other) =>
+            other is BenchmarkSkiaSharpDrawOperation operation &&
+            operation.Bounds == Bounds &&
+            operation._phase == _phase;
+
+        public void Render(ImmediateDrawingContext context)
+        {
+            ISkiaSharpApiLeaseFeature? feature =
+                context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+            if (feature is null)
+                return;
+
+            using ISkiaSharpApiLease lease = feature.Lease();
+            SKCanvas canvas = lease.SkCanvas;
+            using var fill = new SKPaint
+            {
+                Color = new SKColor(24, 116, 205, 208),
+                IsAntialias = true
+            };
+            using var stroke = new SKPaint
+            {
+                Color = new SKColor(252, 190, 45),
+                IsAntialias = true,
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = 1.5f
+            };
+            using var pathBuilder = new SKPathBuilder();
+            pathBuilder.MoveTo(0, 10);
+            pathBuilder.QuadTo(18, -8, 34, 12);
+            pathBuilder.CubicTo(44, 26, 58, -4, 72, 14);
+            using SKPath path = pathBuilder.Detach();
+
+            float phaseOffset = _phase ? 0.375f : 0f;
+            for (int index = 0; index < 96; index++)
+            {
+                int save = canvas.Save();
+                float x = (index % 12) * 25f + phaseOffset;
+                float y = (index / 12) * 28f;
+                canvas.Translate(x, y);
+                canvas.ClipRect(new SKRect(0, 0, 24, 27));
+                canvas.DrawRect(1, 2, 19, 17, fill);
+                canvas.DrawCircle(12, 13, 7, stroke);
+                canvas.Scale(0.28f);
+                canvas.DrawPath(path, stroke);
+                canvas.RestoreToCount(save);
+            }
+        }
+
+        public void Dispose()
+        {
+        }
     }
 }
 

--- a/integration/AvaloniaControlCatalogHarness/SilkNetInputTelemetrySession.cs
+++ b/integration/AvaloniaControlCatalogHarness/SilkNetInputTelemetrySession.cs
@@ -26,6 +26,8 @@ internal sealed class SilkNetInputTelemetrySession : IDisposable
         "PROGPU_AVALONIA_INPUT_EXPECT";
     private const string TimeoutVariable =
         "PROGPU_AVALONIA_INPUT_TIMEOUT_SECONDS";
+    private const string ExpectedPositionVariable =
+        "PROGPU_AVALONIA_WINDOW_EXPECT_POSITION";
 
     private readonly string _outputPath;
     private readonly HashSet<string> _expected;
@@ -34,6 +36,7 @@ internal sealed class SilkNetInputTelemetrySession : IDisposable
     private readonly IDisposable _windowOpenedSubscription;
     private readonly DispatcherTimer _timer;
     private readonly DateTime _deadline;
+    private readonly PixelPoint? _expectedPosition;
     private Window? _window;
     private PixelPoint _initialPosition;
     private Size _lastLayoutSize;
@@ -49,6 +52,7 @@ internal sealed class SilkNetInputTelemetrySession : IDisposable
     {
         _outputPath = outputPath;
         _expected = expected;
+        _expectedPosition = ParseExpectedPosition();
         _deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
         _windowOpenedSubscription =
             Window.WindowOpenedEvent.AddClassHandler<Window>(
@@ -117,8 +121,6 @@ internal sealed class SilkNetInputTelemetrySession : IDisposable
             return;
 
         _window = window;
-        _initialPosition = window.Position;
-        _hasInitialPosition = true;
         window.PositionChanged += OnPositionChanged;
         window.PropertyChanged += OnWindowPropertyChanged;
         window.LayoutUpdated += OnLayoutUpdated;
@@ -186,11 +188,61 @@ internal sealed class SilkNetInputTelemetrySession : IDisposable
                     () => Record("shortcut"))
             });
         Dispatcher.UIThread.Post(
-            () => window.GetVisualDescendants()
-                .OfType<TextBox>()
-                .FirstOrDefault()?
-                .Focus(),
+            () =>
+            {
+                ValidateInitialPosition();
+                _initialPosition = window.Position;
+                _hasInitialPosition = true;
+                window.GetVisualDescendants()
+                    .OfType<TextBox>()
+                    .FirstOrDefault()?
+                    .Focus();
+                File.WriteAllText(
+                    _outputPath + ".ready",
+                    "ready" + Environment.NewLine);
+            },
             DispatcherPriority.Input);
+    }
+
+    private void ValidateInitialPosition()
+    {
+        if (_window is null || _expectedPosition is not { } expected)
+            return;
+
+        PixelPoint actual = _window.Position;
+        const int tolerance = 8;
+        if (Math.Abs(actual.X - expected.X) <= tolerance &&
+            Math.Abs(actual.Y - expected.Y) <= tolerance)
+        {
+            Record("initial-position");
+            return;
+        }
+
+        Complete(
+            passed: false,
+            error:
+                $"Initial position was {actual.X},{actual.Y}; " +
+                $"expected {expected.X},{expected.Y} ±{tolerance} px.");
+    }
+
+    private static PixelPoint? ParseExpectedPosition()
+    {
+        string? text = Environment.GetEnvironmentVariable(
+            ExpectedPositionVariable);
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+        string[] parts = text.Split(
+            ',',
+            StringSplitOptions.TrimEntries);
+        if (parts.Length != 2 ||
+            !int.TryParse(parts[0], out int x) ||
+            !int.TryParse(parts[1], out int y))
+        {
+            throw new InvalidOperationException(
+                $"{ExpectedPositionVariable} must be X,Y.");
+        }
+
+        return new PixelPoint(x, y);
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs args)
@@ -430,6 +482,13 @@ internal sealed class SilkNetInputTelemetrySession : IDisposable
             writer.WriteNumber("ClientWidth", _window.ClientSize.Width);
             writer.WriteNumber("ClientHeight", _window.ClientSize.Height);
             writer.WriteNumber("RenderScaling", _window.RenderScaling);
+            writer.WriteEndObject();
+        }
+        if (_expectedPosition is { } expectedPosition)
+        {
+            writer.WriteStartObject("ExpectedInitialPosition");
+            writer.WriteNumber("X", expectedPosition.X);
+            writer.WriteNumber("Y", expectedPosition.Y);
             writer.WriteEndObject();
         }
         if (error is not null)

--- a/integration/AvaloniaControlCatalogHarness/windows-run-native-windowing.ps1
+++ b/integration/AvaloniaControlCatalogHarness/windows-run-native-windowing.ps1
@@ -1,0 +1,27 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $AppPath,
+    [Parameter(Mandatory = $true)]
+    [string] $Page,
+    [Parameter(Mandatory = $true)]
+    [string] $OutputPath,
+    [Parameter(Mandatory = $true)]
+    [string] $ScreenshotPath,
+    [int] $WarmupFrames = 10,
+    [int] $MeasureFrames = 20
+)
+
+$ErrorActionPreference = "Stop"
+New-Item -ItemType Directory -Force (Split-Path $OutputPath) |
+    Out-Null
+$env:PROGPU_AVALONIA_BENCHMARK_OUTPUT = $OutputPath
+$env:PROGPU_AVALONIA_BENCHMARK_SCREENSHOT = $ScreenshotPath
+$env:PROGPU_AVALONIA_BENCHMARK_WARMUP_FRAMES =
+    $WarmupFrames.ToString(
+        [System.Globalization.CultureInfo]::InvariantCulture)
+$env:PROGPU_AVALONIA_BENCHMARK_MEASURE_FRAMES =
+    $MeasureFrames.ToString(
+        [System.Globalization.CultureInfo]::InvariantCulture)
+
+& $AppPath --native-windowing --page $Page
+exit $LASTEXITCODE

--- a/integration/AvaloniaSilkNetInputHarness/InputWindow.cs
+++ b/integration/AvaloniaSilkNetInputHarness/InputWindow.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Chrome;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -17,6 +20,7 @@ internal sealed class InputWindow : Window
         MinHeight = 280;
         ExtendClientAreaToDecorationsHint = true;
         ExtendClientAreaTitleBarHeightHint = 44;
+        ApplyWindowPlacement();
 
         var titleBar = new Border
         {
@@ -30,7 +34,22 @@ internal sealed class InputWindow : Window
                 VerticalAlignment = VerticalAlignment.Center
             }
         };
-        titleBar.PointerPressed += OnTitleBarPointerPressed;
+        WindowDecorationProperties.SetElementRole(
+            titleBar,
+            WindowDecorationsElementRole.TitleBar);
+
+        var resizeGrip = new Border
+        {
+            Width = 48,
+            Height = 48,
+            Background = Brushes.Transparent,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            ZIndex = 100
+        };
+        WindowDecorationProperties.SetElementRole(
+            resizeGrip,
+            WindowDecorationsElementRole.ResizeSE);
 
         var editor = new TextBox
         {
@@ -74,18 +93,51 @@ internal sealed class InputWindow : Window
             Children =
             {
                 titleBar,
-                content
+                content,
+                resizeGrip
             }
         };
         Grid.SetRow(content, 1);
+        Grid.SetRowSpan(resizeGrip, 2);
     }
 
-    private void OnTitleBarPointerPressed(
-        object? sender,
-        PointerPressedEventArgs args)
+    private void ApplyWindowPlacement()
     {
-        _ = sender;
-        if (args.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
-            BeginMoveDrag(args);
+        string? position = Environment.GetEnvironmentVariable(
+            "PROGPU_AVALONIA_WINDOW_POSITION");
+        if (!string.IsNullOrWhiteSpace(position))
+        {
+            string[] parts = position.Split(
+                ',',
+                StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 ||
+                !int.TryParse(
+                    parts[0],
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out int x) ||
+                !int.TryParse(
+                    parts[1],
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out int y))
+            {
+                throw new InvalidOperationException(
+                    "PROGPU_AVALONIA_WINDOW_POSITION must be X,Y.");
+            }
+
+            Position = new PixelPoint(x, y);
+        }
+
+        string? startupLocation = Environment.GetEnvironmentVariable(
+            "PROGPU_AVALONIA_WINDOW_STARTUP_LOCATION");
+        if (!string.IsNullOrWhiteSpace(startupLocation) &&
+            Enum.TryParse(
+                startupLocation,
+                ignoreCase: true,
+                out WindowStartupLocation parsed))
+        {
+            WindowStartupLocation = parsed;
+        }
     }
 }

--- a/integration/AvaloniaSilkNetInputHarness/linux-inject-touch.py
+++ b/integration/AvaloniaSilkNetInputHarness/linux-inject-touch.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Inject one real Linux touchscreen contact through uinput."""
+
+import argparse
+import time
+
+from evdev import AbsInfo, UInput, ecodes
+
+
+def axis(maximum: int) -> AbsInfo:
+    return AbsInfo(
+        value=0,
+        min=0,
+        max=maximum,
+        fuzz=0,
+        flat=0,
+        resolution=1,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--x", type=int, default=400)
+    parser.add_argument("--y", type=int, default=350)
+    parser.add_argument("--screen-width", type=int, default=1440)
+    parser.add_argument("--screen-height", type=int, default=900)
+    parser.add_argument("--enumeration-seconds", type=float, default=2)
+    parser.add_argument("--hold-seconds", type=float, default=1)
+    args = parser.parse_args()
+
+    capabilities = {
+        ecodes.EV_KEY: [ecodes.BTN_TOUCH],
+        ecodes.EV_ABS: [
+            (ecodes.ABS_X, axis(args.screen_width - 1)),
+            (ecodes.ABS_Y, axis(args.screen_height - 1)),
+            (ecodes.ABS_MT_SLOT, axis(9)),
+            (ecodes.ABS_MT_TRACKING_ID, axis(65535)),
+            (ecodes.ABS_MT_POSITION_X, axis(args.screen_width - 1)),
+            (ecodes.ABS_MT_POSITION_Y, axis(args.screen_height - 1)),
+        ],
+    }
+
+    with UInput(
+        capabilities,
+        name="ProGPU integration touchscreen",
+        bustype=ecodes.BUS_VIRTUAL,
+        input_props=[ecodes.INPUT_PROP_DIRECT],
+    ) as device:
+        # Give Mutter and XWayland time to enumerate the new direct device.
+        time.sleep(args.enumeration_seconds)
+        write_contact(device, args.x, args.y, tracking_id=1, down=True)
+        time.sleep(0.1)
+        write_contact(
+            device,
+            args.x + 12,
+            args.y + 8,
+            tracking_id=1,
+            down=True,
+        )
+        time.sleep(0.1)
+        device.write(ecodes.EV_ABS, ecodes.ABS_MT_TRACKING_ID, -1)
+        device.write(ecodes.EV_KEY, ecodes.BTN_TOUCH, 0)
+        device.syn()
+        time.sleep(args.hold_seconds)
+
+
+def write_contact(
+    device: UInput,
+    x: int,
+    y: int,
+    tracking_id: int,
+    down: bool,
+) -> None:
+    device.write(ecodes.EV_ABS, ecodes.ABS_MT_SLOT, 0)
+    device.write(ecodes.EV_ABS, ecodes.ABS_MT_TRACKING_ID, tracking_id)
+    device.write(ecodes.EV_ABS, ecodes.ABS_MT_POSITION_X, x)
+    device.write(ecodes.EV_ABS, ecodes.ABS_MT_POSITION_Y, y)
+    device.write(ecodes.EV_ABS, ecodes.ABS_X, x)
+    device.write(ecodes.EV_ABS, ecodes.ABS_Y, y)
+    device.write(ecodes.EV_KEY, ecodes.BTN_TOUCH, int(down))
+    device.syn()
+
+
+if __name__ == "__main__":
+    main()

--- a/integration/AvaloniaSilkNetInputHarness/linux-run-input-harness.sh
+++ b/integration/AvaloniaSilkNetInputHarness/linux-run-input-harness.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+    echo "usage: $0 APP_PATH OUTPUT_PATH EXPECTED [TIMEOUT_SECONDS]" >&2
+    exit 2
+fi
+
+app_path=$1
+output_path=$2
+expected=$3
+timeout_seconds=${4:-60}
+display=${DISPLAY:-:0}
+xauthority=${XAUTHORITY:-}
+if [[ -z $xauthority ]]; then
+    for candidate in /run/user/$(id -u)/.mutter-Xwaylandauth.*; do
+        if [[ -f $candidate ]]; then
+            xauthority=$candidate
+            break
+        fi
+    done
+fi
+if [[ -z $xauthority ]]; then
+    echo "XAUTHORITY is required for the XWayland session." >&2
+    exit 3
+fi
+
+export DISPLAY=$display
+export XAUTHORITY=$xauthority
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+export PROGPU_AVALONIA_INPUT_OUTPUT=$output_path
+export PROGPU_AVALONIA_INPUT_EXPECT=$expected
+export PROGPU_AVALONIA_INPUT_TIMEOUT_SECONDS=$timeout_seconds
+unset WAYLAND_DISPLAY
+
+set +e
+"$app_path" >"$output_path.stdout.log" 2>&1
+status=$?
+set -e
+printf '%s\n' "$status" >"$output_path.exit-code"
+exit "$status"

--- a/integration/AvaloniaSilkNetInputHarness/windows-inject-input.ps1
+++ b/integration/AvaloniaSilkNetInputHarness/windows-inject-input.ps1
@@ -1,17 +1,36 @@
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("TitleBarDrag", "Resize", "XButtons")]
-    [string] $Action
+    [ValidateSet("TitleBarDrag", "Resize", "ResizeGrip", "Input", "XButtons", "Touch")]
+    [string] $Action,
+    [string] $OutputPath = "",
+    [string] $ReadyPath = "",
+    [int] $WaitSeconds = 45
 )
 
 $ErrorActionPreference = "Stop"
+trap {
+    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+        New-Item -ItemType Directory -Force (Split-Path $OutputPath) |
+            Out-Null
+        [ordered]@{
+            Action = $Action
+            Error = ($_ | Out-String).Trim()
+        } | ConvertTo-Json -Depth 3 |
+            Set-Content -Path $OutputPath -Encoding UTF8
+    }
+    exit 1
+}
 
 Add-Type -TypeDefinition @"
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
 
 public static class ProGpuWindowsInput
 {
+    private delegate bool EnumWindowCallback(IntPtr window, IntPtr state);
+
     [StructLayout(LayoutKind.Sequential)]
     public struct Rect
     {
@@ -21,9 +40,80 @@ public static class ProGpuWindowsInput
         public int Bottom;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NativePoint
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct PointerInfo
+    {
+        public uint PointerType;
+        public uint PointerId;
+        public uint FrameId;
+        public uint PointerFlags;
+        public IntPtr SourceDevice;
+        public IntPtr WindowTarget;
+        public NativePoint PixelLocation;
+        public NativePoint HimetricLocation;
+        public NativePoint PixelLocationRaw;
+        public NativePoint HimetricLocationRaw;
+        public uint Time;
+        public uint HistoryCount;
+        public int InputData;
+        public uint KeyStates;
+        public ulong PerformanceCount;
+        public uint ButtonChangeType;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct PointerTouchInfo
+    {
+        public PointerInfo PointerInfo;
+        public uint TouchFlags;
+        public uint TouchMask;
+        public Rect Contact;
+        public Rect ContactRaw;
+        public uint Orientation;
+        public uint Pressure;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct PointerTypeInfo
+    {
+        [FieldOffset(0)]
+        public uint Type;
+
+        [FieldOffset(8)]
+        public PointerTouchInfo TouchInfo;
+    }
+
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetWindowRect(IntPtr window, out Rect rect);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumWindows(
+        EnumWindowCallback callback,
+        IntPtr state);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowVisible(IntPtr window);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(
+        IntPtr window,
+        out uint processId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(
+        IntPtr window,
+        StringBuilder className,
+        int capacity);
 
     [DllImport("user32.dll")]
     public static extern uint GetDpiForWindow(IntPtr window);
@@ -33,8 +123,22 @@ public static class ProGpuWindowsInput
     public static extern bool SetCursorPos(int x, int y);
 
     [DllImport("user32.dll")]
+    public static extern IntPtr WindowFromPoint(NativePoint point);
+
+    [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool SetForegroundWindow(IntPtr window);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetWindowPos(
+        IntPtr window,
+        IntPtr insertAfter,
+        int x,
+        int y,
+        int width,
+        int height,
+        uint flags);
 
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -48,10 +152,177 @@ public static class ProGpuWindowsInput
         uint data,
         UIntPtr extraInfo);
 
+    [DllImport("user32.dll")]
+    public static extern void keybd_event(
+        byte virtualKey,
+        byte scanCode,
+        uint flags,
+        UIntPtr extraInfo);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr CreateSyntheticPointerDevice(
+        uint pointerType,
+        uint maxCount,
+        uint mode);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool InjectSyntheticPointerInput(
+        IntPtr device,
+        ref PointerTypeInfo pointerInfo,
+        uint count);
+
+    [DllImport("user32.dll")]
+    private static extern void DestroySyntheticPointerDevice(
+        IntPtr device);
+
     public const uint LeftDown = 0x0002;
     public const uint LeftUp = 0x0004;
+    public const uint RightDown = 0x0008;
+    public const uint RightUp = 0x0010;
+    public const uint MiddleDown = 0x0020;
+    public const uint MiddleUp = 0x0040;
     public const uint XDown = 0x0080;
     public const uint XUp = 0x0100;
+    public const uint Wheel = 0x0800;
+    public const uint NoMove = 0x0002;
+    public const uint NoZOrder = 0x0004;
+    public const uint NoActivate = 0x0010;
+    public const uint KeyUp = 0x0002;
+    public const byte Escape = 0x1b;
+    public const byte Shift = 0x10;
+    public const byte Control = 0x11;
+    public const byte A = 0x41;
+    public const byte K = 0x4b;
+
+    public static void InjectTouchTap(int x, int y)
+    {
+        IntPtr device = CreateSyntheticPointerDevice(2, 1, 3);
+        if (device == IntPtr.Zero)
+        {
+            throw new InvalidOperationException(
+                "CreateSyntheticPointerDevice failed: " +
+                Marshal.GetLastWin32Error());
+        }
+        try
+        {
+            var contact = CreateTouchContact(x, y);
+            contact.PointerInfo.PointerFlags =
+                0x00000001 | 0x00000002 | 0x00000004 |
+                0x00002000 | 0x00004000 | 0x00010000;
+            InjectContact(device, contact);
+            Thread.Sleep(60);
+
+            contact.PointerInfo.PointerFlags =
+                0x00000002 | 0x00000004 |
+                0x00002000 | 0x00004000 | 0x00020000;
+            contact.PointerInfo.PixelLocation.X += 12;
+            contact.PointerInfo.PixelLocation.Y += 8;
+            contact.Contact = ContactRect(
+                contact.PointerInfo.PixelLocation.X,
+                contact.PointerInfo.PixelLocation.Y);
+            contact.ContactRaw = contact.Contact;
+            InjectContact(device, contact);
+            Thread.Sleep(60);
+
+            contact.PointerInfo.PointerFlags = 0x00040000;
+            InjectContact(device, contact);
+        }
+        finally
+        {
+            DestroySyntheticPointerDevice(device);
+        }
+    }
+
+    private static PointerTouchInfo CreateTouchContact(int x, int y)
+    {
+        var point = new NativePoint { X = x, Y = y };
+        var contact = new PointerTouchInfo();
+        contact.PointerInfo.PointerType = 2;
+        contact.PointerInfo.PointerId = 1;
+        contact.PointerInfo.PixelLocation = point;
+        contact.PointerInfo.PixelLocationRaw = point;
+        contact.TouchMask = 0x00000001 | 0x00000002 | 0x00000004;
+        contact.Contact = ContactRect(x, y);
+        contact.ContactRaw = contact.Contact;
+        contact.Orientation = 90;
+        contact.Pressure = 512;
+        return contact;
+    }
+
+    private static Rect ContactRect(int x, int y)
+    {
+        return new Rect
+        {
+            Left = x - 4,
+            Top = y - 4,
+            Right = x + 4,
+            Bottom = y + 4
+        };
+    }
+
+    private static void InjectContact(
+        IntPtr device,
+        PointerTouchInfo contact)
+    {
+        var pointer = new PointerTypeInfo
+        {
+            Type = 2,
+            TouchInfo = contact
+        };
+        if (!InjectSyntheticPointerInput(device, ref pointer, 1))
+        {
+            throw new InvalidOperationException(
+                "InjectSyntheticPointerInput failed: " +
+                Marshal.GetLastWin32Error());
+        }
+    }
+
+    public static IntPtr FindLargestVisibleWindow(int processId)
+    {
+        IntPtr largestWindow = IntPtr.Zero;
+        long largestArea = 0;
+        IntPtr largestGlfwWindow = IntPtr.Zero;
+        long largestGlfwArea = 0;
+        EnumWindows(
+            (window, state) =>
+            {
+                uint owner;
+                Rect rect;
+                GetWindowThreadProcessId(window, out owner);
+                if (owner != (uint) processId || !IsWindowVisible(window) ||
+                    !GetWindowRect(window, out rect))
+                {
+                    return true;
+                }
+
+                long width = Math.Max(0, rect.Right - rect.Left);
+                long height = Math.Max(0, rect.Bottom - rect.Top);
+                long area = width * height;
+                if (area > largestArea)
+                {
+                    largestArea = area;
+                    largestWindow = window;
+                }
+
+                var className = new StringBuilder(64);
+                if (GetClassName(window, className, className.Capacity) > 0 &&
+                    className.ToString().StartsWith(
+                        "GLFW",
+                        StringComparison.Ordinal) &&
+                    area > largestGlfwArea)
+                {
+                    largestGlfwArea = area;
+                    largestGlfwWindow = window;
+                }
+
+                return true;
+            },
+            IntPtr.Zero);
+        return largestGlfwWindow != IntPtr.Zero
+            ? largestGlfwWindow
+            : largestWindow;
+    }
 }
 "@
 
@@ -60,16 +331,45 @@ public static class ProGpuWindowsInput
 [void] [ProGpuWindowsInput]::SetProcessDpiAwarenessContext([IntPtr] (-4))
 
 function Get-TargetProcess {
-    $process = Get-Process -Name "AvaloniaSilkNetInputHarness" `
-        -ErrorAction SilentlyContinue |
-        Where-Object { $_.MainWindowHandle -ne 0 } |
+    $process = Get-Process -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.ProcessName -eq "AvaloniaSilkNetInputHarness"
+        } |
         Sort-Object StartTime -Descending |
         Select-Object -First 1
     if ($null -eq $process) {
+        throw "AvaloniaSilkNetInputHarness is not running."
+    }
+
+    $window = [ProGpuWindowsInput]::FindLargestVisibleWindow($process.Id)
+    if ($window -eq [IntPtr]::Zero) {
         throw "AvaloniaSilkNetInputHarness has no visible top-level window."
     }
 
-    return $process
+    return [ordered]@{
+        Process = $process
+        Window = $window
+    }
+}
+
+function Wait-TargetProcess {
+    $deadline = (Get-Date).AddSeconds([Math]::Max(1, $WaitSeconds))
+    do {
+        try {
+            $target = Get-TargetProcess
+            if (-not [string]::IsNullOrWhiteSpace($ReadyPath) -and
+                -not (Test-Path $ReadyPath)) {
+                throw "The input harness is not ready."
+            }
+            return $target
+        }
+        catch {
+            if ((Get-Date) -ge $deadline) {
+                throw
+            }
+            Start-Sleep -Milliseconds 250
+        }
+    } while ($true)
 }
 
 function Get-WindowRect([IntPtr] $window) {
@@ -87,11 +387,42 @@ function Send-MouseButton([uint32] $down, [uint32] $up, [uint32] $data) {
     [ProGpuWindowsInput]::mouse_event($up, 0, 0, $data, [UIntPtr]::Zero)
 }
 
-$target = Get-TargetProcess
-$window = [IntPtr] $target.MainWindowHandle
+function Send-Key([byte] $virtualKey) {
+    [ProGpuWindowsInput]::keybd_event(
+        $virtualKey,
+        0,
+        0,
+        [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 40
+    [ProGpuWindowsInput]::keybd_event(
+        $virtualKey,
+        0,
+        [ProGpuWindowsInput]::KeyUp,
+        [UIntPtr]::Zero)
+}
+
+$target = Wait-TargetProcess
+$window = [IntPtr] $target.Window
 [void] [ProGpuWindowsInput]::SetForegroundWindow($window)
 Start-Sleep -Milliseconds 100
+[ProGpuWindowsInput]::keybd_event(
+    [ProGpuWindowsInput]::Escape,
+    0,
+    0,
+    [UIntPtr]::Zero)
+[ProGpuWindowsInput]::keybd_event(
+    [ProGpuWindowsInput]::Escape,
+    0,
+    [ProGpuWindowsInput]::KeyUp,
+    [UIntPtr]::Zero)
+[ProGpuWindowsInput]::mouse_event(
+    [ProGpuWindowsInput]::LeftUp,
+    0,
+    0,
+    0,
+    [UIntPtr]::Zero)
 $before = Get-WindowRect $window
+$hoverWindow = [IntPtr]::Zero
 
 switch ($Action) {
     "TitleBarDrag" {
@@ -119,9 +450,38 @@ switch ($Action) {
             [UIntPtr]::Zero)
     }
     "Resize" {
-        $x = $before.Right - 3
-        $y = $before.Bottom - 3
+        for ($step = 1; $step -le 20; $step++) {
+            if (-not [ProGpuWindowsInput]::SetWindowPos(
+                $window,
+                [IntPtr]::Zero,
+                0,
+                0,
+                ($before.Right - $before.Left) + (20 * $step),
+                ($before.Bottom - $before.Top) + (12 * $step),
+                [ProGpuWindowsInput]::NoMove -bor
+                    [ProGpuWindowsInput]::NoZOrder -bor
+                    [ProGpuWindowsInput]::NoActivate)) {
+                if ($null -eq (Get-Process -Id $target.Process.Id `
+                    -ErrorAction SilentlyContinue)) {
+                    break
+                }
+                throw "SetWindowPos failed during native resize."
+            }
+            Start-Sleep -Milliseconds 25
+        }
+    }
+    "ResizeGrip" {
+        # Stay inside the 48-logical-pixel Avalonia grip while avoiding the
+        # invisible Win32 resize border, which can consume the mouse message
+        # before the custom decoration role sees it at high DPI.
+        $x = $before.Right - 60
+        $y = $before.Bottom - 60
         [void] [ProGpuWindowsInput]::SetCursorPos($x, $y)
+        Start-Sleep -Milliseconds 100
+        $point = New-Object ProGpuWindowsInput+NativePoint
+        $point.X = $x
+        $point.Y = $y
+        $hoverWindow = [ProGpuWindowsInput]::WindowFromPoint($point)
         [ProGpuWindowsInput]::mouse_event(
             [ProGpuWindowsInput]::LeftDown,
             0,
@@ -141,6 +501,62 @@ switch ($Action) {
             0,
             [UIntPtr]::Zero)
     }
+    "Input" {
+        Send-Key ([ProGpuWindowsInput]::A)
+
+        [ProGpuWindowsInput]::keybd_event(
+            [ProGpuWindowsInput]::Control,
+            0,
+            0,
+            [UIntPtr]::Zero)
+        [ProGpuWindowsInput]::keybd_event(
+            [ProGpuWindowsInput]::Shift,
+            0,
+            0,
+            [UIntPtr]::Zero)
+        Send-Key ([ProGpuWindowsInput]::K)
+        [ProGpuWindowsInput]::keybd_event(
+            [ProGpuWindowsInput]::Shift,
+            0,
+            [ProGpuWindowsInput]::KeyUp,
+            [UIntPtr]::Zero)
+        [ProGpuWindowsInput]::keybd_event(
+            [ProGpuWindowsInput]::Control,
+            0,
+            [ProGpuWindowsInput]::KeyUp,
+            [UIntPtr]::Zero)
+
+        $x = $before.Left + [int] (($before.Right - $before.Left) / 2)
+        $y = $before.Top + [int] (($before.Bottom - $before.Top) * 3 / 4)
+        [void] [ProGpuWindowsInput]::SetCursorPos($x, $y)
+        Start-Sleep -Milliseconds 100
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::LeftDown) `
+            ([ProGpuWindowsInput]::LeftUp) `
+            0
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::RightDown) `
+            ([ProGpuWindowsInput]::RightUp) `
+            0
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::MiddleDown) `
+            ([ProGpuWindowsInput]::MiddleUp) `
+            0
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::XDown) `
+            ([ProGpuWindowsInput]::XUp) `
+            1
+        Send-MouseButton `
+            ([ProGpuWindowsInput]::XDown) `
+            ([ProGpuWindowsInput]::XUp) `
+            2
+        [ProGpuWindowsInput]::mouse_event(
+            [ProGpuWindowsInput]::Wheel,
+            0,
+            0,
+            120,
+            [UIntPtr]::Zero)
+    }
     "XButtons" {
         $x = $before.Left + [int] (($before.Right - $before.Left) / 2)
         $y = $before.Top + [int] (($before.Bottom - $before.Top) / 2)
@@ -153,6 +569,11 @@ switch ($Action) {
             ([ProGpuWindowsInput]::XDown) `
             ([ProGpuWindowsInput]::XUp) `
             2
+    }
+    "Touch" {
+        $x = $before.Left + [int] (($before.Right - $before.Left) / 2)
+        $y = $before.Top + [int] (($before.Bottom - $before.Top) * 3 / 4)
+        [ProGpuWindowsInput]::InjectTouchTap($x, $y)
     }
 }
 
@@ -176,8 +597,10 @@ else {
         Height = $after.Bottom - $after.Top
     }
 }
-[ordered]@{
+$result = [ordered]@{
     Action = $Action
+    WindowHandle = $window.ToInt64()
+    HoverWindowHandle = $hoverWindow.ToInt64()
     Before = [ordered]@{
         Left = $before.Left
         Top = $before.Top
@@ -187,3 +610,9 @@ else {
     After = $afterResult
     TargetExited = $null -eq $after
 } | ConvertTo-Json -Depth 3
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    New-Item -ItemType Directory -Force (Split-Path $OutputPath) |
+        Out-Null
+    Set-Content -Path $OutputPath -Value $result -Encoding UTF8
+}
+$result

--- a/integration/AvaloniaSilkNetInputHarness/windows-run-input-harness.ps1
+++ b/integration/AvaloniaSilkNetInputHarness/windows-run-input-harness.ps1
@@ -1,0 +1,76 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("InitialPosition", "TitleBarDrag", "Resize", "Input", "Touch")]
+    [string] $Scenario,
+    [string] $AppPath = "",
+    [string] $OutputPath = "",
+    [string] $Expected = "",
+    [string] $Position = "",
+    [string] $ExpectedPosition = "",
+    [int] $TimeoutSeconds = 30,
+    [switch] $TraceChromeDrag
+)
+
+$ErrorActionPreference = "Stop"
+if ([string]::IsNullOrWhiteSpace($AppPath)) {
+    $AppPath = Join-Path $PSScriptRoot "AvaloniaSilkNetInputHarness.exe"
+}
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = "C:\Temp\progpu-$($Scenario.ToLowerInvariant()).json"
+}
+
+switch ($Scenario) {
+    "InitialPosition" {
+        $Expected = "initial-position"
+        $Position = "180,140"
+        $ExpectedPosition = "180,140"
+        $TimeoutSeconds = 10
+    }
+    "TitleBarDrag" {
+        $Expected = "move"
+        $TimeoutSeconds = 60
+        $TraceChromeDrag = $true
+    }
+    "Resize" {
+        $Expected = "resize"
+        $TimeoutSeconds = 60
+        $TraceChromeDrag = $true
+    }
+    "Input" {
+        $Expected =
+            "keyboard,text,pointer,wheel,shortcut,mouse-left," +
+            "mouse-right,mouse-middle,mouse-x1,mouse-x2"
+        $TimeoutSeconds = 60
+    }
+    "Touch" {
+        $Expected = "touch"
+        $TimeoutSeconds = 60
+    }
+}
+
+New-Item -ItemType Directory -Force (Split-Path $OutputPath) |
+    Out-Null
+Remove-Item $OutputPath -Force -ErrorAction SilentlyContinue
+Remove-Item "$OutputPath.ready" -Force -ErrorAction SilentlyContinue
+$env:PROGPU_AVALONIA_INPUT_OUTPUT = $OutputPath
+$env:PROGPU_AVALONIA_INPUT_EXPECT = $Expected
+$env:PROGPU_AVALONIA_INPUT_TIMEOUT_SECONDS =
+    $TimeoutSeconds.ToString(
+        [System.Globalization.CultureInfo]::InvariantCulture)
+$env:PROGPU_AVALONIA_WINDOW_POSITION = $Position
+$env:PROGPU_AVALONIA_WINDOW_EXPECT_POSITION = $ExpectedPosition
+$env:PROGPU_AVALONIA_TRACE_CHROME_DRAG = if ($TraceChromeDrag) {
+    "1"
+}
+else {
+    "0"
+}
+$env:PROGPU_AVALONIA_TRACE_WINDOW_EVENTS = "1"
+$env:PROGPU_AVALONIA_TRACE_WINDOW_EVENTS_PATH =
+    "$OutputPath.events.log"
+Remove-Item $env:PROGPU_AVALONIA_TRACE_WINDOW_EVENTS_PATH `
+    -Force `
+    -ErrorAction SilentlyContinue
+
+& $AppPath
+exit $LASTEXITCODE

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaBackendContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaBackendContext.cs
@@ -240,7 +240,7 @@ internal sealed class ProGpuBackendContext : IPlatformRenderInterfaceContext
 
 #if !AVALONIA11
         composition?.Dispose();
-        dawn?.Context.Dispose();
+        dawn?.Dispose();
 #endif
     }
 
@@ -281,7 +281,12 @@ internal sealed class ProGpuBackendContext : IPlatformRenderInterfaceContext
                 return _dawnContext.Context;
         }
 #endif
-        if (WgpuContext.Current is { IsDisposed: false } current)
+        if (WgpuContext.Current is
+            {
+                IsInitialized: true,
+                IsDisposed: false,
+                IsDeviceLost: false
+            } current)
             return current;
         return WgpuContext.TryGetFirstActiveContext(out WgpuContext? active)
             ? active

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaCompositionScene.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaCompositionScene.cs
@@ -1134,18 +1134,6 @@ internal sealed class AvaloniaCompositionScene : IDisposable
             return contentChanged;
         }
 
-        if (source is ServerCompositionCustomVisual)
-        {
-            renderer.RecordRetainedCompositionVisual(
-                source,
-                clip,
-                renderOptions,
-                textOptions,
-                target.BeginCommandRecording());
-            CustomVisualCompilationCount++;
-            return true;
-        }
-
         _ordinaryRecordingContext.Clear();
         try
         {
@@ -1155,10 +1143,18 @@ internal sealed class AvaloniaCompositionScene : IDisposable
                 renderOptions,
                 textOptions,
                 _ordinaryRecordingContext);
+            // A custom visual can record hundreds of wide RenderCommand
+            // values. Convert organically-grown pooled scratch storage into
+            // one retained scene-level buffer after the first recording so a
+            // stable animation does not rent and return that array per frame.
+            _ordinaryRecordingContext.EnsureCommandCapacity(
+                _ordinaryRecordingContext.Commands.Count);
             if (target.TryCompleteCompactRecording(
                     _ordinaryRecordingContext,
                     out bool contentChanged))
             {
+                if (source is ServerCompositionCustomVisual)
+                    CustomVisualCompilationCount++;
                 return contentChanged;
             }
 
@@ -1168,6 +1164,8 @@ internal sealed class AvaloniaCompositionScene : IDisposable
                 renderOptions,
                 textOptions,
                 target.BeginCommandRecording());
+            if (source is ServerCompositionCustomVisual)
+                CustomVisualCompilationCount++;
             return true;
         }
         finally
@@ -2304,6 +2302,13 @@ internal sealed class AvaloniaCompositionVisual : ContainerVisual,
 /// </summary>
 internal sealed class AvaloniaRetainedCommandCache
 {
+    private static readonly bool s_traceCompactFallbacks =
+        string.Equals(
+            Environment.GetEnvironmentVariable(
+                "PROGPU_AVALONIA_TRACE_COMPACT_FALLBACKS"),
+            "1",
+            StringComparison.Ordinal);
+    private static int s_tracedCompactFallbacks;
     private CompactAvaloniaCommand? _singleCommand;
     private CompactAvaloniaCommand[]? _multipleCommands;
     private int _compactCommandCount;
@@ -2328,12 +2333,14 @@ internal sealed class AvaloniaRetainedCommandCache
 
     internal DrawingContext BeginRecording()
     {
+        int previousCount = Count;
         _singleCommand = null;
         _multipleCommands = null;
         _compactCommandCount = 0;
         _presentationDependencies =
             RenderCommandPresentationDependencies.None;
         DrawingContext context = GetOrCreateContext();
+        context.EnsureCommandCapacity(previousCount);
         context.Clear();
         return context;
     }
@@ -2352,7 +2359,14 @@ internal sealed class AvaloniaRetainedCommandCache
         _presentationDependencies =
             GetPresentationDependencies(source);
         if (context.RetainedResourceCount != 0)
+        {
+            TraceCompactFallback(
+                "retained resources",
+                count,
+                -1,
+                default);
             return false;
+        }
         if (count == 0)
         {
             contentChanged = previousCount != 0;
@@ -2416,6 +2430,11 @@ internal sealed class AvaloniaRetainedCommandCache
                     source[0],
                     out CompactAvaloniaCommand? command))
             {
+                TraceCompactFallback(
+                    "unsupported command",
+                    count,
+                    0,
+                    source[0]);
                 return false;
             }
 
@@ -2431,6 +2450,11 @@ internal sealed class AvaloniaRetainedCommandCache
                         source[index],
                         out CompactAvaloniaCommand? command))
                 {
+                    TraceCompactFallback(
+                        "unsupported command",
+                        count,
+                        index,
+                        source[index]);
                     return false;
                 }
 
@@ -2450,6 +2474,25 @@ internal sealed class AvaloniaRetainedCommandCache
         }
 
         return true;
+    }
+
+    private static void TraceCompactFallback(
+        string reason,
+        int count,
+        int index,
+        in RenderCommand command)
+    {
+        if (!s_traceCompactFallbacks ||
+            count < 100 ||
+            Interlocked.Increment(ref s_tracedCompactFallbacks) > 16)
+        {
+            return;
+        }
+
+        Console.Error.WriteLine(
+            $"[Avalonia.ProGpu] compact recording fallback: {reason}; " +
+            $"count={count}; index={index}; type={command.Type}; " +
+            $"gpuTransforms={command.UseGpuTransforms}");
     }
 
     internal RenderCommand GetCommand(int index)
@@ -2513,17 +2556,94 @@ internal abstract class CompactAvaloniaCommand
             case RenderCommandType.DrawRect:
             case RenderCommandType.DrawPath:
             case RenderCommandType.DrawEllipse:
+            case RenderCommandType.DrawCircle:
             case RenderCommandType.DrawRoundedRect:
                 compact = new CompactAvaloniaVectorCommand(command);
                 return true;
             case RenderCommandType.DrawGlyphRun:
                 compact = new CompactAvaloniaGlyphRunCommand(command);
                 return true;
+            case RenderCommandType.PushClip:
+            case RenderCommandType.PopClip:
+            case RenderCommandType.PushGeometryClip:
+            case RenderCommandType.PopGeometryClip:
+            case RenderCommandType.PushOpacity:
+            case RenderCommandType.PopOpacity:
+            case RenderCommandType.PushBlendMode:
+            case RenderCommandType.PopBlendMode:
+                compact = new CompactAvaloniaStateCommand(command);
+                return true;
             default:
                 compact = null;
                 return false;
         }
     }
+}
+
+internal sealed class CompactAvaloniaStateCommand : CompactAvaloniaCommand
+{
+    private RenderCommandType _type;
+    private ProGpuRect _rect;
+    private ProGPU.Vector.PathGeometry? _path;
+    private Matrix4x4 _transform;
+    private float _scalar;
+    private int _integer;
+
+    internal CompactAvaloniaStateCommand(in RenderCommand command)
+    {
+        if (!TryUpdate(command, out _))
+        {
+            throw new ArgumentException(
+                "The command is not a compact Avalonia state command.",
+                nameof(command));
+        }
+    }
+
+    internal override bool TryUpdate(
+        in RenderCommand command,
+        out bool changed)
+    {
+        if (command.UseGpuTransforms ||
+            command.Type is not (
+                RenderCommandType.PushClip or
+                RenderCommandType.PopClip or
+                RenderCommandType.PushGeometryClip or
+                RenderCommandType.PopGeometryClip or
+                RenderCommandType.PushOpacity or
+                RenderCommandType.PopOpacity or
+                RenderCommandType.PushBlendMode or
+                RenderCommandType.PopBlendMode))
+        {
+            changed = false;
+            return false;
+        }
+
+        changed =
+            _type != command.Type ||
+            _rect != command.Rect ||
+            !ReferenceEquals(_path, command.Path) ||
+            _transform != command.Transform ||
+            _scalar != command.FontSize ||
+            _integer != command.IntParam;
+        _type = command.Type;
+        _rect = command.Rect;
+        _path = command.Path;
+        _transform = command.Transform;
+        _scalar = command.FontSize;
+        _integer = command.IntParam;
+        return true;
+    }
+
+    internal override RenderCommand Expand() =>
+        new()
+        {
+            Type = _type,
+            Rect = _rect,
+            Path = _path,
+            Transform = _transform,
+            FontSize = _scalar,
+            IntParam = _integer
+        };
 }
 
 internal sealed class CompactAvaloniaVectorCommand :
@@ -2570,6 +2690,7 @@ internal sealed class CompactAvaloniaVectorCommand :
                 RenderCommandType.DrawRect or
                 RenderCommandType.DrawPath or
                 RenderCommandType.DrawEllipse or
+                RenderCommandType.DrawCircle or
                 RenderCommandType.DrawRoundedRect))
         {
             changed = false;

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
@@ -1,3 +1,7 @@
+#if PROGPU_AVALONIA_SOURCE_COMPOSITOR
+extern alias AvaloniaSkiaContract;
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -20,6 +24,16 @@ using SceneBrush = ProGPU.Vector.Brush;
 using ScenePen = ProGPU.Vector.Pen;
 using SceneRect = ProGPU.Scene.Rect;
 using AColor = Avalonia.Media.Color;
+#if PROGPU_AVALONIA_SOURCE_COMPOSITOR
+using SkiaApiLeaseFeature =
+    AvaloniaSkiaContract::Avalonia.Skia.ISkiaSharpApiLeaseFeature;
+using SkiaApiLease =
+    AvaloniaSkiaContract::Avalonia.Skia.ISkiaSharpApiLease;
+#else
+using SkiaApiLeaseFeature =
+    Avalonia.Skia.ISkiaSharpApiLeaseFeature;
+using SkiaApiLease = Avalonia.Skia.ISkiaSharpApiLease;
+#endif
 
 namespace Avalonia.ProGpu;
 
@@ -54,6 +68,7 @@ internal partial class DrawingContextImpl :
     private readonly Matrix? _physicalScale;
     private readonly string _presentationPath;
     private readonly AvaloniaDrawingState _drawingState;
+    private readonly LeaseFeature _leaseFeature;
     private readonly Stack<double> _opacityFrames;
     private readonly Stack<bool> _clipFrames;
     private readonly Stack<AvaloniaSkiaClipState> _skiaClipFrames;
@@ -121,6 +136,7 @@ internal partial class DrawingContextImpl :
         _drawingState = _reusableRecording
             ? new AvaloniaDrawingState()
             : _resources.RentDrawingState();
+        _leaseFeature = new LeaseFeature(this);
         _opacityFrames = _drawingState.OpacityFrames;
         _clipFrames = _drawingState.GeometryClipFrames;
         _skiaClipFrames = _drawingState.SkiaClipFrames;
@@ -710,10 +726,9 @@ internal partial class DrawingContextImpl :
     {
         ArgumentNullException.ThrowIfNull(featureType);
         if (featureType == typeof(IProGpuApiLeaseFeature) ||
-            featureType ==
-                typeof(Avalonia.Skia.ISkiaSharpApiLeaseFeature))
+            featureType == typeof(SkiaApiLeaseFeature))
         {
-            return new LeaseFeature(this);
+            return _leaseFeature;
         }
 #if PROGPU_AVALONIA_SOURCE_COMPOSITOR
         if (featureType == typeof(ICompositionRenderDataDrawingContextFeature))
@@ -1059,7 +1074,7 @@ internal partial class DrawingContextImpl :
 
     private sealed class LeaseFeature :
         IProGpuApiLeaseFeature,
-        Avalonia.Skia.ISkiaSharpApiLeaseFeature
+        SkiaApiLeaseFeature
     {
         private readonly DrawingContextImpl _owner;
 
@@ -1070,8 +1085,8 @@ internal partial class DrawingContextImpl :
 
         public IProGpuApiLease Lease() => new Lease(_owner);
 
-        Avalonia.Skia.ISkiaSharpApiLease
-            Avalonia.Skia.ISkiaSharpApiLeaseFeature.Lease() =>
+        SkiaApiLease
+            SkiaApiLeaseFeature.Lease() =>
                 new ProGpuSkiaSharpApiLease(
                     new Lease(_owner),
                     _owner._skiaClipState);

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaDrawingContext.cs
@@ -760,6 +760,14 @@ internal partial class DrawingContextImpl :
                 submitted = Submit();
             }
         }
+        catch when (GpuContext.IsDeviceLost)
+        {
+            // Device loss can arrive synchronously from a resource write or
+            // queue operation in the middle of this frame. Drop that frame;
+            // the platform context manager observes the terminal state and
+            // supplies a fresh device on the next render pass.
+            submitted = false;
+        }
         finally
         {
             _afterSubmit?.Invoke(submitted);

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaGlyphRun.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaGlyphRun.cs
@@ -61,19 +61,13 @@ internal sealed class GlyphRunImpl : IGlyphRunImpl
             ProGpuGlyphPositions[index] =
                 new Vector2((float)x, (float)y);
 
-            if (scale > 0 &&
-                Typeface.Font.TryGetGlyphBounds(
+            if (TryGetGlyphInkBounds(
                     info.GlyphIndex,
-                    out short xMin,
-                    out short yMin,
-                    out short xMax,
-                    out short yMax))
+                    x,
+                    y,
+                    scale,
+                    out Rect local))
             {
-                var local = new Rect(
-                    x + xMin * scale,
-                    y - yMax * scale,
-                    Math.Max(0, (xMax - xMin) * scale),
-                    Math.Max(0, (yMax - yMin) * scale));
                 bounds = hasBounds ? bounds.Union(local) : local;
                 hasBounds = true;
             }
@@ -123,25 +117,22 @@ internal sealed class GlyphRunImpl : IGlyphRunImpl
         for (int index = 0; index < GlyphIndices.Length; index++)
         {
             Vector2 position = ProGpuGlyphPositions[index];
-            if (scale <= 0 ||
-                !Typeface.Font.TryGetGlyphBounds(
+            if (!TryGetGlyphInkBounds(
                     GlyphIndices[index],
-                    out short xMin,
-                    out short yMin,
-                    out short xMax,
-                    out short yMax))
+                    position.X,
+                    position.Y,
+                    scale,
+                    out Rect bounds))
             {
                 continue;
             }
 
-            double top = position.Y - yMax * scale;
-            double bottom = position.Y - yMin * scale;
-            if (bottom < lowerLimit || top > upperLimit)
+            if (bounds.Bottom < lowerLimit || bounds.Top > upperLimit)
                 continue;
 
             intervals.Add(new Interval(
-                (float)(position.X + xMin * scale),
-                (float)(position.X + xMax * scale)));
+                (float)bounds.Left,
+                (float)bounds.Right));
         }
 
         if (intervals.Count == 0)
@@ -175,6 +166,45 @@ internal sealed class GlyphRunImpl : IGlyphRunImpl
 
     public void Dispose()
     {
+    }
+
+    private bool TryGetGlyphInkBounds(
+        ushort glyphIndex,
+        double x,
+        double y,
+        double outlineScale,
+        out Rect bounds)
+    {
+        if (outlineScale > 0 &&
+            Typeface.Font.TryGetGlyphBounds(
+                glyphIndex,
+                out short xMin,
+                out short yMin,
+                out short xMax,
+                out short yMax))
+        {
+            bounds = new Rect(
+                x + xMin * outlineScale,
+                y - yMax * outlineScale,
+                Math.Max(0, (xMax - xMin) * outlineScale),
+                Math.Max(0, (yMax - yMin) * outlineScale));
+            return true;
+        }
+
+        if (BoundedColorGlyphMetrics.TryGetMetrics(
+                Typeface.Font,
+                glyphIndex,
+                FontRenderingEmSize,
+                out ColorGlyphMetrics metrics))
+        {
+            bounds = metrics.GetBounds(
+                new Point(x, y),
+                FontRenderingEmSize);
+            return bounds.Width > 0 && bounds.Height > 0;
+        }
+
+        bounds = default;
+        return false;
     }
 
     private readonly record struct Interval(float Start, float End);

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaGpuDevicePool.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaGpuDevicePool.cs
@@ -60,17 +60,38 @@ internal static unsafe class AvaloniaGpuDevicePool
         if (surfaceHandle != IntPtr.Zero &&
             WgpuContext.TryGetActiveContextForSurface(
                 surfaceHandle,
-                out WgpuContext? surfaceContext) &&
-            surfaceContext is { IsDisposed: false })
+                out WgpuContext? surfaceContext))
         {
-            WgpuContext.Current = surfaceContext;
-            return surfaceContext;
+            if (surfaceContext is
+            {
+                IsInitialized: true,
+                IsDisposed: false,
+                IsDeviceLost: false
+            })
+            {
+                WgpuContext.Current = surfaceContext;
+                return surfaceContext;
+            }
+            if (surfaceContext.IsDeviceLost)
+            {
+                throw new RenderTargetNotReadyException();
+            }
         }
 
-        if (WgpuContext.Current is { IsDisposed: false } current)
+        if (WgpuContext.Current is
+            {
+                IsInitialized: true,
+                IsDisposed: false,
+                IsDeviceLost: false
+            } current)
             return current;
         if (WgpuContext.TryGetFirstActiveContext(out WgpuContext? active) &&
-            active is { IsDisposed: false })
+            active is
+            {
+                IsInitialized: true,
+                IsDisposed: false,
+                IsDeviceLost: false
+            })
         {
             WgpuContext.Current = active;
             return active;
@@ -79,8 +100,10 @@ internal static unsafe class AvaloniaGpuDevicePool
         lock (s_gate)
         {
             if (s_standaloneContext is null ||
-                s_standaloneContext.IsDisposed)
+                s_standaloneContext.IsDisposed ||
+                s_standaloneContext.IsDeviceLost)
             {
+                s_standaloneContext?.Dispose();
                 s_standaloneContext = new WgpuContext();
                 s_standaloneContext.Initialize(window: null);
             }
@@ -144,8 +167,32 @@ internal static unsafe class AvaloniaGpuDevicePool
             if (surfaceTexture.Status !=
                 SurfaceGetCurrentTextureStatus.Success)
             {
-                throw new InvalidOperationException(
-                    $"The WebGPU surface did not provide a drawable texture: {surfaceTexture.Status}.");
+                if (surfaceTexture.Status ==
+                    SurfaceGetCurrentTextureStatus.DeviceLost)
+                {
+                    context.ReportDeviceLost(
+                        DeviceLostReason.Unknown,
+                        "The presentation surface reported device loss.");
+                    throw new RenderTargetCorruptedException(
+                        "The WebGPU presentation device is lost.");
+                }
+                if (surfaceTexture.Status ==
+                    SurfaceGetCurrentTextureStatus.OutOfMemory)
+                {
+                    throw new OutOfMemoryException(
+                        "The WebGPU presentation surface ran out of memory.");
+                }
+                if (surfaceTexture.Status is
+                    SurfaceGetCurrentTextureStatus.Outdated or
+                    SurfaceGetCurrentTextureStatus.Lost)
+                {
+                    context.InvalidateSurfaceConfiguration();
+                    context.TryConfigureSwapChain(
+                        checked((uint)size.Width),
+                        checked((uint)size.Height),
+                        refreshCapabilities: true);
+                }
+                throw new RenderTargetNotReadyException();
             }
 
             var viewDescriptor = new TextureViewDescriptor

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaGpuDevicePool.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaGpuDevicePool.cs
@@ -39,6 +39,7 @@ internal static unsafe class AvaloniaGpuDevicePool
             InitialVertexCount = 1024,
             InitialIndexCount = 1536,
             InitialColorGlyphAtlasSize = 64,
+            ColorGlyphAtlasSize = 1024,
             GlyphUniformStagingBytes = 16 * 1024,
             GlyphCoverageStagingBytes =
                 GlyphAtlas.DefaultCoverageRingBufferSize,

--- a/src/ProGPU.Avalonia.Rendering/AvaloniaRetainedCompositionRecorder.cs
+++ b/src/ProGPU.Avalonia.Rendering/AvaloniaRetainedCompositionRecorder.cs
@@ -147,7 +147,13 @@ partial class DrawingContextImpl
         try
         {
             record();
-            destination.TrimRetainedCommandCapacity();
+            // Large custom visuals initially grow through pooled scratch
+            // storage. Retain the observed high-water capacity once so a
+            // subsequent Clear does not return the buffer and force another
+            // rent on the next animation frame. Unlike trimming to Count,
+            // this also avoids reallocating when command counts fluctuate.
+            destination.EnsureCommandCapacity(
+                destination.Commands.Count);
         }
         finally
         {

--- a/src/ProGPU.Avalonia.Rendering/DawnMetalRenderTarget.cs
+++ b/src/ProGPU.Avalonia.Rendering/DawnMetalRenderTarget.cs
@@ -33,9 +33,12 @@ internal sealed class DawnMetalRenderTarget : IRenderTarget
     private readonly IMetalDevice _metalDevice;
     private readonly IMetalExternalObjectsFeature _externalObjects;
     private readonly DawnGpuContext _dawnContext;
+    private readonly IDisposable _contextLifetime;
     private readonly OffscreenTextureCache _textureCache;
     private readonly Dictionary<nint, DrawableSlot> _slots = new();
     private IMetalPlatformSurfaceRenderTarget? _target;
+    private bool _corrupted;
+    private bool _disposed;
     private long _frameId;
 
     public DawnMetalRenderTarget(
@@ -65,11 +68,22 @@ internal sealed class DawnMetalRenderTarget : IRenderTarget
                 "Avalonia's Metal device does not accept MTLSharedEvent synchronization.");
         }
 
-        _metalDevice = metalDevice;
-        _dawnContext = dawnContext;
-        _textureCache = new OffscreenTextureCache(
-            requireNativeCompositionScene);
-        _target = surface.CreateMetalRenderTarget(metalDevice);
+        IDisposable contextLifetime =
+            dawnContext.AcquireLifetimeLease();
+        try
+        {
+            _metalDevice = metalDevice;
+            _dawnContext = dawnContext;
+            _contextLifetime = contextLifetime;
+            _textureCache = new OffscreenTextureCache(
+                requireNativeCompositionScene);
+            _target = surface.CreateMetalRenderTarget(metalDevice);
+        }
+        catch
+        {
+            contextLifetime.Dispose();
+            throw;
+        }
     }
 
     public RenderTargetProperties Properties => new()
@@ -79,12 +93,19 @@ internal sealed class DawnMetalRenderTarget : IRenderTarget
     };
 
     public PlatformRenderTargetState PlatformRenderTargetState =>
-        _target?.State ?? PlatformRenderTargetState.Disposed;
+        _corrupted || _dawnContext.Context.IsDeviceLost
+            ? PlatformRenderTargetState.Corrupted
+            : _target?.State ?? PlatformRenderTargetState.Disposed;
 
     public IDrawingContextImpl CreateDrawingContext(
         IRenderTarget.RenderTargetSceneInfo sceneInfo,
         out RenderTargetDrawingContextProperties properties)
     {
+        if (_dawnContext.Context.IsDeviceLost)
+        {
+            throw new RenderTargetCorruptedException(
+                "The Dawn Metal presentation device is lost.");
+        }
         IMetalPlatformSurfaceRenderingSession? session = null;
         MetalFrameLease? frameLease = null;
         try
@@ -139,11 +160,18 @@ internal sealed class DawnMetalRenderTarget : IRenderTarget
                 },
                 frameLease);
         }
-        catch
+        catch (RenderTargetNotReadyException)
         {
             frameLease?.Dispose();
             session?.Dispose();
             throw;
+        }
+        catch (Exception exception)
+        {
+            frameLease?.Dispose();
+            session?.Dispose();
+            _corrupted = true;
+            throw new RenderTargetCorruptedException(exception);
         }
     }
 
@@ -207,6 +235,10 @@ internal sealed class DawnMetalRenderTarget : IRenderTarget
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
         _target?.Dispose();
         _target = null;
         foreach (DrawableSlot slot in _slots.Values)
@@ -215,6 +247,8 @@ internal sealed class DawnMetalRenderTarget : IRenderTarget
         }
         _slots.Clear();
         _textureCache.Dispose();
+        _contextLifetime.Dispose();
+        _disposed = true;
     }
 
     private sealed unsafe class DrawableSlot : IDisposable

--- a/src/ProGPU.Avalonia.Rendering/DawnNativeWindowRenderTarget.cs
+++ b/src/ProGPU.Avalonia.Rendering/DawnNativeWindowRenderTarget.cs
@@ -21,6 +21,7 @@ internal sealed class DawnNativeWindowRenderTarget : IRenderTarget
     private readonly DawnNativeWindowSource _windowSource;
     private readonly DawnNativePresentationSurface _presentationSurface;
     private readonly OffscreenTextureCache _textureCache;
+    private bool _corrupted;
     private bool _disposed;
 
     internal DawnNativeWindowRenderTarget(
@@ -58,6 +59,8 @@ internal sealed class DawnNativeWindowRenderTarget : IRenderTarget
     public PlatformRenderTargetState PlatformRenderTargetState =>
         _disposed
             ? PlatformRenderTargetState.Disposed
+            : _corrupted || _presentationSurface.IsDeviceLost
+                ? PlatformRenderTargetState.Corrupted
             : _platformSurface.IsReady
                 ? PlatformRenderTargetState.Ready
                 : PlatformRenderTargetState.NotReadyTryLater;
@@ -67,6 +70,11 @@ internal sealed class DawnNativeWindowRenderTarget : IRenderTarget
         out RenderTargetDrawingContextProperties properties)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_presentationSurface.IsDeviceLost)
+        {
+            throw new RenderTargetCorruptedException(
+                "The Dawn presentation device is lost.");
+        }
         PixelSize size = _platformSurface.Size;
         if (!_platformSurface.IsReady ||
             size.Width <= 0 ||
@@ -104,10 +112,16 @@ internal sealed class DawnNativeWindowRenderTarget : IRenderTarget
                 },
                 frame);
         }
-        catch
+        catch (TimeoutException exception)
         {
             frame?.Dispose();
-            throw;
+            throw new RenderTargetNotReadyException(exception);
+        }
+        catch (Exception exception)
+        {
+            frame?.Dispose();
+            _corrupted = true;
+            throw new RenderTargetCorruptedException(exception);
         }
     }
 

--- a/src/ProGPU.Avalonia.Rendering/ImmutableProGpuBitmap.cs
+++ b/src/ProGPU.Avalonia.Rendering/ImmutableProGpuBitmap.cs
@@ -14,8 +14,8 @@ namespace Avalonia.ProGpu;
 
 /// <summary>
 /// Immutable Avalonia bitmap backed by one lazily created ProGPU texture.
-/// Encoded and decoded CPU representations are released after an ordinary
-/// upload; portable snapshots retain exactly one decoded representation.
+/// Encoded inputs retain their compressed payload and generated inputs retain
+/// one decoded snapshot so the bitmap can migrate to a replacement device.
 /// </summary>
 internal sealed class ImmutableBitmap :
     IProGpuBitmapSource,
@@ -62,6 +62,7 @@ internal sealed class ImmutableBitmap :
         PixelSize = destinationSize;
         Dpi = source.Dpi;
         _alphaMode = source._alphaMode;
+        _retainPortablePixels = true;
         EnsureGpuTexture();
     }
 
@@ -112,6 +113,7 @@ internal sealed class ImmutableBitmap :
         PixelSize = new PixelSize(width, height);
         Dpi = new Vector(96, 96);
         _alphaMode = GpuTextureAlphaMode.Straight;
+        _retainPortablePixels = true;
         EnsureGpuTexture();
     }
 
@@ -129,6 +131,7 @@ internal sealed class ImmutableBitmap :
         _alphaMode = ToTextureAlphaMode(alphaFormat);
         _pendingPixels =
             AvaloniaPixelTransfer.CopyToRgba(size, stride, format, data);
+        _retainPortablePixels = true;
         EnsureGpuTexture();
     }
 
@@ -152,7 +155,9 @@ internal sealed class ImmutableBitmap :
         Dpi = dpi;
         _alphaMode = ToTextureAlphaMode(alphaFormat);
         _pendingPixels = pixels;
-        _retainPortablePixels = retainPixelsForContextMigration;
+        // A bitmap without an encoded payload needs this bounded CPU snapshot
+        // to recreate its device-owned texture after device loss.
+        _retainPortablePixels = true;
         if (!retainPixelsForContextMigration)
             EnsureGpuTexture();
     }
@@ -183,9 +188,17 @@ internal sealed class ImmutableBitmap :
             }
 
             Rgba32[] pixels = _pendingPixels ??
-                (Texture is { IsDisposed: false } previous
-                    ? ReadTexture(previous)
-                    : Decode(_encoded));
+                (_encoded is not null
+                    ? Decode(_encoded)
+                    : Texture is
+                        {
+                            IsDisposed: false,
+                            Context.IsDisposed: false,
+                            Context.IsDeviceLost: false
+                        } previous
+                        ? ReadTexture(previous)
+                        : throw new InvalidOperationException(
+                            "The immutable bitmap has no device-independent recovery representation."));
             Texture?.Dispose();
             Texture = new GpuTexture(
                 requiredContext,
@@ -199,7 +212,6 @@ internal sealed class ImmutableBitmap :
                 alphaMode: _alphaMode);
             Texture.WritePixels(pixels);
 
-            _encoded = null;
             if (_retainPortablePixels)
                 _pendingPixels = pixels;
             else

--- a/src/ProGPU.Avalonia.Rendering/ProGPU.Avalonia.Rendering.csproj
+++ b/src/ProGPU.Avalonia.Rendering/ProGPU.Avalonia.Rendering.csproj
@@ -36,8 +36,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ProGpuAvaloniaSourceRoot)' != ''">
+    <Compile Remove="SkiaSharpApiLeaseContracts.cs" />
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\packages\Avalonia\Avalonia.csproj"
                       GlobalPropertiesToRemove="AvaloniaAccessUnstablePrivateApis;Avalonia_I_Want_To_Use_Private_Apis_IN_NUGET_PACKAGE;Avalonia_I_Want_To_Use_Private_Apis_In_Nuget_Package_And_Promise_To_Pin_The_Exact_Avalonia_Version_In_Package_Dependency" />
+    <ProjectReference Include="..\ProGPU.Avalonia.SkiaSourceCompatibility\ProGPU.Avalonia.SkiaSourceCompatibility.csproj"
+                      Aliases="AvaloniaSkiaContract"
+                      AdditionalProperties="ProGpuAvaloniaSourceRoot=$(ProGpuAvaloniaSourceRoot)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -66,11 +70,11 @@
     </PropertyGroup>
     <ItemGroup>
       <Reference Remove="@(Reference)"
-                 Condition="$([System.String]::Copy('%(Filename)').StartsWith('Avalonia'))" />
+                 Condition="$([System.String]::Copy('%(Reference.Filename)').StartsWith('Avalonia')) and '%(Reference.Aliases)' != 'AvaloniaSkiaContract'" />
       <ReferencePath Remove="@(ReferencePath)"
-                     Condition="$([System.String]::Copy('%(Filename)').StartsWith('Avalonia'))" />
+                     Condition="$([System.String]::Copy('%(ReferencePath.Filename)').StartsWith('Avalonia')) and '%(ReferencePath.Aliases)' != 'AvaloniaSkiaContract'" />
       <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)"
-                                      Condition="$([System.String]::Copy('%(Filename)').StartsWith('Avalonia'))" />
+                                      Condition="$([System.String]::Copy('%(ReferencePathWithRefAssemblies.Filename)').StartsWith('Avalonia')) and '%(ReferencePathWithRefAssemblies.Aliases)' != 'AvaloniaSkiaContract'" />
       <PinnedAvaloniaAssembly Include="$(PinnedAvaloniaOutput)\Avalonia*.dll" />
       <Reference Include="@(PinnedAvaloniaAssembly)" />
       <ReferencePath Include="@(PinnedAvaloniaAssembly)" />

--- a/src/ProGPU.Avalonia.Rendering/ProGpuDrawingLayer.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuDrawingLayer.cs
@@ -81,7 +81,11 @@ internal sealed class SurfaceRenderTarget :
     public PixelSize PixelSize { get; }
     public Vector Dpi { get; }
     public int Version { get; private set; } = 1;
-    public bool IsCorrupted => false;
+    public bool IsCorrupted =>
+        Texture is null ||
+        Texture.IsDisposed ||
+        Texture.Context.IsDisposed ||
+        Texture.Context.IsDeviceLost;
     public bool CanBlit => true;
     public bool HasRenderContextAffinity =>
         Texture is { IsDisposed: false };

--- a/src/ProGPU.Avalonia.Rendering/ProGpuRenderTargetBitmap.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuRenderTargetBitmap.cs
@@ -47,7 +47,14 @@ internal sealed class RenderTargetBitmapImpl :
         CreateContext(useScaledDrawing: true);
 #endif
 
-    public bool IsCorrupted => false;
+    public bool IsCorrupted =>
+        Texture?.Context is
+        {
+            IsDisposed: true
+        } or
+        {
+            IsDeviceLost: true
+        };
 
     public IFramebufferRenderTarget CreateFramebufferRenderTarget() =>
         new FuncFramebufferRenderTarget(Lock);

--- a/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
+++ b/src/ProGPU.Avalonia.Rendering/ProGpuSkiaSharpApiLease.cs
@@ -1,5 +1,19 @@
+#if PROGPU_AVALONIA_SOURCE_COMPOSITOR
+extern alias AvaloniaSkiaContract;
+#endif
+
 using System;
 using System.Numerics;
+#if PROGPU_AVALONIA_SOURCE_COMPOSITOR
+using SkiaApiLease =
+    AvaloniaSkiaContract::Avalonia.Skia.ISkiaSharpApiLease;
+using SkiaPlatformGraphicsApiLease =
+    AvaloniaSkiaContract::Avalonia.Skia.ISkiaSharpPlatformGraphicsApiLease;
+#else
+using SkiaApiLease = Avalonia.Skia.ISkiaSharpApiLease;
+using SkiaPlatformGraphicsApiLease =
+    Avalonia.Skia.ISkiaSharpPlatformGraphicsApiLease;
+#endif
 
 namespace Avalonia.ProGpu;
 
@@ -8,7 +22,7 @@ namespace Avalonia.ProGpu;
 /// SkiaSharp-compatible lease contract.
 /// </summary>
 internal sealed class ProGpuSkiaSharpApiLease :
-    Avalonia.Skia.ISkiaSharpApiLease
+    SkiaApiLease
 {
     private readonly int _threadId;
     private readonly int _canvasRestoreCount;
@@ -63,7 +77,7 @@ internal sealed class ProGpuSkiaSharpApiLease :
     public SkiaSharp.SKCanvas SkCanvas =>
         _canvas ??
         throw new ObjectDisposedException(
-            nameof(Avalonia.Skia.ISkiaSharpApiLease));
+            nameof(SkiaApiLease));
 
     public SkiaSharp.GRContext? GrContext
     {
@@ -86,10 +100,10 @@ internal sealed class ProGpuSkiaSharpApiLease :
     public double CurrentOpacity =>
         (_lease ??
          throw new ObjectDisposedException(
-             nameof(Avalonia.Skia.ISkiaSharpApiLease)))
+             nameof(SkiaApiLease)))
         .CurrentOpacity;
 
-    public Avalonia.Skia.ISkiaSharpPlatformGraphicsApiLease?
+    public SkiaPlatformGraphicsApiLease?
         TryLeasePlatformGraphicsApi()
     {
         _ = SkCanvas;

--- a/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
+++ b/src/ProGPU.Avalonia.SilkNet/NativeInputRouter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Numerics;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
@@ -28,6 +29,15 @@ namespace Avalonia.SilkNet;
 /// </remarks>
 internal sealed unsafe class SilkNetInputRouter : IDisposable
 {
+    private static readonly bool s_traceChromeDrag =
+        string.Equals(
+            Environment.GetEnvironmentVariable(
+                "PROGPU_AVALONIA_TRACE_CHROME_DRAG"),
+            "1",
+            StringComparison.Ordinal);
+    private static readonly string? s_chromeDragTracePath =
+        Environment.GetEnvironmentVariable(
+            "PROGPU_AVALONIA_TRACE_WINDOW_EVENTS_PATH");
     private readonly WindowImpl _owner;
     private readonly SilkNetClipboard _clipboard;
     private readonly MouseDevice _mouseDevice = new();
@@ -51,9 +61,11 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
     private RawInputModifiers _pointerButtons;
     private RawInputModifiers _glfwKeyModifiers;
     private Vector2 _lastPointerPosition;
+    private bool _hasPointerPosition;
     private bool _pointerInside;
     private bool _insideGlfwKeyCallback;
     private bool _suppressPromotedMouseForPoll;
+    private bool _chromeDragActive;
 
     internal SilkNetInputRouter(
         WindowImpl owner,
@@ -494,15 +506,28 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
     {
         if (ShouldSuppressPromotedMouse())
             return;
+        Vector2 position = ResolvePointerPosition(
+            _hasPointerPosition,
+            _lastPointerPosition,
+            mouse.Position);
         _pointerInside = true;
-        _lastPointerPosition = mouse.Position;
+        _hasPointerPosition = true;
+        _lastPointerPosition = position;
         RawPointerEventType? eventType =
             MapButton(button, pressed: true);
         if (eventType is null)
             return;
+        if (button == SilkMouseButton.Left)
+            _chromeDragActive = false;
+        if (button == SilkMouseButton.Left &&
+            TryBeginChromeDrag(position))
+        {
+            _chromeDragActive = true;
+            return;
+        }
         _pointerButtons |= ButtonModifier(button);
         EmitPointer(
-            mouse.Position,
+            position,
             eventType.Value);
     }
 
@@ -512,8 +537,19 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
     {
         if (ShouldSuppressPromotedMouse())
             return;
+        Vector2 position = ResolvePointerPosition(
+            _hasPointerPosition,
+            _lastPointerPosition,
+            mouse.Position);
         _pointerInside = true;
-        _lastPointerPosition = mouse.Position;
+        _hasPointerPosition = true;
+        _lastPointerPosition = position;
+        if (button == SilkMouseButton.Left && _chromeDragActive)
+        {
+            _chromeDragActive = false;
+            _owner.EndNativeDrag();
+            return;
+        }
         _owner.UpdateNativeDrag(
             CurrentNativePointer);
         if (button == SilkMouseButton.Left)
@@ -524,8 +560,59 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
             return;
         _pointerButtons &= ~ButtonModifier(button);
         EmitPointer(
-            mouse.Position,
+            position,
             eventType.Value);
+    }
+
+    private bool TryBeginChromeDrag(Vector2 position)
+    {
+#if AVALONIA11
+        _ = position;
+        return false;
+#else
+        IInputRoot? root = _inputRoot;
+        if (root is null)
+            return false;
+
+        Point logicalPosition = ToPoint(position);
+        WindowDecorationsElementRole? role =
+            SilkNetWindowChrome.ResolveChromeRole(
+                root,
+                logicalPosition);
+        if (role == WindowDecorationsElementRole.TitleBar)
+        {
+            bool started = _owner.BeginNativeMoveDrag();
+            if (s_traceChromeDrag)
+            {
+                TraceChromeDrag(
+                    $"title start={started} position={position}");
+            }
+            return started;
+        }
+
+        if (role is { } resizeRole &&
+            SilkNetWindowChrome.TryMapResizeRole(
+                resizeRole,
+                out NativeResizeEdge edge))
+        {
+            bool started = _owner.BeginNativeResizeDrag(edge);
+            if (s_traceChromeDrag)
+            {
+                TraceChromeDrag(
+                    $"resize edge={edge} start={started} " +
+                    $"position={position}");
+            }
+            return started;
+        }
+
+        if (s_traceChromeDrag)
+        {
+            TraceChromeDrag(
+                $"no role position={position} " +
+                $"logical={logicalPosition}");
+        }
+        return false;
+#endif
     }
 
     private void OnMouseMove(
@@ -535,12 +622,45 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
         if (ShouldSuppressPromotedMouse())
             return;
         _pointerInside = true;
+        _hasPointerPosition = true;
         _lastPointerPosition = position;
-        _owner.UpdateNativeDrag(
+        if (s_traceChromeDrag)
+        {
+            TraceChromeDrag(
+                $"pointer move position={position} " +
+                $"logical={ToPoint(position)}");
+        }
+        bool dragUpdated = _owner.UpdateNativeDrag(
             CurrentNativePointer);
+        if (dragUpdated && s_traceChromeDrag)
+            TraceChromeDrag($"update position={position}");
         EmitPointer(
             position,
             RawPointerEventType.Move);
+    }
+
+    private static void TraceChromeDrag(string message)
+    {
+        string line = $"[Avalonia.SilkNet] chrome drag: {message}";
+        string? path = s_chromeDragTracePath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            Console.Error.WriteLine(line);
+            return;
+        }
+
+        try
+        {
+            File.AppendAllText(path, line + Environment.NewLine);
+        }
+        catch (IOException)
+        {
+            Console.Error.WriteLine(line);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine(line);
+        }
     }
 
     private void OnMouseScroll(
@@ -549,8 +669,13 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
     {
         if (ShouldSuppressPromotedMouse())
             return;
+        Vector2 position = ResolvePointerPosition(
+            _hasPointerPosition,
+            _lastPointerPosition,
+            mouse.Position);
         _pointerInside = true;
-        _lastPointerPosition = mouse.Position;
+        _hasPointerPosition = true;
+        _lastPointerPosition = position;
         IInputRoot? root = _inputRoot;
         if (root is null || !_owner.TryAcceptInput())
             return;
@@ -560,10 +685,16 @@ internal sealed unsafe class SilkNetInputRouter : IDisposable
                 _mouseDevice,
                 Timestamp(),
                 root,
-                ToPoint(mouse.Position),
+                ToPoint(position),
                 new Vector(wheel.X, wheel.Y),
                 ReadModifiers() | _pointerButtons));
     }
+
+    internal static Vector2 ResolvePointerPosition(
+        bool hasCallbackPosition,
+        Vector2 callbackPosition,
+        Vector2 reportedPosition) =>
+        hasCallbackPosition ? callbackPosition : reportedPosition;
 
     private void EmitPointer(
         Vector2 position,

--- a/src/ProGPU.Avalonia.SilkNet/SharedWebGpuDevices.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SharedWebGpuDevices.cs
@@ -17,17 +17,27 @@ internal static class SharedWebGpuDevices
     internal static WgpuContext Create(IWindow window)
     {
         ArgumentNullException.ThrowIfNull(window);
-        var context = new WgpuContext();
         lock (s_gate)
         {
-            WgpuContext? owner = FindHealthyContext();
-            if (owner is not null && SharingEnabled())
-                context.InitializeSharedDevice(window, owner);
-            else
-                context.Initialize(window);
+            WgpuContext context = CreateCore(window);
+            if (context.IsDeviceLost)
+            {
+                context.Dispose();
+                context = CreateCore(window);
+            }
             s_contexts.Add(new WeakReference<WgpuContext>(context));
+            return context;
         }
+    }
 
+    private static WgpuContext CreateCore(IWindow window)
+    {
+        var context = new WgpuContext();
+        WgpuContext? owner = FindHealthyContext();
+        if (owner is not null && SharingEnabled())
+            context.InitializeSharedDevice(window, owner);
+        else
+            context.Initialize(window);
         return context;
     }
 

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -35,6 +36,15 @@ public sealed class WindowImpl :
     IPopupImpl,
     ISilkNetLoopParticipant
 {
+    private static readonly bool s_traceWindowEvents =
+        string.Equals(
+            Environment.GetEnvironmentVariable(
+                "PROGPU_AVALONIA_TRACE_WINDOW_EVENTS"),
+            "1",
+            StringComparison.Ordinal);
+    private static readonly string? s_windowEventTracePath =
+        Environment.GetEnvironmentVariable(
+            "PROGPU_AVALONIA_TRACE_WINDOW_EVENTS_PATH");
     private readonly SilkNetWindowingPlatform _platform;
     private WindowImpl? _parent;
     private readonly bool _isPopup;
@@ -649,11 +659,7 @@ public sealed class WindowImpl :
             return;
 
         e.Pointer.Capture(null);
-        NativeWindowPoint pointer =
-            _input.CurrentNativePointer;
-        Dispatcher.UIThread.Post(
-            () => _windowController?.BeginMove(pointer),
-            DispatcherPriority.Send);
+        _ = BeginNativeMoveDrag();
     }
 
     public void BeginResizeDrag(
@@ -663,9 +669,8 @@ public sealed class WindowImpl :
         ArgumentNullException.ThrowIfNull(e);
         if (_input is not null)
         {
-            _windowController?.BeginResize(
-                SilkNetWindowChrome.MapResizeEdge(edge),
-                _input.CurrentNativePointer);
+            _ = BeginNativeResizeDrag(
+                SilkNetWindowChrome.MapResizeEdge(edge));
         }
     }
 
@@ -919,12 +924,39 @@ public sealed class WindowImpl :
                 (int)MathF.Round(clientY)));
     }
 
-    internal void UpdateNativeDrag(
+    internal bool UpdateNativeDrag(
         NativeWindowPoint pointer) =>
-        _windowController?.UpdateDrag(pointer);
+        _windowController?.UpdateDrag(pointer) == true;
 
     internal void EndNativeDrag() =>
         _windowController?.EndDrag();
+
+    internal bool BeginNativeMoveDrag()
+    {
+        if (_input is null)
+            return false;
+
+        NativeWindowPoint pointer = _input.CurrentNativePointer;
+        return StartMoveResize(
+            () => _windowController?.BeginMove(pointer));
+    }
+
+    internal bool BeginNativeResizeDrag(NativeResizeEdge edge)
+    {
+        if (_input is null)
+            return false;
+
+        NativeWindowPoint pointer = _input.CurrentNativePointer;
+        return StartMoveResize(
+            () => _windowController?.BeginResize(edge, pointer));
+    }
+
+    private bool StartMoveResize(Func<bool?> action)
+    {
+        if (_windowController is null)
+            return false;
+        return action() == true;
+    }
 
     internal void SetNativeTouchHandler(
         Action<NativeTouchEvent>? handler)
@@ -965,6 +997,7 @@ public sealed class WindowImpl :
             return _window;
 
         Size requestedLogicalSize = _desiredSize;
+        PixelPoint? requestedPosition = _desiredPosition;
         Vector2D<int> size = new(
             Math.Max(
                 1,
@@ -985,6 +1018,11 @@ public sealed class WindowImpl :
                 FramesPerSecond = 0,
                 UpdatesPerSecond = 0,
                 Size = size,
+                Position = requestedPosition is { } initialPosition
+                    ? new Vector2D<int>(
+                        initialPosition.X,
+                        initialPosition.Y)
+                    : WindowOptions.Default.Position,
                 Title = _title,
                 WindowState =
                     ToSilkState(_windowState),
@@ -1016,7 +1054,7 @@ public sealed class WindowImpl :
         Resize(
             requestedLogicalSize,
             WindowResizeReason.Layout);
-        if (_desiredPosition is { } desired)
+        if (requestedPosition is { } desired)
             Move(desired);
         _platform.EventLoop.Register(this);
         return window;
@@ -1027,6 +1065,14 @@ public sealed class WindowImpl :
         if (_window is null)
             return;
         _windowController?.Attach();
+        if (s_traceWindowEvents)
+        {
+            TraceWindowEvent(
+                $"[Avalonia.SilkNet] load handle={Handle?.Handle} " +
+                $"window={_window.Size} " +
+                $"framebuffer={_window.FramebufferSize} " +
+                $"scaling={RenderScaling}");
+        }
 #if AVALONIA11
         if (!_isHitTestVisible)
             SetHitTestVisible(false);
@@ -1080,6 +1126,13 @@ public sealed class WindowImpl :
 
     private void OnResize(Vector2D<int> size)
     {
+        if (s_traceWindowEvents)
+        {
+            TraceWindowEvent(
+                $"[Avalonia.SilkNet] resize size={size} " +
+                $"framebuffer={_window?.FramebufferSize} " +
+                $"scaling={RenderScaling}");
+        }
         NotifyScalingChanged();
         _desiredSize =
             SilkNetDisplayMetrics.ResolveLogicalClientSize(
@@ -1096,6 +1149,12 @@ public sealed class WindowImpl :
 
     private void OnFramebufferResize(Vector2D<int> size)
     {
+        if (s_traceWindowEvents)
+        {
+            TraceWindowEvent(
+                $"[Avalonia.SilkNet] framebuffer-resize size={size} " +
+                $"window={_window?.Size} scaling={RenderScaling}");
+        }
         _ = size;
         NotifyScalingChanged();
         QueuePaint();
@@ -1103,9 +1162,40 @@ public sealed class WindowImpl :
 
     private void OnMove(Vector2D<int> position)
     {
-        _ = position;
+        if (s_traceWindowEvents)
+        {
+            TraceWindowEvent(
+                $"[Avalonia.SilkNet] move position={position} " +
+                $"scaling={RenderScaling}");
+        }
+        _desiredPosition = new PixelPoint(
+            position.X,
+            position.Y);
         NotifyScalingChanged();
-        PositionChanged?.Invoke(Position);
+        PositionChanged?.Invoke(_desiredPosition.Value);
+    }
+
+    private static void TraceWindowEvent(string message)
+    {
+        string? path = s_windowEventTracePath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            Console.Error.WriteLine(message);
+            return;
+        }
+
+        try
+        {
+            File.AppendAllText(path, message + Environment.NewLine);
+        }
+        catch (IOException)
+        {
+            Console.Error.WriteLine(message);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine(message);
+        }
     }
 
     private void NotifyScalingChanged()

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetDesktopWindow.cs
@@ -1279,6 +1279,8 @@ public sealed class WindowImpl :
         Silk.NET.WebGPU.DeviceLostReason reason,
         string message)
     {
+        if (_webGpuContext?.IsDeviceLost != true)
+            return;
         _paintQueued = true;
         _platform.EventLoop.Wake();
     }

--- a/src/ProGPU.Avalonia.SilkNet/SilkNetWindowChrome.cs
+++ b/src/ProGPU.Avalonia.SilkNet/SilkNetWindowChrome.cs
@@ -1,7 +1,14 @@
 using System;
 using System.Collections.Generic;
 using Avalonia.Controls;
+#if !AVALONIA11
+using Avalonia.Controls.Chrome;
+using Avalonia.Input;
+#endif
 using Avalonia.Platform;
+#if !AVALONIA11
+using Avalonia.VisualTree;
+#endif
 #if !AVALONIA11
 using Avalonia.Controls.Platform;
 #endif
@@ -123,6 +130,54 @@ internal static class SilkNetWindowChrome
                 edge,
                 "Unsupported resize edge.")
         };
+
+#if !AVALONIA11
+    internal static bool TryMapResizeRole(
+        WindowDecorationsElementRole role,
+        out NativeResizeEdge edge)
+    {
+        edge = role switch
+        {
+            WindowDecorationsElementRole.ResizeN => NativeResizeEdge.Top,
+            WindowDecorationsElementRole.ResizeS => NativeResizeEdge.Bottom,
+            WindowDecorationsElementRole.ResizeE => NativeResizeEdge.Right,
+            WindowDecorationsElementRole.ResizeW => NativeResizeEdge.Left,
+            WindowDecorationsElementRole.ResizeNE => NativeResizeEdge.TopRight,
+            WindowDecorationsElementRole.ResizeNW => NativeResizeEdge.TopLeft,
+            WindowDecorationsElementRole.ResizeSE => NativeResizeEdge.BottomRight,
+            WindowDecorationsElementRole.ResizeSW => NativeResizeEdge.BottomLeft,
+            _ => default
+        };
+        return role is
+            WindowDecorationsElementRole.ResizeN or
+            WindowDecorationsElementRole.ResizeS or
+            WindowDecorationsElementRole.ResizeE or
+            WindowDecorationsElementRole.ResizeW or
+            WindowDecorationsElementRole.ResizeNE or
+            WindowDecorationsElementRole.ResizeNW or
+            WindowDecorationsElementRole.ResizeSE or
+            WindowDecorationsElementRole.ResizeSW;
+    }
+
+    internal static WindowDecorationsElementRole? ResolveChromeRole(
+        IInputRoot inputRoot,
+        Point point)
+    {
+        ArgumentNullException.ThrowIfNull(inputRoot);
+        Visual? current = inputRoot.FocusRoot.InputHitTest(
+            point,
+            enabledElementsOnly: false) as Visual;
+        for (; current is not null; current = current.GetVisualParent())
+        {
+            WindowDecorationsElementRole role =
+                WindowDecorationProperties.GetElementRole(current);
+            if (role != WindowDecorationsElementRole.None)
+                return role;
+        }
+
+        return null;
+    }
+#endif
 
     internal static NativeWindowSize ToMinimumSize(
         Size size,

--- a/src/ProGPU.Avalonia.SilkNet/WebGpuFramebufferSurface.cs
+++ b/src/ProGPU.Avalonia.SilkNet/WebGpuFramebufferSurface.cs
@@ -132,7 +132,8 @@ internal sealed unsafe class SilkNetFramebufferSurface :
             new ReadOnlySpan<byte>(
                 (void*)address,
                 byteCount));
-        context.ReconfigureIfNeeded(width, height);
+        if (!context.TryReconfigureIfNeeded(width, height))
+            return;
 
         var surfaceTexture = new SurfaceTexture();
         context.Api.SurfaceGetCurrentTexture(
@@ -143,6 +144,25 @@ internal sealed unsafe class SilkNetFramebufferSurface :
         {
             if (surfaceTexture.Texture is not null)
                 context.Api.TextureRelease(surfaceTexture.Texture);
+            if (surfaceTexture.Status ==
+                SurfaceGetCurrentTextureStatus.DeviceLost)
+            {
+                context.ReportDeviceLost(
+                    DeviceLostReason.Unknown,
+                    "The Avalonia Silk.NET presentation surface reported device loss.");
+            }
+            else if (surfaceTexture.Status ==
+                SurfaceGetCurrentTextureStatus.OutOfMemory)
+            {
+                throw new OutOfMemoryException(
+                    "The Avalonia Silk.NET presentation surface ran out of memory.");
+            }
+            else if (surfaceTexture.Status is
+                SurfaceGetCurrentTextureStatus.Outdated or
+                SurfaceGetCurrentTextureStatus.Lost)
+            {
+                context.InvalidateSurfaceConfiguration();
+            }
             return;
         }
 

--- a/src/ProGPU.Avalonia.SilkNet/X11TouchInputSource.cs
+++ b/src/ProGPU.Avalonia.SilkNet/X11TouchInputSource.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using ProGPU.Backend;
 using Silk.NET.Windowing;
@@ -7,8 +8,8 @@ using Silk.NET.Windowing;
 namespace Avalonia.SilkNet;
 
 /// <summary>
-/// Selects XI2 touch events on GLFW's X11 connection and removes only those
-/// events before GLFW drains the shared Xlib queue.
+/// Selects XI2 touch events on a dedicated X11 connection so GLFW's earlier
+/// per-client XI2 negotiation cannot constrain touch support to version 2.0.
 /// </summary>
 internal sealed unsafe class X11TouchInputSource : IDisposable
 {
@@ -21,6 +22,14 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
     private const int XiTouchEnd = 20;
     private const int XiTouchEmulatingPointer = 1 << 17;
     private static readonly object Gate = new();
+    private static readonly bool TraceEnabled = string.Equals(
+        Environment.GetEnvironmentVariable(
+            "PROGPU_AVALONIA_TRACE_TOUCH"),
+        "1",
+        StringComparison.Ordinal);
+    private static readonly string? TracePath =
+        Environment.GetEnvironmentVariable(
+            "PROGPU_AVALONIA_TRACE_WINDOW_EVENTS_PATH");
     private static readonly Dictionary<nint, Pump> Pumps = [];
     private static readonly XEventPredicate TouchPredicate = IsTouchEvent;
 
@@ -45,6 +54,9 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
             x11.Display == 0 ||
             x11.Window == 0)
         {
+            Trace(
+                $"unavailable native={window.Native is not null} " +
+                $"x11={window.Native?.X11 is not null}");
             return null;
         }
 
@@ -56,16 +68,24 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
                 {
                     pump = Pump.TryCreate(x11.Display);
                     if (pump is null)
+                    {
+                        Trace($"pump unavailable display={x11.Display}");
                         return null;
+                    }
                     Pumps.Add(x11.Display, pump);
                 }
 
                 if (!pump.Register(x11.Window, handler))
                 {
                     if (pump.Count == 0)
+                    {
                         Pumps.Remove(x11.Display);
+                        pump.Dispose();
+                    }
                     return null;
                 }
+
+                Trace($"registered display={x11.Display} window={x11.Window}");
 
                 return new X11TouchInputSource(pump, x11.Window);
             }
@@ -97,7 +117,10 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
         {
             _pump.Unregister(_window);
             if (_pump.Count == 0)
-                Pumps.Remove(_pump.Display);
+            {
+                Pumps.Remove(_pump.SharedDisplay);
+                _pump.Dispose();
+            }
         }
     }
 
@@ -121,17 +144,33 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
         private readonly Dictionary<nuint, Action<NativeTouchEvent>>
             _handlers = [];
 
-        private Pump(nint display, int extension)
+        private Pump(
+            nint sharedDisplay,
+            nint display,
+            int extension)
         {
+            SharedDisplay = sharedDisplay;
             Display = display;
             _extension = extension;
         }
 
+        internal nint SharedDisplay { get; }
         internal nint Display { get; }
         internal int Count => _handlers.Count;
 
-        internal static Pump? TryCreate(nint display)
+        internal static Pump? TryCreate(nint sharedDisplay)
         {
+            nint displayNamePointer = XDisplayString(sharedDisplay);
+            string? displayName = displayNamePointer == 0
+                ? null
+                : Marshal.PtrToStringAnsi(displayNamePointer);
+            nint display = XOpenDisplay(displayName);
+            if (display == 0)
+            {
+                Trace($"XOpenDisplay failed name={displayName}");
+                return null;
+            }
+
             if (XQueryExtension(
                     display,
                     "XInputExtension",
@@ -139,16 +178,32 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
                     out _,
                     out _) == 0)
             {
+                Trace("XInputExtension unavailable");
+                _ = XCloseDisplay(display);
                 return null;
             }
 
             int major = 2;
             int minor = 2;
-            return XIQueryVersion(display, ref major, ref minor) == 0 &&
-                (major > 2 || major == 2 && minor >= 2)
-                    ? new Pump(display, extension)
-                    : null;
+            int status = XIQueryVersion(
+                display,
+                ref major,
+                ref minor);
+            Trace($"XIQueryVersion status={status} version={major}.{minor}");
+            if (status == 0 &&
+                (major > 2 || major == 2 && minor >= 2))
+            {
+                return new Pump(
+                    sharedDisplay,
+                    display,
+                    extension);
+            }
+
+            _ = XCloseDisplay(display);
+            return null;
         }
+
+        internal void Dispose() => _ = XCloseDisplay(Display);
 
         internal bool Register(
             nuint window,
@@ -167,7 +222,9 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
                 MaskLength = 3,
                 Mask = eventMask
             };
-            if (XISelectEvents(Display, window, &mask, 1) != 0)
+            int status = XISelectEvents(Display, window, &mask, 1);
+            Trace($"XISelectEvents status={status} window={window}");
+            if (status != 0)
                 return false;
             _ = XFlush(Display);
             _handlers[window] = handler;
@@ -201,6 +258,10 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
                     return;
                 }
 
+                Trace(
+                    $"event cookie type={xevent.Cookie.EventType} " +
+                    $"extension={xevent.Cookie.Extension}");
+
                 XGenericEventCookie* cookie = &xevent.Cookie;
                 if (XGetEventData(Display, cookie) == 0)
                     continue;
@@ -218,11 +279,18 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
         private void Dispatch(in XiDeviceEvent touch)
         {
             if (!_handlers.TryGetValue(
-                    touch.Event,
-                    out Action<NativeTouchEvent>? handler))
+                touch.Event,
+                out Action<NativeTouchEvent>? handler))
             {
+                Trace(
+                    $"unhandled event window={touch.Event} " +
+                    $"root={touch.Root}");
                 return;
             }
+
+            Trace(
+                $"dispatch type={touch.EventType} id={touch.Detail} " +
+                $"window={touch.Event} position={touch.EventX},{touch.EventY}");
 
             NativeTouchPhase phase = touch.EventType switch
             {
@@ -244,6 +312,31 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
         private static void SetMask(byte* mask, int eventType) =>
             mask[eventType >> 3] |=
                 (byte)(1 << (eventType & 7));
+    }
+
+    private static void Trace(string message)
+    {
+        if (!TraceEnabled)
+            return;
+        string line = "[Avalonia.SilkNet] X11 touch: " + message;
+        if (string.IsNullOrWhiteSpace(TracePath))
+        {
+            Console.Error.WriteLine(line);
+            return;
+        }
+
+        try
+        {
+            File.AppendAllText(TracePath, line + Environment.NewLine);
+        }
+        catch (IOException)
+        {
+            Console.Error.WriteLine(line);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine(line);
+        }
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -330,6 +423,15 @@ internal sealed unsafe class X11TouchInputSource : IDisposable
         [FieldOffset(0)]
         public XGenericEventCookie Cookie;
     }
+
+    [DllImport(X11Library)]
+    private static extern nint XDisplayString(nint display);
+
+    [DllImport(X11Library)]
+    private static extern nint XOpenDisplay(string? displayName);
+
+    [DllImport(X11Library)]
+    private static extern int XCloseDisplay(nint display);
 
     [DllImport(X11Library)]
     private static extern int XQueryExtension(

--- a/src/ProGPU.Avalonia.SkiaSourceCompatibility/ProGPU.Avalonia.SkiaSourceCompatibility.csproj
+++ b/src/ProGPU.Avalonia.SkiaSourceCompatibility/ProGPU.Avalonia.SkiaSourceCompatibility.csproj
@@ -18,7 +18,7 @@
     <AvaloniaSkiaSourceRoot Condition="'$(ProGpuAvaloniaSourceRoot)' != ''">$(ProGpuAvaloniaSourceRoot)\src\Skia\Avalonia.Skia</AvaloniaSkiaSourceRoot>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(AvaloniaSkiaSourceRoot)' != ''">
     <Compile Include="$(AvaloniaSkiaSourceRoot)\**\*.cs"
              Exclude="$(AvaloniaSkiaSourceRoot)\bin\**\*.cs;$(AvaloniaSkiaSourceRoot)\obj\**\*.cs">
       <Link>Upstream\%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\SkiaSharp\SkiaSharp.csproj" />
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\packages\Avalonia\Avalonia.csproj"
                       Condition="'$(ProGpuAvaloniaSourceRoot)' != ''"
-                      GlobalPropertiesToRemove="AvaloniaAccessUnstablePrivateApis;Avalonia_I_Want_To_Use_Private_Apis_In_Nuget_Package_And_Promise_To_Pin_The_Exact_Avalonia_Version_In_Package_Dependency" />
+                      GlobalPropertiesToRemove="AvaloniaAccessUnstablePrivateApis;Avalonia_I_Want_To_Use_Private_Apis_IN_NUGET_PACKAGE;Avalonia_I_Want_To_Use_Private_Apis_In_Nuget_Package_And_Promise_To_Pin_The_Exact_Avalonia_Version_In_Package_Dependency" />
   </ItemGroup>
 
   <Target Name="ValidatePinnedAvaloniaSkiaSources"

--- a/src/ProGPU.Backend.Dawn/DawnGpuContext.cs
+++ b/src/ProGPU.Backend.Dawn/DawnGpuContext.cs
@@ -29,6 +29,10 @@ public sealed unsafe partial class DawnGpuContext :
     private static readonly object NativeLibrarySync = new();
     private static nint s_iosNativeLibrary;
     private static bool s_iosResolversInstalled;
+    private readonly object _lifetimeGate = new();
+    private int _lifetimeReferenceCount = 1;
+    private bool _ownerLifetimeReleased;
+    private bool _contextLifetimeDisposed;
 
     static DawnGpuContext()
     {
@@ -167,11 +171,57 @@ public sealed unsafe partial class DawnGpuContext :
         internal string Message = string.Empty;
     }
 
+    private sealed class DeviceLossCallbackState
+    {
+        private readonly object _sync = new();
+        private WgpuContext? _context;
+        private bool _isLost;
+        private string _message = string.Empty;
+
+        internal void Bind(WgpuContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            bool report;
+            string message;
+            lock (_sync)
+            {
+                _context = context;
+                report = _isLost;
+                message = _message;
+            }
+            if (report)
+            {
+                context.ReportDeviceLost(
+                    SW.DeviceLostReason.Unknown,
+                    message);
+            }
+        }
+
+        internal void Report(string message)
+        {
+            WgpuContext? context;
+            lock (_sync)
+            {
+                if (_isLost)
+                {
+                    return;
+                }
+                _isLost = true;
+                _message = message;
+                context = _context;
+            }
+            context?.ReportDeviceLost(
+                SW.DeviceLostReason.Unknown,
+                message);
+        }
+    }
+
     private sealed class NativeLifetime(
         InstanceHandle instance,
         AdapterHandle adapter,
         DeviceHandle device,
-        QueueHandle queue) : IWebGpuExternalDeviceLifetime
+        QueueHandle queue,
+        GCHandle deviceLossStateHandle) : IWebGpuExternalDeviceLifetime
     {
         private bool _disposed;
 
@@ -200,7 +250,24 @@ public sealed unsafe partial class DawnGpuContext :
             device.Release();
             adapter.Release();
             instance.Release();
+            if (deviceLossStateHandle.IsAllocated)
+            {
+                deviceLossStateHandle.Free();
+            }
             _disposed = true;
+        }
+    }
+
+    private sealed class ContextLifetimeLease(
+        DawnGpuContext owner) : IDisposable
+    {
+        private DawnGpuContext? _owner = owner;
+
+        public void Dispose()
+        {
+            DawnGpuContext? released =
+                Interlocked.Exchange(ref _owner, null);
+            released?.ReleaseLifetimeReference();
         }
     }
 
@@ -227,6 +294,22 @@ public sealed unsafe partial class DawnGpuContext :
     public DeviceHandle Device { get; }
     public QueueHandle Queue { get; }
     public DawnSharedTextureMemoryFeature SharedTextureMemory { get; }
+
+    internal IDisposable AcquireLifetimeLease()
+    {
+        lock (_lifetimeGate)
+        {
+            ObjectDisposedException.ThrowIf(
+                _ownerLifetimeReleased ||
+                _contextLifetimeDisposed,
+                this);
+            checked
+            {
+                _lifetimeReferenceCount++;
+            }
+            return new ContextLifetimeLease(this);
+        }
+    }
 
     /// <summary>
     /// Returns the exact native WebGPU handles owned by this context as a
@@ -297,6 +380,8 @@ public sealed unsafe partial class DawnGpuContext :
         AdapterHandle adapter = AdapterHandle.Null;
         DeviceHandle device = DeviceHandle.Null;
         QueueHandle queue = QueueHandle.Null;
+        DeviceLossCallbackState? deviceLossState = null;
+        GCHandle deviceLossStateHandle = default;
         WgpuContext? context = null;
         try
         {
@@ -336,7 +421,9 @@ public sealed unsafe partial class DawnGpuContext :
             device = RequestDevice(
                 instance,
                 adapter,
-                requiredFeatures[..featureCount]);
+                requiredFeatures[..featureCount],
+                out deviceLossState,
+                out deviceLossStateHandle);
             queue = device.GetQueue();
             if (queue == QueueHandle.Null)
             {
@@ -356,7 +443,9 @@ public sealed unsafe partial class DawnGpuContext :
                     instance,
                     adapter,
                     device,
-                    queue);
+                    queue,
+                    deviceLossStateHandle);
+            deviceLossStateHandle = default;
             context = new WgpuContext();
             context.InitializeExternalNativeDevice(
                 new DawnWebGpuApi(),
@@ -374,6 +463,7 @@ public sealed unsafe partial class DawnGpuContext :
                     supportsTextureFormatsTier1,
                 adapterBackendType: SW.BackendType.Metal,
                 adapterName: "Dawn Metal");
+            deviceLossState.Bind(context);
 
             InstanceHandle ownedInstance = instance;
             AdapterHandle ownedAdapter = adapter;
@@ -394,6 +484,10 @@ public sealed unsafe partial class DawnGpuContext :
         catch
         {
             context?.Dispose();
+            if (deviceLossStateHandle.IsAllocated)
+            {
+                deviceLossStateHandle.Free();
+            }
             if (queue != QueueHandle.Null)
             {
                 queue.Release();
@@ -417,7 +511,45 @@ public sealed unsafe partial class DawnGpuContext :
 
     public void Dispose()
     {
-        Context.Dispose();
+        bool disposeContext;
+        lock (_lifetimeGate)
+        {
+            if (_ownerLifetimeReleased)
+            {
+                return;
+            }
+            _ownerLifetimeReleased = true;
+            disposeContext = --_lifetimeReferenceCount == 0;
+            if (disposeContext)
+            {
+                _contextLifetimeDisposed = true;
+            }
+        }
+        if (disposeContext)
+        {
+            Context.Dispose();
+        }
+    }
+
+    private void ReleaseLifetimeReference()
+    {
+        bool disposeContext;
+        lock (_lifetimeGate)
+        {
+            if (_lifetimeReferenceCount <= 0)
+            {
+                return;
+            }
+            disposeContext = --_lifetimeReferenceCount == 0;
+            if (disposeContext)
+            {
+                _contextLifetimeDisposed = true;
+            }
+        }
+        if (disposeContext)
+        {
+            Context.Dispose();
+        }
     }
 
     public bool TryImportExternalTexture(
@@ -672,60 +804,82 @@ public sealed unsafe partial class DawnGpuContext :
     private static DeviceHandle RequestDevice(
         InstanceHandle instance,
         AdapterHandle adapter,
-        ReadOnlySpan<W.FeatureName> requiredFeatures)
+        ReadOnlySpan<W.FeatureName> requiredFeatures,
+        out DeviceLossCallbackState deviceLossState,
+        out GCHandle deviceLossStateHandle)
     {
         var state = new DeviceRequest();
         GCHandle stateHandle = GCHandle.Alloc(state);
-        fixed (W.FeatureName* features = requiredFeatures)
-        fixed (byte* label =
-            "ProGPU Dawn Primary Device\0"u8)
+        deviceLossState = new DeviceLossCallbackState();
+        deviceLossStateHandle = GCHandle.Alloc(deviceLossState);
+        try
         {
-            try
+            fixed (W.FeatureName* features = requiredFeatures)
+            fixed (byte* label =
+                "ProGPU Dawn Primary Device\0"u8)
             {
-                var descriptor = new DeviceDescriptorFFI
+                try
                 {
-                    Label =
-                        StringViewFFI.CreateNullTerminated(label),
-                    RequiredFeatureCount =
-                        (nuint)requiredFeatures.Length,
-                    RequiredFeatures = features,
-                    DeviceLostCallbackInfo =
-                        new DeviceLostCallbackInfoFFI
-                        {
-                            Mode =
-                                W.CallbackMode.AllowSpontaneous,
-                            Callback = &OnDeviceLost
-                        },
-                    UncapturedErrorCallbackInfo =
-                        new UncapturedErrorCallbackInfoFFI
-                        {
-                            Callback = &OnUncapturedError
-                        }
-                };
-                var callback = new RequestDeviceCallbackInfoFFI
+                    var descriptor = new DeviceDescriptorFFI
+                    {
+                        Label =
+                            StringViewFFI.CreateNullTerminated(label),
+                        RequiredFeatureCount =
+                            (nuint)requiredFeatures.Length,
+                        RequiredFeatures = features,
+                        DeviceLostCallbackInfo =
+                            new DeviceLostCallbackInfoFFI
+                            {
+                                Mode =
+                                    W.CallbackMode.AllowSpontaneous,
+                                Callback = &OnDeviceLost,
+                                Userdata1 =
+                                    (void*)GCHandle.ToIntPtr(
+                                        deviceLossStateHandle)
+                            },
+                        UncapturedErrorCallbackInfo =
+                            new UncapturedErrorCallbackInfoFFI
+                            {
+                                Callback = &OnUncapturedError,
+                                Userdata1 =
+                                    (void*)GCHandle.ToIntPtr(
+                                        deviceLossStateHandle)
+                            }
+                    };
+                    var callback = new RequestDeviceCallbackInfoFFI
+                    {
+                        Mode = W.CallbackMode.WaitAnyOnly,
+                        Callback = &CompleteDeviceRequest,
+                        Userdata1 =
+                            (void*)GCHandle.ToIntPtr(stateHandle)
+                    };
+                    W.Future future =
+                        adapter.RequestDevice(&descriptor, callback);
+                    Wait(instance, future, "request a Dawn device");
+                }
+                finally
                 {
-                    Mode = W.CallbackMode.WaitAnyOnly,
-                    Callback = &CompleteDeviceRequest,
-                    Userdata1 =
-                        (void*)GCHandle.ToIntPtr(stateHandle)
-                };
-                W.Future future =
-                    adapter.RequestDevice(&descriptor, callback);
-                Wait(instance, future, "request a Dawn device");
+                    stateHandle.Free();
+                }
             }
-            finally
-            {
-                stateHandle.Free();
-            }
-        }
 
-        if (state.Status != W.RequestDeviceStatus.Success ||
-            state.Device == DeviceHandle.Null)
-        {
-            throw new InvalidOperationException(
-                $"Dawn failed to request a device: {state.Status}. {state.Message}");
+            if (state.Status != W.RequestDeviceStatus.Success ||
+                state.Device == DeviceHandle.Null)
+            {
+                throw new InvalidOperationException(
+                    $"Dawn failed to request a device: {state.Status}. {state.Message}");
+            }
+            return state.Device;
         }
-        return state.Device;
+        catch
+        {
+            if (deviceLossStateHandle.IsAllocated)
+            {
+                deviceLossStateHandle.Free();
+            }
+            deviceLossStateHandle = default;
+            throw;
+        }
     }
 
     private static void WaitForQueue(
@@ -837,6 +991,13 @@ public sealed unsafe partial class DawnGpuContext :
         WgpuContext.RaiseWebGpuError(
             ErrorType(type),
             errorMessage);
+        if (userData1 != null &&
+            IsTerminalDeviceFailure(type, errorMessage) &&
+            GCHandle.FromIntPtr((nint)userData1).Target is
+                DeviceLossCallbackState state)
+        {
+            state.Report(errorMessage);
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
@@ -854,9 +1015,12 @@ public sealed unsafe partial class DawnGpuContext :
         string lossMessage = Message(message);
         Console.Error.WriteLine(
             $"[Dawn Device Lost] {reason}: {lossMessage}");
-        WgpuContext.RaiseWebGpuDeviceLost(
-            SW.DeviceLostReason.Unknown,
-            lossMessage);
+        if (userData1 != null &&
+            GCHandle.FromIntPtr((nint)userData1).Target is
+                DeviceLossCallbackState state)
+        {
+            state.Report(lossMessage);
+        }
     }
 
     private static string Message(StringViewFFI message) =>
@@ -874,6 +1038,20 @@ public sealed unsafe partial class DawnGpuContext :
             W.ErrorType.Unknown => SW.ErrorType.Unknown,
             _ => SW.ErrorType.Unknown
         };
+
+    private static bool IsTerminalDeviceFailure(
+        W.ErrorType type,
+        string message) =>
+        type is W.ErrorType.Internal or W.ErrorType.Unknown ||
+        message.Contains(
+            "device is lost",
+            StringComparison.OrdinalIgnoreCase) ||
+        message.Contains(
+            "device lost",
+            StringComparison.OrdinalIgnoreCase) ||
+        message.Contains(
+            "Creation of a resource failed for a reason other than running out of memory",
+            StringComparison.OrdinalIgnoreCase);
 }
 
 /// <summary>

--- a/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
+++ b/src/ProGPU.Backend.Dawn/DawnNativePresentation.cs
@@ -41,6 +41,8 @@ public sealed unsafe partial class DawnGpuContext
         AdapterHandle adapter = AdapterHandle.Null;
         DeviceHandle device = DeviceHandle.Null;
         QueueHandle queue = QueueHandle.Null;
+        DeviceLossCallbackState? deviceLossState = null;
+        GCHandle deviceLossStateHandle = default;
         WgpuContext? context = null;
         try
         {
@@ -161,7 +163,9 @@ public sealed unsafe partial class DawnGpuContext
             device = RequestDevice(
                 instance,
                 adapter,
-                requiredFeatures[..featureCount]);
+                requiredFeatures[..featureCount],
+                out deviceLossState,
+                out deviceLossStateHandle);
             queue = device.GetQueue();
             if (queue == QueueHandle.Null)
             {
@@ -181,7 +185,9 @@ public sealed unsafe partial class DawnGpuContext
                     instance,
                     adapter,
                     device,
-                    queue);
+                    queue,
+                    deviceLossStateHandle);
+            deviceLossStateHandle = default;
             context = new WgpuContext();
             context.InitializeExternalNativeDevice(
                 new DawnWebGpuApi(),
@@ -200,6 +206,7 @@ public sealed unsafe partial class DawnGpuContext
                 adapterBackendType:
                     ToSilkBackendType(source.BackendType),
                 adapterName: source.BackendName);
+            deviceLossState.Bind(context);
 
             InstanceHandle ownedInstance = instance;
             AdapterHandle ownedAdapter = adapter;
@@ -217,6 +224,10 @@ public sealed unsafe partial class DawnGpuContext
         catch
         {
             context?.Dispose();
+            if (deviceLossStateHandle.IsAllocated)
+            {
+                deviceLossStateHandle.Free();
+            }
             if (compatibilitySurface != SurfaceHandle.Null)
             {
                 compatibilitySurface.Release();
@@ -536,6 +547,7 @@ public sealed unsafe partial class DawnGpuContext
 public sealed unsafe class DawnNativePresentationSurface : IDisposable
 {
     private readonly DawnGpuContext _owner;
+    private IDisposable? _ownerLifetime;
     private SurfaceHandle _surface;
     private readonly W.TextureFormat _format;
     private readonly W.CompositeAlphaMode _alphaMode;
@@ -551,6 +563,7 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
         W.CompositeAlphaMode alphaMode)
     {
         _owner = owner;
+        _ownerLifetime = owner.AcquireLifetimeLease();
         _surface = surface;
         _format = format;
         _alphaMode = alphaMode;
@@ -561,6 +574,8 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
 
     public bool UsesPremultipliedAlpha =>
         _alphaMode == W.CompositeAlphaMode.Premultiplied;
+
+    public bool IsDeviceLost => _owner.Context.IsDeviceLost;
 
     internal SW.Surface* SilkSurface =>
         (SW.Surface*)_surface.GetAddress();
@@ -581,6 +596,11 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
 
         lock (_owner.Context.RenderLock)
         {
+            if (_owner.Context.IsDeviceLost)
+            {
+                throw new InvalidOperationException(
+                    "The Dawn presentation device is lost.");
+            }
             ConfigureIfNeeded(width, height);
             SurfaceTextureFFI acquired = default;
             _surface.GetCurrentTexture(ref acquired);
@@ -605,6 +625,14 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
                 if (acquired.Texture != TextureHandle.Null)
                 {
                     acquired.Texture.Release();
+                }
+                if (acquired.Status is
+                    W.SurfaceGetCurrentTextureStatus.Timeout or
+                    W.SurfaceGetCurrentTextureStatus.Outdated or
+                    W.SurfaceGetCurrentTextureStatus.Lost)
+                {
+                    throw new TimeoutException(
+                        $"Dawn presentation is temporarily unavailable: {acquired.Status}.");
                 }
                 throw new InvalidOperationException(
                     $"Dawn could not acquire the presentation texture: {acquired.Status}.");
@@ -751,6 +779,11 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
 
     private void Configure(uint width, uint height)
     {
+        if (_owner.Context.IsDeviceLost)
+        {
+            throw new InvalidOperationException(
+                "The Dawn presentation device is lost.");
+        }
         var configuration = new SurfaceConfigurationFFI
         {
             Device = _owner.Device,
@@ -761,7 +794,13 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
             PresentMode = W.PresentMode.Fifo,
             AlphaMode = _alphaMode
         };
+        _configured = false;
         _surface.Configure(configuration);
+        if (_owner.Context.IsDeviceLost)
+        {
+            throw new InvalidOperationException(
+                "Dawn lost the device while configuring the presentation surface.");
+        }
         _width = width;
         _height = height;
         _configured = true;
@@ -775,13 +814,22 @@ public sealed unsafe class DawnNativePresentationSurface : IDisposable
         }
         lock (_owner.Context.RenderLock)
         {
-            if (_configured)
+            try
             {
-                _surface.Unconfigure();
+                if (_configured && !_owner.Context.IsDeviceLost)
+                {
+                    _surface.Unconfigure();
+                }
+                _surface.Release();
+                _surface = SurfaceHandle.Null;
+                _configured = false;
             }
-            _surface.Release();
-            _surface = SurfaceHandle.Null;
-            _configured = false;
+            finally
+            {
+                Interlocked.Exchange(
+                    ref _ownerLifetime,
+                    null)?.Dispose();
+            }
         }
     }
 }

--- a/src/ProGPU.Backend.Dawn/ProGPU.Backend.Dawn.csproj
+++ b/src/ProGPU.Backend.Dawn/ProGPU.Backend.Dawn.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\ProGPU.Backend\ProGPU.Backend.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Avalonia.ProGpu, PublicKey=$(ProGPUPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.ProGpu.UnitTests, PublicKey=$(ProGPUPublicKey)" />
   </ItemGroup>
 </Project>

--- a/src/ProGPU.Backend/GpuTextureSurfacePresenter.cs
+++ b/src/ProGPU.Backend/GpuTextureSurfacePresenter.cs
@@ -29,7 +29,12 @@ public static unsafe class GpuTextureSurfacePresenter
                 throw new ObjectDisposedException(nameof(WgpuContext));
             }
 
-            context.ReconfigureIfNeeded(source.Width, source.Height);
+            if (!context.TryReconfigureIfNeeded(
+                    source.Width,
+                    source.Height))
+            {
+                return;
+            }
             var surfaceTexture = new SurfaceTexture();
             TextureView* targetView = null;
             context.Wgpu.SurfaceGetCurrentTexture((Surface*)surfaceHandle, &surfaceTexture);
@@ -37,6 +42,25 @@ public static unsafe class GpuTextureSurfacePresenter
             {
                 if (surfaceTexture.Status != SurfaceGetCurrentTextureStatus.Success)
                 {
+                    if (surfaceTexture.Status ==
+                        SurfaceGetCurrentTextureStatus.DeviceLost)
+                    {
+                        context.ReportDeviceLost(
+                            DeviceLostReason.Unknown,
+                            "The presentation surface reported device loss.");
+                    }
+                    else if (surfaceTexture.Status ==
+                        SurfaceGetCurrentTextureStatus.OutOfMemory)
+                    {
+                        throw new OutOfMemoryException(
+                            "The WebGPU presentation surface ran out of memory.");
+                    }
+                    else if (surfaceTexture.Status is
+                        SurfaceGetCurrentTextureStatus.Outdated or
+                        SurfaceGetCurrentTextureStatus.Lost)
+                    {
+                        context.InvalidateSurfaceConfiguration();
+                    }
                     return;
                 }
 

--- a/src/ProGPU.Backend/MacOsNativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/MacOsNativeWindowPlatform.cs
@@ -236,16 +236,14 @@ internal sealed class MacOsNativeWindowPlatform : GlfwNativeWindowPlatform
 
     public override bool TryBeginMove(NativeWindowPoint pointer)
     {
-        var applicationClass = objc_getClass("NSApplication");
-        var application = SendObject(applicationClass, "sharedApplication");
-        var currentEvent = SendObject(application, "currentEvent");
-        if (currentEvent == 0)
-        {
-            return false;
-        }
-
-        SendVoidObject(_nsWindow, "performWindowDragWithEvent:", currentEvent);
-        return true;
+        _ = pointer;
+        // GLFW dispatch does not preserve the originating NSEvent through its
+        // managed mouse callback. AppKit's performWindowDragWithEvent: has no
+        // success result and can silently ignore NSApplication.currentEvent
+        // after GLFW advances it, which previously suppressed the controller's
+        // reliable pointer-delta fallback. Returning false intentionally arms
+        // that fallback for drawn Avalonia title bars.
+        return false;
     }
 
     public override bool TryBeginResize(NativeResizeEdge edge, NativeWindowPoint pointer) => false;

--- a/src/ProGPU.Backend/WgpuContext.cs
+++ b/src/ProGPU.Backend/WgpuContext.cs
@@ -84,6 +84,7 @@ public unsafe class WgpuContext : IDisposable
     private static long s_deviceLossGeneration;
     private readonly long _deviceLossGeneration =
         Volatile.Read(ref s_deviceLossGeneration);
+    private WgpuDeviceLossState _deviceLossState = new();
 
     public static void RaiseWebGpuError(ErrorType type, string message)
     {
@@ -109,13 +110,32 @@ public unsafe class WgpuContext : IDisposable
     }
 
     /// <summary>
+    /// Marks this context's exact WebGPU device domain as terminally lost.
+    /// Every surface context sharing the device observes the same state, while
+    /// independent devices remain usable.
+    /// </summary>
+    public void ReportDeviceLost(
+        DeviceLostReason reason,
+        string message)
+    {
+        if (reason == DeviceLostReason.Destroyed ||
+            !_deviceLossState.TryMarkLost(reason, message))
+        {
+            return;
+        }
+
+        OnWebGpuDeviceLost?.Invoke(reason, message);
+    }
+
+    /// <summary>
     /// Gets whether a device-loss notification occurred after this context
     /// was created. The value is lock-free and safe to query from Avalonia's
     /// UI and render threads.
     /// </summary>
     public bool IsDeviceLost =>
+        _deviceLossState.IsLost ||
         _deviceLossGeneration !=
-        Volatile.Read(ref s_deviceLossGeneration);
+            Volatile.Read(ref s_deviceLossGeneration);
 
     private PfnErrorCallback _errorCallback;
     private nint _devicePollAddress;
@@ -218,6 +238,11 @@ public unsafe class WgpuContext : IDisposable
         lock (RenderLock)
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
+            if (IsDeviceLost)
+            {
+                throw new InvalidOperationException(
+                    "Cannot submit commands to a lost WebGPU device.");
+            }
             Api.QueueSubmit(Queue, commandCount, commandBuffers);
             Interlocked.Increment(ref _queueSubmissionCount);
         }
@@ -721,7 +746,7 @@ public unsafe class WgpuContext : IDisposable
                 for (var i = 0; i < _activeContexts.Count; i++)
                 {
                     var active = _activeContexts[i];
-                    if (active.IsInitialized &&
+                    if (!active.IsDisposed &&
                         (IntPtr)active.Surface == surfaceHandle)
                     {
                         context = active;
@@ -990,6 +1015,7 @@ public unsafe class WgpuContext : IDisposable
         using var deviceSignal = new ManualResetEventSlim(false);
         var deviceState = new DeviceRequestState(deviceSignal);
         var deviceStateHandle = GCHandle.Alloc(deviceState);
+        var deviceLossStateHandle = GCHandle.Alloc(_deviceLossState);
 
         var adapterLimits = new SupportedLimits();
         Wgpu.AdapterGetLimits(Adapter, &adapterLimits);
@@ -1007,7 +1033,9 @@ public unsafe class WgpuContext : IDisposable
             RequiredLimits = &requiredLimits,
             RequiredFeatureCount = requiredFeatureCount,
             RequiredFeatures = requiredFeatureCount == 0 ? null : requiredFeatures,
-            DeviceLostCallback = new PfnDeviceLostCallback(&OnDeviceLost)
+            DeviceLostCallback = new PfnDeviceLostCallback(&OnDeviceLost),
+            DeviceLostUserdata =
+                (void*)GCHandle.ToIntPtr(deviceLossStateHandle)
         };
 
         try
@@ -1020,17 +1048,21 @@ public unsafe class WgpuContext : IDisposable
                 (void*)GCHandle.ToIntPtr(deviceStateHandle));
             deviceSignal.Wait();
         }
+        catch
+        {
+            deviceLossStateHandle.Free();
+            throw;
+        }
         finally
         {
             deviceStateHandle.Free();
+            SilkMarshal.Free((nint)deviceDesc.Label);
         }
-
-        // Free labeled string
-        SilkMarshal.Free((nint)deviceDesc.Label);
 
         SafeLog($"[WGPUCONTEXT] RequestDevice finished, device={deviceState.Result:X}\n");
         if (deviceState.Result == 0)
         {
+            deviceLossStateHandle.Free();
             throw new InvalidOperationException($"Failed to obtain WebGPU Device. {deviceState.Error}");
         }
         Device = (Device*)deviceState.Result;
@@ -1056,11 +1088,22 @@ public unsafe class WgpuContext : IDisposable
             Adapter,
             Device,
             Queue,
-            _deviceResourceDomain);
+            _deviceResourceDomain,
+            GCHandle.ToIntPtr(deviceLossStateHandle));
 
         // 6. Hook up validation error callback
         _errorCallback = new PfnErrorCallback(&OnUncapturedError);
-        Wgpu.DeviceSetUncapturedErrorCallback(Device, _errorCallback, null);
+        Wgpu.DeviceSetUncapturedErrorCallback(
+            Device,
+            _errorCallback,
+            (void*)GCHandle.ToIntPtr(deviceLossStateHandle));
+
+        // Qualify the freshly created queue before expensive retained-pipeline
+        // construction. Some Windows virtual/RDP adapters accept device
+        // creation and surface configuration, then report the terminal loss
+        // only on the first resource write. Catching that state here avoids a
+        // minutes-long driver stall followed by a native submit abort.
+        ProbeNativeDevice();
 
         // 7. Configure Surface if window exists
         if (Surface != null)
@@ -1081,6 +1124,40 @@ public unsafe class WgpuContext : IDisposable
         }
 
         Current = this;
+    }
+
+    private void ProbeNativeDevice()
+    {
+        var descriptor = new BufferDescriptor
+        {
+            Size = sizeof(uint),
+            Usage = BufferUsage.CopyDst | BufferUsage.Storage
+        };
+        Silk.NET.WebGPU.Buffer* buffer =
+            Api.DeviceCreateBuffer(Device, &descriptor);
+        if (buffer == null)
+        {
+            ReportDeviceLost(
+                DeviceLostReason.Unknown,
+                "WebGPU could not create the device qualification buffer.");
+            return;
+        }
+
+        try
+        {
+            uint value = 0;
+            Api.QueueWriteBuffer(
+                Queue,
+                buffer,
+                0,
+                &value,
+                sizeof(uint));
+            PollDevice(wait: false);
+        }
+        finally
+        {
+            Api.BufferRelease(buffer);
+        }
     }
 
     /// <summary>
@@ -1165,17 +1242,19 @@ public unsafe class WgpuContext : IDisposable
     private void ReleasePresentationSurfaceCore(bool waitForDevice)
     {
         if (Surface == null) return;
-        if (waitForDevice && Device != null) WaitIdle();
+        if (waitForDevice && Device != null && !IsDeviceLost) WaitIdle();
         // Externally owned browser surfaces are opaque command-stream handles and
         // have no native WebGPU instance to unconfigure. Exact-ABI native backends
         // own their configuration and must tear it down through the same ABI.
         if (Api is IWebGpuExternalSurfaceApi externalSurface &&
-            _isSurfaceConfigured)
+            _isSurfaceConfigured &&
+            !IsDeviceLost)
         {
             externalSurface.UnconfigureExternalSurface(Surface);
         }
         else if (BackendKind == WgpuBackendKind.SilkNative &&
-                 _isSurfaceConfigured)
+                 _isSurfaceConfigured &&
+                 !IsDeviceLost)
         {
             Wgpu.SurfaceUnconfigure(Surface);
         }
@@ -1329,7 +1408,33 @@ public unsafe class WgpuContext : IDisposable
         string errorMessage = ReadNativeMessage(message);
         Console.WriteLine($"[WebGPU Error] Type: {type}, Message: {errorMessage}");
         OnWebGpuError?.Invoke(type, errorMessage);
+        if (_ != null &&
+            IsTerminalDeviceFailure(type, errorMessage) &&
+            GCHandle.FromIntPtr((nint)_).Target is
+                WgpuDeviceLossState lossState &&
+            lossState.TryMarkLost(
+                DeviceLostReason.Unknown,
+                errorMessage))
+        {
+            OnWebGpuDeviceLost?.Invoke(
+                DeviceLostReason.Unknown,
+                errorMessage);
+        }
     }
+
+    private static bool IsTerminalDeviceFailure(
+        ErrorType type,
+        string message) =>
+        type is ErrorType.Internal or ErrorType.Unknown ||
+        message.Contains(
+            "device is lost",
+            StringComparison.OrdinalIgnoreCase) ||
+        message.Contains(
+            "device lost",
+            StringComparison.OrdinalIgnoreCase) ||
+        message.Contains(
+            "Creation of a resource failed for a reason other than running out of memory",
+            StringComparison.OrdinalIgnoreCase);
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static void OnDeviceLost(DeviceLostReason reason, byte* message, void* _)
@@ -1341,7 +1446,13 @@ public unsafe class WgpuContext : IDisposable
 
         string errorMessage = ReadNativeMessage(message);
         Console.Error.WriteLine($"[WebGPU Device Lost] Reason: {reason}, Message: {errorMessage}");
-        RaiseWebGpuDeviceLost(reason, errorMessage);
+        if (_ != null &&
+            GCHandle.FromIntPtr((nint)_).Target is
+                WgpuDeviceLossState lossState &&
+            lossState.TryMarkLost(reason, errorMessage))
+        {
+            OnWebGpuDeviceLost?.Invoke(reason, errorMessage);
+        }
     }
 
     private static string ReadNativeMessage(byte* message) =>
@@ -1589,6 +1700,7 @@ public unsafe class WgpuContext : IDisposable
             deviceOwner.SupportsTextureFormatsTier1;
         SetAdapterSelectionDiagnostics(deviceOwner.AdapterSelectionDiagnostics);
         _deviceResourceDomain = deviceOwner._deviceResourceDomain;
+        _deviceLossState = deviceOwner._deviceLossState;
         _sharedDeviceLifetime = sharedDeviceLifetime;
         RenderLock = deviceOwner.RenderLock;
 
@@ -1677,15 +1789,26 @@ public unsafe class WgpuContext : IDisposable
 
     public bool TryConfigureSwapChain(uint width, uint height, bool refreshCapabilities = false)
     {
+        if (IsDeviceLost)
+        {
+            _isSurfaceConfigured = false;
+            return false;
+        }
+
         if (Surface != null &&
             Api is IWebGpuExternalSurfaceApi externalSurface)
         {
             uint configuredWidth = Math.Max(1u, width);
             uint configuredHeight = Math.Max(1u, height);
+            _isSurfaceConfigured = false;
             externalSurface.ConfigureExternalSurface(
                 Surface,
                 configuredWidth,
                 configuredHeight);
+            if (IsDeviceLost)
+            {
+                return false;
+            }
             _lastWidth = configuredWidth;
             _lastHeight = configuredHeight;
             _isSurfaceConfigured = true;
@@ -1782,7 +1905,12 @@ public unsafe class WgpuContext : IDisposable
             Height = height > 0 ? height : 1
         };
 
+        _isSurfaceConfigured = false;
         Wgpu.SurfaceConfigure(Surface, &config);
+        if (IsDeviceLost)
+        {
+            return false;
+        }
         SwapChainFormat = swapChainFormat;
         _lastWidth = config.Width;
         _lastHeight = config.Height;
@@ -1792,6 +1920,16 @@ public unsafe class WgpuContext : IDisposable
         SurfaceConfigurationTimeMs += elapsedMilliseconds;
         MaximumSurfaceConfigurationTimeMs = Math.Max(MaximumSurfaceConfigurationTimeMs, elapsedMilliseconds);
         return true;
+    }
+
+    /// <summary>
+    /// Invalidates presentation state after a recoverable surface acquisition
+    /// failure so the next attempt refreshes capabilities and configuration.
+    /// </summary>
+    public void InvalidateSurfaceConfiguration()
+    {
+        _isSurfaceConfigured = false;
+        _hasSurfaceConfigurationCapabilities = false;
     }
 
     public static bool CanConfigureSurface(
@@ -1959,7 +2097,9 @@ public unsafe class WgpuContext : IDisposable
 
     public bool TryReconfigureIfNeeded(uint width, uint height)
     {
-        if (width != _lastWidth || height != _lastHeight)
+        if (!_isSurfaceConfigured ||
+            width != _lastWidth ||
+            height != _lastHeight)
         {
             return TryConfigureSwapChain(width, height);
         }
@@ -2199,6 +2339,7 @@ public unsafe class WgpuContext : IDisposable
         private Device* _device;
         private Queue* _queue;
         private WgpuDeviceResourceDomain? _deviceResourceDomain;
+        private nint _deviceLossStateHandle;
         private int _referenceCount = 1;
 
         public SharedDeviceLifetime(
@@ -2207,7 +2348,8 @@ public unsafe class WgpuContext : IDisposable
             WgpuAdapter* adapter,
             Device* device,
             Queue* queue,
-            WgpuDeviceResourceDomain deviceResourceDomain)
+            WgpuDeviceResourceDomain deviceResourceDomain,
+            nint deviceLossStateHandle)
         {
             _wgpu = wgpu;
             _instance = instance;
@@ -2215,6 +2357,7 @@ public unsafe class WgpuContext : IDisposable
             _device = device;
             _queue = queue;
             _deviceResourceDomain = deviceResourceDomain;
+            _deviceLossStateHandle = deviceLossStateHandle;
         }
 
         public SharedDeviceLifetime Acquire()
@@ -2235,6 +2378,7 @@ public unsafe class WgpuContext : IDisposable
             Device* device;
             Queue* queue;
             WgpuDeviceResourceDomain? deviceResourceDomain;
+            nint deviceLossStateHandle;
             lock (_sync)
             {
                 if (_referenceCount == 0 || --_referenceCount != 0)
@@ -2248,12 +2392,14 @@ public unsafe class WgpuContext : IDisposable
                 device = _device;
                 queue = _queue;
                 deviceResourceDomain = _deviceResourceDomain;
+                deviceLossStateHandle = _deviceLossStateHandle;
                 _wgpu = null;
                 _instance = null;
                 _adapter = null;
                 _device = null;
                 _queue = null;
                 _deviceResourceDomain = null;
+                _deviceLossStateHandle = 0;
             }
 
             if (wgpu == null)
@@ -2279,7 +2425,24 @@ public unsafe class WgpuContext : IDisposable
             {
                 wgpu.InstanceRelease(instance);
             }
+            if (deviceLossStateHandle != 0)
+            {
+                GCHandle.FromIntPtr(deviceLossStateHandle).Free();
+            }
         }
+    }
+
+    private sealed class WgpuDeviceLossState
+    {
+        private int _isLost;
+
+        public bool IsLost => Volatile.Read(ref _isLost) != 0;
+
+        public bool TryMarkLost(
+            DeviceLostReason reason,
+            string message) =>
+            reason != DeviceLostReason.Destroyed &&
+            Interlocked.Exchange(ref _isLost, 1) == 0;
     }
 
     ~WgpuContext()

--- a/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/Win32NativeWindowPlatform.cs
@@ -1,10 +1,12 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using Silk.NET.Windowing;
 
 namespace ProGPU.Backend;
 
-internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
+internal sealed partial class Win32NativeWindowPlatform :
+    GlfwNativeWindowPlatform
 {
     private const int GwlStyle = -16;
     private const int GwlExStyle = -20;
@@ -28,7 +30,7 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private const uint SwpFrameChanged = 0x0020;
     private const uint WmNcCalcSize = 0x0083;
     private const uint WmNcHitTest = 0x0084;
-    private const uint WmNcLButtonDown = 0x00A1;
+    private const uint WmSysCommand = 0x0112;
     private const uint WmTouch = 0x0240;
     private const uint WmMouseFirst = 0x0200;
     private const uint WmMouseLast = 0x020e;
@@ -36,6 +38,8 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private const uint WmExitSizeMove = 0x0232;
     private const int HtClient = 1;
     private const int HtCaption = 2;
+    private const int ScMove = 0xF010;
+    private const int ScSize = 0xF000;
     private const int HtLeft = 10;
     private const int HtRight = 11;
     private const int HtTop = 12;
@@ -270,13 +274,13 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
 
     public override bool TryBeginMove(NativeWindowPoint pointer)
     {
+        _ = pointer;
         ReleaseCapture();
-        SendMessage(
+        return PostMessage(
             _hwnd,
-            WmNcLButtonDown,
-            HtCaption,
-            PackScreenPoint(pointer));
-        return true;
+            WmSysCommand,
+            ScMove | HtCaption,
+            0) != 0;
     }
 
     public override bool TryBeginResize(NativeResizeEdge edge, NativeWindowPoint pointer)
@@ -287,12 +291,14 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
         }
 
         ReleaseCapture();
-        SendMessage(
+        NativeWindowPoint screenPointer = GetCursorPos(out Point cursor) != 0
+            ? new NativeWindowPoint(cursor.X, cursor.Y)
+            : pointer;
+        return PostMessage(
             _hwnd,
-            WmNcLButtonDown,
-            MapHitTest(edge),
-            PackScreenPoint(pointer));
-        return true;
+            WmSysCommand,
+            ScSize | MapSizeCommand(edge),
+            PackScreenPoint(screenPointer)) != 0;
     }
 
     private nint WindowProcedure(nint hwnd, uint message, nint wParam, nint lParam)
@@ -551,16 +557,16 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
 
     private static long SetFlag(long value, long flag, bool enabled) => enabled ? value | flag : value & ~flag;
 
-    private static int MapHitTest(NativeResizeEdge edge) => edge switch
+    private static int MapSizeCommand(NativeResizeEdge edge) => edge switch
     {
-        NativeResizeEdge.Left => HtLeft,
-        NativeResizeEdge.Top => HtTop,
-        NativeResizeEdge.Right => HtRight,
-        NativeResizeEdge.Bottom => HtBottom,
-        NativeResizeEdge.TopLeft => HtTopLeft,
-        NativeResizeEdge.TopRight => HtTopRight,
-        NativeResizeEdge.BottomLeft => HtBottomLeft,
-        _ => HtBottomRight
+        NativeResizeEdge.Left => 1,
+        NativeResizeEdge.Right => 2,
+        NativeResizeEdge.Top => 3,
+        NativeResizeEdge.TopLeft => 4,
+        NativeResizeEdge.TopRight => 5,
+        NativeResizeEdge.Bottom => 6,
+        NativeResizeEdge.BottomLeft => 7,
+        _ => 8
     };
 
     private static nint PackScreenPoint(
@@ -672,6 +678,9 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private static extern bool EnableWindow(nint hwnd, bool enabled);
     [DllImport("user32.dll")]
     private static extern bool ReleaseCapture();
+    [LibraryImport("user32.dll")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    private static partial int GetCursorPos(out Point point);
     [DllImport("user32.dll")]
     private static extern bool RegisterTouchWindow(nint hwnd, uint flags);
     [DllImport("user32.dll")]
@@ -688,8 +697,13 @@ internal sealed class Win32NativeWindowPlatform : GlfwNativeWindowPlatform
     private static extern bool ScreenToClient(nint hwnd, ref Point point);
     [DllImport("user32.dll")]
     private static extern nint GetMessageExtraInfo();
-    [DllImport("user32.dll", EntryPoint = "SendMessageW")]
-    private static extern nint SendMessage(nint hwnd, uint message, nint wParam, nint lParam);
+    [LibraryImport("user32.dll", EntryPoint = "PostMessageW")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    private static partial int PostMessage(
+        nint hwnd,
+        uint message,
+        nint wParam,
+        nint lParam);
     [DllImport("user32.dll", EntryPoint = "CallWindowProcW")]
     private static extern nint CallWindowProc(nint previous, nint hwnd, uint message, nint wParam, nint lParam);
     [DllImport("user32.dll", EntryPoint = "DefWindowProcW")]

--- a/src/ProGPU.Backend/X11NativeWindowPlatform.cs
+++ b/src/ProGPU.Backend/X11NativeWindowPlatform.cs
@@ -181,23 +181,20 @@ internal sealed unsafe class X11NativeWindowPlatform : GlfwNativeWindowPlatform
         return backdrop is NativeWindowBackdrop.None or NativeWindowBackdrop.Transparent;
     }
 
-    public override bool TryBeginMove(NativeWindowPoint pointer) => SendMoveResize(pointer, 8);
+    public override bool TryBeginMove(NativeWindowPoint pointer)
+    {
+        _ = pointer;
+        // An accepted _NET_WM_MOVERESIZE client message does not mean the
+        // active X11/XWayland window manager honored it. Use the controller's
+        // deterministic pointer-delta move path instead.
+        return false;
+    }
 
     public override bool TryBeginResize(NativeResizeEdge edge, NativeWindowPoint pointer)
     {
-        var direction = edge switch
-        {
-            NativeResizeEdge.TopLeft => 0,
-            NativeResizeEdge.Top => 1,
-            NativeResizeEdge.TopRight => 2,
-            NativeResizeEdge.Right => 3,
-            NativeResizeEdge.BottomRight => 4,
-            NativeResizeEdge.Bottom => 5,
-            NativeResizeEdge.BottomLeft => 6,
-            NativeResizeEdge.Left => 7,
-            _ => 4
-        };
-        return SendMoveResize(pointer, direction);
+        _ = edge;
+        _ = pointer;
+        return false;
     }
 
     private bool SendWindowState(string stateName, bool enabled)
@@ -211,19 +208,6 @@ internal sealed unsafe class X11NativeWindowPlatform : GlfwNativeWindowPlatform
         data[3] = 1;
         data[4] = 0;
         return SendClientMessage(stateAtom, data);
-    }
-
-    private bool SendMoveResize(NativeWindowPoint pointer, int direction)
-    {
-        XUngrabPointer(_display, 0);
-        var atom = XInternAtom(_display, "_NET_WM_MOVERESIZE", false);
-        var data = stackalloc long[5];
-        data[0] = pointer.X;
-        data[1] = pointer.Y;
-        data[2] = direction;
-        data[3] = 1;
-        data[4] = 1;
-        return SendClientMessage(atom, data);
     }
 
     private bool SendClientMessage(nuint messageType, long* values)
@@ -333,8 +317,6 @@ internal sealed unsafe class X11NativeWindowPlatform : GlfwNativeWindowPlatform
         bool propagate,
         long eventMask,
         ref XEvent sendEvent);
-    [DllImport(X11Library)]
-    private static extern int XUngrabPointer(nint display, nuint time);
     [DllImport(X11Library)]
     private static extern int XFlush(nint display);
 }

--- a/src/ProGPU.Tests.Headless/HeadlessWindow.cs
+++ b/src/ProGPU.Tests.Headless/HeadlessWindow.cs
@@ -21,7 +21,18 @@ public unsafe class HeadlessWindow : IDisposable
     private static readonly TimeSpan ReadbackAbortTimeout = TimeSpan.FromSeconds(5);
 
     private static HeadlessWindow? _shared;
-    public static HeadlessWindow Shared => _shared ??= new HeadlessWindow(1280, 800);
+    public static HeadlessWindow Shared
+    {
+        get
+        {
+            if (_shared?.Context.IsDeviceLost == true)
+            {
+                _shared.Dispose();
+                _shared = null;
+            }
+            return _shared ??= new HeadlessWindow(1280, 800);
+        }
+    }
 
     public static void ClearSharedContent()
     {

--- a/src/ProGPU.Tests/WgpuContextTests.cs
+++ b/src/ProGPU.Tests/WgpuContextTests.cs
@@ -8,6 +8,13 @@ using Xunit;
 
 namespace ProGPU.Tests;
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class WgpuContextLossCollection
+{
+    public const string Name = nameof(WgpuContextLossCollection);
+}
+
+[Collection(WgpuContextLossCollection.Name)]
 public sealed class WgpuContextTests
 {
     [Fact]
@@ -63,6 +70,63 @@ public sealed class WgpuContextTests
         Assert.True(existing.IsDeviceLost);
         Assert.False(existing.IsInitialized);
         Assert.False(new WgpuContext().IsDeviceLost);
+    }
+
+    [Fact]
+    public unsafe void ExactDeviceLossDoesNotPoisonIndependentContexts()
+    {
+        using var firstApi = new BrowserWebGpuApi();
+        using var secondApi = new BrowserWebGpuApi();
+        using var first = new WgpuContext();
+        using var second = new WgpuContext();
+        first.InitializeExternal(
+            firstApi,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm);
+        second.InitializeExternal(
+            secondApi,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            BrowserWebGpuApi.SurfaceHandle,
+            TextureFormat.Bgra8Unorm);
+
+        first.ReportDeviceLost(
+            DeviceLostReason.Unknown,
+            "synthetic exact-device loss");
+
+        Assert.True(first.IsDeviceLost);
+        Assert.False(first.IsInitialized);
+        Assert.False(second.IsDeviceLost);
+        Assert.True(second.IsInitialized);
+    }
+
+    [Fact]
+    public unsafe void LostDeviceRejectsQueueSubmissionBeforeNativeCall()
+    {
+        var submissions = 0;
+        using var api = new BrowserWebGpuApi(_ => submissions++);
+        var lifetime = new RecordingExternalDeviceLifetime();
+        using var context = new WgpuContext();
+        context.InitializeExternalNativeDevice(
+            api,
+            lifetime,
+            BrowserWebGpuApi.DeviceHandle,
+            BrowserWebGpuApi.QueueHandle,
+            TextureFormat.Bgra8Unorm);
+        context.ReportDeviceLost(
+            DeviceLostReason.Unknown,
+            "synthetic exact-device loss");
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () =>
+            {
+                CommandBuffer* command = (CommandBuffer*)1;
+                context.Submit(1, &command);
+            });
+
+        Assert.Contains("lost WebGPU device", exception.Message);
+        Assert.Equal(0, submissions);
     }
 
     [Fact]

--- a/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
+++ b/src/ProGPU.Tests/WindowsDpiAwarenessTests.cs
@@ -105,7 +105,23 @@ public sealed class WindowsDpiAwarenessTests
             window,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Dispatcher.UIThread.Post(",
+            "BeginNativeMoveDrag()",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "PixelPoint? requestedPosition = _desiredPosition;",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Position = requestedPosition is { } initialPosition",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if (requestedPosition is { } desired)",
+            window,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "_desiredPosition = new PixelPoint(",
             window,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -125,11 +141,19 @@ public sealed class WindowsDpiAwarenessTests
             win32,
             StringComparison.Ordinal);
         Assert.Contains(
-            "PackScreenPoint(pointer)",
+            "PostMessage(",
             win32,
             StringComparison.Ordinal);
-        Assert.DoesNotContain(
-            "SendMessage(_hwnd, WmNcLButtonDown, HtCaption, 0)",
+        Assert.Contains(
+            "WmSysCommand",
+            win32,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ScMove | HtCaption",
+            win32,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "PackScreenPoint(screenPointer)",
             win32,
             StringComparison.Ordinal);
     }

--- a/tests/ProGPU.Avalonia.ContractTests/AvaloniaGlyphRunContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/AvaloniaGlyphRunContractTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Platform;
 using Xunit;
+using TtfFont = ProGPU.Text.TtfFont;
 
 namespace Avalonia.ProGpu.ContractTests;
 
@@ -68,6 +69,57 @@ public sealed class AvaloniaGlyphRunContractTests
                 (float)(run.Bounds.Bottom - run.BaselineOrigin.Y));
             Assert.NotEmpty(intersections);
             Assert.Equal(0, intersections.Count % 2);
+        }
+        finally
+        {
+            glyphTypeface.Dispose();
+        }
+    }
+
+    [Fact]
+    public void BitmapColorGlyphsContributeInkBounds()
+    {
+        string[] candidates =
+        [
+            "/System/Library/Fonts/Apple Color Emoji.ttc",
+            "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf"
+        ];
+        string? path = Array.Find(candidates, File.Exists);
+        if (path is null)
+            return;
+
+        var font = new TtfFont(path);
+        ushort glyph = font.GetGlyphIndex(0x1f600);
+        if (glyph == 0 ||
+            !font.TryGetBitmapGlyph(glyph, 20, out _))
+        {
+            return;
+        }
+
+        var platformTypeface = new ProGpuTypeface(
+            font,
+            font.FontData,
+            font.FamilyName,
+            FontWeight.Normal,
+            FontStyle.Normal,
+            FontStretch.Normal);
+        var glyphTypeface = new GlyphTypeface(platformTypeface);
+        try
+        {
+            using var run = new GlyphRunImpl(
+                glyphTypeface,
+                20,
+                [new GlyphInfo(
+                    glyph,
+                    GlyphCluster: 0,
+                    font.GetAdvanceWidth(glyph, 20))],
+                new Point(7, 30));
+
+            Assert.True(run.Bounds.Width > 0);
+            Assert.True(run.Bounds.Height > 0);
+            Assert.NotEmpty(run.GetIntersections(
+                (float)(run.Bounds.Top - run.BaselineOrigin.Y),
+                (float)(run.Bounds.Bottom - run.BaselineOrigin.Y)));
         }
         finally
         {

--- a/tests/ProGPU.Avalonia.ContractTests/AvaloniaRetainedCommandCacheContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/AvaloniaRetainedCommandCacheContractTests.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Avalonia.ProGpu;
+using ProGPU.Backend;
 using ProGPU.Scene;
 using ProGPU.Vector;
 using Xunit;
@@ -98,6 +99,29 @@ public sealed class AvaloniaRetainedCommandCacheContractTests
     }
 
     [Fact]
+    public void CircleUsesCompactReplayStorage()
+    {
+        var cache = new AvaloniaRetainedCommandCache();
+        var recording = new DrawingContext();
+        var brush = new SolidColorBrush(Vector4.One);
+        var pen = new Pen(brush, 1.5f);
+        recording.DrawCircle(
+            brush,
+            pen,
+            new Vector2(12f, 13f),
+            7f);
+
+        Assert.True(cache.TryCompactOrdinaryCommands(recording));
+
+        RenderCommand replay = cache.GetCommand(0);
+        Assert.Equal(RenderCommandType.DrawCircle, replay.Type);
+        Assert.Equal(new Vector2(12f, 13f), replay.Position2);
+        Assert.Equal(7f, replay.RadiusX);
+        Assert.Same(brush, replay.Brush);
+        Assert.Same(pen, replay.Pen);
+    }
+
+    [Fact]
     public void StableCompactShapeUpdatesStorageInPlace()
     {
         var cache = new AvaloniaRetainedCommandCache();
@@ -135,6 +159,87 @@ public sealed class AvaloniaRetainedCommandCacheContractTests
         Assert.Same(secondBrush, replay.Brush);
         Assert.Equal(4f, replay.RadiusX);
         Assert.Equal(5f, replay.RadiusY);
+    }
+
+    [Fact]
+    public void CanvasStateCommandsUseCompactReplayStorage()
+    {
+        var cache = new AvaloniaRetainedCommandCache();
+        var recording = new DrawingContext();
+        var clipPath = new PathGeometry();
+        var transform = Matrix4x4.CreateTranslation(3f, 5f, 0f);
+        recording.Commands.Add(
+            new RenderCommand
+            {
+                Type = RenderCommandType.PushClip,
+                Rect = new Rect(1f, 2f, 30f, 40f),
+                Transform = transform
+            });
+        recording.Commands.Add(
+            new RenderCommand
+            {
+                Type = RenderCommandType.PushGeometryClip,
+                Path = clipPath,
+                Transform = transform
+            });
+        recording.PushOpacity(0.75f);
+        recording.PopOpacity();
+        recording.PushBlendMode(GpuBlendMode.Multiply);
+        recording.PopBlendMode();
+        recording.PopGeometryClip();
+        recording.PopClip();
+
+        Assert.True(cache.TryCompactOrdinaryCommands(recording));
+        Assert.Equal(8, cache.Count);
+        Assert.All(
+            Assert.IsType<CompactAvaloniaCommand[]>(
+                cache.CompactStorageIdentity),
+            command => Assert.IsType<CompactAvaloniaStateCommand>(command));
+
+        RenderCommand rectangleClip = cache.GetCommand(0);
+        Assert.Equal(RenderCommandType.PushClip, rectangleClip.Type);
+        Assert.Equal(new Rect(1f, 2f, 30f, 40f), rectangleClip.Rect);
+        Assert.Equal(transform, rectangleClip.Transform);
+
+        RenderCommand geometryClip = cache.GetCommand(1);
+        Assert.Equal(
+            RenderCommandType.PushGeometryClip,
+            geometryClip.Type);
+        Assert.Same(clipPath, geometryClip.Path);
+        Assert.Equal(transform, geometryClip.Transform);
+        Assert.Equal(0.75f, cache.GetCommand(2).FontSize);
+        Assert.Equal(
+            (int)GpuBlendMode.Multiply,
+            cache.GetCommand(4).IntParam);
+    }
+
+    [Fact]
+    public void StableCanvasStateUpdatesStorageInPlace()
+    {
+        var cache = new AvaloniaRetainedCommandCache();
+        var recording = new DrawingContext();
+        recording.PushClip(new Rect(0f, 0f, 10f, 10f));
+        recording.PopClip();
+
+        Assert.True(cache.TryCompactOrdinaryCommands(recording));
+        object storage = Assert.IsType<CompactAvaloniaCommand[]>(
+            cache.CompactStorageIdentity);
+
+        recording.Commands[0] = new RenderCommand
+        {
+            Type = RenderCommandType.PushClip,
+            Rect = new Rect(2f, 3f, 20f, 30f)
+        };
+        Assert.True(
+            cache.TryCompactOrdinaryCommands(
+                recording,
+                out bool contentChanged));
+
+        Assert.True(contentChanged);
+        Assert.Same(storage, cache.CompactStorageIdentity);
+        Assert.Equal(
+            new Rect(2f, 3f, 20f, 30f),
+            cache.GetCommand(0).Rect);
     }
 
     [Fact]

--- a/tests/ProGPU.Avalonia.ContractTests/ColorGlyphMetricCacheContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/ColorGlyphMetricCacheContractTests.cs
@@ -10,6 +10,15 @@ namespace Avalonia.ProGpu.ContractTests;
 public sealed class ColorGlyphMetricCacheContractTests
 {
     [Fact]
+    public void AvaloniaColorAtlasRetainsLargeBitmapEmojiWorkingSets()
+    {
+        Assert.Equal(64u,
+            AvaloniaGpuDevicePool.Options.InitialColorGlyphAtlasSize);
+        Assert.True(
+            AvaloniaGpuDevicePool.Options.ColorGlyphAtlasSize >= 1024u);
+    }
+
+    [Fact]
     public void SbixCoordinatesArePlacedRelativeToTheBaseline()
     {
         var metrics = new ColorGlyphMetrics(

--- a/tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
+++ b/tests/ProGPU.Avalonia.ContractTests/ProGPU.Avalonia.ContractTests.csproj
@@ -8,7 +8,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AssemblyName>Avalonia.ProGpu.UnitTests</AssemblyName>
     <RootNamespace>ProGPU.Avalonia.ContractTests</RootNamespace>
-    <ProGpuAvaloniaSourceRoot Condition="'$(ProGpuAvaloniaSourceRoot)' == ''">$(MSBuildThisFileDirectory)..\..\.worktrees\avalonia-12.1.1</ProGpuAvaloniaSourceRoot>
+    <ProGpuAvaloniaSourceRoot Condition="'$(ProGpuAvaloniaSourceRoot)' == ''">$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\..\.worktrees\avalonia-12.1.1'))</ProGpuAvaloniaSourceRoot>
     <AvaloniaAccessUnstablePrivateApis>true</AvaloniaAccessUnstablePrivateApis>
     <Avalonia_I_Want_To_Use_Private_Apis_IN_NUGET_PACKAGE>true</Avalonia_I_Want_To_Use_Private_Apis_IN_NUGET_PACKAGE>
   </PropertyGroup>
@@ -60,5 +60,9 @@
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\packages\Avalonia\Avalonia.csproj" />
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\src\Avalonia.Fonts.Inter\Avalonia.Fonts.Inter.csproj" />
     <ProjectReference Include="$(ProGpuAvaloniaSourceRoot)\src\HarfBuzz\Avalonia.HarfBuzz\Avalonia.HarfBuzz.csproj" />
+    <Reference Include="Avalonia.Skia">
+      <HintPath>..\..\src\ProGPU.Avalonia.SkiaSourceCompatibility\bin\$(Configuration)\$(TargetFramework)\Avalonia.Skia.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
+++ b/tests/ProGPU.Avalonia.ContractTests/SkiaSharpApiLeaseContractTests.cs
@@ -82,6 +82,9 @@ public sealed class SkiaSharpApiLeaseContractTests
             context.GetFeature(typeof(IProGpuApiLeaseFeature)));
         Assert.IsAssignableFrom<ISkiaSharpApiLeaseFeature>(
             context.GetFeature(typeof(ISkiaSharpApiLeaseFeature)));
+        Assert.Same(
+            context.GetFeature(typeof(IProGpuApiLeaseFeature)),
+            context.GetFeature(typeof(ISkiaSharpApiLeaseFeature)));
     }
 
     [Fact]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/InputAndCursorContractTests.cs
@@ -157,6 +157,33 @@ public sealed class InputAndCursorContractTests
                 isHovered));
     }
 
+    [Fact]
+    public void MouseButtonsUseLatestCursorCallbackPosition()
+    {
+        var callbackPosition = new Vector2(350, 72);
+        var staleReportedPosition = new Vector2(1008.5f, 578.3f);
+
+        Assert.Equal(
+            callbackPosition,
+            SilkNetInputRouter.ResolvePointerPosition(
+                hasCallbackPosition: true,
+                callbackPosition,
+                staleReportedPosition));
+    }
+
+    [Fact]
+    public void MouseButtonsFallBackToReportedPositionBeforeFirstMove()
+    {
+        var reportedPosition = new Vector2(200, 100);
+
+        Assert.Equal(
+            reportedPosition,
+            SilkNetInputRouter.ResolvePointerPosition(
+                hasCallbackPosition: false,
+                callbackPosition: default,
+                reportedPosition));
+    }
+
     [Theory]
     [InlineData(SilkKey.A, Key.A, PhysicalKey.A)]
     [InlineData(SilkKey.Number7, Key.D7, PhysicalKey.Digit7)]

--- a/tests/ProGPU.Avalonia.SilkNet.ContractTests/WindowChromeContractTests.cs
+++ b/tests/ProGPU.Avalonia.SilkNet.ContractTests/WindowChromeContractTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.SilkNet;
 using ProGPU.Backend;
@@ -239,6 +240,42 @@ public sealed class WindowChromeContractTests
             expected,
             SilkNetWindowChrome.MapResizeEdge(source));
     }
+
+#if !AVALONIA11
+    [Theory]
+    [InlineData(WindowDecorationsElementRole.ResizeN, NativeResizeEdge.Top)]
+    [InlineData(WindowDecorationsElementRole.ResizeS, NativeResizeEdge.Bottom)]
+    [InlineData(WindowDecorationsElementRole.ResizeE, NativeResizeEdge.Right)]
+    [InlineData(WindowDecorationsElementRole.ResizeW, NativeResizeEdge.Left)]
+    [InlineData(WindowDecorationsElementRole.ResizeNE, NativeResizeEdge.TopRight)]
+    [InlineData(WindowDecorationsElementRole.ResizeNW, NativeResizeEdge.TopLeft)]
+    [InlineData(WindowDecorationsElementRole.ResizeSE, NativeResizeEdge.BottomRight)]
+    [InlineData(WindowDecorationsElementRole.ResizeSW, NativeResizeEdge.BottomLeft)]
+    public void DrawnDecorationResizeRolesMapExactly(
+        WindowDecorationsElementRole role,
+        NativeResizeEdge expected)
+    {
+        Assert.True(
+            SilkNetWindowChrome.TryMapResizeRole(
+                role,
+                out NativeResizeEdge actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(WindowDecorationsElementRole.None)]
+    [InlineData(WindowDecorationsElementRole.TitleBar)]
+    [InlineData(WindowDecorationsElementRole.User)]
+    [InlineData(WindowDecorationsElementRole.DecorationsElement)]
+    public void InteractiveAndTitleRolesAreNotResizeEdges(
+        WindowDecorationsElementRole role)
+    {
+        Assert.False(
+            SilkNetWindowChrome.TryMapResizeRole(
+                role,
+                out _));
+    }
+#endif
 
     [Fact]
     public void SizeConstraintsNormalizeForNativeWindowing()

--- a/tools/profile-avalonia-controlcatalog.sh
+++ b/tools/profile-avalonia-controlcatalog.sh
@@ -17,6 +17,7 @@ opacity_mask_fixture="${PROGPU_AVALONIA_OPACITY_MASK_FIXTURE:-0}"
 inherited_drawing_options_fixture="${PROGPU_AVALONIA_INHERITED_DRAWING_OPTIONS_FIXTURE:-0}"
 topology_fixture="${PROGPU_AVALONIA_TOPOLOGY_FIXTURE:-0}"
 adorner_fixture="${PROGPU_AVALONIA_ADORNER_FIXTURE:-0}"
+skiasharp_custom_fixture="${PROGPU_AVALONIA_SKIASHARP_CUSTOM_FIXTURE:-0}"
 skia_project="$repo_root/integration/AvaloniaSkiaControlCatalogReference/AvaloniaSkiaControlCatalogReference.csproj"
 skia_app="$repo_root/integration/AvaloniaSkiaControlCatalogReference/bin/Release/net10.0/AvaloniaSkiaControlCatalogReference.dll"
 source_project="$repo_root/integration/AvaloniaSourceControlCatalog/AvaloniaSourceControlCatalog.csproj"
@@ -289,6 +290,7 @@ for page in "${pages[@]}"; do
          PROGPU_AVALONIA_BENCHMARK_INHERITED_DRAWING_OPTIONS_CHANNEL="$inherited_drawing_options_fixture" \
          PROGPU_AVALONIA_BENCHMARK_TOPOLOGY_CHANNEL="$topology_fixture" \
          PROGPU_AVALONIA_BENCHMARK_ADORNER_CHANNEL="$adorner_fixture" \
+         PROGPU_AVALONIA_BENCHMARK_SKIASHARP_CUSTOM_DRAW="$skiasharp_custom_fixture" \
          "${native_launch[@]}" \
          dotnet "$app" "${app_args[@]}" 2>&1 | tee "$log_path"; then
         if [[ -s "$json_path" ]]; then


### PR DESCRIPTION
## Summary

- fix Avalonia Silk.NET startup placement, Windows 200% DPI behavior, live resize/layout updates, and custom title-bar/resize-role dragging
- make pointer coordinates reliable on macOS and add real Windows touch plus XI2.2 Linux touch routing without promoted duplicate mouse input
- preserve exact source-built `Avalonia.Skia` lease identity while reducing animated SkiaSharp custom-draw allocations from 238.09–307.73 KiB/frame to 16.02–18.97 KiB/frame
- fix bitmap-only color-emoji bounds/culling and grow the managed Avalonia color atlas for the ControlCatalog text workload
- add reusable Windows/Linux integration runners, physical input telemetry, native-windowing screenshots, and cross-platform audit/performance evidence

## Validation

- ProGPU core: 3,808 passed
- ProGPU headless: 240 passed
- Avalonia rendering contracts: 104 passed from a clean source-mode build
- Avalonia Silk.NET contracts: 129 passed on Avalonia 12.1.1; 104 passed on Avalonia 11.3.20
- Avalonia headless pixel contract: 1 passed
- pinned Avalonia compositor: 28 passed
- pinned Avalonia text/Skia: 307 passed, 5 platform/profile skips
- source-built ControlCatalog: zero warnings and zero errors
- macOS, Windows 11 Parallels at 200% DPI, and Ubuntu X11 Parallels: startup position, title drag, live resize/layout, keyboard/text/shortcut, pointer/buttons/wheel, and supported touch paths passed
- native Avalonia macOS/Win32/X11 windowing rendered the ControlCatalog Border, Canvas, ScrollViewer, TextBlock, and Viewbox pages through ProGPU without clipping regressions
- matched Xcode Allocations/VM Tracker, Time Profiler, and Metal System Trace runs found no compiler spill, hang-risk, command-buffer, or native-memory regression

## Research and applicability

The clean-room implementation and managed/native applicability audit are recorded in `docs/progpu-avalonia-silknet-platform-audit.md` and `docs/AVALONIA_SKIASHARP_LEASE_COMPATIBILITY_RESEARCH.md`. Primary references include the official Avalonia public lease contract, GLFW window coordinate documentation, Microsoft `WM_SYSCOMMAND`, X.Org XI2, Skia, DirectWrite/Direct2D/Win2D, WebRender, Vello/Parley, and HarfBuzz sources linked there.

The native C++ renderer has no Avalonia custom-draw lease or managed command-array ownership. Its color atlas already grows to 4096 and does not use Avalonia glyph bounds for culling, so no paired native defect or ABI/shader change applies.



## Device-loss and remote-session recovery

- track loss per exact WebGPU device for both Silk/wgpu-native and Dawn, including uncaptured terminal device/resource errors
- reject queue submission after loss, invalidate affected surfaces, drop the failed Avalonia frame cleanly, and recreate only from healthy contexts
- retain immutable bitmap CPU sources so cross-device recovery can rebuild GPU resources
- hold explicit Dawn device leases until presentation surfaces/render targets are released, avoiding unsafe teardown ordering; skip unsafe idle/unconfigure operations after loss
- add deterministic loss injection with JSON telemetry and CI smoke coverage for both source-progpu and source-progpu-native

Primary references and the clean-room design record are in docs/progpu-avalonia-rendering-research.md: W3C WebGPU device-loss semantics, Dawn surface state handling, Avalonia context-manager recovery, Microsoft Direct2D/Direct3D/Win2D device-loss guidance, Skia context abandonment, and WebRender/Vello/Parley/HarfBuzz architecture.

Physical recovery validation used the ControlCatalog Border page (including circular image clipping):

- macOS: Silk recovered in 1 frame; Dawn Metal/IOSurface recovered in 2 frames
- Windows 11 Parallels/RDP-representative session at 200% DPI: Silk and Dawn D3D12/HWND recovered in 1 frame, preserving 1024x800 logical / 2048x1600 physical sizing
- Ubuntu Parallels/X11: Silk and Dawn Vulkan/Xlib recovered in 1 frame; screenshots remained visually correct

The final full ProGPU suite passed 3,808 tests; the focused headless, Avalonia rendering, Silk.NET Avalonia 11/12, pixel, and retained-compositor suites also passed. The managed/native applicability audit found no shader, scene-format, or C ABI change: both renderers share the exact device-loss boundary, while native presentation received the corresponding status and teardown handling.