### PR TITLE
Add typed cross-toolkit native window ownership

### DIFF
--- a/eng/progpu-package-list.sh
+++ b/eng/progpu-package-list.sh
@@ -248,6 +248,7 @@ progpu_package_purposes=("${progpu_portable_package_purposes[@]}" "${progpu_mobi
 # non-shipping. The verifier fails when a newly added project is omitted.
 progpu_nonshipping_projects=(
   src/PresentationCore/PresentationCore.csproj
+  src/ProGPU.Backend.Tests/ProGPU.Backend.Tests.csproj
   src/ProGPU.Avalonia.SkiaSourceCompatibility/ProGPU.Avalonia.SkiaSourceCompatibility.csproj
   src/ProGPU.Avalonia.Skia.BinaryCompatibility/ProGPU.Avalonia.Skia.BinaryCompatibility.csproj
   src/ProGPU.Avalonia.Skia.BinaryCompatibility.V11/ProGPU.Avalonia.Skia.BinaryCompatibility.V11.csproj
@@ -272,6 +273,7 @@ progpu_nonshipping_projects=(
 
 progpu_nonshipping_reasons=(
   "Framework implementation shim; shipped through consuming compatibility packages."
+  "Backend ownership-registry and native-window state test project."
   "Non-shipping source dependency used to validate the ProGPU SkiaSharp contract against Avalonia's ordinary Skia backend."
   "Non-shipping Avalonia.Skia facade shipped inside ProGPU.BinaryCompatibility."
   "Non-shipping Avalonia 11 validation facade for the universal compatibility identity."

--- a/eng/progpu-verify-package-list.sh
+++ b/eng/progpu-verify-package-list.sh
@@ -108,8 +108,8 @@ while IFS= read -r project; do
   fi
 done < <(find "${repo_root}/src" -type f -name '*.csproj' -not -path '*/bin/*' -not -path '*/obj/*' | sort)
 
-if [[ "${#classified_projects[@]}" -ne 69 ]]; then
-  echo "Expected 69 classified projects, found ${#classified_projects[@]}. Update the manifest and this audit count together." >&2
+if [[ "${#classified_projects[@]}" -ne 70 ]]; then
+  echo "Expected 70 classified projects, found ${#classified_projects[@]}. Update the manifest and this audit count together." >&2
   exit 1
 fi
 

--- a/src/ProGPU.Backend.Tests/NativeWindowOwnerRegistryTests.cs
+++ b/src/ProGPU.Backend.Tests/NativeWindowOwnerRegistryTests.cs
@@ -1,0 +1,95 @@
+using ProGPU.Backend;
+using Xunit;
+
+namespace ProGPU.Backend.Tests;
+
+public sealed class NativeWindowOwnerRegistryTests
+{
+    [Fact]
+    public void RegistrationResolvesTypedOwnerAndNativeHandleUntilDisposed()
+    {
+        nint presentationHandle = (nint)0x505701;
+        var owner = new TestOwner(new NativeWindowHandle(
+            NativeWindowKind.X11,
+            (nint)0x1234,
+            (nint)0x5678,
+            "X11"));
+
+        using IDisposable registration = NativeWindowOwnerRegistry.Register(presentationHandle, owner);
+
+        Assert.True(NativeWindowOwnerRegistry.TryResolve(presentationHandle, out INativeWindowOwner? resolved));
+        Assert.Same(owner, resolved);
+        Assert.True(NativeWindowOwnerRegistry.TryResolveNativeHandle(presentationHandle, out NativeWindowHandle native));
+        Assert.Equal(owner.NativeHandle, native);
+
+        registration.Dispose();
+
+        Assert.False(NativeWindowOwnerRegistry.TryResolve(presentationHandle, out _));
+        Assert.False(NativeWindowOwnerRegistry.TryResolveNativeHandle(presentationHandle, out native));
+        Assert.Equal(NativeWindowHandle.Empty, native);
+    }
+
+    [Fact]
+    public void StaleRegistrationCannotRemoveReplacement()
+    {
+        nint presentationHandle = (nint)0x505702;
+        var first = new TestOwner(new NativeWindowHandle(NativeWindowKind.X11, (nint)1, (nint)2, "first"));
+        var replacement = new TestOwner(new NativeWindowHandle(NativeWindowKind.X11, (nint)3, (nint)4, "replacement"));
+        IDisposable staleRegistration = NativeWindowOwnerRegistry.Register(presentationHandle, first);
+        using IDisposable replacementRegistration = NativeWindowOwnerRegistry.Register(presentationHandle, replacement);
+
+        staleRegistration.Dispose();
+
+        Assert.True(NativeWindowOwnerRegistry.TryResolve(presentationHandle, out INativeWindowOwner? resolved));
+        Assert.Same(replacement, resolved);
+    }
+
+    [Fact]
+    public void DeadOrNotYetNativeOwnerDoesNotYieldNativeHandle()
+    {
+        nint presentationHandle = (nint)0x505703;
+        var owner = new TestOwner(NativeWindowHandle.Empty);
+        using IDisposable registration = NativeWindowOwnerRegistry.Register(presentationHandle, owner);
+
+        Assert.True(NativeWindowOwnerRegistry.TryResolve(presentationHandle, out _));
+        Assert.False(NativeWindowOwnerRegistry.TryResolveNativeHandle(presentationHandle, out _));
+
+        owner.IsAlive = false;
+
+        Assert.False(NativeWindowOwnerRegistry.TryResolve(presentationHandle, out _));
+    }
+
+    [Fact]
+    public void RegistrationRejectsZeroHandleAndDeadOwner()
+    {
+        var liveOwner = new TestOwner(NativeWindowHandle.Empty);
+        var deadOwner = new TestOwner(NativeWindowHandle.Empty) { IsAlive = false };
+
+        Assert.Throws<ArgumentException>(() => NativeWindowOwnerRegistry.Register(0, liveOwner));
+        Assert.Throws<ArgumentException>(() => NativeWindowOwnerRegistry.Register((nint)1, deadOwner));
+    }
+
+    private sealed class TestOwner : INativeWindowOwner
+    {
+        public TestOwner(NativeWindowHandle nativeHandle)
+        {
+            NativeHandle = nativeHandle;
+        }
+
+        public NativeWindowHandle NativeHandle { get; set; }
+
+        public bool IsAlive { get; set; } = true;
+
+        public bool IsVisible { get; set; } = true;
+
+        public bool IsEnabled { get; private set; } = true;
+
+        public bool TrySetEnabled(bool enabled)
+        {
+            IsEnabled = enabled;
+            return true;
+        }
+
+        public bool TryActivate() => true;
+    }
+}

--- a/src/ProGPU.Backend.Tests/ProGPU.Backend.Tests.csproj
+++ b/src/ProGPU.Backend.Tests/ProGPU.Backend.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProGPU.Backend\ProGPU.Backend.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ProGPU.Backend/NativeWindowOwnerRegistry.cs
+++ b/src/ProGPU.Backend/NativeWindowOwnerRegistry.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ProGPU.Backend;
+
+/// <summary>
+/// Describes a live top-level window that can own windows created by another
+/// managed desktop stack in the same process.
+/// </summary>
+public interface INativeWindowOwner
+{
+    NativeWindowHandle NativeHandle { get; }
+
+    bool IsAlive { get; }
+
+    bool IsVisible { get; }
+
+    bool IsEnabled { get; }
+
+    bool TrySetEnabled(bool enabled);
+
+    bool TryActivate();
+}
+
+/// <summary>
+/// Resolves process-local presentation handles to typed native top-level
+/// windows without exposing toolkit objects or probing them with reflection.
+/// </summary>
+public static class NativeWindowOwnerRegistry
+{
+    private sealed record Entry(long RegistrationId, WeakReference<INativeWindowOwner> Owner);
+
+    private static readonly object s_sync = new();
+    private static readonly Dictionary<nint, Entry> s_owners = [];
+    private static long s_nextRegistrationId;
+
+    public static IDisposable Register(nint presentationHandle, INativeWindowOwner owner)
+    {
+        if (presentationHandle == 0)
+        {
+            throw new ArgumentException(
+                "A presentation handle must be non-zero.",
+                nameof(presentationHandle));
+        }
+
+        ArgumentNullException.ThrowIfNull(owner);
+        if (!owner.IsAlive)
+        {
+            throw new ArgumentException("The native window owner must be live.", nameof(owner));
+        }
+
+        long registrationId = Interlocked.Increment(ref s_nextRegistrationId);
+        lock (s_sync)
+        {
+            s_owners[presentationHandle] = new Entry(
+                registrationId,
+                new WeakReference<INativeWindowOwner>(owner));
+        }
+
+        return new Registration(presentationHandle, registrationId);
+    }
+
+    public static bool TryResolve(
+        nint presentationHandle,
+        [NotNullWhen(true)] out INativeWindowOwner? owner)
+    {
+        owner = null;
+        if (presentationHandle == 0)
+        {
+            return false;
+        }
+
+        lock (s_sync)
+        {
+            if (!s_owners.TryGetValue(presentationHandle, out Entry? entry))
+            {
+                return false;
+            }
+
+            if (!entry.Owner.TryGetTarget(out INativeWindowOwner? registeredOwner)
+                || !registeredOwner.IsAlive)
+            {
+                s_owners.Remove(presentationHandle);
+                return false;
+            }
+
+            owner = registeredOwner;
+            return true;
+        }
+    }
+
+    public static bool TryResolveNativeHandle(
+        nint presentationHandle,
+        out NativeWindowHandle nativeHandle)
+    {
+        if (TryResolve(presentationHandle, out INativeWindowOwner? owner)
+            && owner.NativeHandle is { IsValid: true } resolvedHandle)
+        {
+            nativeHandle = resolvedHandle;
+            return true;
+        }
+
+        nativeHandle = NativeWindowHandle.Empty;
+        return false;
+    }
+
+    private static void Unregister(nint presentationHandle, long registrationId)
+    {
+        lock (s_sync)
+        {
+            if (s_owners.TryGetValue(presentationHandle, out Entry? entry)
+                && entry.RegistrationId == registrationId)
+            {
+                s_owners.Remove(presentationHandle);
+            }
+        }
+    }
+
+    private sealed class Registration : IDisposable
+    {
+        private readonly nint _presentationHandle;
+        private long _registrationId;
+
+        public Registration(nint presentationHandle, long registrationId)
+        {
+            _presentationHandle = presentationHandle;
+            _registrationId = registrationId;
+        }
+
+        public void Dispose()
+        {
+            long registrationId = Interlocked.Exchange(ref _registrationId, 0);
+            if (registrationId != 0)
+            {
+                Unregister(_presentationHandle, registrationId);
+            }
+        }
+    }
+}

--- a/src/ProGPU.Backend/SilkWindowController.cs
+++ b/src/ProGPU.Backend/SilkWindowController.cs
@@ -20,6 +20,7 @@ public sealed class SilkWindowController : IDisposable
 
     public bool IsAttached => _platform != null;
     public NativeWindowHandle Handle => _platform?.Handle ?? ResolvePendingHandle();
+    public bool IsEnabled => _state.Enabled;
     public NativeWindowCapabilities Capabilities =>
         _platform?.Capabilities ?? NativeWindowCapabilities.ForKind(Handle.Kind);
     public bool IsClientAreaExtended =>

--- a/src/ProGPU.slnx
+++ b/src/ProGPU.slnx
@@ -2,6 +2,7 @@
   <Project Path="SkiaSharp/SkiaSharp.csproj" />
   <Project Path="ProGPU.Transpiler/ProGPU.Transpiler.csproj" />
   <Project Path="ProGPU.Backend/ProGPU.Backend.csproj" />
+  <Project Path="ProGPU.Backend.Tests/ProGPU.Backend.Tests.csproj" />
   <Project Path="ProGPU.Backend.Native/ProGPU.Backend.Native.csproj" />
   <Project Path="ProGPU.Backend.Dawn/ProGPU.Backend.Dawn.csproj" />
   <Project Path="ProGPU.Media/ProGPU.Media.csproj" />


### PR DESCRIPTION
## Review stack

Slice 2 of 3. Depends on #140 and contains only the typed native-window ownership seam. PR #157 targets this branch for the subsequent metafile parity work.

## Summary

- add a typed process-local registry that maps desktop presentation handles to live native top-level owners
- expose native handle, visibility, enabled-state, activation, and modal enable/disable operations without reflection
- add a focused backend test project and lifecycle coverage for registration replacement and disposal

## Validation

- `/usr/local/share/dotnet/dotnet test src/ProGPU.Backend.Tests/ProGPU.Backend.Tests.csproj -c Release --no-restore` (4 passed, 0 failed, warning-clean)

## Consumer

This is the shared backend seam used by the LibreWPF/LibreWinForms source-first integration so canonical `IWin32Window` owners can cross toolkit boundaries.