### PR TITLE
Gate System.Drawing SVG performance regressions

### DIFF
--- a/.github/workflows/svg-system-drawing-parity.yml
+++ b/.github/workflows/svg-system-drawing-parity.yml
@@ -18,6 +18,7 @@ on:
       - eng/system-drawing-svg-known-exceptions.txt
       - eng/system-drawing-svg-threshold-overrides.txt
       - eng/system-drawing-svg-benchmark-fixtures.txt
+      - eng/system-drawing-svg-performance-budget.json
       - .github/workflows/svg-system-drawing-parity.yml
   push:
     branches:
@@ -35,6 +36,7 @@ on:
       - eng/system-drawing-svg-known-exceptions.txt
       - eng/system-drawing-svg-threshold-overrides.txt
       - eng/system-drawing-svg-benchmark-fixtures.txt
+      - eng/system-drawing-svg-performance-budget.json
       - .github/workflows/svg-system-drawing-parity.yml
 
 permissions:
@@ -132,7 +134,6 @@ jobs:
 
   performance:
     name: SVG.NET representative performance
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -191,6 +192,7 @@ jobs:
           --corpus-root "${{ github.workspace }}/external/Svg.Skia"
           --artifacts "${{ github.workspace }}/artifacts/svg-system-drawing/performance"
           --benchmark-fixtures "${{ github.workspace }}/eng/system-drawing-svg-benchmark-fixtures.txt"
+          --performance-budget "${{ github.workspace }}/eng/system-drawing-svg-performance-budget.json"
           --iterations 7
 
       - name: Upload SVG performance evidence
