### PR TITLE
Add application drawing extension registration for WinUI package consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ PROGPU_PACKAGE_GROUP=portable ./eng/progpu-pack.sh
 ./scripts/progpu-pack.sh
 ```
 
+See [application drawing extensions](docs/drawing-extensions.md) for registering
+custom GPU drawing from an ordinary WinUI NuGet consumer.
+
 See [`docs/progpu-packaging.md`](docs/progpu-packaging.md) for package-only
 consumer validation, version overrides, and publishing.
 

--- a/docs/drawing-extensions.md
+++ b/docs/drawing-extensions.md
@@ -1,0 +1,161 @@
+# Application drawing extensions
+
+Applications and libraries can implement custom GPU drawing using only the
+`ProGPU.WinUI` NuGet package and its transitive dependencies. No ProGPU source
+changes, signing key, friend assembly, reflection, or registration in a built-in
+extension table are required.
+
+The low-level `ICompositorExtension`, `Compositor.RegisterExtension(int, ...)`, and
+`DrawingContext.DrawExtension(int, ...)` APIs were already public. The typed API
+adds application identity, window lifecycle registration, local bounds and payload
+type checking while using those same compilation and GPU submission paths.
+
+## Register once, record many times
+
+Declare a shared definition in the application or extension library:
+
+```csharp
+public static readonly DrawingExtension<MyBatch> MyDrawing =
+    new("My application artwork", static () => new MyPipeline());
+```
+
+`MyPipeline` implements the existing public `ICompositorExtension` contract.
+`MyBatch` is an application-owned reference type containing retained drawing data.
+Using a class avoids boxing or copying a struct payload for each command.
+
+Register on every window that can display the drawing, before calling `Activate`:
+
+```csharp
+var window = new Window();
+window.RegisterDrawingExtension(MyDrawing);
+window.Activate();
+```
+
+Registration can also occur after activation, outside a compilation or rendering
+callback. Re-registering the same definition is idempotent. Its factory runs once
+per compositor, never per command or frame. Registration before activation does
+not create a GPU device. When a mobile host suspends and recreates the window's
+renderer, the window registers a fresh instance automatically.
+
+Record from a control's existing `OnRender` override or a `DrawingContext` extension
+method in the application:
+
+```csharp
+context.DrawExtension(MyDrawing, new Rect(0, 0, width, height), batch);
+```
+
+An optional final `Matrix4x4 transform` argument has the same semantics as the
+legacy command. Recording emits one ordinary `DrawExtension` command containing
+the definition's integer identity, bounds, original payload reference and transform.
+It does not invoke the factory, resolve a service, copy an array, create a wrapper,
+upload a buffer, or cross a native boundary.
+
+For standalone/offscreen use, call
+`compositor.RegisterDrawingExtension(MyDrawing)`. To configure an existing instance,
+use `compositor.GetDrawingExtension(MyDrawing)` and cast to your pipeline type.
+
+## Ownership and invalidation
+
+- Share definitions, not pipeline instances. A factory must return a fresh instance
+  for each compositor, and that instance must reject resources from other devices.
+- Create shaders, pipelines and buffers lazily in the instance. Retain and reuse
+  them across frames. The compositor calls the existing lifecycle hooks and
+  disposes instances implementing `IDisposable` when its renderer is disposed.
+- The command retains the payload reference. Keep it stable from recording through
+  submission. Advance its generation and invalidate the owning visual whenever
+  pixels change. Do not mutate it inside `OnRender` or behind a retained cache.
+- `Compile` prepares CPU command metadata. `TryPrepareDrawCall` can prepare GPU
+  resources before the active render pass. `Render` encodes into that existing
+  pass. Keep preparation/submission batching and resource leases in the extension.
+- Use the compositor's physical target dimensions, render format and current
+  sample count. Offscreen targets, transforms, clipping, opacity and masks remain
+  the extension author's responsibility under the existing callback contract.
+- Definitions are process-local identities, not portable serialized IDs. Numeric
+  IDs generated for the typed API must not be reused with the legacy API.
+- Register on the owning UI/render thread outside callbacks. This is a startup
+  operation; definitions cannot be unregistered while retained commands reference
+  them. Dispose the compositor/window to end their instance lifetimes.
+
+## Shader resources from a package consumer
+
+Put static WGSL in the application's `Shaders` directory and embed it explicitly
+in its project. Repository-wide build properties are not needed:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="ProGPU.WinUI" Version="YOUR_PACKAGE_VERSION" />
+  <EmbeddedResource Include="Shaders/*.wgsl"
+                    LogicalName="$(AssemblyName).Shaders.%(Filename)%(Extension)" />
+</ItemGroup>
+```
+
+Load once with `ShaderResource.Load<MyPipeline>("Artwork.wgsl")` into a static
+readonly string. Shader files must document their algorithm and time/space costs.
+The [unsigned consumer fixture](../eng/fixtures/drawing-extension-package-consumer)
+contains a complete original shader and pipeline. Its verification script copies
+it outside the repository and restores only NuGet packages, proving that no source
+checkout properties or privileged assembly access are involved.
+
+## Design, provenance and backend applicability
+
+This is an original wrapper over existing ProGPU-owned contracts in
+`ICompositorExtension.cs`, `Compositor.cs`, `RenderCommand.cs`, and WinUI `Window.cs`.
+It preserves their callback interfaces, command representation and resource
+ownership. No foreign implementation was copied or translated.
+
+Primary-source design review (2026-09-05):
+
+| Reference | Decision for this API |
+| --- | --- |
+| [Direct2D custom effects](https://learn.microsoft.com/en-us/windows/win32/direct2d/custom-effects) and [Win2D offscreen drawing](https://microsoft.github.io/Win2D/WinUI3/html/Offscreen.htm) | Adopt a definition/factory separate from a device-owned instance. Keep initialization separate from drawing; use ProGPU's existing typed callbacks instead of COM or a property bag. |
+| [Skia design documents](https://skia.org/docs/dev/design/) and [text architecture](https://skia.org/docs/dev/design/text_overview/) | Keep retained CPU recording separate from GPU resources. Registration does not initialize fonts, shape text or invalidate text caches. |
+| [WebRender](https://github.com/servo/webrender) | Retain existing display-list reuse and visibility culling. No extra traversal or worker preparation is introduced for registration. |
+| [Vello](https://github.com/linebender/vello), [Parley](https://github.com/linebender/parley), [HarfBuzz](https://harfbuzz.github.io/what-does-harfbuzz-do.html) | Keep rendering and reusable CPU shaping/layout separate. A custom drawing registration is not a new shaping engine or scene compiler. |
+
+The architecture audit covers startup/factory timing, scene reuse, visibility,
+cache identity, uploads, workers, GPU batching, DPI/subpixel behavior, font fallback,
+variable fonts and device loss. Only application registration/instance recreation
+changes. The existing renderer handles the other mechanisms unchanged; extensions
+retain the same obligations for target-aware pipelines, generation invalidation and
+owned resources. No text, rasterizer, shader algorithm or native boundary changes.
+
+Managed/native applicability: `ProGPU.Scene` owns the managed callback compositor
+used by WinUI Desktop, iOS and Browser. The C++ renderer exposes a pointer-free C
+scene ABI, not a WinUI window or a managed render-pass callback host. Its
+`GpuPictureNativeSceneCompiler` supports specified built-in extensions and explicitly
+rejects arbitrary application extension commands; this wrapper does not change that
+contract or transport an object/delegate through C. See
+`src/ProGPU.Scene.Native/GpuPictureNativeSceneCompiler.cs`,
+`NativePictureCommandCapability.cs`, and `src/ProGPU.Native/include/progpu_native.h`.
+There is no new GPU algorithm to port, no canonical shader change in the renderer,
+and no generated wire declaration change. Native custom callback support would be
+a separate ABI feature with ownership and submission requirements of its own.
+
+## Validation
+
+On macOS 26.6 / Apple M3 Pro with .NET 10, the core Release suite passes 3,814
+tests, including five new registration/recording/lifecycle/native-rejection tests.
+The package-only fixture restores 13 locally packed ProGPU dependencies outside
+the source tree and builds unsigned with zero warnings. The optional `--gpu` run
+renders the original packaged shader through both APIs: all 16,384 compared RGBA8
+channels match, with 661 draws per path and no retained payload uploads.
+
+Three alternating, same-binary Release runs after JIT and GPU warmup:
+
+| Run | Direct recording p50, ns | Typed recording p50, ns | Legacy submit + wait p50/p95/p99, ms | Typed submit + wait p50/p95/p99, ms |
+| --- | ---: | ---: | --- | --- |
+| 1 | 62.177 | 63.555 | 1.796 / 6.413 / 7.744 | 1.823 / 7.585 / 8.606 |
+| 2 | 60.322 | 63.222 | 1.836 / 7.460 / 7.957 | 1.822 / 6.726 / 8.284 |
+| 3 | 64.084 | 66.588 | 1.787 / 6.509 / 7.885 | 1.802 / 6.421 / 7.885 |
+
+Each recording path allocates zero bytes, emits one command, copies zero payload
+bytes and makes zero native calls. The inlined typed wrapper has a measured
+1.4–2.9 ns median recording cost in this fixture. It adds no GPU pass, draw, resource,
+upload or per-frame callback. Submission medians differ by at most about 1.5%; tails
+vary with host scheduling. These are serialized completion latencies, not display
+FPS or an assertion that every timing sample is identical.
+
+The fixture and commands are checked in. Logs, exact-binary hashes and Instruments
+exports live under `artifacts/public-drawing-extensions/` in the validation checkout.
+`eng/progpu-pack.sh` runs the package consumer gate for portable/all packaging; set
+`PROGPU_EXTENSION_GPU_TEST=1` on a WebGPU-capable host to include GPU validation.

--- a/docs/drawing-extensions.md
+++ b/docs/drawing-extensions.md
@@ -135,6 +135,7 @@ a separate ABI feature with ownership and submission requirements of its own.
 
 On macOS 26.6 / Apple M3 Pro with .NET 10, the core Release suite passes 3,814
 tests, including five new registration/recording/lifecycle/native-rejection tests.
+All 240 headless Release rendering tests also pass.
 The package-only fixture restores 13 locally packed ProGPU dependencies outside
 the source tree and builds unsigned with zero warnings. The optional `--gpu` run
 renders the original packaged shader through both APIs: all 16,384 compared RGBA8
@@ -157,5 +158,11 @@ FPS or an assertion that every timing sample is identical.
 
 The fixture and commands are checked in. Logs, exact-binary hashes and Instruments
 exports live under `artifacts/public-drawing-extensions/` in the validation checkout.
+Time Profiler captured 3,234 samples and Metal System Trace recorded the complete
+alternating workload, with a 6,455,296-byte peak Metal allocation. Both instrumented
+runs completed the same pixel/draw checks. Some managed JIT frames remain raw
+addresses; the trace is not used to assign nanosecond wrapper costs. Exported tables
+were parsed and gzip round trips/hash-verified before removing the two raw `.trace`
+bundles at the user's request. No runtime performance logging is added to ProGPU.
 `eng/progpu-pack.sh` runs the package consumer gate for portable/all packaging; set
 `PROGPU_EXTENSION_GPU_TEST=1` on a WebGPU-capable host to include GPU validation.

--- a/eng/fixtures/drawing-extension-package-consumer/DrawingExtension.PackageConsumer.csproj
+++ b/eng/fixtures/drawing-extension-package-consumer/DrawingExtension.PackageConsumer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <SignAssembly>false</SignAssembly>
+    <ProGpuPackageVersion Condition="'$(ProGpuPackageVersion)' == ''">0.1.0-preview.62</ProGpuPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ProGPU.WinUI" Version="$(ProGpuPackageVersion)" />
+    <EmbeddedResource Include="Shaders/*.wgsl" LogicalName="$(AssemblyName).Shaders.%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/eng/fixtures/drawing-extension-package-consumer/Program.cs
+++ b/eng/fixtures/drawing-extension-package-consumer/Program.cs
@@ -1,0 +1,124 @@
+using System.Diagnostics;
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Vector;
+using Silk.NET.WebGPU;
+
+namespace PackageConsumer;
+
+internal static class Program
+{
+    private sealed class Frame;
+    private static readonly DrawingExtension<Frame> Definition = new("Package consumer triangle", static () => new Triangle());
+    private static readonly Frame Data = new();
+    private static readonly Rect Bounds = new(0, 0, 64, 64);
+
+    public static void Main(string[] args)
+    {
+        // This fixture is copied outside the repository before building. It has
+        // no signing key, project references, friend access, or source imports.
+        if (typeof(Program).Assembly.GetName().GetPublicKeyToken()?.Length != 0)
+            throw new Exception("The external package consumer must remain unsigned.");
+        var window = new Window(); window.RegisterDrawingExtension(Definition); window.RegisterDrawingExtension(Definition);
+        if (window.Compositor is not null) throw new Exception("Registration initialized the renderer eagerly.");
+        var context = new DrawingContext(); context.DrawExtension(Definition, Bounds, Data);
+        var command = context.Commands[0];
+        if (!ReferenceEquals(command.DataParam, Data) || command.Rect != Bounds) throw new Exception("Payload or bounds changed.");
+        if (!ShaderResource.Load<ProgramAnchor>("Consumer.wgsl").Contains("@fragment", StringComparison.Ordinal))
+            throw new Exception("Packaged consumer shader was not embedded.");
+        RecordBenchmark(command.ExtensionId);
+        if (args.Contains("--gpu", StringComparer.Ordinal)) RunGpu();
+        Console.WriteLine("Unsigned package-only drawing extension consumer passed.");
+    }
+
+    private sealed class ProgramAnchor;
+    private static void Record(DrawingContext context, bool typed, int id)
+    {
+        context.Clear();
+        if (typed) context.DrawExtension(Definition, Bounds, Data);
+        else context.Commands.Add(new RenderCommand { Type = RenderCommandType.DrawExtension, ExtensionId = id, Rect = Bounds, DataParam = Data });
+    }
+    private static void RecordBenchmark(int id)
+    {
+        const int iterations = 100_000;
+        var context = new DrawingContext(); context.EnsureCommandCapacity(1);
+        // Let tiered JIT/PGO finish before collecting steady-state samples.
+        long warmup = Stopwatch.GetTimestamp();
+        while (Stopwatch.GetElapsedTime(warmup).TotalSeconds < 2)
+        { Record(context, false, id); Record(context, true, id); }
+        var legacy = new double[31]; var typed = new double[31];
+        for (int sample = 0; sample < legacy.Length; sample++)
+            for (int pass = 0; pass < 2; pass++)
+            {
+                bool useTyped = (sample + pass) % 2 == 0;
+                long allocated = GC.GetAllocatedBytesForCurrentThread(); long start = Stopwatch.GetTimestamp();
+                for (int i = 0; i < iterations; i++) Record(context, useTyped, id);
+                double ns = Stopwatch.GetElapsedTime(start).TotalNanoseconds / iterations;
+                long bytes = GC.GetAllocatedBytesForCurrentThread() - allocated;
+                if (bytes != 0) throw new Exception($"Recording allocated {bytes} bytes.");
+                (useTyped ? typed : legacy)[sample] = ns;
+            }
+        Report("legacy.record.ns", legacy); Report("typed.record.ns", typed);
+        Console.WriteLine("record.allocated=0; record.commands=1; payload.copied.bytes=0; recording.native.calls=0");
+    }
+
+    private static unsafe void RunGpu()
+    {
+        using var context = new WgpuContext(); context.Initialize(null);
+        using var target = new GpuTexture(context, 64, 64, TextureFormat.Rgba8Unorm, TextureUsage.RenderAttachment | TextureUsage.TextureBinding | TextureUsage.CopySrc);
+        using var compositor = new Compositor(context, TextureFormat.Rgba8Unorm, CompositorOptions.Default with { EnableGpuHitTesting = false, PrimarySampleCount = 1 });
+        var typed = (Triangle)compositor.RegisterDrawingExtension(Definition);
+        var legacy = new Triangle(); compositor.RegisterExtension(7101, legacy);
+        var typedVisual = new DrawingVisual { Size = new(64, 64) };
+        typedVisual.Context.DrawExtension(Definition, Bounds, Data);
+        var legacyVisual = new DrawingVisual { Size = new(64, 64) };
+        legacyVisual.Context.Commands.Add(new RenderCommand { Type = RenderCommandType.DrawExtension, ExtensionId = 7101, Rect = Bounds, DataParam = Data });
+        void Render(DrawingVisual visual) { compositor.RenderScene(visual, 64, 64, 64, 64, 1, target.ViewPtr); context.WaitIdle(); }
+        Render(legacyVisual); byte[] baseline = target.ReadPixels();
+        Render(typedVisual); byte[] actual = target.ReadPixels();
+        if (!baseline.AsSpan().SequenceEqual(actual) || actual[1] < 190 || actual[0] > 40) throw new Exception("Extension pixels differ or the triangle did not render.");
+        for (int i = 0; i < 120; i++) Render(i % 2 == 0 ? typedVisual : legacyVisual);
+        var baselineTime = new double[600]; var typedTime = new double[600];
+        for (int i = 0; i < 600; i++)
+            for (int pass = 0; pass < 2; pass++)
+            {
+                bool useTyped = (i + pass) % 2 == 0;
+                long start = Stopwatch.GetTimestamp(); Render(useTyped ? typedVisual : legacyVisual);
+                (useTyped ? typedTime : baselineTime)[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            }
+        Report("legacy.submission.wait.ms", baselineTime); Report("typed.submission.wait.ms", typedTime);
+        Console.WriteLine($"gpu.pixel.channels.equal={actual.Length}; typed.draws={typed.Draws}; legacy.draws={legacy.Draws}; retained.upload.bytes=0");
+    }
+    private static void Report(string name, double[] values)
+    {
+        Array.Sort(values);
+        Console.WriteLine(FormattableString.Invariant($"{name}: p50={values[(int)(values.Length * .50)]:F3} p95={values[(int)(values.Length * .95)]:F3} p99={values[(int)(values.Length * .99)]:F3}"));
+    }
+
+    private sealed unsafe class Triangle : ICompositorExtension, IDisposable
+    {
+        private static readonly string Shader = ShaderResource.Load<ProgramAnchor>("Consumer.wgsl");
+        private RenderPipelineCache? _cache;
+        private RenderPipeline* _pipeline;
+        public int Draws;
+        public void Compile(Compositor compositor, IRenderDataProvider? provider, Matrix4x4 transform, ref RenderCommand command)
+        {
+            if (command.DataParam is not Frame) throw new Exception("Wrong retained payload.");
+        }
+        public void Render(Compositor compositor, void* encoder, bool offscreen, in Compositor.CompositorDrawCall command)
+        {
+            if (_pipeline == null)
+            {
+                _cache = new(compositor.Context);
+                var shader = _cache.GetOrCreateShader("consumer", Shader);
+                _pipeline = _cache.GetOrCreateRenderPipeline("triangle", shader, ReadOnlySpan<VertexBufferLayout>.Empty,
+                    targetFormat: compositor.RenderFormat, sampleCount: 1, sourceAlphaMode: GpuTextureAlphaMode.Premultiplied);
+            }
+            var api = compositor.Context.Api; var pass = (RenderPassEncoder*)encoder;
+            api.RenderPassEncoderSetPipeline(pass, _pipeline); api.RenderPassEncoderDraw(pass, 3, 1, 0, 0); Draws++;
+        }
+        public void Dispose() { _cache?.Dispose(); _cache = null; _pipeline = null; }
+    }
+}

--- a/eng/fixtures/drawing-extension-package-consumer/Shaders/Consumer.wgsl
+++ b/eng/fixtures/drawing-extension-package-consumer/Shaders/Consumer.wgsl
@@ -1,0 +1,10 @@
+// Algorithm: A single full-target triangle emits an opaque constant test color.
+// Time complexity: O(P) fragment work for P covered pixels; three vertex invocations.
+// Space complexity: O(1) private storage, no textures or buffers, one RGBA output per pixel.
+// Coverage uses the active render pass and its physical viewport; no sampling or loops.
+@vertex fn vs_main(@builtin(vertex_index) vertex: u32) -> @builtin(position) vec4f {
+    let x = select(-1.0, 3.0, vertex == 1u);
+    let y = select(-1.0, 3.0, vertex == 2u);
+    return vec4f(x, y, 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4f { return vec4f(0.1, 0.8, 0.3, 1.0); }

--- a/eng/progpu-pack.sh
+++ b/eng/progpu-pack.sh
@@ -79,6 +79,10 @@ if [[ "${package_group}" == "portable" || "${package_group}" == "all" ]]; then
   PROGPU_PACKAGE_VERSION="${package_version}" \
   PROGPU_PACKAGE_OUTPUT="${package_output}" \
     "${repo_root}/eng/progpu-verify-xaml-package-consumer.sh"
+  PROGPU_CONFIGURATION="${configuration}" \
+  PROGPU_PACKAGE_VERSION="${package_version}" \
+  PROGPU_PACKAGE_OUTPUT="${package_output}" \
+    "${repo_root}/eng/progpu-verify-drawing-extension-package-consumer.sh"
 fi
 
 echo "ProGPU ${package_group} NuGet package build succeeded for ${package_version}."

--- a/eng/progpu-verify-drawing-extension-package-consumer.sh
+++ b/eng/progpu-verify-drawing-extension-package-consumer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_version="${PROGPU_PACKAGE_VERSION:-0.1.0-preview.62}"
+package_output="${PROGPU_PACKAGE_OUTPUT:-${repo_root}/artifacts/packages/Release}"
+configuration="${PROGPU_CONFIGURATION:-Release}"
+consumer_root="$(mktemp -d "${TMPDIR:-/tmp}/progpu-drawing-consumer.XXXXXX")"
+trap 'rm -rf "${consumer_root}"' EXIT
+cp -R "${repo_root}/eng/fixtures/drawing-extension-package-consumer/." "${consumer_root}/"
+project="${consumer_root}/DrawingExtension.PackageConsumer.csproj"
+export NUGET_PACKAGES="${consumer_root}/packages"
+
+dotnet restore "${project}" --source "${package_output}" --source https://api.nuget.org/v3/index.json \
+  "-p:ProGpuPackageVersion=${package_version}" --verbosity minimal
+dotnet build "${project}" -c "${configuration}" --no-restore "-p:ProGpuPackageVersion=${package_version}" --verbosity minimal
+arguments=()
+if [[ "${PROGPU_EXTENSION_GPU_TEST:-0}" == 1 ]]; then arguments+=(--gpu); fi
+dotnet run --project "${project}" -c "${configuration}" --no-build --no-restore \
+  "-p:ProGpuPackageVersion=${package_version}" -- "${arguments[@]}"

--- a/src/ProGPU.Scene/Compositor.DrawingExtensions.cs
+++ b/src/ProGPU.Scene/Compositor.DrawingExtensions.cs
@@ -1,0 +1,40 @@
+namespace ProGPU.Scene;
+
+public unsafe partial class Compositor
+{
+    private Dictionary<DrawingExtension, ICompositorExtension>? _applicationDrawingExtensions;
+
+    /// <summary>
+    /// Creates and owns one extension instance for this compositor. Re-registering
+    /// the same definition is an idempotent lookup. Call on the renderer's owning
+    /// thread outside compilation/render callbacks. IDisposable instances are
+    /// disposed with this compositor through the existing extension lifecycle.
+    /// </summary>
+    public ICompositorExtension RegisterDrawingExtension(DrawingExtension definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        lock (_registeredExtensions)
+        {
+            if (_applicationDrawingExtensions is not null && _applicationDrawingExtensions.TryGetValue(definition, out var existing))
+                return existing;
+            if (_extensionsById.ContainsKey(definition.Id))
+                throw new InvalidOperationException($"The '{definition.Name}' drawing identifier is already registered through the legacy API.");
+            var instance = definition.CreateInstance();
+            if (_registeredExtensions.Contains(instance))
+                throw new InvalidOperationException("A drawing extension factory must return a fresh instance for each registration.");
+            _registeredExtensions.Add(instance);
+            _extensionsById.Add(definition.Id, instance);
+            (_applicationDrawingExtensions ??= new()).Add(definition, instance);
+            _compiledSceneReusable = false;
+            return instance;
+        }
+    }
+
+    /// <summary>Returns the compositor-owned instance, or null before registration.</summary>
+    public ICompositorExtension? GetDrawingExtension(DrawingExtension definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        return GetExtension(definition.Id);
+    }
+}

--- a/src/ProGPU.Scene/DrawingExtension.cs
+++ b/src/ProGPU.Scene/DrawingExtension.cs
@@ -1,0 +1,42 @@
+namespace ProGPU.Scene;
+
+/// <summary>
+/// An application-owned drawing definition. Share one definition between controls
+/// and windows; its factory must return a fresh, device-independent extension for
+/// each compositor. GPU resources should be created lazily by that instance.
+/// </summary>
+public abstract class DrawingExtension
+{
+    private static int s_nextId = 0x4000_0000;
+    internal int Id { get; }
+    public string Name { get; }
+
+    private protected DrawingExtension(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+        Id = Interlocked.Increment(ref s_nextId);
+        if (Id <= 0) throw new InvalidOperationException("Drawing extension identifiers are exhausted.");
+    }
+
+    internal abstract ICompositorExtension CreateInstance();
+}
+
+/// <summary>
+/// Binds retained drawing data to a compositor extension factory without exposing
+/// application-selected numeric IDs. Construction allocates once; recording a
+/// reference-type payload neither boxes nor copies it.
+/// </summary>
+public sealed class DrawingExtension<TData> : DrawingExtension where TData : class
+{
+    private readonly Func<ICompositorExtension> _factory;
+
+    public DrawingExtension(string name, Func<ICompositorExtension> factory) : base(name)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factory = factory;
+    }
+
+    internal override ICompositorExtension CreateInstance() => _factory()
+        ?? throw new InvalidOperationException($"The '{Name}' drawing extension factory returned null.");
+}

--- a/src/ProGPU.Scene/RenderCommand.cs
+++ b/src/ProGPU.Scene/RenderCommand.cs
@@ -4732,6 +4732,29 @@ public class DrawingContext :
             _retainedResources ??= new List<RetainedResourceLease>());
     }
 
+    /// <summary>
+    /// Records one application drawing command. Register the definition with the
+    /// target Window or Compositor before rendering. The payload remains caller
+    /// owned and must stay stable through submission; mutations require visual
+    /// invalidation and any extension-specific generation advance. Bounds are in
+    /// local logical coordinates. This method performs no GPU work or data copy.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void DrawExtension<TData>(DrawingExtension<TData> extension, Rect bounds, TData data, Matrix4x4 transform = default)
+        where TData : class
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        ArgumentNullException.ThrowIfNull(data);
+        Commands.Add(new RenderCommand
+        {
+            Type = RenderCommandType.DrawExtension,
+            ExtensionId = extension.Id,
+            Rect = bounds,
+            DataParam = data,
+            Transform = transform
+        });
+    }
+
     public void DrawExtension(
         int extensionId,
         int intParam = 0,

--- a/src/ProGPU.Tests/DrawingExtensionTests.cs
+++ b/src/ProGPU.Tests/DrawingExtensionTests.cs
@@ -1,0 +1,109 @@
+using System.Numerics;
+using Microsoft.UI.Xaml;
+using ProGPU.Backend;
+using ProGPU.Scene;
+using ProGPU.Scene.Native;
+using ProGPU.Tests.Headless;
+using ProGPU.Vector;
+using Xunit;
+
+namespace ProGPU.Tests;
+
+public sealed class DrawingExtensionTests
+{
+    private sealed class Payload;
+    private sealed unsafe class Probe : ICompositorExtension, IDisposable
+    {
+        public int Compiles, Renders, Begins, Ends, Disposals;
+        public object? Data;
+        public void Compile(Compositor compositor, IRenderDataProvider? provider, Matrix4x4 transform, ref RenderCommand command) { Compiles++; Data = command.DataParam; }
+        public void Render(Compositor compositor, void* pass, bool offscreen, in Compositor.CompositorDrawCall call) { Renders++; Data = call.DataParam; }
+        public void BeginFrame(Compositor compositor) => Begins++;
+        public void EndFrame(Compositor compositor) => Ends++;
+        public void Dispose() => Disposals++;
+    }
+
+    [Fact]
+    public void TypedRecordingPreservesPayloadBoundsAndTransformWithoutAllocation()
+    {
+        var definition = new DrawingExtension<Payload>("fixture", static () => new Probe());
+        var data = new Payload(); var bounds = new Rect(10, 20, 30, 40);
+        var matrix = Matrix4x4.CreateTranslation(3, 7, 0);
+        var context = new DrawingContext(); context.EnsureCommandCapacity(1);
+        void Record() { context.Clear(); context.DrawExtension(definition, bounds, data, matrix); }
+        for (int i = 0; i < 1000; i++) Record();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 10_000; i++) Record();
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - before);
+        var command = Assert.Single(context.Commands);
+        Assert.Equal(RenderCommandType.DrawExtension, command.Type);
+        Assert.Same(data, command.DataParam); Assert.Equal(bounds, command.Rect); Assert.Equal(matrix, command.Transform);
+        var other = new DrawingExtension<object>("fixture", static () => new Probe());
+        context.DrawExtension(other, bounds, data);
+        Assert.NotEqual(command.ExtensionId, context.Commands[1].ExtensionId);
+        Assert.Throws<ArgumentNullException>(() => context.DrawExtension(definition, bounds, null!));
+    }
+
+    [Fact]
+    public void RegistrationIsIdempotentAndUsesExistingCompileRenderAndDisposeLifecycle()
+    {
+        using var window = new HeadlessWindow(32, 32);
+        int factories = 0;
+        var definition = new DrawingExtension<Payload>("fixture", () => { factories++; return new Probe(); });
+        Assert.Null(window.Compositor.GetDrawingExtension(definition));
+        var probe = Assert.IsType<Probe>(window.Compositor.RegisterDrawingExtension(definition));
+        Assert.Same(probe, window.Compositor.RegisterDrawingExtension(definition));
+        Assert.Same(probe, window.Compositor.GetDrawingExtension(definition)); Assert.Equal(1, factories);
+        var data = new Payload(); var visual = new DrawingVisual { Size = new(32, 32) };
+        visual.Context.DrawExtension(definition, new(0, 0, 32, 32), data);
+        using var target = new GpuTexture(window.Context, 32, 32, Silk.NET.WebGPU.TextureFormat.Rgba8Unorm,
+            Silk.NET.WebGPU.TextureUsage.RenderAttachment | Silk.NET.WebGPU.TextureUsage.TextureBinding);
+        unsafe { for (int i = 0; i < 3; i++) window.Compositor.RenderScene(visual, 32, 32, 32, 32, 1, target.ViewPtr); }
+        Assert.Equal(3, probe.Renders); Assert.Same(data, probe.Data); Assert.Equal(probe.Begins, probe.Ends);
+        window.Compositor.Dispose(); window.Compositor.Dispose(); Assert.Equal(1, probe.Disposals);
+        Assert.Throws<ObjectDisposedException>(() => window.Compositor.RegisterDrawingExtension(definition));
+    }
+
+    [Fact]
+    public void NativePictureCompilerStillRejectsApplicationCallbacksExplicitly()
+    {
+        var definition = new DrawingExtension<Payload>("managed callback", static () => new Probe());
+        var drawing = new DrawingContext(); drawing.DrawExtension(definition, new(0, 0, 32, 32), new Payload());
+        using var picture = new GpuPicture(drawing.Commands.ToArray(), [], [], [], []);
+        Assert.False(GpuPictureNativeSceneCompiler.TryCompile(picture, 1, 1, out var compiled, out var failure));
+        Assert.Null(compiled); Assert.Equal(NativePictureCompileError.UnsupportedCommand, failure.Error);
+    }
+
+    [Fact]
+    public void WindowDefersFactoryAndRecreatesInstanceAfterMobileSurfaceSuspension()
+    {
+        var window = new Window(); int factories = 0;
+        var definition = new DrawingExtension<Payload>("fixture", () => { factories++; return new Probe(); });
+        window.RegisterDrawingExtension(definition); window.RegisterDrawingExtension(definition);
+        Assert.Equal(0, factories);
+        using var context = new WgpuContext(); context.Initialize(null);
+        window.InitializeExternalRenderer(context, 1);
+        var first = Assert.IsType<Probe>(window.Compositor!.GetDrawingExtension(definition));
+        Assert.Equal(1, factories);
+        window.RegisterDrawingExtension(definition); Assert.Equal(1, factories);
+        window.SuspendExternalRenderer(); Assert.Equal(1, first.Disposals);
+        window.InitializeExternalRenderer(context, 2);
+        var second = Assert.IsType<Probe>(window.Compositor!.GetDrawingExtension(definition));
+        Assert.NotSame(first, second); Assert.Equal(2, factories);
+        window.SuspendExternalRenderer(); Assert.Equal(1, second.Disposals);
+    }
+
+    [Fact]
+    public void FailedFactoryDoesNotPoisonRegistrationAndLateWindowRegistrationWorks()
+    {
+        var window = new Window(); using var context = new WgpuContext(); context.Initialize(null);
+        window.InitializeExternalRenderer(context, 1);
+        bool fail = true;
+        var definition = new DrawingExtension<Payload>("retry", () => fail ? throw new InvalidOperationException("fixture") : new Probe());
+        Assert.Throws<InvalidOperationException>(() => window.RegisterDrawingExtension(definition));
+        Assert.Null(window.Compositor!.GetDrawingExtension(definition));
+        fail = false; window.RegisterDrawingExtension(definition);
+        var probe = Assert.IsType<Probe>(window.Compositor.GetDrawingExtension(definition));
+        window.SuspendExternalRenderer(); Assert.Equal(1, probe.Disposals);
+    }
+}

--- a/src/ProGPU.WinUI/Core/Window.cs
+++ b/src/ProGPU.WinUI/Core/Window.cs
@@ -105,6 +105,22 @@ public class Window : DependencyObject
     public IWindow? SilkWindow => _silkWindow;
     public WgpuContext? WgpuContext => _wgpuContext;
     public Compositor? Compositor => _compositor;
+    private List<DrawingExtension>? _drawingExtensions;
+
+    /// <summary>
+    /// Registers application drawing on this window, before or after activation.
+    /// A fresh instance is created for each renderer, including after a mobile
+    /// surface is recreated. Definitions are retained; instances and GPU resources
+    /// are owned and disposed by the compositor. Call on the window's UI thread.
+    /// </summary>
+    public void RegisterDrawingExtension(DrawingExtension extension)
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        if (_isClosed) throw new InvalidOperationException("The window is closed.");
+        if (_drawingExtensions?.Contains(extension) == true) return;
+        _compositor?.RegisterDrawingExtension(extension);
+        (_drawingExtensions ??= new()).Add(extension);
+    }
     public WindowInputState? InputState => _inputState;
     public SilkWindowController? NativeWindowController => _windowController;
     public NativeWindowHandle NativeHandle => _windowController?.Handle ?? NativeWindowHandle.Empty;
@@ -609,6 +625,9 @@ public class Window : DependencyObject
     private void ConfigureCompositorHooks()
     {
         if (_compositor == null) return;
+        if (_drawingExtensions is not null)
+            foreach (var extension in _drawingExtensions)
+                _compositor.RegisterDrawingExtension(extension);
         _compositor.PreRender += (w, h) => PopupService.MeasureAndArrangePopups(new Vector2(w, h));
         _compositor.GetExternalLayers = () => PopupService.ActivePopups;
         _compositor.GetTooltip = () => InputSystem.ActiveToolTip;


### PR DESCRIPTION
WinUI applications currently coordinate numeric extension IDs and wait for a compositor before registering custom drawing. Mobile renderer recreation also requires registering another device-owned instance. Add `DrawingExtension<TData>`, `Window.RegisterDrawingExtension`, and typed `DrawingContext.DrawExtension` so application libraries can register before activation, record typed payloads with local bounds, and recreate instances through the window lifecycle.

The existing public compositor callbacks, command stream, GPU pipeline and dispatch path are unchanged. Definitions allocate at setup; recording retains the original reference without boxing, payload copying or native calls. An unsigned consumer is copied outside the repository and built only from locally packed NuGet dependencies, including an original embedded shader. Portable package CI now runs this consumer gate.

Validation: 3,814 core and 240 headless Release tests pass, including five new recording, registration, lifecycle and native-rejection tests. Package-only build passes with zero warnings. Three matched Release GPU runs produce exact pixels, equal draw counts, zero recording allocations and no retained payload uploads. The typed wrapper adds 1.4–2.9 ns median recording cost; GPU submission medians remain within about 1.5%, with host scheduling variance in tails. Time Profiler and Metal System Trace captures were collected. Both instrumented workloads completed; useful exports were verified before removing raw traces. An additional package-only macOS NativeAOT publish and GPU run passed (16,384 identical RGBA8 channels, equal draws and zero retained payload uploads); it reports existing dependency trimming/single-file warnings. The full pinned Svg.Skia workflow comparison also passed locally: native W3C 530 passes/3 skips, resvg 927 passes/37 skips, remaining tests 1,147 passes, and ProGPU W3C 486 passes/44 expected differences/3 skips with the exact inventory verifier passing. Hosted checks have 15 passes; macOS jobs remain queued/in progress. Integration uses the completed local macOS gates rather than treating those pending hosted jobs as passed.

[API usage, research, backend applicability and measurement details](https://github.com/wieslawsoltes/ProGPU/blob/codex/public-drawing-extensions/docs/drawing-extensions.md). This adds a managed WinUI callback registration API; the native C scene ABI continues to explicitly reject arbitrary managed callbacks. No renderer algorithm, native record, production renderer shader or foreign implementation is added. Suntrail PR #158 will adopt this API after this PR is merged, as requested.