@@ -198,5 +200,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: svg-system-drawing-performance-${{ github.sha }}
-          path: artifacts/svg-system-drawing/performance/**
+          path: |
+            artifacts/svg-system-drawing/performance/**
+            eng/system-drawing-svg-performance-budget.json
           if-no-files-found: error

--- a/docs/research/system-drawing-corpus-gates.md
+++ b/docs/research/system-drawing-corpus-gates.md
@@ -84,10 +84,25 @@ reason; unknown fixture keys fail the gate.
 The performance command uses ten representative W3C fixtures spanning basic
 shapes, paths, gradients, patterns, and text. It warms the complete pipeline,
 then records seven isolated Release samples with elapsed time, total managed
-allocation, and a pixel-derived checksum. Results are raw evidence rather than
-a single-run performance claim. Establish regression budgets only after
-several alternating runs on a pinned runner image; keep the complete corpus as
-a correctness gate and use the representative set for iteration speed.
+allocation, and a pixel-derived checksum. The automatic gate requires the
+complete fixture set, at least seven samples, the expected semantic checksum,
+the expected x64 process architecture, and both median and nearest-rank p95
+time/allocation budgets from
+`eng/system-drawing-svg-performance-budget.json`. The JSON evidence also
+records the OS, process architecture, runtime, processor count, and GC mode.
+Keep the complete corpus as the correctness gate and use this representative
+set for bounded regression detection rather than as a universal throughput
+claim.
+
+The hosted x64 budget was calibrated from three successful seven-sample runs.
+Their medians were `4,597.710`, `4,637.553`, and `4,593.515` ms and
+`175,522,168`, `175,528,952`, and `175,521,832` allocated bytes. The gate
+allows `5,750` ms median / `6,500` ms p95 and `185,000,000` B median /
+`190,000,000` B p95. These intentionally broad limits detect material
+regressions while allowing hosted-runner noise. Recalibration requires a
+reviewed reference commit and several equivalent Release runs; an improvement
+does not justify silently relaxing a correctness inventory or changing the
+fixture checksum.
 
 The 2026-09-07 pinned-font local ARM64/.NET 10.0.400 software-WebGPU run records
 a `5,655.852` ms median and `176,001,760` median allocated bytes for the complete
@@ -188,6 +203,7 @@ performance
 --corpus-root <Svg.Skia checkout>
 --artifacts <artifact directory>
 --benchmark-fixtures eng/system-drawing-svg-benchmark-fixtures.txt
+--performance-budget eng/system-drawing-svg-performance-budget.json
 --iterations 7
 ```
 

--- a/eng/SystemDrawing.SvgCorpus/Program.cs
+++ b/eng/SystemDrawing.SvgCorpus/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Drawing.Imaging;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,7 +14,7 @@ internal static class CorpusApplication
 {
     private const int FixtureTimeoutMilliseconds = 30_000;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    internal static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
         NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
@@ -312,20 +313,53 @@ internal static class CorpusApplication
 
         var elapsed = samples.Select(static sample => sample.ElapsedMilliseconds).Order().ToArray();
         var allocations = samples.Select(static sample => sample.AllocatedBytes).Order().ToArray();
+        var budget = options.PerformanceBudgetPath is null
+            ? null
+            : PerformanceBudget.Read(options.PerformanceBudgetPath);
+        var medianElapsed = Median(elapsed);
+        var p95Elapsed = Percentile(elapsed, 0.95);
+        var medianAllocated = Median(allocations);
+        var p95Allocated = Percentile(allocations, 0.95);
+        var evaluation = budget is null
+            ? null
+            : PerformanceBudgetEvaluator.Evaluate(
+                budget,
+                fixtures.Length,
+                samples,
+                medianElapsed,
+                p95Elapsed,
+                medianAllocated,
+                p95Allocated);
         var report = new PerformanceReport(
             Commit: ReadCommit(),
             GeneratedAtUtc: DateTimeOffset.UtcNow,
+            Runtime: RuntimeEvidence.Capture(),
             FontCorpus: fontCorpus,
             FixtureCount: fixtures.Length,
             Iterations: options.Iterations,
-            MedianElapsedMilliseconds: Median(elapsed),
-            MedianAllocatedBytes: Median(allocations),
+            MedianElapsedMilliseconds: medianElapsed,
+            P95ElapsedMilliseconds: p95Elapsed,
+            MedianAllocatedBytes: medianAllocated,
+            P95AllocatedBytes: p95Allocated,
+            BudgetEvaluation: evaluation,
             Samples: samples);
         WriteJson(Path.Combine(options.ArtifactsRoot, "performance-results.json"), report);
         Console.WriteLine(
             FormattableString.Invariant(
-                $"SVG System.Drawing performance: {fixtures.Length} fixtures, median {report.MedianElapsedMilliseconds:F3} ms, median {report.MedianAllocatedBytes:F0} allocated bytes."));
-        return 0;
+                $"SVG System.Drawing performance: {fixtures.Length} fixtures, median/p95 {medianElapsed:F3}/{p95Elapsed:F3} ms, median/p95 {medianAllocated:F0}/{p95Allocated:F0} allocated bytes."));
+
+        if (evaluation is null)
+        {
+            return 0;
+        }
+
+        Console.WriteLine($"Performance budget: {(evaluation.Passed ? "passed" : "failed")}");
+        foreach (string violation in evaluation.Violations)
+        {
+            Console.Error.WriteLine($"Performance budget violation: {violation}");
+        }
+
+        return evaluation.Passed ? 0 : 1;
     }
 
     private static FixtureResult RenderAndCompare(Fixture fixture, string artifactsRoot, double threshold)
@@ -440,6 +474,13 @@ internal static class CorpusApplication
         => sorted.Count % 2 == 0
             ? (sorted[sorted.Count / 2 - 1] + sorted[sorted.Count / 2]) / 2d
             : sorted[sorted.Count / 2];
+
+    private static double Percentile<T>(IReadOnlyList<T> sorted, double percentile)
+        where T : struct, IConvertible
+    {
+        int index = Math.Clamp((int)Math.Ceiling(percentile * sorted.Count) - 1, 0, sorted.Count - 1);
+        return sorted[index].ToDouble(CultureInfo.InvariantCulture);
+    }
 }
 
 internal static class FixtureCatalog
@@ -795,6 +836,7 @@ internal sealed record Options(
     string KnownExceptionsPath,
     string ThresholdOverridesPath,
     string BenchmarkFixturesPath,
+    string? PerformanceBudgetPath,
     string? FixtureKey,
     Suite Suite,
     double Threshold,
@@ -816,6 +858,7 @@ internal sealed record Options(
                 "[--known-differences PATH] [--known-exceptions PATH] " +
                 "[--threshold-overrides PATH] " +
                 "[--benchmark-fixtures PATH] " +
+                "[--performance-budget PATH] " +
                 "[--fixture suite|path] [--suite all|resvg|w3c] " +
                 "[--threshold 0.12] [--iterations 7] [--max-parallelism 4]");
         }
@@ -871,6 +914,7 @@ internal sealed record Options(
             knownExceptions,
             thresholdOverrides,
             benchmarkFixtures,
+            values.GetValueOrDefault("--performance-budget"),
             values.GetValueOrDefault("--fixture"),
             suite,
             threshold,
@@ -968,6 +1012,146 @@ internal sealed record QualityReport(
 
 internal sealed record PerformanceSample(int Iteration, double ElapsedMilliseconds, long AllocatedBytes, ulong Checksum);
 
+internal sealed record RuntimeEvidence(
+    string OperatingSystem,
+    string ProcessArchitecture,
+    string Framework,
+    int ProcessorCount,
+    bool IsServerGc)
+{
+    public static RuntimeEvidence Capture()
+        => new(
+            RuntimeInformation.OSDescription,
+            RuntimeInformation.ProcessArchitecture.ToString(),
+            RuntimeInformation.FrameworkDescription,
+            Environment.ProcessorCount,
+            System.Runtime.GCSettings.IsServerGC);
+}
+
+internal sealed record PerformanceBudget(
+    string ReferenceCommit,
+    string ExpectedProcessArchitecture,
+    int MinimumIterations,
+    int ExpectedFixtureCount,
+    string ExpectedChecksum,
+    double MaximumMedianElapsedMilliseconds,
+    double MaximumP95ElapsedMilliseconds,
+    long MaximumMedianAllocatedBytes,
+    long MaximumP95AllocatedBytes)
+{
+    public static PerformanceBudget Read(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException("Performance budget was not found.", path);
+        }
+
+        var budget = JsonSerializer.Deserialize<PerformanceBudget>(File.ReadAllText(path), CorpusApplication.JsonOptions)
+            ?? throw new InvalidDataException($"Performance budget is empty: {path}");
+        if (budget.ReferenceCommit.Length != 40 ||
+            !budget.ReferenceCommit.All(Uri.IsHexDigit) ||
+            !Enum.TryParse<Architecture>(budget.ExpectedProcessArchitecture, ignoreCase: true, out _) ||
+            budget.MinimumIterations < 1 ||
+            budget.ExpectedFixtureCount < 1 ||
+            !ulong.TryParse(budget.ExpectedChecksum, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _) ||
+            !double.IsFinite(budget.MaximumMedianElapsedMilliseconds) ||
+            budget.MaximumMedianElapsedMilliseconds <= 0 ||
+            !double.IsFinite(budget.MaximumP95ElapsedMilliseconds) ||
+            budget.MaximumP95ElapsedMilliseconds < budget.MaximumMedianElapsedMilliseconds ||
+            budget.MaximumMedianAllocatedBytes <= 0 ||
+            budget.MaximumP95AllocatedBytes < budget.MaximumMedianAllocatedBytes)
+        {
+            throw new InvalidDataException($"Performance budget is invalid: {path}");
+        }
+
+        return budget;
+    }
+}
+
+internal static class PerformanceBudgetEvaluator
+{
+    public static PerformanceBudgetEvaluation Evaluate(
+        PerformanceBudget budget,
+        int fixtureCount,
+        IReadOnlyList<PerformanceSample> samples,
+        double medianElapsedMilliseconds,
+        double p95ElapsedMilliseconds,
+        double medianAllocatedBytes,
+        double p95AllocatedBytes)
+    {
+        var violations = new List<string>();
+        if (!StringComparer.OrdinalIgnoreCase.Equals(
+            RuntimeInformation.ProcessArchitecture.ToString(),
+            budget.ExpectedProcessArchitecture))
+        {
+            violations.Add(
+                $"budget targets {budget.ExpectedProcessArchitecture}, process architecture is {RuntimeInformation.ProcessArchitecture}");
+        }
+
+        if (samples.Count < budget.MinimumIterations)
+        {
+            violations.Add($"required at least {budget.MinimumIterations} samples, observed {samples.Count}");
+        }
+
+        if (fixtureCount != budget.ExpectedFixtureCount)
+        {
+            violations.Add($"expected {budget.ExpectedFixtureCount} fixtures, observed {fixtureCount}");
+        }
+
+        ulong expectedChecksum = ulong.Parse(budget.ExpectedChecksum, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        string[] unexpectedChecksums = samples
+            .Select(static sample => sample.Checksum)
+            .Where(checksum => checksum != expectedChecksum)
+            .Distinct()
+            .Select(static checksum => checksum.ToString("x16", CultureInfo.InvariantCulture))
+            .ToArray();
+        if (unexpectedChecksums.Length > 0)
+        {
+            violations.Add(
+                $"expected checksum {expectedChecksum:x16}, observed {string.Join(", ", unexpectedChecksums)}");
+        }
+
+        AddExceeded(
+            violations,
+            "median elapsed milliseconds",
+            medianElapsedMilliseconds,
+            budget.MaximumMedianElapsedMilliseconds);
+        AddExceeded(
+            violations,
+            "p95 elapsed milliseconds",
+            p95ElapsedMilliseconds,
+            budget.MaximumP95ElapsedMilliseconds);
+        AddExceeded(
+            violations,
+            "median allocated bytes",
+            medianAllocatedBytes,
+            budget.MaximumMedianAllocatedBytes);
+        AddExceeded(
+            violations,
+            "p95 allocated bytes",
+            p95AllocatedBytes,
+            budget.MaximumP95AllocatedBytes);
+
+        return new PerformanceBudgetEvaluation(
+            Passed: violations.Count == 0,
+            Budget: budget,
+            Violations: violations);
+    }
+
+    private static void AddExceeded(List<string> violations, string metric, double observed, double maximum)
+    {
+        if (observed > maximum)
+        {
+            violations.Add(FormattableString.Invariant($"{metric} {observed:F3} exceeded {maximum:F3}"));
+        }
+    }
+}
+
+internal sealed record PerformanceBudgetEvaluation(
+    bool Passed,
+    PerformanceBudget Budget,
+    IReadOnlyList<string> Violations);
+
 internal sealed record FontCorpusEvidence(
     int SourceFileCount,
     int LoadedFaceCount,
@@ -978,11 +1162,15 @@ internal sealed record FontCorpusEvidence(
 internal sealed record PerformanceReport(
     string Commit,
     DateTimeOffset GeneratedAtUtc,
+    RuntimeEvidence Runtime,
     FontCorpusEvidence FontCorpus,
     int FixtureCount,
     int Iterations,
     double MedianElapsedMilliseconds,
+    double P95ElapsedMilliseconds,
     double MedianAllocatedBytes,
+    double P95AllocatedBytes,
+    PerformanceBudgetEvaluation? BudgetEvaluation,
     IReadOnlyList<PerformanceSample> Samples);
 
 internal enum Command

--- a/eng/system-drawing-svg-performance-budget.json
+++ b/eng/system-drawing-svg-performance-budget.json
@@ -1,0 +1,11 @@
+{
+  "ReferenceCommit": "8842f828a47442dd0d3e583f85c57432e3c448e5",
+  "ExpectedProcessArchitecture": "X64",
+  "MinimumIterations": 7,
+  "ExpectedFixtureCount": 10,
+  "ExpectedChecksum": "1eff2c6cbe8504b8",
+  "MaximumMedianElapsedMilliseconds": 5750,
+  "MaximumP95ElapsedMilliseconds": 6500,
+  "MaximumMedianAllocatedBytes": 185000000,
+  "MaximumP95AllocatedBytes": 190000000
+}


### PR DESCRIPTION
## Summary

- make the representative SVG.NET-on-ProGPU performance job automatic for relevant pull requests and main pushes
- enforce minimum samples, fixture identity, semantic checksum, x64 architecture, and median/p95 elapsed/allocation budgets
- record runtime environment and budget evaluation in the uploaded JSON evidence
- document three-run hosted calibration and conservative regression limits

## Calibration

Three successful seven-sample hosted x64 runs produced elapsed medians of 4597.710, 4637.553, and 4593.515 ms and allocation medians of 175522168, 175528952, and 175521832 bytes. The reviewed limits are 5750/6500 ms median/p95 and 185000000/190000000 bytes median/p95.

Latest main calibration: https://github.com/wieslawsoltes/ProGPU/actions/runs/34510142093

## Local validation

- Release corpus runner build: 0 warnings, 0 errors
- budget JSON and workflow YAML parse
- git diff --check
- ARM64 negative-path run writes environment/budget evidence and exits 1 for the explicit X64 target and fewer than seven samples

The exact-head hosted x64 job is the authoritative passing-path gate.